### PR TITLE
Add consistency to URL validation

### DIFF
--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -68,8 +68,6 @@ export const validateEmail = (candidate: string): boolean => {
 
 export const isSSR = () => typeof window === "undefined";
 
-export const uriHasJS = (uri: string) => /javascript:/.test(uri);
-
 export const isEmailUser = (user: Auth0User): user is Auth0EmailUser =>
   user.sub.startsWith("email|");
 

--- a/web/pages/api/v1/oidc/validate.ts
+++ b/web/pages/api/v1/oidc/validate.ts
@@ -1,9 +1,9 @@
-import { NextApiRequest, NextApiResponse } from "next";
 import { errorNotAllowed, errorResponse } from "@/legacy/backend/errors";
 import { fetchOIDCApp } from "@/legacy/backend/oidc";
-import { uriHasJS } from "@/lib/utils";
-import * as yup from "yup";
 import { validateRequestSchema } from "@/legacy/backend/utils";
+import { validateUrl } from "@/lib/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import * as yup from "yup";
 
 const schema = yup.object({
   app_id: yup.string().strict().required("This attribute is required."),
@@ -34,7 +34,7 @@ export default async function handleOIDCValidate(
 
   const { app_id, redirect_uri } = parsedParams;
 
-  if (uriHasJS(redirect_uri)) {
+  if (!validateUrl(redirect_uri, true)) {
     return errorResponse(
       res,
       400,

--- a/web/tests/api/utils.test.ts
+++ b/web/tests/api/utils.test.ts
@@ -51,5 +51,5 @@ describe("validateUrl()", () => {
   test("insecure schema", () => {
     expect(validateUrl("javascript:alert('test')", isStaging)).toBeFalsy();
     expect(validateUrl("jaVasCript:;alert('test');", isStaging)).toBeFalsy();
-  })
+  });
 });

--- a/web/tests/api/utils.test.ts
+++ b/web/tests/api/utils.test.ts
@@ -1,5 +1,5 @@
 import { canVerifyForAction } from "@/legacy/backend/utils";
-import { uriHasJS, validateUrl } from "@/lib/utils";
+import { validateUrl } from "@/lib/utils";
 
 describe("canVerifyForAction()", () => {
   test("can verify if it has not verified before", () => {
@@ -47,15 +47,9 @@ describe("validateUrl()", () => {
   test("localhost prod", () => {
     expect(validateUrl(httpLocalhost, !isStaging)).toBeFalsy();
   });
-});
 
-describe("url js injection", () => {
-  it("without inject", () => {
-    expect(uriHasJS("http://test.com")).toBeFalsy();
-  });
-
-  it("with inject", () => {
-    expect(uriHasJS("javascript:alert('test')")).toBeTruthy();
-    expect(uriHasJS("javascript:;alert('test');")).toBeTruthy();
-  });
+  test("insecure schema", () => {
+    expect(validateUrl("javascript:alert('test')", isStaging)).toBeFalsy();
+    expect(validateUrl("jaVasCript:;alert('test');", isStaging)).toBeFalsy();
+  })
 });


### PR DESCRIPTION
Remove redundant `uriHasJS()` in favor of `validateUrl()` to improve consistency and prevent XSS issues