### PR TITLE
fix: small improvement to anti-XSS regex

### DIFF
--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -62,7 +62,7 @@ export const validateEmail = (candidate: string): boolean => {
 
 export const isSSR = () => typeof window === "undefined";
 
-export const uriHasJS = (uri: string) => /javascript:/.test(uri);
+export const uriHasJS = (uri: string) => /javascript:/i.test(uri);
 
 export const isEmailUser = (user: Auth0User): user is Auth0EmailUser =>
   user.sub.startsWith("email|");


### PR DESCRIPTION
The current version of the regex can be bypassed by simply using a URL with one of the letters capitalized, viz:

```javascript
> /javascript:/.test("javaScript:alert(1)")
false
```

Browsers, though, will execute this code successfully. I tested this by making a link (`<a href="javaScript:alert(1)">test</a>`), and the JS code ran successfully.

This PR fixes this by adding the `i` flag to make the regex case insensitive.