### PR TITLE
feat: call _delete-jwks using a cron trigger

### DIFF
--- a/hasura/metadata/cron_triggers.yaml
+++ b/hasura/metadata/cron_triggers.yaml
@@ -28,7 +28,7 @@
   comment: Schedules all expired JWKS for deletion by KMS
 - name: Update ENS addresses
   webhook: '{{NEXT_API_URL}}/_ens'
-  schedule: 0 * * * *
+  schedule: 0 0 * * *
   include_in_metadata: true
   payload: {}
   retry_conf:

--- a/hasura/metadata/cron_triggers.yaml
+++ b/hasura/metadata/cron_triggers.yaml
@@ -12,6 +12,20 @@
     - name: Authorization
       value_from_env: INTERNAL_ENDPOINTS_SECRET
   comment: ""
+- name: Delete expired jwks
+  webhook: '{{NEXT_API_URL}}/_delete-jwks'
+  schedule: 0 * * * *
+  include_in_metadata: true
+  payload: {}
+  retry_conf:
+    num_retries: 1
+    retry_interval_seconds: 10
+    timeout_seconds: 60
+    tolerance_seconds: 21600
+  headers:
+    - name: Authorization
+      value_from_env: INTERNAL_ENDPOINTS_SECRET
+  comment: Schedules all expired JWKS for deletion by KMS
 - name: Update ENS addresses
   webhook: '{{NEXT_API_URL}}/_ens'
   schedule: 0 * * * *

--- a/hasura/metadata/databases/default/tables/public_api_key.yaml
+++ b/hasura/metadata/databases/default/tables/public_api_key.yaml
@@ -8,9 +8,9 @@ object_relationships:
 insert_permissions:
   - role: user
     permission:
+      check: {}
       set:
         team_id: x-hasura-Team-Id
-      check: {}
       columns:
         - is_active
         - name

--- a/web/src/backend/kms.ts
+++ b/web/src/backend/kms.ts
@@ -17,6 +17,7 @@ export type CreateKeyResult =
   | {
       keyId: string;
       publicKey: string;
+      createdAt: Date;
     }
   | undefined;
 
@@ -41,8 +42,9 @@ export const createKMSKey = async (
     );
 
     const keyId = KeyMetadata?.KeyId;
+    const createdAt = KeyMetadata?.CreationDate;
 
