### PR TITLE
Fix: Update Toast Format WID-692

### DIFF
--- a/web-app-router/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/index.tsx
+++ b/web-app-router/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/index.tsx
@@ -3,11 +3,11 @@ import { IncognitoActionIcon } from "@/components/Icons/IncognitoActionIcon";
 import { LogoLinesIcon } from "@/components/Icons/LogoLines";
 import { WorldcoinBlueprintIcon } from "@/components/Icons/WorldcoinBlueprintIcon";
 import { CreateActionModal } from "./createAction";
-import { TeamSelector } from "@/scenes/Portal/layout/TeamSelector";
 
 type ActionsPageProps = {
   searchParams: Record<string, string> | null | undefined;
 };
+
 // TODO: Ad TWK Lausanne font
 export const ActionsPage = ({ searchParams }: ActionsPageProps) => {
   const createAction = searchParams?.createAction;

--- a/web-app-router/scenes/Portal/Teams/TeamId/layout/index.tsx
+++ b/web-app-router/scenes/Portal/Teams/TeamId/layout/index.tsx
@@ -3,7 +3,12 @@ import { Slide, ToastContainer } from "react-toastify";
 
 export const TeamIdLayout = (props: { children: ReactNode }) => (
   <div>
-    <ToastContainer autoClose={5000} transition={Slide} />
+    <ToastContainer
+      autoClose={4000}
+      transition={Slide}
+      hideProgressBar
+      position="bottom-right"
+    />
     {props.children}
   </div>
 );

--- a/web-app-router/styles/globals.css
+++ b/web-app-router/styles/globals.css
@@ -43,13 +43,35 @@
 /* Begin Toastify overrides */
 
 :root {
-  --toastify-color-success: #4940e0;
-  --toastify-icon-color-success: #4940e0;
+  --toastify-color-info: #4940e0;
+  --toastify-icon-color-info: #4940e0;
+  --toastify-color-success: #00B800;
+  --toastify-icon-color-success: #00B800;
+  --toastify-color-warning: #ff4732;
+  --toastify-icon-color-warning: #ff4732;
 }
 
-/*
+
 .Toastify__toast {
-  @apply rounded-lg font-rubik;
+  border-radius: .75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between; 
+  border-color: #EBECEF;
+  border-width: 1px;
+  min-height: 50px; 
+  font-size: 14px;
+  box-shadow: 0px 4px 6px -2px #191C2008, 0px 12px 16px -4px #191C2014; 
 }
-*/
+
+.Toastify__toast-body {
+  flex: 1; 
+  display: flex;
+  align-items: center; 
+}
+
+.Toastify__close-button {
+  align-self: center; 
+}
+
 /* End Toastify overrides */


### PR DESCRIPTION
<img width="1511" alt="Screenshot 2024-01-28 at 10 24 58 AM" src="https://github.com/worldcoin/developer-portal/assets/41224501/23f11f28-407a-471f-a922-18b092e959b0">

I update toasts css to be bottom right and thinner with no progress bar like in the specs. I don't think it's worth to change the icons since I think the default ones actually look better and it seems we need to manually inject the icon for each toast. 

Merging this directly into WID 679