### PR TITLE
[Fix]: fixes to images title for website loader, hotfix

### DIFF
--- a/web/components/InitialSteps/index.tsx
+++ b/web/components/InitialSteps/index.tsx
@@ -31,7 +31,10 @@ export const InitialSteps = (props: {
       <div className="grid grid-cols-1 place-items-center gap-y-2">
         <Typography variant={TYPOGRAPHY.H6}>{props.title}</Typography>
 
-        <Typography variant={TYPOGRAPHY.R4} className="text-sm text-grey-500">
+        <Typography
+          variant={TYPOGRAPHY.R4}
+          className="text-center text-sm text-grey-500"
+        >
           {props.description}
         </Typography>
       </div>

--- a/web/lib/genarate-title.ts
+++ b/web/lib/genarate-title.ts
@@ -2,6 +2,6 @@ export const generateMetaTitle = (params?: {
   left: string;
   right?: string;
 }) => {
-  const { left, right = "Developer portal" } = params || {};
+  const { left, right = "Developer Portal" } = params || {};
   return left ? `${left} | ${right}` : right;
 };

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/ImageDisplay/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/ImageDisplay/index.tsx
@@ -18,6 +18,7 @@ export const ImageDisplay = (props: {
   // Verified images are cached by cloudfront and Next/Image actually causes slower load times.
   if (type === "verified") {
     return (
+      // eslint-disable-next-line @next/next/no-img-element
       <img
         src={imgSrc}
         alt="verified"

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/ImageDisplay/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/ImageDisplay/index.tsx
@@ -18,6 +18,7 @@ export const ImageDisplay = (props: {
   // Verified images are cached by cloudfront and Next/Image actually causes slower load times.
   if (type === "verified") {
     return (
+      // Note: We use img since cloudfront auto caches the image and we want to avoid a second cache from Next/image.
       // eslint-disable-next-line @next/next/no-img-element
       <img
         src={imgSrc}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/ImageLoader/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/ImageLoader/index.tsx
@@ -1,0 +1,46 @@
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { useEffect, useState } from "react";
+
+const ImageLoader = (props: { name: string }) => {
+  const { name } = props;
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setProgress((oldProgress) => {
+        if (oldProgress >= 99) {
+          clearInterval(timer);
+          return 99;
+        }
+        const newProgress = oldProgress + 9;
+        return Math.min(newProgress, 99);
+      });
+    }, 150);
+    return () => {
+      clearInterval(timer);
+    };
+  }, []);
+
+  return (
+    <div className="flex h-32 w-44 flex-col items-center justify-center gap-y-2 rounded-lg border border-dashed border-grey-200 px-6">
+      <div className="w-full">
+        <Typography variant={TYPOGRAPHY.R5} className="text-grey-400">
+          {progress}%
+        </Typography>
+      </div>
+      <div className="w-full rounded-xl bg-gray-200">
+        <div
+          className="h-2 rounded-xl bg-blue-500 text-center text-xs text-white"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      <div className="w-full">
+        <Typography variant={TYPOGRAPHY.R5} className="text-grey-500">
+          {name}
+        </Typography>
+      </div>
+    </div>
+  );
+};
+
+export default ImageLoader;

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/index.tsx
@@ -402,7 +402,7 @@ export const ImageForm = (props: ImageFormTypes) => {
           </div>
         </ImageDropZone>
       )}
-      <div className="grid grid-cols-3">
+      <div className="grid gap-y-4 md:grid-cols-3">
         {showcaseImgUrls &&
           showcaseImgUrls.map((url: string, index: number) => (
             <div className="relative size-fit" key={index}>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/PageComponents/AppTopBar/LogoImageUpload/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/PageComponents/AppTopBar/LogoImageUpload/index.tsx
@@ -89,7 +89,6 @@ export const LogoImageUpload = (props: LogoImageUploadProps) => {
         // TODO: This is a hotfix since the path names are fixed the browser caches the image and doesn't update it.
         // Will be fixed after the dev-portal update is done to avoid large backend changes for now.
         if (isSecondUpload) {
-          console.log("here");
           window.location.reload();
         } else {
           setIsSecondUpload(true);

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/PageComponents/AppTopBar/LogoImageUpload/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/PageComponents/AppTopBar/LogoImageUpload/index.tsx
@@ -11,6 +11,7 @@ import { getCDNImageUrl } from "@/lib/utils";
 import clsx from "clsx";
 import { useAtom } from "jotai";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { ChangeEvent, useMemo, useRef, useState } from "react";
 import Skeleton from "react-loading-skeleton";
 import { toast } from "react-toastify";
@@ -32,6 +33,7 @@ export const LogoImageUpload = (props: LogoImageUploadProps) => {
   const { appId, appMetadataId, teamId, editable, logoFile } = props;
   const [showDialog, setShowDialog] = useState(false);
   const [verifiedImageError, setVerifiedImageError] = useState(false);
+  const [isSecondUpload, setIsSecondUpload] = useState(false);
   const [disabled] = useState(false);
   const [viewMode] = useAtom(viewModeAtom);
   const [unverifiedImages, setUnverifiedImages] = useAtom(unverifiedImageAtom);
@@ -39,7 +41,7 @@ export const LogoImageUpload = (props: LogoImageUploadProps) => {
   const imageInputRef = useRef<HTMLInputElement>(null);
   const { getImage, uploadViaPresignedPost, validateImageDimensions } =
     useImage();
-
+  const router = useRouter();
   const handleUpload = () => {
     imageInputRef.current?.click();
   };
@@ -84,7 +86,14 @@ export const LogoImageUpload = (props: LogoImageUploadProps) => {
           render: "Image uploaded successfully",
           autoClose: 5000,
         });
-
+        // TODO: This is a hotfix since the path names are fixed the browser caches the image and doesn't update it.
+        // Will be fixed after the dev-portal update is done to avoid large backend changes for now.
+        if (isSecondUpload) {
+          console.log("here");
+          window.location.reload();
+        } else {
+          setIsSecondUpload(true);
+        }
         setShowDialog(false);
       } catch (error) {
         console.error(error);

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/PageComponents/AppTopBar/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/PageComponents/AppTopBar/index.tsx
@@ -267,7 +267,7 @@ export const AppTopBar = (props: AppTopBarProps) => {
         appId={appId}
         isDeveloperAllowListing={appMetaData?.is_developer_allow_listing}
       />
-      <div className="grid grid-cols-auto/1fr/auto items-center gap-x-8">
+      <div className="grid items-center gap-y-4 md:grid-cols-auto/1fr/auto md:gap-x-8">
         <ReviewMessageDialog
           message={appMetaData.review_message}
           metadataId={appMetaData.id}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/index.tsx
@@ -17,7 +17,7 @@ export const SignInWithWorldIdPage = async (
 
   return (
     <div className="size-full">
-      <div className="grid grid-cols-1 gap-x-7 py-6 md:grid-cols-auto/1fr/auto">
+      <div className="grid grid-cols-1 gap-x-7 gap-y-4 py-6 md:grid-cols-auto/1fr/auto">
         <Image
           src="/passport.png"
           alt="passport"
@@ -25,13 +25,9 @@ export const SignInWithWorldIdPage = async (
           height={100}
           className="h-auto w-16"
         />
-        <div className="grid grid-cols-1 items-center justify-items-start gap-y-0">
+        <div className="grid items-center justify-items-start gap-y-0">
           <Typography variant={TYPOGRAPHY.H6}>Sign in with World ID</Typography>
-          <Typography
-            as="p"
-            variant={TYPOGRAPHY.R3}
-            className="text-center text-grey-500"
-          >
+          <Typography as="p" variant={TYPOGRAPHY.R3} className=" text-grey-500">
             Let users sign in to your app with their World ID using OpenID
             Connect (OIDC)
           </Typography>


### PR DESCRIPTION
- ImageLoader
- Added a hotfix to logo image upload. Essentially since we fix the image url path for logo_img.png/jpg. The image is caching on the browser. However, we cannot append any params to the signed_url since it will invalidate the URL. Thus we need to modify the way we upload images to generate a random string each time to invalidate the cache. We handle this for now by refreshing the page if it's their second upload. I will revisit this after merge because it will require large backend changes. Note this also will affect showcase and banner image. But logo is more prominent, on every page, so I hotfix that for now. 
- I also changed the meta tag to capitalize Portal in developer portal, just thought it looked nicer. 
- Also made the gallery more responsive so it doesn't look terrible on mobile. Added some spacing to sign in as well 