### PR TITLE
feat: store nonce for authorization code flow

### DIFF
--- a/hasura/metadata/databases/default/tables/public_auth_code.yaml
+++ b/hasura/metadata/databases/default/tables/public_auth_code.yaml
@@ -12,6 +12,7 @@ insert_permissions:
         - expires_at
         - nullifier_hash
         - scope
+        - signal
 select_permissions:
   - role: service
     permission:
@@ -23,6 +24,7 @@ select_permissions:
         - id
         - nullifier_hash
         - scope
+        - signal
       filter: {}
 delete_permissions:
   - role: service

--- a/hasura/migrations/default/1692722828162_alter_table_public_auth_code_add_column_signal/down.sql
+++ b/hasura/migrations/default/1692722828162_alter_table_public_auth_code_add_column_signal/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."auth_code" add column "signal" varchar
+--  null;

--- a/hasura/migrations/default/1692722828162_alter_table_public_auth_code_add_column_signal/up.sql
+++ b/hasura/migrations/default/1692722828162_alter_table_public_auth_code_add_column_signal/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."auth_code" add column "signal" varchar
+ null;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -49,6 +49,14 @@ export type ActionStatsModel = Array<{
 export enum OIDCResponseType {
   Code = "code", // authorization code
   JWT = "jwt", // implicit flow
+  IdToken = "id_token",
+  Token = "token",
+}
+
+export enum OIDCFlowType {
+  AuthorizationCode = "authorization_code",
+  Implicit = "implicit",
+  Hybrid = "hybrid",
 }
 
 export interface IInternalError {


### PR DESCRIPTION
Closes [WID-531](https://linear.app/worldcoin/issue/WID-531/nonce-must-be-received-in-authorization-code-flow-and-honored)

- Adds `signal` field to `auth_code` table to store `signal`
- Adds signal insertion when it's an authorization code flow.

### REVIEW:
> to pass it back in the id_token
- We are already passing signal [here](https://github.com/worldcoin/developer-portal/blob/8f4231390d0aa137a967f9231aa9fe342f9bcef2/web/src/pages/api/v1/oidc/authorize.ts#L216) 
- [This](https://github.com/worldcoin/developer-portal/compare/igorosipov-wid-531-nonce-must-be-received-in-authorization-code-flow-and?expand=1#diff-74faafc7767c7f0ec4a9ec4ab760891a727e18bf6138909af96016b8d7ebfbf5R188)