### PR TITLE
refactor: update new app & update app modals

### DIFF
--- a/web/src/components/FieldLabel/index.tsx
+++ b/web/src/components/FieldLabel/index.tsx
@@ -3,18 +3,35 @@ import cn from "classnames";
 
 interface FieldLabelInterface extends LabelHTMLAttributes<HTMLLabelElement> {
   required?: boolean;
+  isPublic?: boolean;
+  description?: string;
 }
 
 export const FieldLabel = memo(function FieldLabel(props: FieldLabelInterface) {
-  const { className, children, required, ...otherProps } = props;
+  const {
+    className,
+    children,
+    required,
+    description,
+    isPublic,
+    ...otherProps
+  } = props;
 
   return (
-    <label
-      className={cn(className, "flex gap-x-2 text-16 leading-5")}
-      {...otherProps}
-    >
-      {children}
-      {!required && <span className="text-neutral-secondary">(optional)</span>}
-    </label>
+    <div className={cn("grid gap-y-1", className)}>
+      <label className={cn("flex gap-x-2 text-16 leading-5")} {...otherProps}>
+        {children}
+        {!required && (
+          <span className="text-neutral-secondary">(optional)</span>
+        )}
+        {isPublic && <span className="text-neutral-secondary">(public)</span>}
+      </label>
+
+      {description && (
+        <span className="text-14 text-gray-400 leading-[1.3]">
+          {description}
+        </span>
+      )}
+    </div>
   );
 });

--- a/web/src/scenes/actions/NewAction/index.tsx
+++ b/web/src/scenes/actions/NewAction/index.tsx
@@ -20,7 +20,7 @@ import { VerificationSelect } from "@/scenes/actions/common/VerificationSelect";
 
 const schema = yup.object({
   name: yup.string().required("This field is required"),
-  description: yup.string(),
+  description: yup.string().required(),
   action: yup.string().required("This field is required"),
   maxVerifications: yup.number().required("This field is required"),
 });
@@ -119,13 +119,25 @@ export function NewAction() {
 
   const isFormValid = useMemo(
     () =>
-      !errors.name && !errors.action && dirtyFields.name && dirtyFields.action,
-    [dirtyFields.action, dirtyFields.name, errors.action, errors.name]
+      !errors.name &&
+      !errors.action &&
+      !errors.description &&
+      dirtyFields.name &&
+      dirtyFields.action &&
+      dirtyFields.description,
+    [
+      dirtyFields.action,
+      dirtyFields.description,
+      dirtyFields.name,
+      errors.action,
+      errors.description,
+      errors.name,
+    ]
   );
 
   return (
     <Dialog
-      panelClassName="max-h-full overflow-y-auto lg:min-w-[486px]"
+      panelClassName="max-h-full overflow-y-auto lg:min-w-[490px]"
       open={isOpened}
       onClose={() => setIsOpened(false)}
     >
@@ -151,10 +163,16 @@ export function NewAction() {
         </div>
 
         <div className="mt-6 flex flex-col gap-y-2">
-          <FieldLabel className="font-rubik">Description</FieldLabel>
-          {/* helper: "Tell your users what the action is about. Shown in the World App." */}
+          <FieldLabel
+            required
+            isPublic
+            className="font-rubik"
+            description="Tell your users what the action is about. Shown in the World App."
+          >
+            Description
+          </FieldLabel>
+
           {/* FIXME: Max length 80 chars (API enforced) */}
-          {/* FIXME: Let's actually make this required and change the "(optional) for (public)" */}
           <FieldTextArea
             register={register("description")}
             errors={errors.description}
@@ -166,10 +184,14 @@ export function NewAction() {
         </div>
 
         <div className="mt-6 flex flex-col gap-y-2">
-          <FieldLabel required className="font-rubik">
+          <FieldLabel
+            required
+            className="font-rubik"
+            description="This is the value you will use in IDKit and any API calls."
+          >
             Action Identifier
           </FieldLabel>
-          {/* helper: "This is the value you will use in IDKit and any API calls." */}
+
           {/* FIXME: should only allow letters, numbers, underscore (_) & hyphen (-) */}
           <FieldInput
             register={register("action")}
@@ -185,10 +207,14 @@ export function NewAction() {
         </div>
 
         <div className="mt-6 flex flex-col gap-y-2">
-          <FieldLabel required className="font-rubik">
+          <FieldLabel
+            required
+            className="font-rubik"
+            description="The number of verifications the same person can do for this action."
+          >
             Maximum Verifications Per Person
           </FieldLabel>
-          {/* helper: "The number of verifications the same person can do for this action." */}
+
           <Controller
             name="maxVerifications"
             control={control}

--- a/web/src/scenes/actions/UpdateAction/index.tsx
+++ b/web/src/scenes/actions/UpdateAction/index.tsx
@@ -15,8 +15,8 @@ import { toast } from "react-toastify";
 import { ActionValue } from "../common/ActionValue";
 
 const schema = yup.object({
-  name: yup.string(),
-  description: yup.string(),
+  name: yup.string().required("This field is required"),
+  description: yup.string().required("This field is required"),
 });
 
 export type UpdateActionFormValues = yup.Asserts<typeof schema>;
@@ -68,13 +68,16 @@ export const UpdateAction = memo(function UpdateAction() {
   );
 
   const isFormValid = useMemo(
-    () => dirtyFields.name || dirtyFields.description,
-    [dirtyFields.description, dirtyFields.name]
+    () =>
+      !errors.description &&
+      !errors.name &&
+      (dirtyFields.name || dirtyFields.description),
+    [dirtyFields.description, dirtyFields.name, errors.description, errors.name]
   );
 
   return (
     <Dialog
-      panelClassName="max-h-full overflow-y-auto lg:min-w-[486px]"
+      panelClassName="max-h-full overflow-y-auto lg:min-w-[490px]"
       open={isOpened}
       onClose={() => setIsOpened(false)}
     >
@@ -104,10 +107,16 @@ export const UpdateAction = memo(function UpdateAction() {
         </div>
 
         <div className="mt-6 flex flex-col gap-y-2">
-          <FieldLabel className="font-rubik">Description</FieldLabel>
-          {/* helper: "Tell your users what the action is about. Shown in the World App." */}
+          <FieldLabel
+            required
+            isPublic
+            className="font-rubik"
+            description="Tell your users what the action is about. Shown in the World App."
+          >
+            Description
+          </FieldLabel>
+
           {/* FIXME: Max length 80 chars (API enforced) */}
-          {/* FIXME: Let's actually make this required and change the "(optional) for (public)" */}
           <FieldTextArea
             register={register("description")}
             errors={errors.description}


### PR DESCRIPTION
Related to [Slack message](https://ottofeller.slack.com/archives/C04R16D5EAH/p1681039075858379?thread_ts=1680868006.965309&cid=C04R16D5EAH)

Closes [WID-428](https://linear.app/worldcoin/issue/WID-428/updateadd-new-action-modals-missing-description-caption)

- Adds descriptions under the field label
- Makes description required. (with `(public)` label)

---

https://user-images.githubusercontent.com/89008845/232761870-51bb5a0b-dc83-4c26-a332-885fe9e6b427.mp4


