### PR TITLE
fix: unique constraint on email

### DIFF
--- a/hasura/migrations/default/1690027572107_alter_table_public_user_alter_column_email/down.sql
+++ b/hasura/migrations/default/1690027572107_alter_table_public_user_alter_column_email/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."user" alter column "email" set default ''::character varying;
+alter table "public"."user" alter column "email" set not null;

--- a/hasura/migrations/default/1690027572107_alter_table_public_user_alter_column_email/up.sql
+++ b/hasura/migrations/default/1690027572107_alter_table_public_user_alter_column_email/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."user" alter column "email" drop not null;
+alter table "public"."user" alter column "email" set default null;

--- a/web/src/pages/api/signup.ts
+++ b/web/src/pages/api/signup.ts
@@ -106,7 +106,7 @@ export default async function handleSignUp(
     variables: {
       nullifier_hash,
       team_name,
-      email: email ?? "",
+      email: email ?? null,
       ironclad_id: body.ironclad_id,
     },
   });


### PR DESCRIPTION
Previously we were inserting blank emails as empty strings which was causing errors with the uniqueness constraint. This fixes it.