### PR TITLE
feat: OIDC single domain

### DIFF
--- a/web/api-helpers/jwts.ts
+++ b/web/api-helpers/jwts.ts
@@ -7,11 +7,11 @@
 import { randomUUID } from "crypto";
 import * as jose from "jose";
 import { CredentialType, JwtConfig } from "../types";
-import { JWK_ALG, JWK_ALG_OIDC } from "consts";
+import { JWK_ALG_OIDC } from "consts";
 import { retrieveJWK } from "./jwks";
 import { OIDCScopes } from "./oidc";
 
-const JWT_ISSUER = process.env.JWT_ISSUER;
+export const JWT_ISSUER = process.env.JWT_ISSUER;
 const GENERAL_SECRET_KEY = process.env.GENERAL_SECRET_KEY;
 const JWT_CONFIG: JwtConfig = JSON.parse(
   process.env.HASURA_GRAPHQL_JWT_SECRET || ""

--- a/web/api-helpers/oidc.ts
+++ b/web/api-helpers/oidc.ts
@@ -17,7 +17,11 @@ export const OIDCResponseTypeMapping = {
   token: OIDCResponseType.JWT,
 };
 
-export type OIDCScopes = "openid" | "email" | "profile";
+export enum OIDCScopes {
+  OpenID = "openid",
+  Email = "email",
+  Profile = "profile",
+}
 
 const fetchAppQuery = gql`
   query FetchAppQuery($app_id: String!) {

--- a/web/consts.ts
+++ b/web/consts.ts
@@ -27,8 +27,8 @@ export const DEVELOPER_PORTAL_AUTH_APP = {
   ).digest,
 };
 
-// ANCHOR: OIDC Issuer URI
-export const OIDC_ISSUER = "https://id.worldcoin.org"; // TODO: Need to decide on domain name strategy
+// ANCHOR: OIDC Base URL
+export const OIDC_BASE_URL = "https://id.worldcoin.org";
 
 // ANCHOR: JWKs
 export const JWK_ALG = "PS256";

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -13,7 +13,7 @@ const nextConfig = {
     return [
       {
         source: "/.well-known/openid-configuration",
-        destination: "/api/v1/oidc/.well-known/openid-configuration",
+        destination: "/api/v1/oidc/openid-configuration",
       },
     ];
   },

--- a/web/pages/api/v1/jwks.ts
+++ b/web/pages/api/v1/jwks.ts
@@ -13,10 +13,6 @@ export default async function handleJWKs(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  // FIXME: remove
-  console.log("Starting /jwks endpoint");
-  console.log(req.body);
-
   await runCors(req, res);
   if (!req.method || !["GET", "OPTIONS"].includes(req.method)) {
     return errorNotAllowed(req.method, res);

--- a/web/pages/api/v1/oidc/authorize.ts
+++ b/web/pages/api/v1/oidc/authorize.ts
@@ -92,7 +92,9 @@ export default async function handler(
   const scopes = decodeURIComponent(
     (scope as string | string[])?.toString()
   ).split(" ") as OIDCScopes[];
-  const sanitizedScopes: OIDCScopes[] = scopes.length ? scopes : ["openid"];
+  const sanitizedScopes: OIDCScopes[] = scopes.length
+    ? scopes
+    : [OIDCScopes.OpenID];
 
   // ANCHOR: Check the app is valid and fetch information
   const { app, error: fetchAppError } = await fetchOIDCApp(app_id);

--- a/web/pages/api/v1/oidc/openid-configuration.ts
+++ b/web/pages/api/v1/oidc/openid-configuration.ts
@@ -1,6 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { errorNotAllowed } from "../../../../../api-helpers/errors";
-import { OIDC_ISSUER } from "../../../../../consts";
+import { errorNotAllowed } from "../../../../api-helpers/errors";
+import { OIDC_BASE_URL } from "../../../../consts";
+import { JWT_ISSUER } from "../../../../api-helpers/jwts";
+import { OIDCScopes } from "../../../../api-helpers/oidc";
 
 /**
  * Returns an OpenID Connect discovery document, according to spec
@@ -16,13 +18,13 @@ export default async function handleOidcConfig(
   }
 
   res.status(200).json({
-    issuer: OIDC_ISSUER,
-    authorization_endpoint: `${OIDC_ISSUER}/api/v1/oidc/authorize`,
-    token_endpoint: `${OIDC_ISSUER}/api/v1/oidc/token`,
-    userinfo_endpoint: `${OIDC_ISSUER}/api/v1/oidc/userinfo`,
-    registration_endpoint: `${OIDC_ISSUER}/api/v1/oidc/register`,
-    jwks_uri: `${OIDC_ISSUER}/api/v1/oidc/jwks`,
-    scopes_supported: ["openid"],
+    issuer: JWT_ISSUER,
+    authorization_endpoint: `${OIDC_BASE_URL}/authorize`,
+    token_endpoint: `${OIDC_BASE_URL}/token`,
+    userinfo_endpoint: `${OIDC_BASE_URL}/userinfo`,
+    registration_endpoint: `${OIDC_BASE_URL}/register`,
+    jwks_uri: `${OIDC_BASE_URL}/jwks.json`,
+    scopes_supported: Object.values(OIDCScopes),
     response_types_supported: [
       "code", // Authorization code flow
       "id_token", // Implicit flow
@@ -30,7 +32,7 @@ export default async function handleOidcConfig(
       "code id_token", // Hybrid flow
     ],
     grant_types_supported: ["authorization_code", "implicit"],
-    subject_types_supported: ["public"],
+    subject_types_supported: ["pairwise"], // subject is unique to each application, cannot be used across
     id_token_signing_alg_values_supported: ["RSA"],
   });
 }

--- a/web/pages/api/v1/oidc/token.ts
+++ b/web/pages/api/v1/oidc/token.ts
@@ -51,10 +51,6 @@ export default async function handler(
     );
   }
 
-  // FIXME: remove
-  console.log("Starting /token endpoint");
-  console.log(req.body);
-
   // ANCHOR: Authenticate the request
   let authToken = req.headers.authorization;
 

--- a/web/pages/api/v1/oidc/userinfo.ts
+++ b/web/pages/api/v1/oidc/userinfo.ts
@@ -21,10 +21,6 @@ export default async function handler(
 
   const token = authorization.replace("Bearer ", "");
 
-  // FIXME: remove
-  console.log("Starting /userinfo endpoint");
-  console.log(req.body);
-
   try {
     const payload = await verifyOIDCJWT(token); // TODO: @igorosip0v Add test for expired tokens, invalid tokens, ...
     const response: Record<string, any> = {


### PR DESCRIPTION
We now use a single domain for OIDC, `https://id.worldcoin.org`, endpoints are now very friendly in that domain.