### PR TITLE
feat: default empty string for signal on `/verify` endpoint

### DIFF
--- a/web/src/pages/api/v1/verify/[app_id].ts
+++ b/web/src/pages/api/v1/verify/[app_id].ts
@@ -19,11 +19,7 @@ const schema = yup.object({
     .strict()
     .nonNullable()
     .defined("This attribute is required."),
-  signal: yup
-    .string()
-    .strict()
-    .nonNullable()
-    .defined("This attribute is required."),
+  signal: yup.string().strict().default(""),
   proof: yup.string().strict().required("This attribute is required."),
   nullifier_hash: yup.string().strict().required("This attribute is required."),
   merkle_root: yup.string().strict().required("This attribute is required."),


### PR DESCRIPTION
Uses an empty string as the signal if one is not provided on the `/verify` endpoint.

Since the signal is not a required parameter for IDKit, it doesn't make sense for it to also be required on the API verification endpoint. As long as both default to the same value (an empty string) then this should be fine.