### PR TITLE
update action id field type from varchar to text

### DIFF
--- a/hasura/migrations/default/1674660431117_alter_table_public_action_alter_column_id/down.sql
+++ b/hasura/migrations/default/1674660431117_alter_table_public_action_alter_column_id/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."action" ALTER COLUMN "id" TYPE character varying;

--- a/hasura/migrations/default/1674660431117_alter_table_public_action_alter_column_id/up.sql
+++ b/hasura/migrations/default/1674660431117_alter_table_public_action_alter_column_id/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."action" ALTER COLUMN "id" TYPE text;


### PR DESCRIPTION
Add migration to update the `id` field type in the `action` table, because now it's varchar and the string length is limited by 50 chars. And with the new type of Ids, we need more.

Locally I've created several notes to the action table with varchar Ids, then update table settings, all of the notes were okay after updating. 

But I failed to test locally with a web application. When I launch the web app I get an error (see screenshot). This error happened instantly, even before my changes in hasura. So I can't even register a new profile locally, to test a new approach.
May be I need to add some envs. 

<details>
<summary>❌ Error screenshot</summary>

![image](https://user-images.githubusercontent.com/89008845/214615001-2c041b1b-4eba-48d3-95ba-f39eafd3599b.png)
</details>