### PR TITLE
fix: add name for the nullifier users

### DIFF
--- a/hasura/metadata/databases/default/tables/public_user.yaml
+++ b/hasura/metadata/databases/default/tables/public_user.yaml
@@ -49,6 +49,7 @@ select_permissions:
         - id
         - is_subscribed
         - name
+        - world_id_nullifier
       filter:
         _or:
           - id:

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -94,5 +94,5 @@ export const checkUserPermissions = (
 
 export const getNullifierName = (nullifier: string | undefined | null) => {
   if (!nullifier) return null;
-  return `Anonymous User | ...${nullifier.slice(-5)}`;
+  return `${nullifier.slice(0, 6)}...${nullifier.slice(-4)}`;
 };

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -91,3 +91,8 @@ export const checkUserPermissions = (
   }
   return validRoles.includes(membership?.role);
 };
+
+export const getNullifierName = (nullifier: string | undefined | null) => {
+  if (!nullifier) return null;
+  return `Anonymous User | ...${nullifier.slice(-5)}`;
+};

--- a/web/scenes/Portal/Profile/common/UserInfo/index.tsx
+++ b/web/scenes/Portal/Profile/common/UserInfo/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { Auth0SessionUser } from "@/lib/types";
 import { useFetchUserQuery } from "@/scenes/Portal/Profile/common/graphql/client/fetch-user.generated";
 import { Icon } from "@/scenes/Portal/Profile/layout/UserInfo/Icon";
 import { useUser } from "@auth0/nextjs-auth0/client";
@@ -10,19 +11,18 @@ import { twMerge } from "tailwind-merge";
 
 export type UserInfoProps = {
   name?: string;
-  //email: string | undefined | null;
   className?: string;
 };
 
 export const UserInfo = (props: UserInfoProps) => {
-  const { user } = useUser();
-  const userHasura = user?.hasura as { id: string } | undefined;
+  const { user } = useUser() as Auth0SessionUser;
+  const userHasura = user?.hasura;
   const userId = userHasura?.id;
 
   const userQueryRes = useFetchUserQuery({
     variables: !userId ? undefined : { user_id: userId },
     context: {
-      headers: { team_id: "team_b0b7af3f49ea4b6106332f7b6dd5b708___" },
+      headers: { team_id: "_" },
     },
     skip: !userId,
   });
@@ -49,7 +49,11 @@ export const UserInfo = (props: UserInfoProps) => {
         </Typography>
 
         <Typography variant={TYPOGRAPHY.R4} className="text-grey-500">
-          {!userQueryRes.data?.user ? <Skeleton width={200} /> : user!.email}
+          {!userQueryRes.data?.user ? (
+            <Skeleton width={200} />
+          ) : (
+            userQueryRes.data.user.email || null
+          )}
         </Typography>
       </div>
     </div>

--- a/web/scenes/Portal/Profile/common/graphql/client/fetch-user.generated.ts
+++ b/web/scenes/Portal/Profile/common/graphql/client/fetch-user.generated.ts
@@ -10,7 +10,13 @@ export type FetchUserQueryVariables = Types.Exact<{
 
 export type FetchUserQuery = {
   __typename?: "query_root";
-  user?: { __typename?: "user"; id: string; name: string } | null;
+  user?: {
+    __typename?: "user";
+    id: string;
+    name: string;
+    email?: string | null;
+    world_id_nullifier?: string | null;
+  } | null;
 };
 
 export const FetchUserDocument = gql`
@@ -18,6 +24,8 @@ export const FetchUserDocument = gql`
     user: user_by_pk(id: $user_id) {
       id
       name
+      email
+      world_id_nullifier
     }
   }
 `;

--- a/web/scenes/Portal/Profile/common/graphql/client/fetch-user.graphql
+++ b/web/scenes/Portal/Profile/common/graphql/client/fetch-user.graphql
@@ -2,5 +2,7 @@ query FetchUser($user_id: String!) {
   user: user_by_pk(id: $user_id) {
     id
     name
+    email
+    world_id_nullifier
   }
 }

--- a/web/scenes/Portal/Profile/types.ts
+++ b/web/scenes/Portal/Profile/types.ts
@@ -32,6 +32,11 @@ type AdditionalColors = {
     500: string;
   };
 
+  lightOrange: {
+    100: string;
+    500: string;
+  };
+
   pink: {
     100: string;
     500: string;

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -85,6 +85,7 @@ const config: Config = {
           },
 
           lightOrange: {
+            100: "#FFF7F0",
             500: "#FFA048",
           },
 


### PR DESCRIPTION
- This PR fixes empty name for the user logged in with `sign in with world id`. 
- Also fixes lightOrange color

‼️ I had to add permissions to user role to select world_id_nullifier, so it's a Hasura migration change

### REVIEW:
@andy-t-wang I don't really like current format of nullifier name. I'd prefer if it starts with truncated nullifier value to make it look more unique. Do you have any ideas?  

---

<img width="1047" alt="image" src="https://github.com/worldcoin/developer-portal/assets/89008845/d2064305-de6f-4b9f-bc69-675271b586cb">
