### PR TITLE
fix: On save fix

### DIFF
--- a/web-app-router/next-env.d.ts
+++ b/web-app-router/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/web-app-router/next-env.d.ts
+++ b/web-app-router/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/web/src/hooks/useApps.ts
+++ b/web/src/hooks/useApps.ts
@@ -271,8 +271,8 @@ const updateAppMetadataFetcher = async (
 
   // We don't want to put an empty array in the database and ensure paths are cleaned
   const filtered_showcase_img_urls =
-    which_showcase_img_urls?.filter((url, index) =>
-      url.startsWith(`showcase_img_${index + 1}`)
+    which_showcase_img_urls?.filter(
+      (url, index) => url != null && url.startsWith(`showcase_img_${index + 1}`)
     ) || null;
 
   const formatted_showcase_img_urls = filtered_showcase_img_urls


### PR DESCRIPTION
There's a bug with the filter function which is supposed ensure we remove any null values added to the array from react-hook-form. If the app is in an empty state you cannot save without a showcase image since the url is null and url.startsWith() will throw an error.

The fix is using a loose check for null, should catch null and undefined