### PR TITLE
use fragment response mode

### DIFF
--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -3,6 +3,7 @@ import {
   generateLoginNonce,
   generateLoginUrl,
 } from "src/backend/login-internal";
+import { OIDC_BASE_URL } from "src/lib/constants";
 import { Login } from "src/scenes/login/login";
 export default Login;
 
@@ -11,8 +12,8 @@ export interface ILoginPageProps {
 }
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  if (ctx.query?.id_token) {
-    // If `id_token` is passed, it means that user has been redirected back from the IdP.
+  // if header referrer contains OIDC_BASE_URL, it means that user has been redirected back from the IdP.
+  if (ctx.req.headers.referer?.includes(OIDC_BASE_URL)) {
     return { props: {} };
   }
   const nonce = await generateLoginNonce();

--- a/web/src/scenes/login/login.tsx
+++ b/web/src/scenes/login/login.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Auth } from "src/components/Auth";
 import { Button } from "src/components/Button";
 import { Icon } from "src/components/Icon";
@@ -18,6 +18,12 @@ export function Login({ loginUrl }: ILoginPageProps) {
   const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [loginError, setLoginError] = useState(false);
+  const { asPath } = useRouter();
+
+  const id_token = useMemo(() => {
+    const params = new URLSearchParams(asPath.split("#")[1]);
+    return params.get("id_token");
+  }, [asPath]);
 
   const doLogin = useCallback(
     async (body: LoginRequestBody) => {
@@ -70,13 +76,13 @@ export function Login({ loginUrl }: ILoginPageProps) {
       }
 
       // Handle login and signup cases
-      if (!router.query.error && router.query.id_token) {
+      if (!router.query.error && id_token) {
         doLogin({
-          sign_in_with_world_id_token: router.query.id_token as string,
+          sign_in_with_world_id_token: id_token as string,
         });
       }
     }
-  }, [router, doLogin]);
+  }, [router, doLogin, id_token]);
 
   return (
     <Auth pageTitle="Login" pageUrl="login">


### PR DESCRIPTION
Necessary with updates to world-id-sign-in requiring a fragment encoding of the id_token in the redirect_url. Do not merge until world-id-sign-in changes are deployed.