### PR TITLE
fix: allow undefined signals

### DIFF
--- a/web/src/pages/api/v1/verify/[app_id].ts
+++ b/web/src/pages/api/v1/verify/[app_id].ts
@@ -23,7 +23,7 @@ const schema = yup.object({
     .strict()
     .nonNullable()
     .defined("This attribute is required."),
-  signal: yup.string().strict().default(""),
+  signal: yup.string().default(""),
   proof: yup.string().strict().required("This attribute is required."),
   nullifier_hash: yup.string().strict().required("This attribute is required."),
   merkle_root: yup.string().strict().required("This attribute is required."),

--- a/web/tests/api/verify.test.ts
+++ b/web/tests/api/verify.test.ts
@@ -149,6 +149,44 @@ describe("/api/v1/verify", () => {
       })
     );
   });
+
+  test("can verify without a signal", async () => {
+    // signal defaults to empty string if not provided
+
+    const noSignalPayload: Record<string, any> = { ...validPayload };
+    delete noSignalPayload.signal;
+
+    const payloads = [
+      noSignalPayload,
+      { ...validPayload, signal: undefined },
+      { ...validPayload, signal: "" },
+    ];
+
+    for (const payload of payloads) {
+      const { req, res } = createMocks({
+        method: "POST",
+        body: payload,
+        query: { app_id: "app_staging_112233445566778" },
+      });
+
+      // mocks sequencer response
+      fetchMock.mockResponseOnce(JSON.stringify({ status: "mined" }));
+
+      await handleVerify(req, res);
+
+      console.error(res._getJSONData());
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual(
+        expect.objectContaining({
+          success: true,
+          nullifier_hash:
+            "0x0447c1b95a5a808a36d3966216404ff4d522f1e66ecddf9c22439393f00cf616",
+          action: "verify",
+        })
+      );
+    }
+  });
 });
 
 describe("/api/verify [error cases]", () => {

--- a/web/tests/integration/verify.test.ts
+++ b/web/tests/integration/verify.test.ts
@@ -224,7 +224,7 @@ describe("/api/v1/verify/[app_id]", () => {
       })
     );
 
-    // Send both requests at the same time
+    // Send all requests at the same time
     await Promise.all(requests.map(({ req, res }) => handleVerify(req, res)));
 
     // Only one of the requests should be successful (this test action allows two uses)
@@ -265,5 +265,71 @@ describe("/api/v1/verify/[app_id]", () => {
       `SELECT uses FROM nullifier WHERE nullifier_hash = '${validRequestPayload.nullifier_hash}';`
     );
     expect(nullifierQuery.rows[0].uses).toBe(2);
+  });
+
+  test("handles race conditions with multiple insertions", async () => {
+    // This test case covers the case of the nullifier record being inserted first and then being updated
+    const appQuery = await integrationDBExecuteQuery(
+      "SELECT * FROM app where name = 'Multi-claim App' limit 1;"
+    );
+    const app_id = appQuery.rows[0].id;
+    const actionQuery = await integrationDBExecuteQuery(
+      `SELECT * FROM action where name = 'Multi-claim action' limit 1;`
+    );
+    expect(actionQuery.rows[0].max_verifications).toBe(2); // Sanity check
+    const action = actionQuery.rows[0].action;
+
+    const validRequestPayload = validParams(app_id, action);
+    validRequestPayload.nullifier_hash =
+      "0x011111b95a5a808a36d3966216404ff4d522f1e66ecddf9c22439393f0011111";
+
+    // User verifies for the first time
+    const { req, res } = createMocks({
+      method: "POST",
+      query: { app_id },
+      body: validRequestPayload,
+    });
+    await handleVerify(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual(
+      expect.objectContaining({
+        action,
+        uses: 1,
+        max_uses: 2,
+        success: true,
+        created_at: expect.any(String),
+        nullifier_hash:
+          "0x011111b95a5a808a36d3966216404ff4d522f1e66ecddf9c22439393f0011111",
+      })
+    );
+
+    const requests = [1, 2, 3, 4, 5].map(() =>
+      createMocks({
+        method: "POST",
+        query: { app_id },
+        body: validRequestPayload,
+      })
+    );
+
+    // Send all requests at the same time
+    await Promise.all(requests.map(({ req, res }) => handleVerify(req, res)));
+
+    // Only one of the requests should be successful (this test action allows two uses)
+    const successResponses = requests.filter(
+      ({ res }) => res._getStatusCode() === 200
+    );
+    expect(successResponses.length).toBe(1); // Only one is allowed to reach the maximum of 2 verifications
+    expect(successResponses[0].res._getJSONData()).toEqual(
+      expect.objectContaining({ max_uses: 2, uses: 2 })
+    );
+
+    const errorResponses = requests.filter(
+      ({ res }) => res._getStatusCode() !== 200
+    );
+    expect(errorResponses.length).toBe(4);
+    const updatedNullifierHash = await integrationDBExecuteQuery(
+      `SELECT uses FROM nullifier WHERE nullifier_hash = '${validRequestPayload.nullifier_hash}';`
+    );
+    expect(updatedNullifierHash.rows[0].uses).toBe(2);
   });
 });


### PR DESCRIPTION
`signal` is an optional parameter. This PR fixes the case of not passing a signal which previously resulted in an unhandled error. Test case added to cover.