### PR TITLE
fix: 500 error on session expiry

### DIFF
--- a/web/src/pages/app/[app_id]/actions.tsx
+++ b/web/src/pages/app/[app_id]/actions.tsx
@@ -4,4 +4,6 @@ import { withPageAuthRequired } from "@auth0/nextjs-auth0";
 
 export default Actions;
 
-export const getServerSideProps: GetServerSideProps = withPageAuthRequired();
+export const getServerSideProps: GetServerSideProps = withPageAuthRequired({
+    returnTo: "/api/auth/login-callback",
+});

--- a/web/src/pages/app/[app_id]/actions.tsx
+++ b/web/src/pages/app/[app_id]/actions.tsx
@@ -5,5 +5,5 @@ import { withPageAuthRequired } from "@auth0/nextjs-auth0";
 export default Actions;
 
 export const getServerSideProps: GetServerSideProps = withPageAuthRequired({
-    returnTo: "/api/auth/login-callback",
+  returnTo: "/api/auth/login-callback",
 });

--- a/web/src/pages/app/[app_id]/debugger.tsx
+++ b/web/src/pages/app/[app_id]/debugger.tsx
@@ -5,5 +5,5 @@ import { withPageAuthRequired } from "@auth0/nextjs-auth0";
 export default Debugger;
 
 export const getServerSideProps: GetServerSideProps = withPageAuthRequired({
-    returnTo: "/api/auth/login-callback",
+  returnTo: "/api/auth/login-callback",
 });

--- a/web/src/pages/app/[app_id]/debugger.tsx
+++ b/web/src/pages/app/[app_id]/debugger.tsx
@@ -4,4 +4,6 @@ import { withPageAuthRequired } from "@auth0/nextjs-auth0";
 
 export default Debugger;
 
-export const getServerSideProps: GetServerSideProps = withPageAuthRequired();
+export const getServerSideProps: GetServerSideProps = withPageAuthRequired({
+    returnTo: "/api/auth/login-callback",
+});

--- a/web/src/pages/app/[app_id]/index.tsx
+++ b/web/src/pages/app/[app_id]/index.tsx
@@ -5,5 +5,5 @@ import { withPageAuthRequired } from "@auth0/nextjs-auth0";
 export default App;
 
 export const getServerSideProps: GetServerSideProps = withPageAuthRequired({
-    returnTo: "/api/auth/login-callback",
+  returnTo: "/api/auth/login-callback",
 });

--- a/web/src/pages/app/[app_id]/index.tsx
+++ b/web/src/pages/app/[app_id]/index.tsx
@@ -4,4 +4,6 @@ import { withPageAuthRequired } from "@auth0/nextjs-auth0";
 
 export default App;
 
-export const getServerSideProps: GetServerSideProps = withPageAuthRequired();
+export const getServerSideProps: GetServerSideProps = withPageAuthRequired({
+    returnTo: "/api/auth/login-callback",
+});

--- a/web/src/pages/app/[app_id]/sign-in.tsx
+++ b/web/src/pages/app/[app_id]/sign-in.tsx
@@ -4,4 +4,6 @@ import { withPageAuthRequired } from "@auth0/nextjs-auth0";
 
 export default SignIn;
 
-export const getServerSideProps: GetServerSideProps = withPageAuthRequired();
+export const getServerSideProps: GetServerSideProps = withPageAuthRequired({
+    returnTo: "/api/auth/login-callback",
+});

--- a/web/src/pages/app/[app_id]/sign-in.tsx
+++ b/web/src/pages/app/[app_id]/sign-in.tsx
@@ -5,5 +5,5 @@ import { withPageAuthRequired } from "@auth0/nextjs-auth0";
 export default SignIn;
 
 export const getServerSideProps: GetServerSideProps = withPageAuthRequired({
-    returnTo: "/api/auth/login-callback",
+  returnTo: "/api/auth/login-callback",
 });

