### PR TITLE
chore: fix production Dockerfile

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,7 +1,42 @@
-FROM --platform=linux/amd64 node:16.19-bullseye-slim
+# from https://github.com/vercel/next.js/blob/474b115e6d903394d58a51eef97ffa4f2ae2ce70/examples/with-docker/Dockerfile
+FROM node:18-alpine AS base
+
+# Install dependencies only when needed
+FROM base AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
 WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn --frozen-lockfile
+
+# Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN yarn install --legacy-peer-deps
-RUN yarn run build
+
+RUN yarn build
+
+# Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app
+
+# Uncomment the following line in case you want to disable telemetry during runtime.
+# ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
 EXPOSE 3000
+
 CMD [ "yarn", "start" ]

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  output: "standalone",
   images: {
     domains: ["world-id-public.s3.amazonaws.com"],
   },


### PR DESCRIPTION
Found some deps issues. Needed faster deployments. We went from ~3 GB images to 220 MB, and no known vulnerabilities. Follows the very well executed Vercel Docker context.

**Before**

<img width="1538" alt="" src="https://user-images.githubusercontent.com/5864173/221695618-293dc163-d36f-4a8b-a393-ed5d2571d70e.png">


**After**

<img width="1562" alt="" src="https://user-images.githubusercontent.com/5864173/221695660-d5093df4-b41d-4d1b-9304-f2c446329741.png">
