### PR TITLE
feat: setup rate limit for register method

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -51,6 +51,7 @@
     "jose": "^4.11.1",
     "js-sha3": "^0.8.0",
     "jsonwebtoken": "^9.0.0",
+    "lru-cache": "^10.0.1",
     "next": "^13.5.6",
     "next-redux-wrapper": "^7.0.5",
     "next-safe": "^3.4.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -89,6 +89,9 @@ dependencies:
   jsonwebtoken:
     specifier: ^9.0.0
     version: 9.0.2
+  lru-cache:
+    specifier: ^10.0.1
+    version: 10.0.1
   next:
     specifier: ^13.5.6
     version: 13.5.6(@babel/core@7.23.2)(@opentelemetry/api@1.6.0)(react-dom@18.2.0)(react@18.2.0)
@@ -8802,6 +8805,11 @@ packages:
     dependencies:
       fault: 1.0.4
       highlight.js: 10.7.3
+    dev: false
+
+  /lru-cache@10.0.1:
+    resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
+    engines: {node: 14 || >=16.14}
     dev: false
 
   /lru-cache@5.1.1:

--- a/web/src/lib/rate-limit.ts
+++ b/web/src/lib/rate-limit.ts
@@ -1,0 +1,39 @@
+import type { NextApiResponse } from "next";
+import { LRUCache } from "lru-cache";
+
+type Options = {
+  maxItems?: number;
+  ttl?: number;
+};
+
+// NOTE: by default set max items count in lru cache to 500 and ttl to 1 hour
+const MAX_ITEMS = 500;
+const TTL = 60 * 60 * 1000;
+
+export default function rateLimit(options?: Options) {
+  const cache = new LRUCache({
+    max: options?.maxItems || MAX_ITEMS,
+    ttl: options?.ttl || TTL,
+  });
+
+  return {
+    check: (res: NextApiResponse, limit: number, token: string) =>
+      new Promise<void>((resolve, reject) => {
+        const tokenCount = (cache.get(token) as number[]) || [0];
+        if (tokenCount[0] === 0) {
+          cache.set(token, tokenCount);
+        }
+        tokenCount[0] += 1;
+
+        const currentUsage = tokenCount[0];
+        const isRateLimited = currentUsage > limit;
+        res.setHeader("X-RateLimit-Limit", limit);
+        res.setHeader(
+          "X-RateLimit-Remaining",
+          isRateLimited ? 0 : limit - currentUsage
+        );
+
+        return isRateLimited ? reject() : resolve();
+      }),
+  };
+}

--- a/web/src/lib/rate-limit.ts
+++ b/web/src/lib/rate-limit.ts
@@ -2,18 +2,14 @@ import type { NextApiResponse } from "next";
 import { LRUCache } from "lru-cache";
 
 type Options = {
-  maxItems?: number;
-  ttl?: number;
+  maxItems: number;
+  ttl: number;
 };
 
-// NOTE: by default set max items count in lru cache to 500 and ttl to 1 hour
-const MAX_ITEMS = 500;
-const TTL = 60 * 60 * 1000;
-
-export default function rateLimit(options?: Options) {
+export default function rateLimit(options: Options) {
   const cache = new LRUCache({
-    max: options?.maxItems || MAX_ITEMS,
-    ttl: options?.ttl || TTL,
+    max: options.maxItems,
+    ttl: options.ttl,
   });
 
   return {


### PR DESCRIPTION
Setup rate limit for /register API call, allow 35 total requests and 2 successful calls per 1 hour
To implement rate limit used official [example](https://github.com/vercel/next.js/tree/canary/examples/api-routes-rate-limit) from Next.JS
Use LRU-cache to store entries, where key is user's ip address and value is attempts to call /register endpoint

Notes for video:
- Used Math.random to define random ipAddress(1.1.1.1 or 2.2.2.2) to test rate limit on multiple users
- For test purposes, allow 5 requests per minute for total rate limit and 2 request before making request to Hasura
- Added  logs for debugging `console.log('cache', limit === 5 ? 'total' : 'success', key, value)` to rate-limit.ts
- Locally I didn't run hasura, that's why I receive 500 error, when all rate limits are passed

https://github.com/worldcoin/developer-portal/assets/122529549/73da5b90-7760-44de-b355-16a95393e2b7

