### PR TITLE
[Feat] Account linking

### DIFF
--- a/hasura/metadata/databases/default/tables/public_user.yaml
+++ b/hasura/metadata/databases/default/tables/public_user.yaml
@@ -74,8 +74,10 @@ update_permissions:
   - role: user
     permission:
       columns:
-        - name
+        - email
         - is_allow_tracking
+        - name
+        - world_id_nullifier
       filter:
         id:
           _eq: X-Hasura-User-Id

--- a/web/.env.test
+++ b/web/.env.test
@@ -49,3 +49,6 @@ AUTH0_ISSUER_BASE_URL=
 
 # Precheck Test
 NEXT_PUBLIC_VERIFIED_IMAGES_CDN_URL="https://cdn.test.com"
+
+# Account linking
+NEXT_PUBLIC_AUTH_APP=app_

--- a/web/api/create-team/graphql/insert-membership.generated.ts
+++ b/web/api/create-team/graphql/insert-membership.generated.ts
@@ -20,6 +20,7 @@ export type InsertMembershipMutation = {
       __typename?: "user";
       id: string;
       email?: string | null;
+      world_id_nullifier?: string | null;
       name: string;
       auth0Id?: string | null;
       posthog_id?: string | null;
@@ -45,6 +46,7 @@ export const InsertMembershipDocument = gql`
       user {
         id
         email
+        world_id_nullifier
         name
         auth0Id
         posthog_id

--- a/web/api/create-team/graphql/insert-membership.graphql
+++ b/web/api/create-team/graphql/insert-membership.graphql
@@ -9,6 +9,7 @@ mutation InsertMembership(
     user {
       id
       email
+      world_id_nullifier
       name
       auth0Id
       posthog_id

--- a/web/api/login-callback/graphql/fetch-email-user.generated.ts
+++ b/web/api/login-callback/graphql/fetch-email-user.generated.ts
@@ -15,6 +15,7 @@ export type FetchEmailUserQuery = {
     __typename?: "user";
     id: string;
     email?: string | null;
+    world_id_nullifier?: string | null;
     name: string;
     auth0Id?: string | null;
     posthog_id?: string | null;
@@ -29,6 +30,7 @@ export type FetchEmailUserQuery = {
     __typename?: "user";
     id: string;
     email?: string | null;
+    world_id_nullifier?: string | null;
     name: string;
     auth0Id?: string | null;
     posthog_id?: string | null;
@@ -46,6 +48,7 @@ export const FetchEmailUserDocument = gql`
     userByAuth0Id: user(where: { auth0Id: { _eq: $auth0Id } }) {
       id
       email
+      world_id_nullifier
       name
       auth0Id
       posthog_id
@@ -62,6 +65,7 @@ export const FetchEmailUserDocument = gql`
     userByEmail: user(where: { email: { _eq: $email } }) {
       id
       email
+      world_id_nullifier
       name
       auth0Id
       posthog_id

--- a/web/api/login-callback/graphql/fetch-email-user.graphql
+++ b/web/api/login-callback/graphql/fetch-email-user.graphql
@@ -2,6 +2,7 @@ query FetchEmailUser($auth0Id: String, $email: String) {
   userByAuth0Id: user(where: { auth0Id: { _eq: $auth0Id } }) {
     id
     email
+    world_id_nullifier
     name
     auth0Id
     posthog_id
@@ -19,6 +20,7 @@ query FetchEmailUser($auth0Id: String, $email: String) {
   userByEmail: user(where: { email: { _eq: $email } }) {
     id
     email
+    world_id_nullifier
     name
     auth0Id
     posthog_id

--- a/web/api/login-callback/graphql/fetch-nullifier-user.generated.ts
+++ b/web/api/login-callback/graphql/fetch-nullifier-user.generated.ts
@@ -19,6 +19,7 @@ export type FetchNullifierUserQuery = {
     auth0Id?: string | null;
     posthog_id?: string | null;
     is_allow_tracking?: boolean | null;
+    world_id_nullifier?: string | null;
     memberships: Array<{
       __typename?: "membership";
       role: Types.Role_Enum;
@@ -43,6 +44,7 @@ export const FetchNullifierUserDocument = gql`
       auth0Id
       posthog_id
       is_allow_tracking
+      world_id_nullifier
       name
       memberships {
         team {

--- a/web/api/login-callback/graphql/fetch-nullifier-user.graphql
+++ b/web/api/login-callback/graphql/fetch-nullifier-user.graphql
@@ -13,6 +13,7 @@ query FetchNullifierUser($auth0Id: String!, $world_id_nullifier: String!) {
     auth0Id
     posthog_id
     is_allow_tracking
+    world_id_nullifier
     name
     memberships {
       team {

--- a/web/api/login-callback/link-accounts.ts
+++ b/web/api/login-callback/link-accounts.ts
@@ -1,0 +1,71 @@
+import { ManagementClient, PostIdentitiesRequestProviderEnum } from "auth0";
+
+/**
+ * Links two user accounts in Auth0 based on their email and Auth0 ID.
+ * @param params - The parameters for linking the accounts.
+ * @param params.email - The email of the user.
+ * @param params.auth0Id - The Auth0 ID of the user.
+ * @param params.nullifierHash - The nullifier hash of the user.
+ * @throws {Error} If any of the required Auth0 environment variables are missing.
+ * @throws {Error} If the number of users found is not equal to 2.
+ * @throws {Error} If the primary or secondary user is not found.
+ * @returns {Promise<void>} A promise that resolves when the accounts are linked.
+ */
+export const linkAccounts = async (params: {
+  email: string;
+  auth0Id: string;
+  nullifierHash: string;
+}) => {
+  if (
+    !process.env.AUTH0_CLIENT_ID ||
+    !process.env.AUTH0_CLIENT_SECRET ||
+    !process.env.AUTH0_DOMAIN
+  ) {
+    throw new Error(
+      "Missing Auth0 environment variables. Impossible to link accounts.",
+    );
+  }
+
+  const { email, auth0Id, nullifierHash } = params;
+
+  const managementClient = new ManagementClient({
+    clientId: process.env.AUTH0_CLIENT_ID,
+    clientSecret: process.env.AUTH0_CLIENT_SECRET,
+    domain: process.env.AUTH0_DOMAIN,
+  });
+
+  const users = await managementClient.users.getAll({
+    q: `email:"${email}" OR user_id:"oauth2|worldcoin|${nullifierHash}"`,
+    search_engine: "v3",
+  });
+
+  // NOTE: After a linking secondary account will be removed. So we will get only 1 user after linking and stop here.
+  if (users.data.length !== 2) {
+    throw new Error(
+      `Expected 2 users to link accounts, but found ${users.data.length}.`,
+    );
+  }
+
+  // NOTE: We are setting auth0Id first time when users signs up. This way we can consider this id as primary user.
+  const primaryUser = users.data.find((u) => {
+    u.user_id === auth0Id;
+  });
+
+  const secondaryUser = users.data.find((u) => {
+    u.user_id !== auth0Id;
+  });
+
+  if (!primaryUser || !secondaryUser) {
+    throw new Error("Primary or secondary user not found.");
+  }
+
+  await managementClient.users.link(
+    { id: primaryUser?.user_id },
+    {
+      user_id: secondaryUser?.user_id,
+      provider: secondaryUser?.identities[0]
+        .provider as PostIdentitiesRequestProviderEnum,
+      connection_id: secondaryUser?.identities[0].connection,
+    },
+  );
+};

--- a/web/components/CircleIconContainer/index.tsx
+++ b/web/components/CircleIconContainer/index.tsx
@@ -1,11 +1,13 @@
 import clsx from "clsx";
 import { ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
 
 type Variant = "error" | "info" | "success" | "muted";
 
 export type CircleIconContainerProps = {
   children: ReactNode;
   variant: Variant;
+  className?: string;
 };
 
 type ThemeItem = {
@@ -42,7 +44,7 @@ export const CircleIconContainer = (props: CircleIconContainerProps) => {
   };
 
   return (
-    <div className="relative size-[5.5rem]">
+    <div className={twMerge(clsx("relative size-[5.5rem]", props.className))}>
       <svg
         width="88"
         height="88"

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -128,3 +128,8 @@ export enum KioskScreen {
   VerificationError,
   InvalidRequest,
 }
+
+export enum Connection {
+  Email = "email",
+  Worldcoin = "worldcoin",
+}

--- a/web/scenes/Portal/Profile/page/AuthMethodDialog/EmailForm/graphql/client/add-email-to-user.generated.ts
+++ b/web/scenes/Portal/Profile/page/AuthMethodDialog/EmailForm/graphql/client/add-email-to-user.generated.ts
@@ -1,0 +1,72 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { gql } from "@apollo/client";
+import * as Apollo from "@apollo/client";
+const defaultOptions = {} as const;
+export type AddEmailToUserMutationVariables = Types.Exact<{
+  id: Types.Scalars["String"];
+  email: Types.Scalars["String"];
+}>;
+
+export type AddEmailToUserMutation = {
+  __typename?: "mutation_root";
+  update_user_by_pk?: {
+    __typename?: "user";
+    id: string;
+    email?: string | null;
+  } | null;
+};
+
+export const AddEmailToUserDocument = gql`
+  mutation AddEmailToUser($id: String!, $email: String!) {
+    update_user_by_pk(pk_columns: { id: $id }, _set: { email: $email }) {
+      id
+      email
+    }
+  }
+`;
+export type AddEmailToUserMutationFn = Apollo.MutationFunction<
+  AddEmailToUserMutation,
+  AddEmailToUserMutationVariables
+>;
+
+/**
+ * __useAddEmailToUserMutation__
+ *
+ * To run a mutation, you first call `useAddEmailToUserMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddEmailToUserMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addEmailToUserMutation, { data, loading, error }] = useAddEmailToUserMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      email: // value for 'email'
+ *   },
+ * });
+ */
+export function useAddEmailToUserMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    AddEmailToUserMutation,
+    AddEmailToUserMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    AddEmailToUserMutation,
+    AddEmailToUserMutationVariables
+  >(AddEmailToUserDocument, options);
+}
+export type AddEmailToUserMutationHookResult = ReturnType<
+  typeof useAddEmailToUserMutation
+>;
+export type AddEmailToUserMutationResult =
+  Apollo.MutationResult<AddEmailToUserMutation>;
+export type AddEmailToUserMutationOptions = Apollo.BaseMutationOptions<
+  AddEmailToUserMutation,
+  AddEmailToUserMutationVariables
+>;

--- a/web/scenes/Portal/Profile/page/AuthMethodDialog/EmailForm/graphql/client/add-email-to-user.gql
+++ b/web/scenes/Portal/Profile/page/AuthMethodDialog/EmailForm/graphql/client/add-email-to-user.gql
@@ -1,0 +1,6 @@
+mutation AddEmailToUser($id: String!, $email: String!) {
+  update_user_by_pk(pk_columns: { id: $id }, _set: { email: $email }) {
+    id
+    email
+  }
+}

--- a/web/scenes/Portal/Profile/page/AuthMethodDialog/EmailForm/index.tsx
+++ b/web/scenes/Portal/Profile/page/AuthMethodDialog/EmailForm/index.tsx
@@ -1,0 +1,156 @@
+import { CircleIconContainer } from "@/components/CircleIconContainer";
+import { DecoratedButton } from "@/components/DecoratedButton";
+import { UserAddIcon } from "@/components/Icons/UserAddIcon";
+import { Input } from "@/components/Input";
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { useMeQuery } from "@/scenes/common/me-query/client";
+import { FetchMeDocument } from "@/scenes/common/me-query/client/graphql/client/me-query.generated";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useAtom } from "jotai";
+import { useCallback, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "react-toastify";
+import * as yup from "yup";
+import { authMethodDialogAtom } from "..";
+import { useAddEmailToUserMutation } from "./graphql/client/add-email-to-user.generated";
+import { sendVerificationEmail } from "./send-verification-email";
+import { verifyEmailWithOTP } from "./verify-email-with-otp";
+
+const emailSchema = yup.object({
+  email: yup.string().email().required(),
+});
+
+const otpSchema = yup.object({
+  otp: yup.string().required(),
+});
+
+export type EmailFormValues = yup.InferType<typeof emailSchema>;
+export type OTPFormValues = yup.InferType<typeof otpSchema>;
+
+export const EmailForm = () => {
+  const [emailSent, setEmailSent] = useState(false);
+  const [, setIsOpened] = useAtom(authMethodDialogAtom);
+  const { user } = useMeQuery();
+
+  const [addEmail] = useAddEmailToUserMutation({
+    refetchQueries: [FetchMeDocument],
+  });
+
+  const {
+    handleSubmit: handleEmailSubmit,
+    register: emailRegister,
+    formState: {
+      errors: emailErrors,
+      isSubmitting: isEmailSubmitting,
+      isDirty: isEmailDirty,
+    },
+    getValues: getEmailFormValues,
+  } = useForm<EmailFormValues>({
+    resolver: yupResolver(emailSchema),
+    mode: "onChange",
+  });
+
+  const {
+    handleSubmit: handleOtpSubmit,
+    register: otpRegister,
+    formState: {
+      errors: otpErrors,
+      isSubmitting: isOtpSubmitting,
+      isDirty: isOtpDirty,
+    },
+  } = useForm<OTPFormValues>({
+    resolver: yupResolver(otpSchema),
+    mode: "onChange",
+  });
+
+  const sendEmail = useCallback(async (values: EmailFormValues) => {
+    try {
+      await sendVerificationEmail({ email: values.email });
+    } catch (error) {
+      return toast.error("Error while sending email");
+    }
+
+    toast.success("Email sent!");
+    setEmailSent(true);
+  }, []);
+
+  const verifyOtp = useCallback(
+    async (values: OTPFormValues) => {
+      if (!user.id) {
+        return;
+      }
+
+      const email = getEmailFormValues().email;
+      try {
+        await verifyEmailWithOTP({ email: email, otp: values.otp });
+        await addEmail({ variables: { id: user.id, email } });
+      } catch (error) {
+        toast.error("Error while verifying OTP");
+      }
+
+      setIsOpened(false);
+      toast.success("Email verified successfully");
+    },
+    [addEmail, getEmailFormValues, setIsOpened, user.id],
+  );
+
+  return (
+    <div className="grid w-full gap-y-8">
+      <CircleIconContainer variant="info" className="justify-self-center">
+        <UserAddIcon />
+      </CircleIconContainer>
+
+      <div className="grid gap-y-4">
+        <Typography variant={TYPOGRAPHY.H6} className="justify-self-center">
+          Connect email
+        </Typography>
+
+        {!emailSent && (
+          <form
+            className="grid w-full gap-y-4"
+            onSubmit={handleEmailSubmit(sendEmail)}
+          >
+            <Input
+              register={emailRegister("email")}
+              type="email"
+              label="Email"
+              errors={emailErrors.email}
+            />
+            <DecoratedButton
+              type="submit"
+              disabled={
+                isEmailSubmitting || Boolean(emailErrors.email) || !isEmailDirty
+              }
+              className="mt-2 py-3"
+            >
+              Send email
+            </DecoratedButton>
+          </form>
+        )}
+
+        {emailSent && (
+          <form
+            className="grid w-full gap-y-4"
+            onSubmit={handleOtpSubmit(verifyOtp)}
+          >
+            <Input
+              register={otpRegister("otp")}
+              errors={otpErrors.otp}
+              type="text"
+              label="OTP"
+            />
+            <DecoratedButton
+              type="submit"
+              disabled={
+                isOtpSubmitting || Boolean(otpErrors.otp) || !isOtpDirty
+              }
+              className="mt-2 py-3"
+            >
+              Verify
+            </DecoratedButton>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/web/scenes/Portal/Profile/page/AuthMethodDialog/EmailForm/send-verification-email.ts
+++ b/web/scenes/Portal/Profile/page/AuthMethodDialog/EmailForm/send-verification-email.ts
@@ -1,0 +1,44 @@
+"use server";
+
+import { logger } from "@/lib/logger";
+import { ManagementClient, Passwordless } from "auth0";
+
+export const sendVerificationEmail = async (params: { email: string }) => {
+  if (
+    !process.env.AUTH0_CLIENT_ID ||
+    !process.env.AUTH0_CLIENT_SECRET ||
+    !process.env.AUTH0_DOMAIN
+  ) {
+    logger.error(
+      "Missing Auth0 environment variables. Impossible to send verification email.",
+    );
+
+    throw new Error("Missing Auth0 environment variables.");
+  }
+
+  const { email } = params;
+
+  const managementClient = new ManagementClient({
+    clientId: process.env.AUTH0_CLIENT_ID,
+    clientSecret: process.env.AUTH0_CLIENT_SECRET,
+    domain: process.env.AUTH0_DOMAIN,
+  });
+
+  const passwordless = new Passwordless({
+    clientId: process.env.AUTH0_CLIENT_ID,
+    clientSecret: process.env.AUTH0_CLIENT_SECRET,
+    domain: process.env.AUTH0_DOMAIN,
+  });
+
+  try {
+    const res = await passwordless.sendEmail({
+      email,
+      send: "code",
+    });
+  } catch (error) {
+    logger.error("Failed to send verification email", { error });
+    throw new Error("Failed to send verification email");
+  }
+
+  return { success: true };
+};

--- a/web/scenes/Portal/Profile/page/AuthMethodDialog/EmailForm/verify-email-with-otp.ts
+++ b/web/scenes/Portal/Profile/page/AuthMethodDialog/EmailForm/verify-email-with-otp.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { logger } from "@/lib/logger";
+import { Passwordless } from "auth0";
+
+export const verifyEmailWithOTP = async (params: {
+  email: string;
+  otp: string;
+}) => {
+  if (
+    !process.env.AUTH0_CLIENT_ID ||
+    !process.env.AUTH0_CLIENT_SECRET ||
+    !process.env.AUTH0_DOMAIN
+  ) {
+    logger.error(
+      "Missing Auth0 environment variables. Impossible to send verification email.",
+    );
+
+    throw new Error("Missing Auth0 environment variables.");
+  }
+
+  const { email, otp } = params;
+
+  const passwordless = new Passwordless({
+    clientId: process.env.AUTH0_CLIENT_ID,
+    clientSecret: process.env.AUTH0_CLIENT_SECRET,
+    domain: process.env.AUTH0_DOMAIN,
+  });
+
+  try {
+    await passwordless.loginWithEmail({
+      code: otp,
+      email: email,
+    });
+  } catch (error) {
+    logger.error("Failed to verify email with OTP", { error });
+    throw new Error("Failed to verify email with OTP");
+  }
+
+  return { success: true };
+};

--- a/web/scenes/Portal/Profile/page/AuthMethodDialog/SignInWithWorldcoin/graphql/client/add-nullifier-to-user.generated.ts
+++ b/web/scenes/Portal/Profile/page/AuthMethodDialog/SignInWithWorldcoin/graphql/client/add-nullifier-to-user.generated.ts
@@ -1,0 +1,75 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { gql } from "@apollo/client";
+import * as Apollo from "@apollo/client";
+const defaultOptions = {} as const;
+export type AddNullifierToUserMutationVariables = Types.Exact<{
+  id: Types.Scalars["String"];
+  nullifier_hash: Types.Scalars["String"];
+}>;
+
+export type AddNullifierToUserMutation = {
+  __typename?: "mutation_root";
+  update_user_by_pk?: {
+    __typename?: "user";
+    id: string;
+    world_id_nullifier?: string | null;
+  } | null;
+};
+
+export const AddNullifierToUserDocument = gql`
+  mutation AddNullifierToUser($id: String!, $nullifier_hash: String!) {
+    update_user_by_pk(
+      pk_columns: { id: $id }
+      _set: { world_id_nullifier: $nullifier_hash }
+    ) {
+      id
+      world_id_nullifier
+    }
+  }
+`;
+export type AddNullifierToUserMutationFn = Apollo.MutationFunction<
+  AddNullifierToUserMutation,
+  AddNullifierToUserMutationVariables
+>;
+
+/**
+ * __useAddNullifierToUserMutation__
+ *
+ * To run a mutation, you first call `useAddNullifierToUserMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddNullifierToUserMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addNullifierToUserMutation, { data, loading, error }] = useAddNullifierToUserMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      nullifier_hash: // value for 'nullifier_hash'
+ *   },
+ * });
+ */
+export function useAddNullifierToUserMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    AddNullifierToUserMutation,
+    AddNullifierToUserMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    AddNullifierToUserMutation,
+    AddNullifierToUserMutationVariables
+  >(AddNullifierToUserDocument, options);
+}
+export type AddNullifierToUserMutationHookResult = ReturnType<
+  typeof useAddNullifierToUserMutation
+>;
+export type AddNullifierToUserMutationResult =
+  Apollo.MutationResult<AddNullifierToUserMutation>;
+export type AddNullifierToUserMutationOptions = Apollo.BaseMutationOptions<
+  AddNullifierToUserMutation,
+  AddNullifierToUserMutationVariables
+>;

--- a/web/scenes/Portal/Profile/page/AuthMethodDialog/SignInWithWorldcoin/graphql/client/add-nullifier-to-user.gql
+++ b/web/scenes/Portal/Profile/page/AuthMethodDialog/SignInWithWorldcoin/graphql/client/add-nullifier-to-user.gql
@@ -1,0 +1,9 @@
+mutation AddNullifierToUser($id: String!, $nullifier_hash: String!) {
+  update_user_by_pk(
+    pk_columns: { id: $id }
+    _set: { world_id_nullifier: $nullifier_hash }
+  ) {
+    id
+    world_id_nullifier
+  }
+}

--- a/web/scenes/Portal/Profile/page/AuthMethodDialog/SignInWithWorldcoin/index.tsx
+++ b/web/scenes/Portal/Profile/page/AuthMethodDialog/SignInWithWorldcoin/index.tsx
@@ -1,0 +1,190 @@
+import { restAPIRequest } from "@/lib/frontend-api";
+import { Auth0SessionUser, KioskScreen } from "@/lib/types";
+import { Connected } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Components/Kiosk/Connected";
+import { IDKitBridge } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Components/Kiosk/IDKitBridge";
+import { KioskError } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Components/Kiosk/KioskError";
+import { Success } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Components/Kiosk/Success";
+import { Waiting } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Components/Kiosk/Waiting";
+import { useMeQuery } from "@/scenes/common/me-query/client";
+import { FetchMeDocument } from "@/scenes/common/me-query/client/graphql/client/me-query.generated";
+import { useUser } from "@auth0/nextjs-auth0/client";
+import {
+  ISuccessResult,
+  VerificationLevel,
+  useWorldBridgeStore,
+} from "@worldcoin/idkit-core";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { useAddNullifierToUserMutation } from "./graphql/client/add-nullifier-to-user.generated";
+
+type ProofResponse = {
+  success: boolean;
+  action_id?: string;
+  nullifier_hash?: string;
+  created_at?: string;
+  code?: string;
+  detail?: string;
+  attribute?: string;
+};
+
+export const SignInWithWorldcoin = () => {
+  const [screen, setScreen] = useState<KioskScreen>(KioskScreen.Waiting);
+  const [qrData, setQrData] = useState<string | null>(null);
+  const [proofResult, setProofResult] = useState<ISuccessResult | null>(null);
+  const [connectionTimeout, setConnectionTimeout] = useState<boolean>(true);
+
+  const { reset } = useWorldBridgeStore();
+  const { user: auth0User } = useUser() as Auth0SessionUser;
+  const { user } = useMeQuery();
+
+  const resetFlow = useCallback(() => {
+    setScreen(KioskScreen.Waiting);
+    reset();
+    setQrData(null);
+    setProofResult(null);
+    setConnectionTimeout(true);
+  }, [reset]);
+
+  // Reset kiosk if the action changes
+  useEffect(() => {
+    resetFlow();
+  }, [resetFlow]);
+
+  const [addNullifier] = useAddNullifierToUserMutation({
+    refetchQueries: [FetchMeDocument],
+  });
+
+  const verifyProof = useCallback(
+    async (result: ISuccessResult) => {
+      let response;
+      setConnectionTimeout(false);
+      try {
+        response = await restAPIRequest<ProofResponse>(
+          `/verify/${process.env.NEXT_PUBLIC_AUTH_APP}`,
+          {
+            method: "POST",
+            json: { action: "", signal: "", ...result },
+          },
+        );
+      } catch (e) {
+        console.warn("Error verifying proof. Please check network logs.");
+        try {
+          if ((e as Record<string, any>).code) {
+            response = {
+              success: false,
+              code: (e as Record<string, any>).code,
+            };
+          }
+        } catch {
+          response = { success: false, code: "unknown" };
+        }
+      }
+
+      if (response?.success) {
+        setScreen(KioskScreen.Success);
+
+        if (!user.id || !response.nullifier_hash || !auth0User?.sub) {
+          throw new Error("user id or nullifier hash is missing");
+        }
+
+        try {
+          await addNullifier({
+            variables: {
+              id: user.id,
+              nullifier_hash: response.nullifier_hash,
+            },
+          });
+        } catch (error) {
+          console.error("error adding nullifier", error);
+          toast.error("Error adding sign in with worldcoin auth method");
+        }
+      } else {
+        if (response?.code === "max_verifications_reached") {
+          setScreen(KioskScreen.AlreadyVerified);
+        } else if (response?.code === "invalid_merkle_root") {
+          setScreen(KioskScreen.InvalidIdentity);
+        } else {
+          setScreen(KioskScreen.VerificationError);
+        }
+      }
+    },
+    [addNullifier, auth0User?.sub, user.id],
+  );
+
+  useEffect(() => {
+    if (proofResult) {
+      verifyProof(proofResult);
+      setProofResult(null);
+    }
+  }, [proofResult, verifyProof]);
+
+  return (
+    <div>
+      <IDKitBridge
+        app_id={
+          (process.env.NEXT_PUBLIC_AUTH_APP as `app_${string}`) || "app_123"
+        }
+        action={""}
+        action_description={"Add a new authentication method to your account."}
+        verificationLevel={VerificationLevel.Device}
+        setScreen={setScreen}
+        setQrData={setQrData}
+        setProofResult={setProofResult}
+        resetKiosk={resetFlow}
+        connectionTimeout={connectionTimeout}
+      />
+
+      {screen === KioskScreen.Waiting && (
+        <Waiting qrData={qrData} showSimulator={false} qrCodeSize={180} />
+      )}
+
+      {screen === KioskScreen.Connected && <Connected reset={resetFlow} />}
+      {screen === KioskScreen.Success && <Success reset={resetFlow} />}
+
+      {screen === KioskScreen.ConnectionError && (
+        <KioskError
+          title="Connection Error"
+          description="We cannot establish a connection to the person's World App. Please refresh and try again."
+          buttonText="Retry"
+          reset={resetFlow}
+        />
+      )}
+
+      {screen === KioskScreen.AlreadyVerified && (
+        <KioskError
+          title="Already Verified"
+          description="This person has already verified for this action."
+          buttonText="New verification"
+          reset={resetFlow}
+        />
+      )}
+
+      {screen === KioskScreen.VerificationRejected && (
+        <KioskError
+          title="Verification Rejected"
+          description="Person rejected the verification in the World App."
+          buttonText="Try again"
+          reset={resetFlow}
+        />
+      )}
+
+      {screen === KioskScreen.InvalidIdentity && (
+        <KioskError
+          title="Not verified"
+          description="User has not been verified by an orb. Please try again after verifying."
+          buttonText="New verification"
+          reset={resetFlow}
+        />
+      )}
+
+      {screen === KioskScreen.VerificationError && (
+        <KioskError
+          title="Verification Error"
+          description="We couldn't verify this person. Please try again."
+          buttonText="Retry"
+          reset={resetFlow}
+        />
+      )}
+    </div>
+  );
+};

--- a/web/scenes/Portal/Profile/page/AuthMethodDialog/index.tsx
+++ b/web/scenes/Portal/Profile/page/AuthMethodDialog/index.tsx
@@ -1,0 +1,24 @@
+import { Dialog } from "@/components/Dialog";
+import { DialogOverlay } from "@/components/DialogOverlay";
+import { DialogPanel } from "@/components/DialogPanel";
+import { Connection } from "@/lib/types";
+import { atom, useAtom } from "jotai";
+import { EmailForm } from "./EmailForm";
+import { SignInWithWorldcoin } from "./SignInWithWorldcoin";
+
+export const authMethodDialogAtom = atom(false);
+
+export const AuthMethodDialog = (props: { variant: Connection }) => {
+  const [isOpened, setIsOpened] = useAtom(authMethodDialogAtom);
+
+  return (
+    <Dialog open={isOpened} onClose={() => setIsOpened(false)}>
+      <DialogOverlay />
+
+      <DialogPanel>
+        {props.variant === Connection.Worldcoin && <SignInWithWorldcoin />}
+        {props.variant === Connection.Email && <EmailForm />}
+      </DialogPanel>
+    </Dialog>
+  );
+};


### PR DESCRIPTION
This PR: 
- Adds forms for adding additional auth methods (Sign in with worldcoin / Email) directly from the logged in user UI. 

Logic: 
Once the user logs in with the one of auth methods, there will be an option on `/profile` page to add alternative method. Adding a method simply adds `email`/`world_id_nullifier` to the user's row in a Hasura user table.

On the next login (in `/login-callback)` we will check if the Hasura user has both `email` and `world_id_nullifier` we will try to fetch users from the `auth0` database using auth0 management API. And in case we have found two accounts (1: `email|<id>`, 2:`oauth2|worldcoin|<hash>`) we can link them using the `auth0Id` field from the Hasura `user` table to define the primary account. After linking accounts primary auth0 account will stay, and the second one will be removed from the users list and added as identity to the primary account.

NOTE: 
- This PR is not fully solves the issue, but it will be still an improvement, as I can see it. 
  - To make this work we will need to add some additional flow that will inform the user that it's worth connecting both auth methods, I think.
  - Also not fully clear what we should do in case if some of users actively using both auth method with different accounts right now.


- ‼️ Not fully tested
  - I didn't succeed in making sign in with worldcoin method working locally. 
    - It fails [here](https://github.com/worldcoin/developer-portal/blob/3f928f0513cd87a3357eb9aaa4b5de2a344d00ab/web/legacy/backend/kms.ts#L92-L97). I've decided not to spend much time on it and finish PR first.

---

<details>
<summary>Adding sign in with worldcoin</summary>

https://github.com/worldcoin/developer-portal/assets/89008845/83a47013-85c2-4d80-9bd5-3c76276a835e
</details>

<details>
<summary>Adding Email</summary>


https://github.com/worldcoin/developer-portal/assets/89008845/750f5b5d-ef83-4c56-a393-631d93f7885e


</details>