### PR TITLE
fix: signup query

### DIFF
--- a/web/src/api/signup/graphql/signup.generated.ts
+++ b/web/src/api/signup/graphql/signup.generated.ts
@@ -5,12 +5,8 @@ import { GraphQLClient } from "graphql-request";
 import { GraphQLClientRequestHeaders } from "graphql-request/build/cjs/types";
 import gql from "graphql-tag";
 export type SignupMutationVariables = Types.Exact<{
-  nullifier_hash: Types.Scalars["String"];
   team_name: Types.Scalars["String"];
-  ironclad_id: Types.Scalars["String"];
-  auth0Id: Types.Scalars["String"];
-  name?: Types.InputMaybe<Types.Scalars["String"]>;
-  email: Types.Scalars["String"];
+  data: Array<Types.User_Insert_Input> | Types.User_Insert_Input;
 }>;
 
 export type SignupMutation = {
@@ -30,28 +26,8 @@ export type SignupMutation = {
 };
 
 export const SignupDocument = gql`
-  mutation Signup(
-    $nullifier_hash: String!
-    $team_name: String!
-    $ironclad_id: String!
-    $auth0Id: String!
-    $name: String = ""
-    $email: String!
-  ) {
-    insert_team_one(
-      object: {
-        name: $team_name
-        users: {
-          data: {
-            ironclad_id: $ironclad_id
-            world_id_nullifier: $nullifier_hash
-            auth0Id: $auth0Id
-            name: $name
-            email: $email
-          }
-        }
-      }
-    ) {
+  mutation Signup($team_name: String!, $data: [user_insert_input!]!) {
+    insert_team_one(object: { name: $team_name, users: { data: $data } }) {
       id
       name
       users {

--- a/web/src/api/signup/graphql/signup.graphql
+++ b/web/src/api/signup/graphql/signup.graphql
@@ -1,25 +1,5 @@
-mutation Signup(
-  $nullifier_hash: String!
-  $team_name: String!
-  $ironclad_id: String!
-  $auth0Id: String!
-  $name: String = ""
-  $email: String!
-) {
-  insert_team_one(
-    object: {
-      name: $team_name
-      users: {
-        data: {
-          ironclad_id: $ironclad_id
-          world_id_nullifier: $nullifier_hash
-          auth0Id: $auth0Id
-          name: $name
-          email: $email
-        }
-      }
-    }
-  ) {
+mutation Signup($team_name: String!, $data: [user_insert_input!]!) {
+  insert_team_one(object: { name: $team_name, users: { data: $data } }) {
     id
     name
     users {

--- a/web/src/api/signup/index.ts
+++ b/web/src/api/signup/index.ts
@@ -53,12 +53,18 @@ export const handleSignup = withApiAuthRequired(
     const client = await getAPIServiceGraphqlClient();
 
     const data = await getSdk(client).Signup({
-      name: auth0User.name,
-      auth0Id: auth0User.sub,
       team_name,
-      ironclad_id,
-      nullifier_hash: nullifier_hash ?? "",
-      email: (auth0User.email_verified && auth0User.sub) || "",
+
+      data: {
+        name: auth0User.name,
+        auth0Id: auth0User.sub,
+        ironclad_id,
+        ...(nullifier_hash ? { world_id_nullifier: nullifier_hash } : {}),
+
+        ...(auth0User.email_verified && auth0User.email
+          ? { email: auth0User.email }
+          : {}),
+      },
     });
 
     const team = data.insert_team_one;


### PR DESCRIPTION
### Problem
Empty string `""` was used as fallback in Signup query for `email` or `nullified_hash` in case we don't have some of this data.
But `email` and `world_id_nullifier` fields have a uniqueness rule, so in case we have someone in database with `""` email or nullifier_hash it will throw an error. 

### Fix
I've updated code to pass these fields only if we have data. In this case, the missing field will be written as `null` 