### PR TITLE
fix: initial steps header overlap

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/page/ClientPage/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/page/ClientPage/index.tsx
@@ -15,7 +15,7 @@ export const ClientPage = () => {
 
   return (
     <Fragment>
-      <SizingWrapper gridClassName="h-full flex justify-center items-center">
+      <SizingWrapper gridClassName="h-full flex justify-center items-center pb-10">
         <InitialSteps
           title="Build your first project"
           description="Welcome to World ID! Let's get started by creating your first app."

--- a/web/scenes/Portal/Teams/TeamId/Apps/page/ClientPage/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/page/ClientPage/index.tsx
@@ -15,7 +15,7 @@ export const ClientPage = () => {
 
   return (
     <Fragment>
-      <SizingWrapper gridClassName="h-full flex justify-center items-center -mt-10">
+      <SizingWrapper gridClassName="h-full flex justify-center items-center">
         <InitialSteps
           title="Build your first project"
           description="Welcome to World ID! Let's get started by creating your first app."


### PR DESCRIPTION
- Initial steps were moved -40px to top and it was blocking navigation on header

---

What was fixed: 

<img width="1276" alt="image" src="https://github.com/worldcoin/developer-portal/assets/89008845/832a9c11-5c94-4085-a280-1dbda0f33f3a">
 