### PR TITLE
fix: precheck

### DIFF
--- a/web/src/pages/api/v1/precheck/[app_id].ts
+++ b/web/src/pages/api/v1/precheck/[app_id].ts
@@ -153,7 +153,6 @@ export default async function handlePrecheck(
     value: req.body,
   });
 
-  console.log("parsedParams:", parsedParams);
 
   if (!isValid) {
     return handleError(req, res);

--- a/web/src/pages/api/v1/precheck/[app_id].ts
+++ b/web/src/pages/api/v1/precheck/[app_id].ts
@@ -112,7 +112,13 @@ const createActionQuery = gql`
 
 const schema = yup.object().shape({
   action: yup.string().strict().nullable().default(""),
-  nullifier_hash: yup.string().strict().nullable().default(""),
+
+  nullifier_hash: yup
+    .string()
+    .nullable()
+    .default("")
+    .transform((value) => (value === null ? "" : value)),
+
   external_nullifier: yup
     .string()
     .strict()
@@ -147,6 +153,8 @@ export default async function handlePrecheck(
     value: req.body,
   });
 
+  console.log("parsedParams:", parsedParams);
+
   if (!isValid) {
     return handleError(req, res);
   }
@@ -163,6 +171,7 @@ export default async function handlePrecheck(
   // ANCHOR: Fetch app from Hasura
   const appQueryResult = await client.query<AppPrecheckQueryInterface>({
     query: appPrecheckQuery,
+
     variables: {
       app_id,
       nullifier_hash,


### PR DESCRIPTION
Problem: 
- When passing null to `nullifier_hash` with `nullable` the default value not applies.
- After this we passing null to the gql query where we expect String type and this is throws an error. 

Fix: 
- Add additional `transform` to the schema to convert `null` to `""`