### PR TITLE
[Fix] Make mini kiosk more stable

### DIFF
--- a/web/components/DialogPanel/index.tsx
+++ b/web/components/DialogPanel/index.tsx
@@ -14,7 +14,7 @@ export const DialogPanel = (props: DialogPanelProps) => {
   return (
     <Dialog.Panel
       className={twMerge(
-        "relative grid min-w-[25rem] justify-items-center rounded-20 bg-grey-0 p-7",
+        "relative z-50 grid min-w-[25rem] justify-items-center rounded-20 bg-grey-0 p-7",
         className,
       )}
       {...otherProps}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/MiniKiosk/IDKitBridge/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/MiniKiosk/IDKitBridge/index.tsx
@@ -77,7 +77,6 @@ export const IDKitBridge = memo(function IDKitBridge(props: IDKitBridgeProps) {
 
   // Change the shown screen based on current verificationState and errorCode
   useEffect(() => {
-    console.log(idKitVerificationState);
     switch (idKitVerificationState) {
       case VerificationState.WaitingForConnection:
         setScreen(KioskScreen.Waiting);

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/MiniKiosk/IDKitBridge/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/MiniKiosk/IDKitBridge/index.tsx
@@ -77,6 +77,7 @@ export const IDKitBridge = memo(function IDKitBridge(props: IDKitBridgeProps) {
 
   // Change the shown screen based on current verificationState and errorCode
   useEffect(() => {
+    console.log(idKitVerificationState);
     switch (idKitVerificationState) {
       case VerificationState.WaitingForConnection:
         setScreen(KioskScreen.Waiting);
@@ -91,7 +92,6 @@ export const IDKitBridge = memo(function IDKitBridge(props: IDKitBridgeProps) {
           clearInterval(intervalId);
         }
 
-        setScreen(KioskScreen.Success);
         break;
 
       case VerificationState.Failed:
@@ -101,8 +101,6 @@ export const IDKitBridge = memo(function IDKitBridge(props: IDKitBridgeProps) {
         // Prevent connection failure
         if (connectionTimeout) {
           resetKiosk();
-        } else {
-          setScreen(KioskScreen.VerificationError);
         }
         break;
     }


### PR DESCRIPTION
Before it was changing screen state in idkit as well which is causing weird flashes. We rely on proof verification endpoint to determine if it should be in error or success state. 