### PR TITLE
chore: update errors from sequencer

### DIFF
--- a/web/legacy/backend/verify.ts
+++ b/web/legacy/backend/verify.ts
@@ -8,8 +8,10 @@ import { VerificationLevel } from "@worldcoin/idkit-core";
 import { hashToField } from "@worldcoin/idkit-core/hashing";
 import { validateABILikeEncoding } from "@/legacy/lib/hashing";
 
-// rawMessage is error from the sequencer: https://github.com/worldcoin/signup-sequencer/blob/main/src/server/error.rs
 const KNOWN_ERROR_CODES = [
+  // rawMessage: error text from sequencer. reference https://github.com/worldcoin/signup-sequencer/blob/main/src/server/error.rs
+  // code: error code to return to the client
+  // detail: error message to return to the client
   {
     rawMessage: "invalid root",
     code: "invalid_merkle_root",

--- a/web/legacy/backend/verify.ts
+++ b/web/legacy/backend/verify.ts
@@ -8,18 +8,16 @@ import { VerificationLevel } from "@worldcoin/idkit-core";
 import { hashToField } from "@worldcoin/idkit-core/hashing";
 import { validateABILikeEncoding } from "@/legacy/lib/hashing";
 
-// TODO: Pull router updated error codes from the ABI of the contract
+// rawMessage is error from the sequencer: https://github.com/worldcoin/signup-sequencer/blob/main/src/server/error.rs
 const KNOWN_ERROR_CODES = [
   {
-    rawCode: "0x504570e3",
     rawMessage: "invalid root",
     code: "invalid_merkle_root",
     detail:
       "The provided Merkle root is invalid. User appears to be unverified.",
   },
   {
-    rawCode: "0x09bde339",
-    rawMessage: "invalid proof",
+    rawMessage: "invalid semaphore proof",
     code: "invalid_proof",
     detail:
       "The provided proof is invalid and it cannot be verified. Please check all inputs and try again.",
@@ -29,6 +27,12 @@ const KNOWN_ERROR_CODES = [
     code: "root_too_old",
     detail:
       "The provided merkle root is too old. Please generate a new proof and try again.",
+  },
+  {
+    rawMessage: "prover error",
+    code: "prover_error",
+    detail:
+      "The prover encountered an error while verifying the proof. Please try again.",
   },
 ];
 

--- a/web/tests/api/verify.test.ts
+++ b/web/tests/api/verify.test.ts
@@ -278,7 +278,7 @@ describe("/api/verify [error cases]", () => {
     });
 
     // mocks sequencer response
-    fetchMock.mockResponseOnce("invalid proof", {
+    fetchMock.mockResponseOnce("invalid semaphore proof", {
       status: 500,
     });
 


### PR DESCRIPTION
Updates `KNOWN_ERROR_CODES` to align with possible error codes from signup sequencer's `/verifySemaphoreProof` endpoint. Adds link to relevant error definitions.

Removes `rawCode` as it's unused.