### PR TITLE
fix: link prefetch

### DIFF
--- a/web/components/Link/index.tsx
+++ b/web/components/Link/index.tsx
@@ -33,6 +33,7 @@ export const Link = memo(function Link(props: CommonLinkProps) {
       {!external && (
         <NextLink
           href={href ?? "!#"}
+          prefetch={false}
           className={clsx("leading-none", className)}
           {...restProps}
         >


### PR DESCRIPTION
With prefetch, next's Link adds some query params to the URL. And, for example, the logout URL will be something like `/api/auth/logout?param=value`. This caused errors on the auth0 side because we need to configure callback, logout, login, etc strictly. Prefetch caused a URL mismatch.