### PR TITLE
[Feat] Create an endpoint for reviewer to view images

### DIFF
--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -1,9 +1,19 @@
 type Mutation {
-  delete_unverified_images(app_id: String!): DeleteImageOutput
+  delete_unverified_images(
+    app_id: String!
+  ): DeleteImageOutput
 }
 
 type Query {
-  get_all_unverified_images(app_id: String!): ImageGetAllUnverifiedImagesOutput
+  get_all_unverified_images(
+    app_id: String!
+  ): ImageGetAllUnverifiedImagesOutput
+}
+
+type Query {
+  get_app_review_images(
+    app_id: String!
+  ): ImageGetAppReviewImagesOutput
 }
 
 type Query {
@@ -15,15 +25,21 @@ type Query {
 }
 
 type Mutation {
-  invite_team_members(emails: [String!]): InviteTeamMembersOutput
+  invite_team_members(
+    emails: [String!]
+  ): InviteTeamMembersOutput
 }
 
 type Mutation {
-  reset_api_key(id: String!): ResetAPIOutput
+  reset_api_key(
+    id: String!
+  ): ResetAPIOutput
 }
 
 type Mutation {
-  reset_client_secret(app_id: String!): ResetClientOutput
+  reset_client_secret(
+    app_id: String!
+  ): ResetClientOutput
 }
 
 type Query {
@@ -99,3 +115,10 @@ type DeleteImageOutput {
 type VerifyAppOutput {
   success: Boolean
 }
+
+type ImageGetAppReviewImagesOutput {
+  logo_img_url: String
+  hero_image_url: String
+  showcase_img_urls: [String!]
+}
+

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -29,6 +29,26 @@ actions:
     permissions:
       - role: user
       - role: api_key
+  - name: get_app_review_images
+    definition:
+      kind: ""
+      handler: '{{NEXT_API_URL}}/images/_get_app_review_images'
+      headers:
+        - name: Authorization
+          value_from_env: INTERNAL_ENDPOINTS_SECRET
+      request_transform:
+        method: GET
+        query_params:
+          app_id: '{{$body.input.app_id}}'
+        request_headers:
+          add_headers: {}
+          remove_headers:
+            - content-type
+        template_engine: Kriti
+        version: 2
+    permissions:
+      - role: reviewer
+    comment: Used by the reviewer to get in review app images
   - name: get_uploaded_image
     definition:
       kind: ""
@@ -141,4 +161,5 @@ custom_types:
     - name: PresignedPostOutput
     - name: DeleteImageOutput
     - name: VerifyAppOutput
+    - name: ImageGetAppReviewImagesOutput
   scalars: []

--- a/web/legacy/api/images/get_app_review_images.ts
+++ b/web/legacy/api/images/get_app_review_images.ts
@@ -1,32 +1,40 @@
-import { getSdk as getUnverifiedImagesSDK } from "@/legacy/api/images/graphql/getUnverifiedImages.generated";
+import { getSdk as getAppReviewImages } from "@/legacy/api/images/graphql/getAppReviewImages.generated";
 import {
   errorHasuraQuery,
   errorNotAllowed,
   errorResponse,
 } from "@/legacy/backend/errors";
-import { getAPIServiceGraphqlClient } from "@/legacy/backend/graphql";
+import { getAPIReviewerGraphqlClient } from "@/legacy/backend/graphql";
 import { protectInternalEndpoint } from "@/legacy/backend/utils";
 import { logger } from "@/lib/logger";
 import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { NextApiRequest, NextApiResponse } from "next";
 
-export type ImageGetAllUnverifiedImagesResponse = {
+export type ImageGetAppReviewImagesOutput = {
   logo_img_url?: string;
   hero_image_url?: string;
   showcase_img_urls?: string[];
 };
 
 /**
- * Used when an app is loaded to show all unverified images
+ * Used when a reviewer is reviewing an app
  * @param req
  * @param res
  */
-export const handleGetAllUnverifiedImages = async (
+export const handleGetAppReviewImages = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
   try {
+    if (!process.env.ASSETS_S3_REGION) {
+      throw new Error("AWS Region must be set.");
+    }
+
+    if (!process.env.ASSETS_S3_BUCKET_NAME) {
+      throw new Error("AWS Bucket Name must be set.");
+    }
+
     if (!protectInternalEndpoint(req, res)) {
       return;
     }
@@ -34,8 +42,10 @@ export const handleGetAllUnverifiedImages = async (
     if (req.method !== "GET") {
       return errorNotAllowed(req.method, res, req);
     }
+
     const body = JSON.parse(req.body);
-    if (body?.action.name !== "get_all_unverified_images") {
+
+    if (body?.action.name !== "get_app_review_images") {
       return errorHasuraQuery({
         res,
         req,
@@ -44,24 +54,10 @@ export const handleGetAllUnverifiedImages = async (
       });
     }
 
-    const userId = body.session_variables["x-hasura-user-id"];
-    if (!userId) {
-      return errorHasuraQuery({
-        res,
-        req,
-        detail: "userId must be set.",
-        code: "required",
-      });
-    }
-
-    const teamId = body.session_variables["x-hasura-team-id"];
-    if (!teamId) {
-      return errorHasuraQuery({
-        res,
-        req,
-        detail: "teamId must be set.",
-        code: "required",
-      });
+    if (body.session_variables["x-hasura-role"] !== "reviewer") {
+      logger.error("Unauthorized access."),
+        { role: body.session_variables["x-hasura-role"] };
+      return errorHasuraQuery({ res, req });
     }
 
     const app_id = req.query.app_id;
@@ -73,15 +69,17 @@ export const handleGetAllUnverifiedImages = async (
         code: "required",
       });
     }
-    const client = await getAPIServiceGraphqlClient();
-    const { app: appInfo } = await getUnverifiedImagesSDK(
+
+    // Anchor: Get relative paths for images from the database
+    const client = await getAPIReviewerGraphqlClient();
+
+    const { app: appInfo } = await getAppReviewImages(
       client,
-    ).GetUnverifiedImages({
-      team_id: teamId,
+    ).GetAppReviewImages({
       app_id: app_id as string,
-      user_id: userId,
     });
-    // All roles can view the unverified images awaiting review.
+
+    // If the app is not found, return an error
     if (appInfo.length === 0 || appInfo[0].app_metadata.length === 0) {
       return errorHasuraQuery({
         res,
@@ -92,15 +90,12 @@ export const handleGetAllUnverifiedImages = async (
     }
 
     const app = appInfo[0].app_metadata[0];
-    if (!process.env.ASSETS_S3_REGION) {
-      throw new Error("AWS Region must be set.");
-    }
+
     const s3Client = new S3Client({
       region: process.env.ASSETS_S3_REGION,
     });
-    if (!process.env.ASSETS_S3_BUCKET_NAME) {
-      throw new Error("AWS Bucket Name must be set.");
-    }
+
+    // Anchor: Get Signed URLS for images
     const objectKey = `unverified/${app_id}/`;
     const bucketName = process.env.ASSETS_S3_BUCKET_NAME;
     const urlPromises = [];
@@ -108,7 +103,7 @@ export const handleGetAllUnverifiedImages = async (
       Bucket: bucketName,
       Key: objectKey + app.logo_img_url,
     });
-    // We check for any image values that are defined in the unverified row and generate a signed URL for that image
+
     if (app.logo_img_url) {
       urlPromises.push(
         getSignedUrl(s3Client, command, { expiresIn: 7200 }).then((url) => ({
@@ -146,16 +141,19 @@ export const handleGetAllUnverifiedImages = async (
     } else {
       urlPromises.push({ showcase_img_urls: [] });
     }
+
     const signedUrls = await Promise.all(urlPromises);
     const formattedSignedUrl = signedUrls.reduce(
       (a, urlObj) => ({ ...a, ...urlObj }),
       {},
     );
+
     res.status(200).json({
       ...formattedSignedUrl,
     });
   } catch (error) {
     logger.error("Error getting images.", { error });
+
     return errorResponse(
       res,
       500,

--- a/web/legacy/api/images/graphql/getAppReviewImages.generated.ts
+++ b/web/legacy/api/images/graphql/getAppReviewImages.generated.ts
@@ -1,0 +1,70 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient } from "graphql-request";
+import { GraphQLClientRequestHeaders } from "graphql-request/build/cjs/types";
+import gql from "graphql-tag";
+export type GetAppReviewImagesQueryVariables = Types.Exact<{
+  app_id: Types.Scalars["String"];
+}>;
+
+export type GetAppReviewImagesQuery = {
+  __typename?: "query_root";
+  app: Array<{
+    __typename?: "app";
+    app_metadata: Array<{
+      __typename?: "app_metadata";
+      logo_img_url: string;
+      showcase_img_urls?: any | null;
+      hero_image_url: string;
+    }>;
+  }>;
+};
+
+export const GetAppReviewImagesDocument = gql`
+  query GetAppReviewImages($app_id: String!) {
+    app(where: { id: { _eq: $app_id } }) {
+      app_metadata(where: { verification_status: { _eq: "awaiting_review" } }) {
+        logo_img_url
+        showcase_img_urls
+        hero_image_url
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    GetAppReviewImages(
+      variables: GetAppReviewImagesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetAppReviewImagesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetAppReviewImagesQuery>(
+            GetAppReviewImagesDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "GetAppReviewImages",
+        "query",
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/legacy/api/images/graphql/getAppReviewImages.graphql
+++ b/web/legacy/api/images/graphql/getAppReviewImages.graphql
@@ -1,0 +1,9 @@
+query GetAppReviewImages($app_id: String!) {
+  app(where: { id: { _eq: $app_id } }) {
+    app_metadata(where: { verification_status: { _eq: "awaiting_review" } }) {
+      logo_img_url
+      showcase_img_urls
+      hero_image_url
+    }
+  }
+}

--- a/web/pages/api/images/_get_app_review_images.ts
+++ b/web/pages/api/images/_get_app_review_images.ts
@@ -1,0 +1,3 @@
+// NOTE: use src/api when you need to make gql request using codegen
+import { handleGetAppReviewImages } from "@/legacy/api/images/get_app_review_images";
+export default handleGetAppReviewImages;


### PR DESCRIPTION
Let's reviewers see images awaiting review. Separate endpoint so we can have more granular permissions and since conditions are different. This seems cleaner