### PR TITLE
[Fix] remove image resize

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,6 @@
     "react-dom": "^18",
     "react-dropzone": "^14.2.3",
     "react-hook-form": "^7.49.3",
-    "react-image-file-resizer": "^0.4.8",
     "react-loading-skeleton": "^3.4.0",
     "react-qr-code": "^2.0.12",
     "react-syntax-highlighter": "^15.5.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@apollo/client':
     specifier: 3.9.0-rc.1
@@ -124,9 +128,6 @@ dependencies:
   react-hook-form:
     specifier: ^7.49.3
     version: 7.50.1(react@18.2.0)
-  react-image-file-resizer:
-    specifier: ^0.4.8
-    version: 0.4.8
   react-loading-skeleton:
     specifier: ^3.4.0
     version: 3.4.0(react@18.2.0)
@@ -9949,10 +9950,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /react-image-file-resizer@0.4.8:
-    resolution: {integrity: sha512-Ue7CfKnSlsfJ//SKzxNMz8avDgDSpWQDOnTKOp/GNRFJv4dO9L5YGHNEnj40peWkXXAK2OK0eRIoXhOYpUzUTQ==}
-    dev: false
-
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -11650,7 +11647,3 @@ packages:
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/index.tsx
@@ -426,7 +426,7 @@ export const ImageForm = (props: ImageFormTypes) => {
               </Typography>
             </div>
             <Typography variant={TYPOGRAPHY.R5} className="text-grey-500">
-              {`JPG or PNG (max 250kb), required aspect ratio 16:9. Recommended size: ${1920}x${1080}px`}{" "}
+              {`JPG or PNG (max 250kb), required aspect ratio 16:9. Recommended size: ${1920}x${1080}px`}
             </Typography>
           </div>
         </ImageDropZone>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/index.tsx
@@ -198,6 +198,7 @@ export const ImageForm = (props: ImageFormTypes) => {
           toastId: "upload_toast",
           autoClose: false,
         });
+
         toast.dismiss("ImageValidationError");
 
         await uploadViaPresignedPost(file, appId, teamId, imageType);
@@ -363,7 +364,7 @@ export const ImageForm = (props: ImageFormTypes) => {
               </Typography>
             </div>
             <Typography variant={TYPOGRAPHY.R5} className="text-grey-500">
-              {`JPG or PNG (max 250kb). Required size: ${1600}x${1200}px`}
+              {`JPG or PNG (max 250kb), required aspect ratio 4:3. \nRecommended size: ${1600}x${1200}px`}
             </Typography>
           </div>
         </ImageDropZone>
@@ -425,7 +426,7 @@ export const ImageForm = (props: ImageFormTypes) => {
               </Typography>
             </div>
             <Typography variant={TYPOGRAPHY.R5} className="text-grey-500">
-              {`JPG or PNG (max 250kb). Required size: ${1920}x${1080}px`}
+              {`JPG or PNG (max 250kb), required aspect ratio 16:9. Recommended size: ${1920}x${1080}px`}{" "}
             </Typography>
           </div>
         </ImageDropZone>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Gallery/page/ImageForm/index.tsx
@@ -47,12 +47,8 @@ export const ImageForm = (props: ImageFormTypes) => {
   const { user } = useUser() as Auth0SessionUser;
   const [updateHeroImageMutation] = useUpdateHeroImageMutation();
   const [updateShowcaseImagesMutation] = useUpdateShowcaseImagesMutation();
-  const {
-    resizeFile,
-    getImage,
-    uploadViaPresignedPost,
-    validateImageAspectRatio,
-  } = useImage();
+  const { getImage, uploadViaPresignedPost, validateImageAspectRatio } =
+    useImage();
 
   const showcaseImgFileNames = useMemo(
     () => appMetadata?.showcase_img_urls ?? [],
@@ -191,13 +187,12 @@ export const ImageForm = (props: ImageFormTypes) => {
         } else {
           throw new Error("Invalid aspect ratio");
         }
+
         await validateImageAspectRatio(
           file,
           aspectRatioWidth,
           aspectRatioHeight,
         );
-
-        const resizedImage = await resizeFile(file, width, height, file.type);
 
         toast.info("Uploading image", {
           toastId: "upload_toast",
@@ -205,7 +200,7 @@ export const ImageForm = (props: ImageFormTypes) => {
         });
         toast.dismiss("ImageValidationError");
 
-        await uploadViaPresignedPost(resizedImage, appId, teamId, imageType);
+        await uploadViaPresignedPost(file, appId, teamId, imageType);
 
         const imageUrl = await getImage(
           fileTypeEnding,
@@ -368,7 +363,7 @@ export const ImageForm = (props: ImageFormTypes) => {
               </Typography>
             </div>
             <Typography variant={TYPOGRAPHY.R5} className="text-grey-500">
-              {`JPG or PNG (max 250kb), required aspect ratio 4:3. \nRecommended size: ${1600}x${1200}px`}
+              {`JPG or PNG (max 250kb). Required size: ${1600}x${1200}px`}
             </Typography>
           </div>
         </ImageDropZone>
@@ -430,7 +425,7 @@ export const ImageForm = (props: ImageFormTypes) => {
               </Typography>
             </div>
             <Typography variant={TYPOGRAPHY.R5} className="text-grey-500">
-              {`JPG or PNG (max 250kb), required aspect ratio 16:9. Recommended size: ${1920}x${1080}px`}
+              {`JPG or PNG (max 250kb). Required size: ${1920}x${1080}px`}
             </Typography>
           </div>
         </ImageDropZone>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/PageComponents/AppTopBar/LogoImageUpload/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/PageComponents/AppTopBar/LogoImageUpload/index.tsx
@@ -40,12 +40,8 @@ export const LogoImageUpload = (props: LogoImageUploadProps) => {
   const [unverifiedImages, setUnverifiedImages] = useAtom(unverifiedImageAtom);
   const [updateLogoMutation, { loading }] = useUpdateLogoMutation();
   const imageInputRef = useRef<HTMLInputElement>(null);
-  const {
-    resizeFile,
-    getImage,
-    uploadViaPresignedPost,
-    validateImageAspectRatio,
-  } = useImage();
+  const { getImage, uploadViaPresignedPost, validateImageAspectRatio } =
+    useImage();
   const router = useRouter();
   const handleUpload = () => {
     imageInputRef.current?.click();
@@ -67,10 +63,8 @@ export const LogoImageUpload = (props: LogoImageUploadProps) => {
           autoClose: false,
         });
 
-        const resizedImage = await resizeFile(file, 512, 512, file.type);
         toast.dismiss("ImageValidationError");
-
-        await uploadViaPresignedPost(resizedImage, appId, teamId, imageType);
+        await uploadViaPresignedPost(file, appId, teamId, imageType);
 
         const imageUrl = await getImage(
           fileTypeEnding,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/hook/use-image.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/hook/use-image.tsx
@@ -1,4 +1,3 @@
-import Resizer from "react-image-file-resizer";
 import { toast } from "react-toastify";
 import { useGetUploadedImageLazyQuery } from "./graphql/client/get-uploaded-image.generated";
 import { useUploadImageLazyQuery } from "./graphql/client/upload-image.generated";
@@ -9,29 +8,6 @@ export class ImageValidationError extends Error {
     this.name = "ImageValidationError";
   }
 }
-
-export const resizeFile = (
-  file: File,
-  width: number,
-  height: number,
-  fileType: string,
-): Promise<File> =>
-  new Promise((resolve) => {
-    Resizer.imageFileResizer(
-      file,
-      width,
-      height,
-      fileType === "image/png" ? "png" : "jpeg",
-      100,
-      0,
-      (uri) => {
-        resolve(uri as File);
-      },
-      "file",
-      width,
-      height,
-    );
-  });
 
 export const useImage = () => {
   const [getUploadedImage] = useGetUploadedImageLazyQuery();
@@ -144,7 +120,6 @@ export const useImage = () => {
   };
 
   return {
-    resizeFile,
     getImage,
     validateImageAspectRatio,
     uploadViaPresignedPost,


### PR DESCRIPTION
Resizing the image was causing the file size to increase. The tradeoff then was that we either increase the file limit or remove resize. Given paolo had security concerns for increasing file size we will just remove automatic resizing. This is better behavior anyways since we have no idea what the file size will be after resizing.

We still let them upload different sizes that are compliant with our aspect ratio 

completes WID-855