### PR TITLE
fix: world_id_nullifier no longer required

### DIFF
--- a/hasura/migrations/default/1699244895189_alter_table_public_user_alter_column_world_id_nullifier/down.sql
+++ b/hasura/migrations/default/1699244895189_alter_table_public_user_alter_column_world_id_nullifier/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."user" alter column "world_id_nullifier" set not null;
+ALTER TABLE "public"."user" ALTER COLUMN "world_id_nullifier" drop default;

--- a/hasura/migrations/default/1699244895189_alter_table_public_user_alter_column_world_id_nullifier/up.sql
+++ b/hasura/migrations/default/1699244895189_alter_table_public_user_alter_column_world_id_nullifier/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."user" alter column "world_id_nullifier" drop not null;
+alter table "public"."user" alter column "world_id_nullifier" set default null;


### PR DESCRIPTION
With the introduction of Auth0, users will now be able to log in with other methods, without using World ID. This PR allows creating users without a nullifier hash.