### PR TITLE
Fix owner delete

### DIFF
--- a/hasura/metadata/databases/default/tables/public_membership.yaml
+++ b/hasura/metadata/databases/default/tables/public_membership.yaml
@@ -68,12 +68,28 @@ delete_permissions:
     permission:
       filter:
         _or:
-          - user_id:
-              _eq: X-Hasura-User-Id
-          - team:
-              memberships:
-                _and:
-                  - user_id:
-                      _eq: X-Hasura-User-Id
-                  - role:
-                      _eq: OWNER
+          - _and:
+              - user_id:
+                  _eq: X-Hasura-User-Id
+              - role:
+                  _neq: OWNER
+          - _and:
+              - user_id:
+                  _eq: X-Hasura-User-Id
+              - role:
+                  _eq: OWNER
+              - team:
+                  team_owners_count:
+                    _gt: "1"
+          - _and:
+              - team:
+                  memberships:
+                    _and:
+                      - user_id:
+                          _eq: X-Hasura-User-Id
+                      - role:
+                          _eq: OWNER
+              - user_id:
+                  _neq: X-Hasura-User-Id
+              - role:
+                  _neq: OWNER

--- a/hasura/metadata/databases/default/tables/public_team.yaml
+++ b/hasura/metadata/databases/default/tables/public_team.yaml
@@ -23,6 +23,13 @@ array_relationships:
         table:
           name: membership
           schema: public
+computed_fields:
+  - name: team_owners_count
+    definition:
+      function:
+        name: get_team_owners_count
+        schema: public
+    comment: A computed field that returns a quantity of team owners
 insert_permissions:
   - role: service
     permission:

--- a/hasura/migrations/default/1712070347860_create_get_team_owners_count_func/down.sql
+++ b/hasura/migrations/default/1712070347860_create_get_team_owners_count_func/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION get_team_owners_count(team_row team);

--- a/hasura/migrations/default/1712070347860_create_get_team_owners_count_func/up.sql
+++ b/hasura/migrations/default/1712070347860_create_get_team_owners_count_func/up.sql
@@ -1,0 +1,6 @@
+CREATE FUNCTION get_team_owners_count(team_row team)
+RETURNS integer AS $$
+    SELECT COUNT(*)
+    FROM "public"."membership"
+    WHERE team_id = team_row.id AND role = 'OWNER'
+$$ LANGUAGE sql STABLE;

