### PR TITLE
fix: apply max verifications on submit when creating new action

### DIFF
--- a/web/src/scenes/actions/NewAction/index.tsx
+++ b/web/src/scenes/actions/NewAction/index.tsx
@@ -86,6 +86,7 @@ export function NewAction() {
             currentApp.id,
             values.action
           ).digest,
+          max_verifications: values.maxVerifications,
         });
 
         if (result instanceof Error) {


### PR DESCRIPTION
[WID-429](https://linear.app/worldcoin/issue/WID-429/create-new-action-max-verification-broken)

- `max_verifications` was not passed on submit
---

https://user-images.githubusercontent.com/89008845/231196083-bebfc5f3-74ec-48d0-b734-ceb9e31555be.mp4

