### PR TITLE
feat: add conference invite code functionality

### DIFF
--- a/web/src/pages/api/login.ts
+++ b/web/src/pages/api/login.ts
@@ -130,18 +130,24 @@ export default async function handleLogin(
   let email: string | undefined;
   if (!user) {
     if (invite_token) {
-      try {
-        email = await verifyInviteJWT(invite_token);
-      } catch {}
+      // NOTE: Temporary static invite codes set in env for hackers at conferences
+      if (
+        !process.env.CONFERENCE_INVITE_CODE ||
+        process.env.CONFERENCE_INVITE_CODE !== invite_token
+      ) {
+        try {
+          email = await verifyInviteJWT(invite_token);
+        } catch {}
 
-      if (!email) {
-        // Invite token is invalid, return an error
-        return errorValidation(
-          "invalid_invite_token",
-          "Invite token was invalid, and may be expired.",
-          "invite_token",
-          res
-        );
+        if (!email) {
+          // Invite token is invalid, return an error
+          return errorValidation(
+            "invalid_invite_token",
+            "Invite token was invalid, and may be expired.",
+            "invite_token",
+            res
+          );
+        }
       }
 
       const signup_token = await generateSignUpJWT(payload.sub);


### PR DESCRIPTION
Rather than adding and removing functionality in the codebase for each conference, we can simplify to a single environment variable: CONFERENCE_INVITE_CODE.

If the environment variable is set, then it can be used as an invite code for hackathon participants. When the conference is finished, we can simply delete the environment variable; the code gracefully handles the condition where the environment variable is undefined.