--- a/web/tests/integration/membership.test.ts
+++ b/web/tests/integration/membership.test.ts
@@ -1,0 +1,144 @@
+import { gql } from "@apollo/client";
+
+import { integrationDBClean, integrationDBExecuteQuery } from "./setup";
+
+import { getAPIUserClient } from "./test-utils";
+// TODO: Consider moving this to a generalized jest environment
+beforeEach(integrationDBClean);
+
+describe("user role", () => {
+  test("owner users can't delete their own membership when there is only one owner in the team", async () => {
+    const { rows: ownerMemberships } = (await integrationDBExecuteQuery(
+      `SELECT id, user_id FROM "public"."membership" WHERE role = 'OWNER'`,
+    )) as { rows: Array<{ id: string; user_id: string }> };
+
+    const ownerMembership = ownerMemberships[0];
+
+    const client = await getAPIUserClient({
+      user_id: ownerMembership.user_id,
+    });
+
+    const mutation = gql`
+      mutation DeleteMembership($id: String!) {
+        delete_membership_by_pk(id: $id) {
+          id
+        }
+      }
+    `;
+
+    const response = await client.mutate({
+      mutation,
+      variables: {
+        id: ownerMembership.id,
+      },
+    });
+
+    expect(response.data.delete_membership_by_pk).toBeNull();
+  });
+
+  test("owner users can delete their own membership when there is more than one owner in the team", async () => {
+    const { rows: ownerMemberships } = (await integrationDBExecuteQuery(
+      `SELECT id, user_id, team_id FROM "public"."membership" WHERE role = 'OWNER'`,
+    )) as { rows: Array<{ id: string; user_id: string; team_id: string }> };
+
+    const firstOwnerMember = ownerMemberships[0];
+
+    const { rows: membersFromAnotherTeam } = (await integrationDBExecuteQuery(
+      `SELECT id, user_id, team_id FROM "public"."membership" WHERE role = 'MEMBER' AND team_id != '${firstOwnerMember.team_id}'`,
+    )) as { rows: Array<{ id: string; user_id: string; team_id: string }> };
+
+    const secondOwnerMember = membersFromAnotherTeam[0];
+
+    const { rows: insertedSecondOwnerMembership } =
+      (await integrationDBExecuteQuery(
+        `INSERT INTO "public"."membership" (user_id, team_id, role) VALUES ('${secondOwnerMember.user_id}', '${secondOwnerMember.team_id}', 'OWNER') RETURNING id, user_id, team_id`,
+      )) as { rows: Array<{ id: string; user_id: string; team_id: string }> };
+
+    const insertedOwner = insertedSecondOwnerMembership[0];
+
+    const client = await getAPIUserClient({
+      user_id: insertedOwner.user_id,
+    });
+
+    const mutation = gql`
+      mutation DeleteMembership($id: String!) {
+        delete_membership_by_pk(id: $id) {
+          id
+        }
+      }
+    `;
+
+    const response = await client.mutate({
+      mutation,
+      variables: {
+        id: insertedOwner.id,
+      },
+    });
+
+    expect(response.data.delete_membership_by_pk.id).toBe(insertedOwner.id);
+  });
+
+  test("member can leave the team", async () => {
+    const { rows: memberMemberships } = (await integrationDBExecuteQuery(
+      `SELECT id, user_id FROM "public"."membership" WHERE role = 'MEMBER'`,
+    )) as { rows: Array<{ id: string; user_id: string }> };
+
+    const memberMembership = memberMemberships[0];
+
+    const client = await getAPIUserClient({
+      user_id: memberMembership.user_id,
+    });
+
+    const mutation = gql`
+      mutation DeleteMembership($id: String!) {
+        delete_membership_by_pk(id: $id) {
+          id
+        }
+      }
+    `;
+
+    const response = await client.mutate({
+      mutation,
+      variables: {
+        id: memberMembership.id,
+      },
+    });
+
+    expect(response.data.delete_membership_by_pk.id).toBe(memberMembership.id);
+  });
+
+  test("owner can remove a member from the team", async () => {
+    const { rows: ownerMemberships } = (await integrationDBExecuteQuery(
+      `SELECT id, user_id, team_id FROM "public"."membership" WHERE role = 'OWNER'`,
+    )) as { rows: Array<{ id: string; user_id: string; team_id: string }> };
+
+    const ownerMembership = ownerMemberships[0];
+
+    const { rows: memberMemberships } = (await integrationDBExecuteQuery(
+      `SELECT id, user_id FROM "public"."membership" WHERE role = 'MEMBER' AND team_id = '${ownerMembership.team_id}'`,
+    )) as { rows: Array<{ id: string; user_id: string }> };
+
+    const memberMembership = memberMemberships[0];
+
+    const client = await getAPIUserClient({
+      user_id: ownerMembership.user_id,
+    });
+
+    const mutation = gql`
+      mutation DeleteMembership($id: String!) {
+        delete_membership_by_pk(id: $id) {
+          id
+        }
+      }
+    `;
+
+    const response = await client.mutate({
+      mutation,
+      variables: {
+        id: memberMembership.id,
+      },
+    });
+
+    expect(response.data.delete_membership_by_pk.id).toBe(memberMembership.id);
+  });
+});


### PR DESCRIPTION
Closes [WID-836](https://linear.app/worldcoin/issue/WID-836/idor-devportal-team-owners-can-delete-themselves-off-of-their-own-team)

This PR:
- Adds a `team_owners_count` computed field to the team table that counts a number of owners in the team. 
- Adds a restriction for the owner users to remove themselves from the team in case they are the only owner in the team. 
- Adds test for membership table