### PR TITLE
[Fix] fix for image caching

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -38,6 +38,9 @@ COPY . .
 # TODO: Leverage Next.JS standalone output to significantly reduce image size
 RUN pnpm build
 
+# Change ownership of the .next directory to nextjs user
+RUN chown -R nextjs:nodejs /app/.next
+
 USER nextjs
 
 EXPOSE 3000


### PR DESCRIPTION
Fix image cache permission issue in datadog
⨯ Failed to write image to cache Mh8l5UFbTGA5nKOeFglEcL-ZNiLbLdYtN8O9Q+MaD8k= [Error: EACCES: permission denied, mkdir '/app/.next/cache/images'] {

Right now we create the .next file after we change ownership which is causing permission issues since permissions are assigned to the creator of the file and in this case it's root.