### PR TITLE
fix: temp login issue for new users

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -47,7 +47,7 @@ const nextConfig = {
     domains: ["world-id-public.s3.amazonaws.com"],
   },
   publicRuntimeConfig: Object.fromEntries(
-    Object.entries(process.env).filter(([key, value]) =>
+    Object.entries(process.env).filter(([key]) =>
       key.startsWith("NEXT_PUBLIC_")
     )
   ),

--- a/web/src/components/Layout/LoggedUserDisplay/hooks/user-hooks.ts
+++ b/web/src/components/Layout/LoggedUserDisplay/hooks/user-hooks.ts
@@ -14,9 +14,10 @@ export const useFetchUser = (id: string) => {
   const { data, ...other } = useFetchUserQuery({
     variables: { id },
     onCompleted: (data) => {
-      if (!data.user[0]) {
-        router.push("/logout");
-      }
+      // FIXME: Temporary fix for NoApps issue
+      // if (!data.user[0]) {
+      //   router.push("/logout");
+      // }
     },
   });
   return { user: data?.user[0], ...other };

--- a/web/src/components/NoApps/index.tsx
+++ b/web/src/components/NoApps/index.tsx
@@ -5,7 +5,6 @@ import { Layout } from "src/components/Layout";
 import { NewAppDialog } from "src/components/Layout/NewAppDialog";
 import { useToggle } from "src/hooks/useToggle";
 import { LinkCard } from "./LinkCard";
-import { PageInfo } from "@/components/PageInfo";
 
 export const NoApps = memo(function NoApps(props: { pageInfo: ReactNode }) {
   const newAppDialog = useToggle();

--- a/web/src/pages/app/[app_id]/index.tsx
+++ b/web/src/pages/app/[app_id]/index.tsx
@@ -1,5 +1,4 @@
 import { GetServerSideProps } from "next";
-import { isAuthCookieValid } from "src/backend/cookies";
 import { requireAuthentication } from "src/lib/require-authentication";
 import { App } from "src/scenes/app";
 export default App;

--- a/web/src/pages/logout.tsx
+++ b/web/src/pages/logout.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "src/components/Spinner";
 import { GetServerSideProps, Redirect } from "next";
-import { removeCookies } from "cookies-next";
+import { deleteCookie } from "cookies-next";
 
 export default function Logout(): JSX.Element {
   return (
@@ -11,7 +11,7 @@ export default function Logout(): JSX.Element {
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  removeCookies("auth", context);
+  deleteCookie("auth", context);
 
   return {
     redirect: {

--- a/web/src/scenes/login/login.tsx
+++ b/web/src/scenes/login/login.tsx
@@ -76,7 +76,7 @@ export function Login({ loginUrl }: ILoginPageProps) {
         });
       }
     }
-  }, [router, doLogin, loginUrl]);
+  }, [router, doLogin]);
 
   return (
     <Auth pageTitle="Login" pageUrl="login">


### PR DESCRIPTION
The real issue is that the `NoApps` component pulls `Layout` which expects a `userId` that's not being downstream passed. We should handle this better. Passing down the `userId` to a bunch of downstream components is not great.