### PR TITLE
fix: attributes in /precheck can be null & enforce nonce in Sign in with Worldcoin

### DIFF
--- a/web/src/pages/api/v1/oidc/authorize.ts
+++ b/web/src/pages/api/v1/oidc/authorize.ts
@@ -45,7 +45,7 @@ const schema = yup.object({
     .required("This attribute is required.")
     .oneOf(Object.values(CredentialType)),
   app_id: yup.string().strict().required("This attribute is required."),
-  signal: yup.string(), // `signal` in the context of World ID; `nonce` in the context of OIDC
+  signal: yup.string().strict().required("This attribute is required."), // `signal` in the context of World ID; `nonce` in the context of OIDC
   code_challenge: yup.string(),
   code_challenge_method: yup.string(),
   scope: yup.string().strict().required("The openid scope is always required."),
@@ -180,7 +180,7 @@ export default async function handleOIDCAuthorize(
       proof,
       nullifier_hash,
       merkle_root,
-      signal: signal ?? "",
+      signal,
       external_nullifier: app.external_nullifier,
     },
     {

--- a/web/src/pages/api/v1/precheck/[app_id].ts
+++ b/web/src/pages/api/v1/precheck/[app_id].ts
@@ -111,11 +111,12 @@ const createActionQuery = gql`
 `;
 
 const schema = yup.object().shape({
-  action: yup.string().strict().default(""),
-  nullifier_hash: yup.string().default(""),
+  action: yup.string().strict().nullable().default(""),
+  nullifier_hash: yup.string().strict().nullable().default(""),
   external_nullifier: yup
     .string()
     .strict()
+    .nullable()
     .when("action", {
       is: (action: unknown) => action === null,
       then: (s) =>


### PR DESCRIPTION
1. Allows optional attributes in `/precheck` to be `null` in addition to empty strings for better support of other clients.
2. Enforces `nonce` / signal when using Sign in with Worldcoin. CC @0xPenryn 