--- a/web/src/pages/app/actions.tsx
+++ b/web/src/pages/app/actions.tsx
@@ -31,6 +31,7 @@ const appsQuery = gql`
 `;
 
 export const getServerSideProps: GetServerSideProps = withPageAuthRequired({
+  returnTo: "/api/auth/login-callback",
   getServerSideProps: async ({ req, res }) => {
     const session = await getSession(req, res);
     const client = await getAPIServiceClient();

--- a/web/src/pages/app/index.tsx
+++ b/web/src/pages/app/index.tsx
@@ -32,6 +32,7 @@ const appsQuery = gql`
 `;
 
 export const getServerSideProps = withPageAuthRequired({
+  returnTo: "/api/auth/login-callback",
   getServerSideProps: async ({ req, res, query }) => {
     const session = await getSession(req, res);
     const client = await getAPIServiceClient();

--- a/web/src/pages/app/sign-in.tsx
+++ b/web/src/pages/app/sign-in.tsx
@@ -31,6 +31,7 @@ const query = gql`
 `;
 
 export const getServerSideProps: GetServerSideProps = withPageAuthRequired({
+  returnTo: "/api/auth/login-callback",
   getServerSideProps: async ({ req, res }) => {
     const session = await getSession(req, res);
     const client = await getAPIServiceClient();

--- a/web/src/pages/signup.tsx
+++ b/web/src/pages/signup.tsx
@@ -17,6 +17,7 @@ export type SignupSSRProps = {
 };
 
 export const getServerSideProps = withPageAuthRequired({
+  returnTo: "/api/auth/login-callback",
   getServerSideProps: async (context) => {
     const session = await getSession(context.req, context.res);
     const hasAuth0User = Boolean(session?.user);

--- a/web/src/pages/team.tsx
+++ b/web/src/pages/team.tsx
@@ -5,5 +5,5 @@ import { withPageAuthRequired } from "@auth0/nextjs-auth0";
 export default Team;
 
 export const getServerSideProps: GetServerSideProps = withPageAuthRequired({
-    returnTo: "/api/auth/login-callback",
+  returnTo: "/api/auth/login-callback",
 });

--- a/web/src/pages/team.tsx
+++ b/web/src/pages/team.tsx
@@ -4,4 +4,6 @@ import { withPageAuthRequired } from "@auth0/nextjs-auth0";
 
 export default Team;
 
-export const getServerSideProps: GetServerSideProps = withPageAuthRequired();
+export const getServerSideProps: GetServerSideProps = withPageAuthRequired({
+    returnTo: "/api/auth/login-callback",
+});


### PR DESCRIPTION
Fixes the 500 error users would receive when their login sessions expired by ensuring Hasura user data is included. Tested locally.

**Walkthrough of the Issue:**
Let's say a logged-in user has the page `/app/app_6efd0...` open in their browser. While they step away, the `appSession` cookie expires. They re-open the tab, and `nextjs-auth0`'s `withPageAuthRequired()` helper is called, realizes the user no longer has a session cookie, and redirects them to `/api/auth/login?returnTo=%2Fapp%2Fapp_6efd0...`. They go through the login flow (usually without interaction, as the session on Auth0's page is valid for a longer time), and are redirected back to the page they originally requested.

The issue lies in that `returnTo` query parameter -- it would override the returnTo value that we set in `pages/api/auth/[auth0].ts`:

```typescript
export default handleAuth({
  login: (req: NextApiRequest, res: NextApiResponse) => {
    const invite_id = req.query.invite_id;

    return handleLogin(req, res, {
      returnTo: invite_id
        ? `/api/auth/login-callback?invite_id=${invite_id}`
        : "/api/auth/login-callback",
    });
  },
// ...
``` 

`login-callback` handles coordination of data between Hasura and Auth0, including the crucial step of adding the user's `id` and `team_id` from Hasura into the current session, so that they can be used to do things like retrieve a list of that user's applications. 

When that `returnTo` value was overridden and `login-callback` was bypassed, the user's Hasura `id` and `team_id` were not added to the session, causing 500 errors when pages attempted to query applications by `user_id`, without a `user_id`.

**The Fix:**
Manually configure every authenticated page's `withPageAuthRequired` helper to return to `/api/auth/login-callback` after the user has logged back in,  rather than the current page.

**Drawbacks:**
This does come with a downside -- if a user was at `/app/app_6efd0.../actions`, they will always be redirected to the first app for that user in Hasura after logging back in. 

This could be remedied by merging `nextjs-auth0`'s `handleCallback` and the `login-callback` handler into a single function handler for `/api/auth/callback` instead of manually setting `returnTo` as done in this PR, however I elected against this approach as it could potentially impact team invitation functionality.