### PR TITLE
Fix: create edit rows for already verified apps

### DIFF
--- a/hasura/migrations/default/1705367428341_create_edit_rows_for_verified_apps/down.sql
+++ b/hasura/migrations/default/1705367428341_create_edit_rows_for_verified_apps/down.sql
@@ -1,0 +1,7 @@
+DELETE FROM "public"."app_metadata"
+WHERE verification_status = 'unverified'
+AND app_id IN (
+    SELECT app_id
+    FROM "public"."app_metadata"
+    WHERE verification_status = 'verified'
+);

--- a/hasura/migrations/default/1705367428341_create_edit_rows_for_verified_apps/up.sql
+++ b/hasura/migrations/default/1705367428341_create_edit_rows_for_verified_apps/up.sql
@@ -1,0 +1,11 @@
+INSERT INTO
+    "public"."app_metadata" (app_id, name, logo_img_url, verification_status)
+SELECT
+    app_id,
+    name,
+    logo_img_url,
+    'unverified'
+FROM
+    "public"."app_metadata"
+WHERE
+    verification_status = 'verified';


### PR DESCRIPTION
If some rows already are verified we need to create their verified rows so that users can edit.