### PR TITLE
Fix image log issue

### DIFF
--- a/web-app-router/next-env.d.ts
+++ b/web-app-router/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/web-app-router/next-env.d.ts
+++ b/web-app-router/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -36,6 +36,9 @@ COPY . .
 # TODO: Leverage Next.JS standalone output to significantly reduce image size
 RUN pnpm build
 
+# Change ownership of the .next directory to nextjs user
+RUN chown -R nextjs:nodejs /app/.next
+
 USER nextjs
 
 EXPOSE 3000


### PR DESCRIPTION
Fix image cache permission issue in datadog
⨯ Failed to write image to cache Mh8l5UFbTGA5nKOeFglEcL-ZNiLbLdYtN8O9Q+MaD8k= [Error: EACCES: permission denied, mkdir '/app/.next/cache/images'] {

Right now we create the .next file after we change ownership which is causing permission issues since permissions are assigned to the creator of the file and in this case it's root.
