### PR TITLE
add action for auto-deploy

### DIFF
--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -1,0 +1,19 @@
+name: Dispatch event
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.PAT }}
+          repository: worldcoin/developer-portal-deployment
+          event-type: deploy
+          client-payload: '{"ref": "${{ github.ref }}"}'


### PR DESCRIPTION
Sends an event message to [worldcoin/developer-portal-deployment](github.com/worldcoin/developer-portal-deployment), which then triggers a deployment for the corresponding branch. 