### PR TITLE
fix: team members can edit tos and privacy policy urls

### DIFF
--- a/hasura/metadata/databases/default/tables/public_action.yaml
+++ b/hasura/metadata/databases/default/tables/public_action.yaml
@@ -173,11 +173,29 @@ update_permissions:
         - status
         - terms_uri
       filter:
-        app:
-          team:
-            memberships:
-              user_id:
-                _eq: X-Hasura-User-Id
+        _or:
+          - _and:
+              - action:
+                  _neq: ""
+              - app:
+                  team:
+                    memberships:
+                      user_id:
+                        _eq: X-Hasura-User-Id
+          - _and:
+              - action:
+                  _eq: ""
+              - app:
+                  team:
+                    memberships:
+                      _and:
+                        - user_id:
+                            _eq: X-Hasura-User-Id
+                        - _or:
+                            - role:
+                                _eq: OWNER
+                            - role:
+                                _eq: ADMIN
       check: null
 delete_permissions:
   - role: api_key

--- a/web/tests/integration/action.test.ts
+++ b/web/tests/integration/action.test.ts
@@ -136,7 +136,7 @@ describe("user role", () => {
     expect(response.data.update_action_by_pk.id).toEqual(actionId);
   });
 
-  test("member can't update sign in with worldcoin action", async () => {
+  test("member can't update sign in with World ID privacy policy", async () => {
     const serviceClient = await getAPIServiceClient();
 
     const query = gql(`query GetUserId {

--- a/web/tests/integration/action.test.ts
+++ b/web/tests/integration/action.test.ts
@@ -115,16 +115,18 @@ describe("user role", () => {
       user_id: ownerUserId,
     });
 
-    const mutation = gql`
+    const url = "http://example.com";
+
+    const mutation = gql(`
       mutation UpdateAction($id: String!) {
         update_action_by_pk(
           pk_columns: { id: $id }
-          _set: { privacy_policy_uri: "http://example.com" }
+          _set: { privacy_policy_uri: "${url}" }
         ) {
-          id
+          privacy_policy_uri
         }
       }
-    `;
+    `);
 
     const response = await client.mutate({
       mutation,
@@ -133,7 +135,7 @@ describe("user role", () => {
       },
     });
 
-    expect(response.data.update_action_by_pk.id).toEqual(actionId);
+    expect(response.data.update_action_by_pk.privacy_policy_uri).toEqual(url);
   });
 
   test("member can't update sign in with World ID privacy policy", async () => {

--- a/web/tests/integration/action.test.ts
+++ b/web/tests/integration/action.test.ts
@@ -69,7 +69,7 @@ describe("service role", () => {
 });
 
 describe("user role", () => {
-  test("owner can update sign in with worldcoin action", async () => {
+  test("Owner can update sign in with World ID", async () => {
     const serviceClient = await getAPIServiceClient();
 
     const query = gql(`query GetUserId {


### PR DESCRIPTION
Closes [WID-706](https://linear.app/worldcoin/issue/WID-706/team-members-can-edit-tos-and-privacy-policy-urls)

- Changes update permissions for user role on `action` table
- Adds tests

---


https://github.com/worldcoin/developer-portal/assets/89008845/736283e9-a230-46bc-93b9-85ef984dc3b3

