### PR TITLE
[fix] Ordering of rankings

### DIFF
--- a/hasura/migrations/default/1712177502163_alter_table_app_rankings_constraint/down.sql
+++ b/hasura/migrations/default/1712177502163_alter_table_app_rankings_constraint/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.app_rankings
+DROP CONSTRAINT IF EXISTS app_rankings_platform_country_unique;

--- a/hasura/migrations/default/1712177502163_alter_table_app_rankings_constraint/up.sql
+++ b/hasura/migrations/default/1712177502163_alter_table_app_rankings_constraint/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.app_rankings ADD CONSTRAINT app_rankings_platform_country_unique UNIQUE (platform, country);

--- a/web/api/public/apps/index.ts
+++ b/web/api/public/apps/index.ts
@@ -55,7 +55,6 @@ export async function GET(request: Request) {
   const endIndex = startIndex + limit;
 
   const appIdsToFetch = rankings.slice(startIndex, endIndex);
-
   // Anchor: Get the list of app metadata that corresponds to the platform and country
   // TODO: We are currently not checking platform inside this call, it's not breaking but if we decide we don't want to show some apps on the app store and don't rank them then we need to implement this.
   const { ranked_apps, unranked_apps } = await getAppMetadataSdk(
@@ -65,6 +64,10 @@ export async function GET(request: Request) {
     limit: limit - appIdsToFetch.length,
     offset: Math.max(startIndex - appIdsToFetch.length, 0),
   });
+
+  ranked_apps.sort(
+    (a, b) => appIdsToFetch.indexOf(a.app_id) - appIdsToFetch.indexOf(b.app_id),
+  );
 
   const apps = [...ranked_apps, ...unranked_apps].map((app) => {
     return {


### PR DESCRIPTION
Fix the ordering of rankings. Updated the tests to cover this. Previously only had one example so didn't notice that graphql was returning the apps out of order

Also added an enforcement that the platform and country has only one. I chose not to make a computed field here and upsert on it because the flow for making rankings should be that they first fetch the existing ranking. Thus we should know that there exists a ranking or not. And based on documentation if we know the column is not present we should not upsert