-    if (keyId) {
+    if (keyId && createdAt) {
       const { PublicKey } = await client.send(
         new GetPublicKeyCommand({ KeyId: keyId })
       );
@@ -52,7 +54,7 @@ export const createKMSKey = async (
 ${Buffer.from(PublicKey).toString("base64")}
 -----END PUBLIC KEY-----`;
 
-        return { keyId, publicKey };
+        return { keyId, publicKey, createdAt };
       }
     }
   } catch (error) {

--- a/web/src/pages/api/_delete-jwks.ts
+++ b/web/src/pages/api/_delete-jwks.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { createAndStoreJWK } from "src/backend/jwks";
+import { _deleteExpiredJWKs, createAndStoreJWK } from "src/backend/jwks";
 import { protectInternalEndpoint } from "src/backend/utils";
 import { errorNotAllowed } from "../../backend/errors";
 
@@ -8,7 +8,7 @@ import { errorNotAllowed } from "../../backend/errors";
  * @param req
  * @param res
  */
-export default async function handleJWKGen(
+export default async function handleDeleteJWKS(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
@@ -20,7 +20,11 @@ export default async function handleJWKGen(
     return errorNotAllowed(req.method, res);
   }
 
-  const jwk = await createAndStoreJWK();
+  console.info("Starting deletion of expired jwks.");
 
-  return res.status(201).json({ success: true, jwk });
+  const response = await _deleteExpiredJWKs();
+
+  console.info(`Deleted ${response} expired jwks.`);
+
+  return res.status(204).end();
 }

--- a/web/src/pages/api/_gen-jwks.ts
+++ b/web/src/pages/api/_gen-jwks.ts
@@ -1,0 +1,26 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createAndStoreJWK } from "src/backend/jwks";
+import { protectInternalEndpoint } from "src/backend/utils";
+import { errorNotAllowed } from "../../backend/errors";
+
+/**
+ * Generates JWKs to verify proofs offline
+ * @param req
+ * @param res
+ */
+export default async function handleGenJWKS(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (!protectInternalEndpoint(req, res)) {
+    return;
+  }
+
+  if (req.method !== "POST") {
+    return errorNotAllowed(req.method, res);
+  }
+
+  const jwk = await createAndStoreJWK();
+
+  return res.status(201).json({ success: true, jwk });
+}

--- a/web/tests/api/__mocks__/kms.mock.ts
+++ b/web/tests/api/__mocks__/kms.mock.ts
@@ -25,4 +25,5 @@ module.exports = {
       publicKey: pemKey,
     };
   }),
+  scheduleKeyDeletion: jest.fn(),
 };

--- a/web/tests/api/delete-jwks.test.ts
+++ b/web/tests/api/delete-jwks.test.ts
@@ -1,0 +1,114 @@
+import { createMocks } from "node-mocks-http";
+import handleDeleteJWKS from "src/pages/api/_delete-jwks";
+import { when } from "jest-when";
+
+let consoleInfoSpy: jest.SpyInstance;
+const requestReturnFn = jest.fn();
+const mutateReturnFn = jest.fn();
+
+jest.mock(
+  "src/backend/graphql",
+  jest.fn(() => ({
+    getAPIServiceClient: () => ({
+      query: requestReturnFn,
+      mutate: mutateReturnFn,
+    }),
+  }))
+);
+
+jest.mock("src/backend/kms", () => require("tests/api/__mocks__/kms.mock.ts"));
+
+beforeEach(() => {
+  consoleInfoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleInfoSpy.mockRestore();
+  mutateReturnFn.mockClear();
+});
+
+describe("/api/v1/_delete-jwks", () => {
+  test("endpoint is only accessible with specific token (Hasura)", async () => {
+    const { req, res } = createMocks({
+      method: "POST",
+    });
+
+    await handleDeleteJWKS(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      code: "permission_denied",
+      detail: "You do not have permission to perform this action.",
+      attr: null,
+    });
+  });
+
+  test("will not delete jwks if none are expired", async () => {
+    const { req, res } = createMocks({
+      method: "POST",
+      headers: {
+        authorization: process.env.INTERNAL_ENDPOINTS_SECRET,
+      },
+    });
+
+    when(mutateReturnFn)
+      .calledWith(expect.anything())
+      .mockResolvedValue({
+        data: {
+          delete_jwks: { returning: [], __typename: "jwks_mutation_response" },
+        },
+      });
+
+    await handleDeleteJWKS(req, res);
+
+    expect(res._getStatusCode()).toBe(204);
+    expect(consoleInfoSpy).toHaveBeenCalledTimes(2);
+    expect(consoleInfoSpy).toHaveBeenNthCalledWith(
+      1,
+      "Starting deletion of expired jwks."
+    );
+    expect(consoleInfoSpy).toHaveBeenNthCalledWith(
+      2,
+      "Deleted 0 expired jwks."
+    );
+  });
+
+  test("will delete all jwks if past expiration date", async () => {
+    const { req, res } = createMocks({
+      method: "POST",
+      headers: {
+        authorization: process.env.INTERNAL_ENDPOINTS_SECRET,
+      },
+    });
+
+    when(mutateReturnFn)
+      .calledWith(expect.anything())
+      .mockResolvedValue({
+        data: {
+          delete_jwks: {
+            returning: [
+              {
+                id: "jwk_4b4e07011e4766c69062b90ff384afc4",
+                kms_id: "f9f0ba3b-054b-4c27-bcc4-3c22c328117e",
+                __typename: "jwks",
+              },
+            ],
+            __typename: "jwks_mutation_response",
+          },
+        },
+      });
+
+    await handleDeleteJWKS(req, res);
+
+    expect(res._getStatusCode()).toBe(204);
+    expect(consoleInfoSpy).toHaveBeenCalledTimes(2);
+    expect(consoleInfoSpy).toHaveBeenNthCalledWith(
+      1,
+      "Starting deletion of expired jwks."
+    );
+    expect(consoleInfoSpy).toHaveBeenNthCalledWith(
+      2,
+      "Deleted 1 expired jwks."
+    );
+  });
+});

--- a/web/tests/api/gen-jwks.test.ts
+++ b/web/tests/api/gen-jwks.test.ts
@@ -1,15 +1,15 @@
 import { createMocks } from "node-mocks-http";
-import handleJWKGen from "src/pages/api/_jwk-gen";
+import handleGenJWKS from "src/pages/api/_gen-jwks";
 
 // FIXME
-describe("/api/v1/_jwk-gen", () => {
+describe("/api/v1/_gen-jwks", () => {
   test("can generate new JWK", async () => {});
   test("endpoint is only accessible with specific token (Hasura)", async () => {
     const { req, res } = createMocks({
       method: "POST",
     });
 
-    await handleJWKGen(req, res);
+    await handleGenJWKS(req, res);
 
     expect(res._getStatusCode()).toBe(403);
     expect(res._getJSONData()).toEqual({


### PR DESCRIPTION
Adds a cron trigger to Hasura to call the `/_delete-jwks` endpoint every hour, which will schedule all expired jwks for deletion within KMS.  Additionally, the expiration date is now directly pulled from the KMS key creation event.