### PR TITLE
feat: update user constraint

### DIFF
--- a/hasura/migrations/default/1707493190197_alter_table_public_user_alter_column_team_id/down.sql
+++ b/hasura/migrations/default/1707493190197_alter_table_public_user_alter_column_team_id/down.sql
@@ -1,0 +1,6 @@
+alter table "public"."user" alter column "team_id" set not null;
+alter table "public"."user" drop constraint "user_team_id_fkey",
+  add constraint "user_team_id_fkey"
+  foreign key ("team_id")
+  references "public"."team"
+  ("id") on update restrict on delete cascade;

--- a/hasura/migrations/default/1707493190197_alter_table_public_user_alter_column_team_id/up.sql
+++ b/hasura/migrations/default/1707493190197_alter_table_public_user_alter_column_team_id/up.sql
@@ -1,0 +1,6 @@
+alter table "public"."user" alter column "team_id" drop not null;
+alter table "public"."user" drop constraint "user_team_id_fkey",
+  add constraint "user_team_id_fkey"
+  foreign key ("team_id")
+  references "public"."team"
+  ("id") on update restrict on delete set null;


### PR DESCRIPTION
When we delete a team, the relationship is also removed from the membership table, along with any associated applications and actions. This is achieved through foreign constraints.
However, currently, the user is also deleted along with the team. To prevent this from happening, I've adjusted the team_id field, making it nullable, and also updated the constraint.
We're not using the team_id field in the user table; it's kept for backward compatibility with the old frontend. We'll need to remove it entirely.