### PR TITLE
feat: add system status fetching

### DIFF
--- a/web/.env.test
+++ b/web/.env.test
@@ -37,3 +37,5 @@ PGHOST=localhost
 PGPASSWORD=password
 PGDATABASE=postgres
 PGPORT=5433
+
+# UPTIME_ROBOT_API_KEY=<api_key>

--- a/web/src/components/Layout/SystemStatus/index.tsx
+++ b/web/src/components/Layout/SystemStatus/index.tsx
@@ -1,36 +1,33 @@
 import cn from "classnames";
-import { memo, useState } from "react";
-
-enum Status {
-  Online,
-  Offline,
-}
+import { memo } from "react";
+import { useUptimeRobot } from "src/hooks/useUptimeRobot";
+import { GetMonitorsResponse } from "src/pages/api/status";
 
 export const SystemStatus = memo(function SystemStatus() {
-  const [status, _setStatus] = useState<Status>(Status.Online);
+  const { status, error: systemStatusError } = useUptimeRobot();
 
-  const statusDescription = {
-    [Status.Online]: "All systems are up and running",
-    [Status.Offline]: "Some systems are down",
+  const statusDescription: { [key in GetMonitorsResponse["stat"]]: string } = {
+    ok: "All systems are up and running",
+    fail: "Some systems are down",
   };
 
-  return (
+  return !systemStatusError && status ? (
     <div
       className={cn(
         "px-4 py-2.5 w-full grid items-center rounded-[10px] gap-x-3 grid-cols-auto/1fr",
-        { "bg-success-light text-success": status === Status.Online },
-        { "bg-danger-light text-danger": status === Status.Offline }
+        { "bg-success-light text-success": status.stat === "ok" },
+        { "bg-danger-light text-danger": status.stat === "fail" }
       )}
     >
       <div
         className={cn(
           "h-1.5 w-1.5 rounded-full",
-          { "bg-success": status === Status.Online },
-          { "bg-danger": status === Status.Offline }
+          { "bg-success": status.stat === "ok" },
+          { "bg-danger": status.stat === "fail" }
         )}
       />
 
-      <span className="text-12">{statusDescription[status]}</span>
+      <span className="text-12">{statusDescription[status.stat]}</span>
     </div>
-  );
+  ) : null;
 });

--- a/web/src/hooks/useUptimeRobot.ts
+++ b/web/src/hooks/useUptimeRobot.ts
@@ -1,0 +1,20 @@
+import { GetMonitorsResponse } from "src/pages/api/status";
+import useSWR from "swr";
+
+export const useUptimeRobot = () => {
+  const fetcher = async (url: string) => {
+    const response = await fetch(url);
+    const result = await response.json();
+    return result;
+  };
+
+  const { data, error } = useSWR<GetMonitorsResponse>(
+    `${process.env.NEXT_PUBLIC_APP_URL}/api/status`,
+    fetcher
+  );
+
+  return {
+    status: data,
+    error,
+  };
+};

--- a/web/src/pages/api/status/index.ts
+++ b/web/src/pages/api/status/index.ts
@@ -1,0 +1,72 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+export type GetMonitorsResponse = {
+  stat: "ok" | "fail";
+  pagination: {
+    offset: number;
+    limit: number;
+    total: number;
+  };
+  monitors: [
+    {
+      id: number;
+      friendly_name: string;
+      url: string;
+      type: number;
+      sub_type: string;
+      keyword_type: 1 | 2 | null;
+      keyword_case_type: 0 | 1 | null;
+      keyword_value: string;
+      http_username: string;
+      http_password: string;
+      port: string;
+      interval: number;
+      timeout: unknown | null;
+      status: number;
+      create_datetime: number;
+    }
+  ];
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const API_KEY = process.env.UPTIME_ROBOT_API_KEY;
+  const _BASE_URL = "https://api.uptimerobot.com/v2/";
+
+  const _getUrl = (route: string) => {
+    const url = new URL(route, _BASE_URL);
+    url.searchParams.append("api_key", API_KEY as string);
+    url.searchParams.append("format", "json");
+    return url.toString();
+  };
+
+  const fetcher = async <T = any>(url: string): Promise<T | Error> => {
+    let result;
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      result = await response.json();
+    } catch (error) {
+      console.log(error);
+      return Error("Error fetching data", { cause: error });
+    }
+
+    return result;
+  };
+
+  const result = await fetcher<GetMonitorsResponse>(_getUrl("getMonitors"));
+
+  if (result instanceof Error) {
+    return res.status(500).json({ error: result.message, cause: result.cause });
+  }
+
+  return res.status(200).json(result);
+}


### PR DESCRIPTION
- Add fetching System status from UptimeRobot
  - [API docs](https://uptimerobot.com/api/)

### To make it work we need to add the API key. 

There are some types of Keys that exist for this API:
<details>
<summary>API Keys</summary>

![image](https://user-images.githubusercontent.com/89008845/226446013-cebb7375-3c4d-4d2c-bf16-670c187ce573.png)
</details>

I guess we need a monitor-specific API key. You can get it in the account settings

<details>
<summary>How to get API key</summary>

1. ![image](https://user-images.githubusercontent.com/89008845/226446328-29b76ce0-5b2c-419a-b3a5-669a29f04691.png)

2. ![image](https://user-images.githubusercontent.com/89008845/226446596-3427624e-34be-4618-83db-f97cc372e64b.png)

</details>

---

<details>
<summary>Result</summary>

![image](https://user-images.githubusercontent.com/89008845/226447072-c0ead3fe-44e3-42b8-9007-575815ca42e4.png)
![image](https://user-images.githubusercontent.com/89008845/226447126-235e0a93-94ae-4ffd-b835-3070d88f07f4.png)

</details>