### PR TITLE
fix: remove unused ENS code

### DIFF
--- a/web/src/backend/jwks.ts
+++ b/web/src/backend/jwks.ts
@@ -133,7 +133,7 @@ export const generateJWK = async (): Promise<CreateJWKResult> => {
   const client = await getKMSClient();
 
   if (client) {
-    const result = await createKMSKey(client, "RSA_2048"); // TODO: alg parameter for other key types
+    const result = await createKMSKey(client, "RSA_2048");
     if (result?.keyId && result?.publicKey) {
       const publicJwk = createPublicKey(result.publicKey).export({
         format: "jwk",

--- a/web/src/backend/oidc.ts
+++ b/web/src/backend/oidc.ts
@@ -7,7 +7,6 @@ import {
   OIDCResponseType,
 } from "src/lib/types";
 import { getAPIServiceClient } from "./graphql";
-import { getSmartContractENSName } from "./utils";
 
 const GENERAL_SECRET_KEY = process.env.GENERAL_SECRET_KEY;
 if (!GENERAL_SECRET_KEY) {
@@ -86,7 +85,6 @@ interface OIDCApp {
   is_staging: AppModel["is_staging"];
   external_nullifier: ActionModel["external_nullifier"];
   action_id: ActionModel["id"];
-  contract_address: string;
   registered_redirect_uri?: string;
 }
 
@@ -105,7 +103,6 @@ type FetchOIDCAppResult = {
 
 export const fetchOIDCApp = async (
   app_id: string,
-  credential_type: CredentialType,
   redirect_uri: string
 ): Promise<{ app?: OIDCApp; error?: IInternalError }> => {
   const client = await getAPIServiceClient();
@@ -154,27 +151,12 @@ export const fetchOIDCApp = async (
   const registered_redirect_uri = app.actions[0].redirects[0]?.redirect_uri;
   delete app.actions;
 
-  const ensName = getSmartContractENSName(app.is_staging, credential_type);
-
-  const contractRecord = data.cache.find(({ key }) => key === ensName);
-  if (!contractRecord) {
-    return {
-      error: {
-        message:
-          "There was an internal issue verifying this proof. Please try again.",
-        code: "contract_not_found",
-        statusCode: 500,
-      },
-    };
-  }
-
   return {
     app: {
       ...app,
       action_id,
       external_nullifier,
       registered_redirect_uri,
-      contract_address: contractRecord.value,
     },
   };
 };

--- a/web/src/backend/utils.ts
+++ b/web/src/backend/utils.ts
@@ -4,7 +4,7 @@
 import { gql } from "@apollo/client";
 import { randomUUID } from "crypto";
 import { NextApiRequest, NextApiResponse } from "next";
-import { CredentialType, IInternalError } from "src/lib/types";
+import { IInternalError } from "src/lib/types";
 import { getWLDAppBackendServiceClient } from "./graphql";
 import crypto from "crypto";
 
@@ -126,26 +126,6 @@ export const reportAPIEventToPostHog = async (
   } catch (e) {
     console.error(`Error reporting ${event} to PostHog`, e);
   }
-};
-
-/**
- * Returns the ENS name for the relevant Semaphore smart contract
- * @param is_staging
- * @param credential_type
- */
-export const getSmartContractENSName = (
-  is_staging: boolean,
-  credential_type: CredentialType
-): string => {
-  if (credential_type === CredentialType.Orb) {
-    return is_staging ? "staging.semaphore.wld.eth" : "semaphore.wld.eth";
-  }
-  if (credential_type === CredentialType.Phone) {
-    return is_staging ? "staging.phone.wld.eth" : "phone.wld.eth";
-  }
-  throw new Error(
-    `Invalid credential type for getSmartContractENSName: ${credential_type}`
-  );
 };
 
 /**

--- a/web/src/pages/api/v1/debugger.ts
+++ b/web/src/pages/api/v1/debugger.ts
@@ -3,23 +3,10 @@ import {
   errorNotAllowed,
   errorRequiredAttribute,
   errorResponse,
-  errorValidation,
 } from "../../../backend/errors";
 import { runCors } from "../../../backend/cors";
 import { internal as IDKitInternal } from "@worldcoin/idkit";
 import { verifyProof } from "src/backend/verify";
-import { getSmartContractENSName } from "src/backend/utils";
-import { gql } from "@apollo/client";
-import { getAPIServiceClient } from "src/backend/graphql";
-
-const cacheQuery = gql`
-  query FetchCache($ensName: String!) {
-    cache(where: { key: { _eq: $ensName } }) {
-      key
-      value
-    }
-  }
-`;
 
 export default async function handler(
   req: NextApiRequest,
@@ -49,21 +36,6 @@ export default async function handler(
     req.body.action
   ).digest;
 
-  const ensName = getSmartContractENSName(
-    req.body.is_staging,
-    req.body.credential_type
-  );
-
-  const client = await getAPIServiceClient();
-  const { data } = await client.query<{
-    cache: [{ key: string; value: string }];
-  }>({
-    query: cacheQuery,
-    variables: { ensName },
-  });
-
-  const contract_address = data.cache[0].value;
-
   const result = await verifyProof(
     {
       merkle_root: req.body.merkle_root,
@@ -73,7 +45,6 @@ export default async function handler(
       proof: req.body.proof,
     },
     {
-      contract_address: contract_address,
       is_staging: req.body.is_staging,
       credential_type: req.body.credential_type,
       chain: req.body.chain,

--- a/web/src/pages/api/v1/oidc/authorize.ts
+++ b/web/src/pages/api/v1/oidc/authorize.ts
@@ -113,7 +113,6 @@ export default async function handleOIDCAuthorize(
   // ANCHOR: Check the app is valid and fetch information
   const { app, error: fetchAppError } = await fetchOIDCApp(
     app_id,
-    credential_type,
     redirect_uri ?? ""
   );
   if (!app || fetchAppError) {
@@ -160,7 +159,6 @@ export default async function handleOIDCAuthorize(
     },
     {
       is_staging: app.is_staging,
-      contract_address: app.contract_address,
       credential_type,
       chain: Chain.Polygon, // TODO: Add support for Optimism after production deployment
     }

--- a/web/src/pages/api/v1/oidc/validate.ts
+++ b/web/src/pages/api/v1/oidc/validate.ts
@@ -5,7 +5,6 @@ import {
   errorResponse,
 } from "src/backend/errors";
 import { fetchOIDCApp } from "src/backend/oidc";
-import { CredentialType } from "src/lib/types";
 
 /**
  * Prevalidates app_id & redirect_uri is valid for Sign in with World ID for early user feedback
@@ -30,7 +29,6 @@ export default async function handleOIDCValidate(
 
   const { app, error: fetchAppError } = await fetchOIDCApp(
     app_id,
-    CredentialType.Orb, // ignored at this step, any credential type would do
     redirect_uri ?? ""
   );
   if (!app || fetchAppError) {

--- a/web/src/pages/api/v1/verify/[app_id].ts
+++ b/web/src/pages/api/v1/verify/[app_id].ts
@@ -65,8 +65,7 @@ export default async function handleVerify(
     client,
     req.query.app_id?.toString(),
     req.body.nullifier_hash,
-    req.body.action,
-    req.body.credential_type
+    req.body.action
   );
 
   if (data.error || !data.app) {
@@ -124,7 +123,6 @@ export default async function handleVerify(
       external_nullifier: action.external_nullifier,
     },
     {
-      contract_address: data.contractAddress,
       is_staging: app.is_staging,
       credential_type: req.body.credential_type as CredentialType,
       chain: (req.body.chain as Chain) ?? Chain.Polygon, // Default to Polygon for now


### PR DESCRIPTION
We no longer need the ENS information because we now verify proofs with the sequencer.