### PR TITLE
fix: hide secret section for members

### DIFF
--- a/web/src/scenes/sign-in-with-world-id/index.tsx
+++ b/web/src/scenes/sign-in-with-world-id/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect } from "react";
+import { memo, useEffect, useMemo } from "react";
 import { Layout } from "src/components/Layout";
 import { Preloader } from "src/components/Preloader";
 import useApps from "src/hooks/useApps";
@@ -10,12 +10,27 @@ import { Urls } from "./Urls";
 import { NotFound } from "@/components/NotFound";
 import { useRouter } from "next/router";
 import { urls } from "src/lib/urls";
+import { Auth0SessionUser } from "@/lib/types";
+import { useUser } from "@auth0/nextjs-auth0/client";
+import { Role_Enum } from "@/graphql/graphql";
 
 export const SignIn = memo(function SignIn() {
   const { currentApp, isLoading: appIsLoading } = useApps();
   const { actionIsLoading } = useSignInAction();
   const router = useRouter();
+  const { user } = useUser() as Auth0SessionUser;
   const team_id = router.query.team_id as string;
+
+  const isEnoughPermissions = useMemo(() => {
+    const membership = user?.hasura.memberships.find(
+      (m) => m.team?.id === team_id
+    );
+
+    return (
+      membership?.role === Role_Enum.Owner ||
+      membership?.role === Role_Enum.Admin
+    );
+  }, [team_id, user?.hasura.memberships]);
 
   useEffect(() => {
     if (currentApp?.engine === "on-chain") {
@@ -38,8 +53,8 @@ export const SignIn = memo(function SignIn() {
         <div className="grid gap-y-12 content-start">
           <Header />
           <Credentials />
-          <Redirects />
-          <Urls />
+          {isEnoughPermissions && <Redirects />}
+          {isEnoughPermissions && <Urls />}
           {/* NOTE: https://linear.app/worldcoin/issue/WID-370#comment-d47da43e  */}
           {/* <DefaultAuthorizationLink /> */}
         </div>


### PR DESCRIPTION
Closes [this](https://tfh.slack.com/archives/C05NJ4QFCLE/p1706041937278389?thread_ts=1706031364.968379&cid=C05NJ4QFCLE) and [this](https://tfh.slack.com/archives/C05NJ4QFCLE/p1706042415683769?thread_ts=1706031364.968379&cid=C05NJ4QFCLE)

We using Hasura action `_reset-secret-key` to reset secret key and there is only two options for actions: allow or forbid action for the entire user role, so I decided simply not show client secret section for the members

Also hide Redirects and Urls components from MEMBER on /sign-in page

<img width="1355" alt="image" src="https://github.com/worldcoin/developer-portal/assets/89008845/782e55a6-c089-4714-b87c-92970121012a">
