### PR TITLE
fix: default value not applies

### DIFF
--- a/web/src/pages/api/v1/oidc/register.ts
+++ b/web/src/pages/api/v1/oidc/register.ts
@@ -62,9 +62,9 @@ const insertRedirectsQuery = gql`
 const schema = yup.object({
   client_name: yup.string().strict(),
   logo_uri: yup.string().strict(),
-  application_type: yup.string().strict().default("web"),
-  grant_types: yup.string().strict().default("authorization_code"),
-  response_types: yup.string().strict().default("code"),
+  application_type: yup.string().default("web"),
+  grant_types: yup.string().default("authorization_code"),
+  response_types: yup.string().default("code"),
   redirect_uris: yup
     .array()
     .of(yup.string().strict().required())

--- a/web/src/pages/api/v1/oidc/token.ts
+++ b/web/src/pages/api/v1/oidc/token.ts
@@ -32,7 +32,7 @@ const verifyAuthCodeQuery = gql`
 `;
 
 const schema = yup.object({
-  grant_type: yup.string().strict().default("authorization_code"),
+  grant_type: yup.string().default("authorization_code"),
   code: yup.string().strict().required("This attribute is required."),
 });
 

--- a/web/src/pages/api/v1/precheck/[app_id].ts
+++ b/web/src/pages/api/v1/precheck/[app_id].ts
@@ -107,7 +107,7 @@ const createActionQuery = gql`
 
 const schema = yup.object({
   action: yup.string().strict(),
-  nullifier_hash: yup.string().strict().default(""),
+  nullifier_hash: yup.string().default(""),
   external_nullifier: yup
     .string()
     .strict()


### PR DESCRIPTION
Related to [Slack message](https://ottofeller.slack.com/archives/C04R16D5EAH/p1692359053419079).

I noticed that if we have `.strict()` in the yup schema then the default value not applies. 

- Remove `.strict()` from fields where we have `.default()`
 