### PR TITLE
[Fix] Shouldn't be able to access a user from another team

### DIFF
--- a/hasura/metadata/databases/default/tables/public_api_key.yaml
+++ b/hasura/metadata/databases/default/tables/public_api_key.yaml
@@ -75,9 +75,8 @@ update_permissions:
             _and:
               - user_id:
                   _eq: X-Hasura-User-Id
-              - team:
-                  id:
-                    _eq: X-Hasura-Team-Id
+              - team_id:
+                  _eq: X-Hasura-Team-Id
               - role:
                   _eq: OWNER
       check: null

--- a/hasura/metadata/databases/default/tables/public_user.yaml
+++ b/hasura/metadata/databases/default/tables/public_user.yaml
@@ -56,8 +56,11 @@ select_permissions:
           - id:
               _eq: X-Hasura-User-Id
           - memberships:
-              team_id:
-                _eq: X-Hasura-Team-Id
+              _and:
+                - user_id:
+                    _eq: X-Hasura-User-Id
+                - team_id:
+                    _eq: X-Hasura-Team-Id
 update_permissions:
   - role: service
     permission:

--- a/web/tests/integration/user.test.ts
+++ b/web/tests/integration/user.test.ts
@@ -143,4 +143,63 @@ describe("user role", () => {
 
     expect(response.data.user).toEqual([]);
   });
+
+  // We pass team ID as a header now
+  test("can't select user from a team you are not a part of, with a spoofed team_id", async () => {
+    const { rows: teams } = (await integrationDBExecuteQuery(
+      `SELECT id, name FROM "public"."team"`,
+    )) as { rows: Array<{ id: string; name: string }> };
+
+    const { rows: teamMemberships } = (await integrationDBExecuteQuery(
+      `SELECT id, user_id, team_id, role FROM "public"."membership"`,
+    )) as {
+      rows: Array<{
+        id: string;
+        user_id: string;
+        team_id: string;
+        role: Role_Enum;
+      }>;
+    };
+
+    const query = gql`
+      query FetchUser($id: String!) {
+        user(where: { id: { _eq: $id } }) {
+          id
+          email
+          name
+          auth0Id
+          memberships {
+            id
+            team {
+              id
+              name
+            }
+            role
+          }
+        }
+      }
+    `;
+
+    const userFromTeam0 = teamMemberships.find(
+      (membership) => membership.team_id === teams[0].id,
+    );
+
+    const userFromTeam1 = teamMemberships.find(
+      (membership) => membership.team_id === teams[1].id,
+    );
+
+    const client = await getAPIUserClient({
+      team_id: teams[1].id,
+      user_id: userFromTeam0?.user_id,
+    });
+
+    const response = await client.query({
+      query,
+      variables: {
+        id: userFromTeam1?.user_id,
+      },
+    });
+
+    expect(response.data.user).toEqual([]);
+  });
 });

--- a/web/tests/integration/user.test.ts
+++ b/web/tests/integration/user.test.ts
@@ -1,11 +1,11 @@
+import { Role_Enum } from "@/graphql/graphql";
+import { gql } from "@apollo/client";
 import {
+  integrationDBExecuteQuery,
   integrationDBSetup,
   integrationDBTearDown,
-  integrationDBExecuteQuery,
 } from "./setup";
 import { getAPIUserClient } from "./test-utils";
-import { gql } from "@apollo/client";
-import { Role_Enum } from "@/graphql/graphql";
 
 // TODO: Consider moving this to a generalized jest environment
 beforeEach(integrationDBSetup);
@@ -84,5 +84,63 @@ describe("user role", () => {
         `SELECT name FROM "public"."user" WHERE id = '${anotherUserFromTeam0?.user_id}'`,
       )) as { rows: Array<{ name: string }> };
     expect(anotherUserFromTeam1AfterUpdate[0].name).not.toBe("new name");
+  });
+
+  test("can't select user from a team you are not a part of", async () => {
+    const { rows: teams } = (await integrationDBExecuteQuery(
+      `SELECT id, name FROM "public"."team"`,
+    )) as { rows: Array<{ id: string; name: string }> };
+
+    const { rows: teamMemberships } = (await integrationDBExecuteQuery(
+      `SELECT id, user_id, team_id, role FROM "public"."membership"`,
+    )) as {
+      rows: Array<{
+        id: string;
+        user_id: string;
+        team_id: string;
+        role: Role_Enum;
+      }>;
+    };
+
+    const query = gql`
+      query FetchUser($id: String!) {
+        user(where: { id: { _eq: $id } }) {
+          id
+          email
+          name
+          auth0Id
+          memberships {
+            id
+            team {
+              id
+              name
+            }
+            role
+          }
+        }
+      }
+    `;
+
+    const userFromTeam0 = teamMemberships.find(
+      (membership) => membership.team_id === teams[0].id,
+    );
+
+    const userFromTeam1 = teamMemberships.find(
+      (membership) => membership.team_id === teams[1].id,
+    );
+
+    const client = await getAPIUserClient({
+      team_id: teams[0].id,
+      user_id: userFromTeam0?.user_id,
+    });
+
+    const response = await client.query({
+      query,
+      variables: {
+        id: userFromTeam1?.user_id,
+      },
+    });
+
+    expect(response.data.user).toEqual([]);
   });
 });


### PR DESCRIPTION
Added a test case
https://linear.app/worldcoin/issue/WID-788/idor-vulnerability-allows-seeing-cross-team-user-information

Problem was that users could spoof team-id as it's just a header so we need to check user_id as well

- Fixed one other permission that was just not in line with the existing permissions