### PR TITLE
feat: add hint for app name field

### DIFF
--- a/web/src/scenes/app/Configuration.tsx
+++ b/web/src/scenes/app/Configuration.tsx
@@ -10,6 +10,7 @@ const Label = memo(function Label(props: {
   saving?: boolean;
   onSave: (value: string) => void;
   disabled?: boolean;
+  disabledMessage?: string;
 }) {
   const { value, onSave, disabled } = props;
 
@@ -45,10 +46,10 @@ const Label = memo(function Label(props: {
   return (
     <label>
       <span className="text-14 font-medium">{props.label}</span>
-      <div className="relative">
+      <div className="relative group">
         <FieldInput
           ref={ref}
-          className="text-14 w-full"
+          className="text-14 w-full disabled:cursor-not-allowed"
           defaultValue={value}
           onBlur={handleBlur}
           onKeyPress={handleKeyPress}
@@ -60,6 +61,11 @@ const Label = memo(function Label(props: {
             name="spinner"
             noMask
           />
+        )}
+        {disabled && props.disabledMessage && (
+          <div className="absolute invisible group-hover:visible top-[100%] mt-1 text-14 text-neutral-secondary">
+            {props.disabledMessage}
+          </div>
         )}
       </div>
     </label>
@@ -85,6 +91,11 @@ export const Configuration = memo(function Configuration() {
         saving={isUpdateAppNameMutating}
         onSave={updateAppName}
         disabled={currentApp?.is_verified}
+        disabledMessage={
+          currentApp?.is_verified
+            ? "Verified app name can't be changed."
+            : undefined
+        }
       />
 
       <Label


### PR DESCRIPTION
Added message that appears when hovering over the field, if the application is verified.

![image](https://user-images.githubusercontent.com/104859710/227602717-5b8d1205-15ab-492f-9bae-00ced930495d.png)
