### PR TITLE
fix: content security directive warnings

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,46 +1,46 @@
-// @ts-check
-
-/** @type {import('next-safe').nextSafe} */
-// @ts-ignore
-const nextSafe = require("next-safe");
-const isDev = process.env.NODE_ENV !== "production";
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   async headers() {
     return [
       {
-        source: "/:path*",
-        headers: nextSafe({
-          isDev,
-          contentSecurityPolicy: {
-            mergeDefaultDirectives: true,
-            "img-src": [
-              "'self'",
-              "https://world-id-public.s3.amazonaws.com",
-              "https://worldcoin.org",
-            ],
-            "style-src": "'unsafe-inline'",
-            "connect-src": [
-              "'self'",
-              "wss://relay.walletconnect.com",
-              "https://app.posthog.com",
-              "https://cookie-cdn.cookiepro.com",
-            ],
-            "script-src": ["'self'", "https://cookie-cdn.cookiepro.com"],
+        source: "/(.*)",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value:
+              "connect-src 'self' https://app.posthog.com https://cookie-cdn.cookiepro.com wss://relay.walletconnect.com; img-src 'self' https://cookie-cdn.cookiepro.com https://world-id-public.s3.amazonaws.com https://worldcoin.org; script-src 'self' 'unsafe-eval' https://cookie-cdn.cookiepro.com; style-src 'unsafe-inline';",
           },
-          permissionsPolicy: {
-            "clipboard-write": `self`,
+          {
+            key: "Permissions-Policy",
+            value: "clipboard-write=(self)",
           },
-        }),
+        ],
       },
     ];
   },
-
-  reactStrictMode: true,
   images: {
-    domains: ["world-id-public.s3.amazonaws.com"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "cookie-cdn.cookiepro.com",
+        port: "",
+        pathname: "**",
+      },
+      {
+        protocol: "https",
+        hostname: "world-id-public.s3.amazonaws.com",
+        port: "",
+        pathname: "**",
+      },
+      {
+        protocol: "https",
+        hostname: "worldcoin.org",
+        port: "",
+        pathname: "**",
+      },
+    ],
   },
+  reactStrictMode: true,
   publicRuntimeConfig: Object.fromEntries(
     Object.entries(process.env).filter(([key, value]) =>
       key.startsWith("NEXT_PUBLIC_")

--- a/web/package.json
+++ b/web/package.json
@@ -44,7 +44,6 @@
     "next": "13.2.0",
     "next-logger": "3.0.1",
     "next-redux-wrapper": "^7.0.5",
-    "next-safe": "^3.4.1",
     "next-seo": "^5.15.0",
     "postcss-import": "^15.1.0",
     "postcss-selector-matches": "^4.0.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -76,9 +76,6 @@ dependencies:
   next-redux-wrapper:
     specifier: ^7.0.5
     version: 7.0.5(next@13.2.0)(react-redux@8.0.5)(react@18.2.0)
-  next-safe:
-    specifier: ^3.4.1
-    version: 3.4.1(next@13.2.0)
   next-seo:
     specifier: ^5.15.0
     version: 5.15.0(next@13.2.0)(react-dom@18.2.0)(react@18.2.0)
@@ -8439,14 +8436,6 @@ packages:
       next: 13.2.0(@babel/core@7.21.4)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-redux: 8.0.5(@types/react-dom@18.0.11)(@types/react@18.0.33)(react-dom@18.2.0)(react@18.2.0)
-    dev: false
-
-  /next-safe@3.4.1(next@13.2.0):
-    resolution: {integrity: sha512-GOam3DYMHUIKwxHeqVg9pkuYFhvtUeivHexdbL3lg0mjibsnIB3NOD81dKDgaeX+cReWbugdCtWYllzXmmpE+Q==}
-    peerDependencies:
-      next: ^9.5.0 || ^10.2.1 || ^11.1.0 || ^12.1.0 || ^13.0.0
-    dependencies:
-      next: 13.2.0(@babel/core@7.21.4)(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
   /next-seo@5.15.0(next@13.2.0)(react-dom@18.2.0)(react@18.2.0):


### PR DESCRIPTION
@igorosip0v Most of the warnings are being thrown by `next-safe`, so I've removed that in favor of setting the headers directly.

For some reason, it forces me to add `'unsafe-eval'` to `script-src`, which is probably not what we want (caused by cookiepro)