### PR TITLE
API endpoint update

### DIFF
--- a/hasura/metadata/databases/default/tables/public_app_metadata.yaml
+++ b/hasura/metadata/databases/default/tables/public_app_metadata.yaml
@@ -210,8 +210,10 @@ update_permissions:
         - review_message
         - verification_status
       filter:
-        verification_status:
-          _eq: awaiting_review
+        - verification_status:
+            _in:
+              - changes_requested
+              - verified
       check:
         _and:
           - verification_status:

--- a/hasura/metadata/databases/default/tables/public_app_metadata.yaml
+++ b/hasura/metadata/databases/default/tables/public_app_metadata.yaml
@@ -210,10 +210,11 @@ update_permissions:
         - review_message
         - verification_status
       filter:
-        - verification_status:
-            _in:
-              - changes_requested
-              - verified
+        _and:
+          - verification_status:
+              _in:
+                - changes_requested
+                - verified
       check:
         _and:
           - verification_status:

--- a/hasura/metadata/databases/default/tables/public_app_metadata.yaml
+++ b/hasura/metadata/databases/default/tables/public_app_metadata.yaml
@@ -113,6 +113,7 @@ select_permissions:
         - verification_status
         - created_at
         - updated_at
+        - world_app_button_text
       filter:
         verification_status:
           _neq: unverified
@@ -135,6 +136,7 @@ select_permissions:
         - is_reviewer_app_store_approved
         - is_reviewer_world_app_approved
         - verification_status
+        - world_app_button_text
       filter: {}
   - role: user
     permission:
@@ -158,6 +160,7 @@ select_permissions:
         - review_message
         - verification_status
         - updated_at
+        - world_app_button_text
       filter:
         app:
           team:
@@ -230,6 +233,7 @@ update_permissions:
         - app_website_url
         - source_code_url
         - verification_status
+        - world_app_button_text
       filter:
         _and:
           - verification_status:

--- a/hasura/migrations/default/1712797451184_alter_table_public_app_metadata_add_column_world_app_button_text/down.sql
+++ b/hasura/migrations/default/1712797451184_alter_table_public_app_metadata_add_column_world_app_button_text/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."app_metadata"
+drop column "world_app_button_text"

--- a/hasura/migrations/default/1712797451184_alter_table_public_app_metadata_add_column_world_app_button_text/up.sql
+++ b/hasura/migrations/default/1712797451184_alter_table_public_app_metadata_add_column_world_app_button_text/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."app_metadata"
+add column "world_app_button_text" varchar not null default 'Use Integration';

--- a/web/api/public/app/[app_id]/graphql/get-app-metadata.generated.ts
+++ b/web/api/public/app/[app_id]/graphql/get-app-metadata.generated.ts
@@ -17,6 +17,7 @@ export type GetAppMetadataQuery = {
     showcase_img_urls?: any | null;
     hero_image_url: string;
     world_app_description: string;
+    world_app_button_text: string;
     description: string;
     category: string;
     integration_url: string;
@@ -46,6 +47,7 @@ export const GetAppMetadataDocument = gql`
       showcase_img_urls
       hero_image_url
       world_app_description
+      world_app_button_text
       description
       category
       integration_url

--- a/web/api/public/app/[app_id]/graphql/get-app-metadata.graphql
+++ b/web/api/public/app/[app_id]/graphql/get-app-metadata.graphql
@@ -14,6 +14,7 @@ query GetAppMetadata($app_id: String!) {
     showcase_img_urls
     hero_image_url
     world_app_description
+    world_app_button_text
     description
     category
     integration_url

--- a/web/api/public/app/[app_id]/index.ts
+++ b/web/api/public/app/[app_id]/index.ts
@@ -39,6 +39,7 @@ export async function GET(
   const { app, ...appMetadataReturned } = app_metadata[0];
   const dataToReturn = {
     ...appMetadataReturned,
+    description: JSON.parse(appMetadataReturned.description),
     logo_img_url: getCDNImageUrl(app_id, appMetadataReturned.logo_img_url),
     hero_image_url: appMetadataReturned.hero_image_url
       ? getCDNImageUrl(app_id, appMetadataReturned?.hero_image_url)

--- a/web/api/public/apps/graphql/get-app-metadata.generated.ts
+++ b/web/api/public/apps/graphql/get-app-metadata.generated.ts
@@ -22,6 +22,7 @@ export type GetAppMetadataQuery = {
     showcase_img_urls?: any | null;
     hero_image_url: string;
     world_app_description: string;
+    world_app_button_text: string;
     description: string;
     category: string;
     integration_url: string;
@@ -40,6 +41,7 @@ export type GetAppMetadataQuery = {
     showcase_img_urls?: any | null;
     hero_image_url: string;
     world_app_description: string;
+    world_app_button_text: string;
     description: string;
     category: string;
     integration_url: string;
@@ -70,6 +72,7 @@ export const GetAppMetadataDocument = gql`
       showcase_img_urls
       hero_image_url
       world_app_description
+      world_app_button_text
       description
       category
       integration_url
@@ -99,6 +102,7 @@ export const GetAppMetadataDocument = gql`
       showcase_img_urls
       hero_image_url
       world_app_description
+      world_app_button_text
       description
       category
       integration_url

--- a/web/api/public/apps/graphql/get-app-metadata.graphql
+++ b/web/api/public/apps/graphql/get-app-metadata.graphql
@@ -15,6 +15,7 @@ query GetAppMetadata($app_ids: [String!], $limit: Int!, $offset: Int!) {
     showcase_img_urls
     hero_image_url
     world_app_description
+    world_app_button_text
     description
     category
     integration_url
@@ -45,6 +46,7 @@ query GetAppMetadata($app_ids: [String!], $limit: Int!, $offset: Int!) {
     showcase_img_urls
     hero_image_url
     world_app_description
+    world_app_button_text
     description
     category
     integration_url

--- a/web/api/public/apps/graphql/get-app-rankings.generated.ts
+++ b/web/api/public/apps/graphql/get-app-rankings.generated.ts
@@ -16,6 +16,10 @@ export type GetAppRankingsQuery = {
     __typename?: "app_rankings";
     rankings?: any | null;
   }>;
+  featured_app_rankings: Array<{
+    __typename?: "app_rankings";
+    rankings?: any | null;
+  }>;
 };
 
 export const GetAppRankingsDocument = gql`
@@ -27,6 +31,11 @@ export const GetAppRankingsDocument = gql`
     }
     default_app_rankings: app_rankings(
       where: { platform: { _eq: $platform }, country: { _eq: "default" } }
+    ) {
+      rankings
+    }
+    featured_app_rankings: app_rankings(
+      where: { platform: { _eq: "web" }, country: { _eq: "featured" } }
     ) {
       rankings
     }

--- a/web/api/public/apps/graphql/get-app-rankings.graphql
+++ b/web/api/public/apps/graphql/get-app-rankings.graphql
@@ -9,4 +9,9 @@ query GetAppRankings($platform: String!, $country: String!) {
   ) {
     rankings
   }
+  featured_app_rankings: app_rankings(
+    where: { platform: { _eq: "web" }, country: { _eq: "featured" } }
+  ) {
+    rankings
+  }
 }

--- a/web/api/public/apps/index.ts
+++ b/web/api/public/apps/index.ts
@@ -126,12 +126,10 @@ export async function GET(request: Request) {
     };
   });
 
-  const featured_app_ids = featured_app_rankings[0]?.rankings ?? [];
+  const featured_app_ids = featured_app_rankings?.[0]?.rankings ?? [];
   const featured_apps = apps.filter((app) =>
     featured_app_ids.includes(app.app_id),
   );
-
-  // TODO: Return the localise string
 
   return NextResponse.json(
     { apps: apps, featured: featured_apps },

--- a/web/api/public/apps/index.ts
+++ b/web/api/public/apps/index.ts
@@ -82,7 +82,6 @@ export async function GET(request: Request) {
 
   const apps = [...ranked_apps, ...unranked_apps].map((appData) => {
     const { app, ...appMetadata } = appData;
-    const parsedDescription = JSON.parse(appMetadata.description);
     return {
       ...appMetadata,
       logo_img_url: getCDNImageUrl(
@@ -104,25 +103,26 @@ export async function GET(request: Request) {
         : appMetadata.category,
       description: isApp
         ? {
-            overview: createLocaliseField(appMetadata.app_id, "overview"),
+            overview: createLocaliseField(
+              appMetadata.app_id,
+              "description_overview",
+            ),
             how_it_works: createLocaliseField(
               appMetadata.app_id,
-              "how_it_works",
+              "description_how_it_works",
             ),
             how_to_connect: createLocaliseField(
               appMetadata.app_id,
-              "how_to_connect",
+              "description_connect",
             ),
           }
-        : parsedDescription,
-      world_app_button_text: createLocaliseField(
-        appMetadata.app_id,
-        "world_app_button_text",
-      ),
-      world_app_description: createLocaliseField(
-        appMetadata.app_id,
-        "world_app_description",
-      ),
+        : JSON.parse(appMetadata.description),
+      world_app_button_text: isApp
+        ? createLocaliseField(appMetadata.app_id, "world_app_button_text")
+        : appMetadata.world_app_button_text,
+      world_app_description: isApp
+        ? createLocaliseField(appMetadata.app_id, "world_app_description")
+        : appMetadata.world_app_description,
     };
   });
 

--- a/web/api/public/apps/index.ts
+++ b/web/api/public/apps/index.ts
@@ -40,12 +40,11 @@ export async function GET(request: Request) {
   const client = await getAPIServiceGraphqlClient();
 
   // Anchor: Fetch the country ordering if exists, otherwise get default ordering
-  const { app_rankings, default_app_rankings } = await getAppRankingsSdk(
-    client,
-  ).GetAppRankings({
-    platform,
-    country,
-  });
+  const { app_rankings, default_app_rankings, featured_app_rankings } =
+    await getAppRankingsSdk(client).GetAppRankings({
+      platform,
+      country,
+    });
 
   let rankings = [];
 
@@ -79,6 +78,7 @@ export async function GET(request: Request) {
     const { app, ...appMetadata } = appData;
     return {
       ...appMetadata,
+      description: JSON.parse(appMetadata.description),
       logo_img_url: getCDNImageUrl(
         appMetadata.app_id,
         appMetadata.logo_img_url,
@@ -96,5 +96,15 @@ export async function GET(request: Request) {
     };
   });
 
-  return NextResponse.json({ apps: apps }, { status: 200 });
+  const featured_app_ids = featured_app_rankings[0]?.rankings ?? [];
+  const featured_apps = apps.filter((app) =>
+    featured_app_ids.includes(app.app_id),
+  );
+
+  // TODO: Return the query string
+
+  return NextResponse.json(
+    { apps: apps, featured_apps: featured_apps },
+    { status: 200 },
+  );
 }

--- a/web/graphql/graphql.schema.json
+++ b/web/graphql/graphql.schema.json
@@ -12084,6 +12084,22 @@
             "deprecationReason": null
           },
           {
+            "name": "world_app_button_text",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "world_app_description",
             "description": null,
             "args": [],
@@ -12905,6 +12921,18 @@
             "deprecationReason": null
           },
           {
+            "name": "world_app_button_text",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "world_app_description",
             "description": null,
             "type": {
@@ -13221,6 +13249,18 @@
             "deprecationReason": null
           },
           {
+            "name": "world_app_button_text",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "world_app_description",
             "description": null,
             "type": {
@@ -13435,6 +13475,18 @@
             "deprecationReason": null
           },
           {
+            "name": "world_app_button_text",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "world_app_description",
             "description": null,
             "args": [],
@@ -13640,6 +13692,18 @@
           },
           {
             "name": "verified_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "world_app_button_text",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -13865,6 +13929,18 @@
             "deprecationReason": null
           },
           {
+            "name": "world_app_button_text",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "world_app_description",
             "description": null,
             "args": [],
@@ -14070,6 +14146,18 @@
           },
           {
             "name": "verified_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "world_app_button_text",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -14482,6 +14570,18 @@
             "deprecationReason": null
           },
           {
+            "name": "world_app_button_text",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "world_app_description",
             "description": null,
             "type": {
@@ -14655,6 +14755,12 @@
           },
           {
             "name": "verified_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "world_app_button_text",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -14997,6 +15103,18 @@
             "deprecationReason": null
           },
           {
+            "name": "world_app_button_text",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "world_app_description",
             "description": null,
             "type": {
@@ -15311,6 +15429,18 @@
             "deprecationReason": null
           },
           {
+            "name": "world_app_button_text",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "world_app_description",
             "description": null,
             "type": {
@@ -15457,6 +15587,12 @@
           },
           {
             "name": "verified_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "world_app_button_text",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -16466,6 +16602,12 @@
           {
             "name": "app_rankings_pkey",
             "description": "unique or primary key constraint on columns \"id\"",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_rankings_platform_country_unique",
+            "description": "unique or primary key constraint on columns \"platform\", \"country\"",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -47256,6 +47398,18 @@
             "deprecationReason": null
           },
           {
+            "name": "team_owners_count",
+            "description": "A computed field that returns a quantity of team owners",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "args": [],
@@ -47330,6 +47484,18 @@
         "description": "aggregate fields of \"team\"",
         "fields": [
           {
+            "name": "avg",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "team_avg_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "count",
             "description": null,
             "args": [
@@ -47397,6 +47563,113 @@
             "type": {
               "kind": "OBJECT",
               "name": "team_min_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "team_stddev_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_pop",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "team_stddev_pop_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_samp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "team_stddev_samp_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sum",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "team_sum_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_pop",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "team_var_pop_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_samp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "team_var_samp_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "variance",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "team_variance_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "team_avg_fields",
+        "description": "aggregate avg on columns",
+        "fields": [
+          {
+            "name": "team_owners_count",
+            "description": "A computed field that returns a quantity of team owners",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "isDeprecated": false,
@@ -47575,6 +47848,18 @@
             "deprecationReason": null
           },
           {
+            "name": "team_owners_count",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "type": {
@@ -47745,6 +48030,18 @@
             "deprecationReason": null
           },
           {
+            "name": "team_owners_count",
+            "description": "A computed field that returns a quantity of team owners",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "args": [],
@@ -47798,6 +48095,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_owners_count",
+            "description": "A computed field that returns a quantity of team owners",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "isDeprecated": false,
@@ -48053,6 +48362,18 @@
             "deprecationReason": null
           },
           {
+            "name": "team_owners_count",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "type": {
@@ -48191,6 +48512,75 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "team_stddev_fields",
+        "description": "aggregate stddev on columns",
+        "fields": [
+          {
+            "name": "team_owners_count",
+            "description": "A computed field that returns a quantity of team owners",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "team_stddev_pop_fields",
+        "description": "aggregate stddev_pop on columns",
+        "fields": [
+          {
+            "name": "team_owners_count",
+            "description": "A computed field that returns a quantity of team owners",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "team_stddev_samp_fields",
+        "description": "aggregate stddev_samp on columns",
+        "fields": [
+          {
+            "name": "team_owners_count",
+            "description": "A computed field that returns a quantity of team owners",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "team_stream_cursor_input",
         "description": "Streaming cursor of the table \"team\"",
@@ -48289,6 +48679,29 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "team_sum_fields",
+        "description": "aggregate sum on columns",
+        "fields": [
+          {
+            "name": "team_owners_count",
+            "description": "A computed field that returns a quantity of team owners",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "team_update_column",
         "description": "update columns of table \"team\"",
@@ -48359,6 +48772,75 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "team_var_pop_fields",
+        "description": "aggregate var_pop on columns",
+        "fields": [
+          {
+            "name": "team_owners_count",
+            "description": "A computed field that returns a quantity of team owners",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "team_var_samp_fields",
+        "description": "aggregate var_samp on columns",
+        "fields": [
+          {
+            "name": "team_owners_count",
+            "description": "A computed field that returns a quantity of team owners",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "team_variance_fields",
+        "description": "aggregate variance on columns",
+        "fields": [
+          {
+            "name": "team_owners_count",
+            "description": "A computed field that returns a quantity of team owners",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },

--- a/web/graphql/graphql.ts
+++ b/web/graphql/graphql.ts
@@ -1566,6 +1566,7 @@ export type App_Metadata = {
   updated_at: Scalars["timestamptz"];
   verification_status: Scalars["String"];
   verified_at?: Maybe<Scalars["timestamptz"]>;
+  world_app_button_text: Scalars["String"];
   world_app_description: Scalars["String"];
 };
 
@@ -1658,6 +1659,7 @@ export type App_Metadata_Bool_Exp = {
   updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
   verification_status?: InputMaybe<String_Comparison_Exp>;
   verified_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  world_app_button_text?: InputMaybe<String_Comparison_Exp>;
   world_app_description?: InputMaybe<String_Comparison_Exp>;
 };
 
@@ -1695,6 +1697,7 @@ export type App_Metadata_Insert_Input = {
   updated_at?: InputMaybe<Scalars["timestamptz"]>;
   verification_status?: InputMaybe<Scalars["String"]>;
   verified_at?: InputMaybe<Scalars["timestamptz"]>;
+  world_app_button_text?: InputMaybe<Scalars["String"]>;
   world_app_description?: InputMaybe<Scalars["String"]>;
 };
 
@@ -1717,6 +1720,7 @@ export type App_Metadata_Max_Fields = {
   updated_at?: Maybe<Scalars["timestamptz"]>;
   verification_status?: Maybe<Scalars["String"]>;
   verified_at?: Maybe<Scalars["timestamptz"]>;
+  world_app_button_text?: Maybe<Scalars["String"]>;
   world_app_description?: Maybe<Scalars["String"]>;
 };
 
@@ -1738,6 +1742,7 @@ export type App_Metadata_Max_Order_By = {
   updated_at?: InputMaybe<Order_By>;
   verification_status?: InputMaybe<Order_By>;
   verified_at?: InputMaybe<Order_By>;
+  world_app_button_text?: InputMaybe<Order_By>;
   world_app_description?: InputMaybe<Order_By>;
 };
 
@@ -1760,6 +1765,7 @@ export type App_Metadata_Min_Fields = {
   updated_at?: Maybe<Scalars["timestamptz"]>;
   verification_status?: Maybe<Scalars["String"]>;
   verified_at?: Maybe<Scalars["timestamptz"]>;
+  world_app_button_text?: Maybe<Scalars["String"]>;
   world_app_description?: Maybe<Scalars["String"]>;
 };
 
@@ -1781,6 +1787,7 @@ export type App_Metadata_Min_Order_By = {
   updated_at?: InputMaybe<Order_By>;
   verification_status?: InputMaybe<Order_By>;
   verified_at?: InputMaybe<Order_By>;
+  world_app_button_text?: InputMaybe<Order_By>;
   world_app_description?: InputMaybe<Order_By>;
 };
 
@@ -1824,6 +1831,7 @@ export type App_Metadata_Order_By = {
   updated_at?: InputMaybe<Order_By>;
   verification_status?: InputMaybe<Order_By>;
   verified_at?: InputMaybe<Order_By>;
+  world_app_button_text?: InputMaybe<Order_By>;
   world_app_description?: InputMaybe<Order_By>;
 };
 
@@ -1877,6 +1885,8 @@ export enum App_Metadata_Select_Column {
   /** column name */
   VerifiedAt = "verified_at",
   /** column name */
+  WorldAppButtonText = "world_app_button_text",
+  /** column name */
   WorldAppDescription = "world_app_description",
 }
 
@@ -1927,6 +1937,7 @@ export type App_Metadata_Set_Input = {
   updated_at?: InputMaybe<Scalars["timestamptz"]>;
   verification_status?: InputMaybe<Scalars["String"]>;
   verified_at?: InputMaybe<Scalars["timestamptz"]>;
+  world_app_button_text?: InputMaybe<Scalars["String"]>;
   world_app_description?: InputMaybe<Scalars["String"]>;
 };
 
@@ -1961,6 +1972,7 @@ export type App_Metadata_Stream_Cursor_Value_Input = {
   updated_at?: InputMaybe<Scalars["timestamptz"]>;
   verification_status?: InputMaybe<Scalars["String"]>;
   verified_at?: InputMaybe<Scalars["timestamptz"]>;
+  world_app_button_text?: InputMaybe<Scalars["String"]>;
   world_app_description?: InputMaybe<Scalars["String"]>;
 };
 
@@ -2008,6 +2020,8 @@ export enum App_Metadata_Update_Column {
   VerificationStatus = "verification_status",
   /** column name */
   VerifiedAt = "verified_at",
+  /** column name */
+  WorldAppButtonText = "world_app_button_text",
   /** column name */
   WorldAppDescription = "world_app_description",
 }
@@ -2140,6 +2154,8 @@ export type App_Rankings_Bool_Exp = {
 export enum App_Rankings_Constraint {
   /** unique or primary key constraint on columns "id" */
   AppRankingsPkey = "app_rankings_pkey",
+  /** unique or primary key constraint on columns "platform", "country" */
+  AppRankingsPlatformCountryUnique = "app_rankings_platform_country_unique",
 }
 
 /** input type for inserting data into table "app_rankings" */
@@ -6620,6 +6636,8 @@ export type Team = {
   /** An aggregate relationship */
   memberships_aggregate: Membership_Aggregate;
   name?: Maybe<Scalars["String"]>;
+  /** A computed field that returns a quantity of team owners */
+  team_owners_count?: Maybe<Scalars["Int"]>;
   updated_at: Scalars["timestamptz"];
 };
 
@@ -6687,15 +6705,30 @@ export type Team_Aggregate = {
 /** aggregate fields of "team" */
 export type Team_Aggregate_Fields = {
   __typename?: "team_aggregate_fields";
+  avg?: Maybe<Team_Avg_Fields>;
   count: Scalars["Int"];
   max?: Maybe<Team_Max_Fields>;
   min?: Maybe<Team_Min_Fields>;
+  stddev?: Maybe<Team_Stddev_Fields>;
+  stddev_pop?: Maybe<Team_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Team_Stddev_Samp_Fields>;
+  sum?: Maybe<Team_Sum_Fields>;
+  var_pop?: Maybe<Team_Var_Pop_Fields>;
+  var_samp?: Maybe<Team_Var_Samp_Fields>;
+  variance?: Maybe<Team_Variance_Fields>;
 };
 
 /** aggregate fields of "team" */
 export type Team_Aggregate_FieldsCountArgs = {
   columns?: InputMaybe<Array<Team_Select_Column>>;
   distinct?: InputMaybe<Scalars["Boolean"]>;
+};
+
+/** aggregate avg on columns */
+export type Team_Avg_Fields = {
+  __typename?: "team_avg_fields";
+  /** A computed field that returns a quantity of team owners */
+  team_owners_count?: Maybe<Scalars["Int"]>;
 };
 
 /** Boolean expression to filter rows from the table "team". All fields are combined with a logical 'AND'. */
@@ -6712,6 +6745,7 @@ export type Team_Bool_Exp = {
   memberships?: InputMaybe<Membership_Bool_Exp>;
   memberships_aggregate?: InputMaybe<Membership_Aggregate_Bool_Exp>;
   name?: InputMaybe<String_Comparison_Exp>;
+  team_owners_count?: InputMaybe<Int_Comparison_Exp>;
   updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
 };
 
@@ -6738,6 +6772,8 @@ export type Team_Max_Fields = {
   created_at?: Maybe<Scalars["timestamptz"]>;
   id?: Maybe<Scalars["String"]>;
   name?: Maybe<Scalars["String"]>;
+  /** A computed field that returns a quantity of team owners */
+  team_owners_count?: Maybe<Scalars["Int"]>;
   updated_at?: Maybe<Scalars["timestamptz"]>;
 };
 
@@ -6747,6 +6783,8 @@ export type Team_Min_Fields = {
   created_at?: Maybe<Scalars["timestamptz"]>;
   id?: Maybe<Scalars["String"]>;
   name?: Maybe<Scalars["String"]>;
+  /** A computed field that returns a quantity of team owners */
+  team_owners_count?: Maybe<Scalars["Int"]>;
   updated_at?: Maybe<Scalars["timestamptz"]>;
 };
 
@@ -6781,6 +6819,7 @@ export type Team_Order_By = {
   id?: InputMaybe<Order_By>;
   memberships_aggregate?: InputMaybe<Membership_Aggregate_Order_By>;
   name?: InputMaybe<Order_By>;
+  team_owners_count?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
 };
 
@@ -6809,6 +6848,27 @@ export type Team_Set_Input = {
   updated_at?: InputMaybe<Scalars["timestamptz"]>;
 };
 
+/** aggregate stddev on columns */
+export type Team_Stddev_Fields = {
+  __typename?: "team_stddev_fields";
+  /** A computed field that returns a quantity of team owners */
+  team_owners_count?: Maybe<Scalars["Int"]>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Team_Stddev_Pop_Fields = {
+  __typename?: "team_stddev_pop_fields";
+  /** A computed field that returns a quantity of team owners */
+  team_owners_count?: Maybe<Scalars["Int"]>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Team_Stddev_Samp_Fields = {
+  __typename?: "team_stddev_samp_fields";
+  /** A computed field that returns a quantity of team owners */
+  team_owners_count?: Maybe<Scalars["Int"]>;
+};
+
 /** Streaming cursor of the table "team" */
 export type Team_Stream_Cursor_Input = {
   /** Stream column input with initial value */
@@ -6823,6 +6883,13 @@ export type Team_Stream_Cursor_Value_Input = {
   id?: InputMaybe<Scalars["String"]>;
   name?: InputMaybe<Scalars["String"]>;
   updated_at?: InputMaybe<Scalars["timestamptz"]>;
+};
+
+/** aggregate sum on columns */
+export type Team_Sum_Fields = {
+  __typename?: "team_sum_fields";
+  /** A computed field that returns a quantity of team owners */
+  team_owners_count?: Maybe<Scalars["Int"]>;
 };
 
 /** update columns of table "team" */
@@ -6842,6 +6909,27 @@ export type Team_Updates = {
   _set?: InputMaybe<Team_Set_Input>;
   /** filter the rows which have to be updated */
   where: Team_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type Team_Var_Pop_Fields = {
+  __typename?: "team_var_pop_fields";
+  /** A computed field that returns a quantity of team owners */
+  team_owners_count?: Maybe<Scalars["Int"]>;
+};
+
+/** aggregate var_samp on columns */
+export type Team_Var_Samp_Fields = {
+  __typename?: "team_var_samp_fields";
+  /** A computed field that returns a quantity of team owners */
+  team_owners_count?: Maybe<Scalars["Int"]>;
+};
+
+/** aggregate variance on columns */
+export type Team_Variance_Fields = {
+  __typename?: "team_variance_fields";
+  /** A computed field that returns a quantity of team owners */
+  team_owners_count?: Maybe<Scalars["Int"]>;
 };
 
 /** Boolean expression to compare columns of type "timestamptz". All fields are combined with logical 'AND'. */

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -129,3 +129,11 @@ export const isValidHostName = (request: Request) => {
   }
   return true;
 };
+
+export const createCategory = (category: string) => {
+  return `world_id_partner_category_${category.toLowerCase()}`;
+};
+
+export const createField = (app_id: string, field: string) => {
+  return `world_id_partner_${app_id}_${field}`;
+};

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -130,10 +130,10 @@ export const isValidHostName = (request: Request) => {
   return true;
 };
 
-export const createCategory = (category: string) => {
+export const createLocaliseCategory = (category: string) => {
   return `world_id_partner_category_${category.toLowerCase()}`;
 };
 
-export const createField = (app_id: string, field: string) => {
+export const createLocaliseField = (app_id: string, field: string) => {
   return `world_id_partner_${app_id}_${field}`;
 };

--- a/web/pages/api/v1/precheck/[app_id].ts
+++ b/web/pages/api/v1/precheck/[app_id].ts
@@ -1,4 +1,5 @@
-import { ApolloError, gql } from "@apollo/client";
+import { runCors } from "@/legacy/backend/cors";
+import { errorNotAllowed, errorResponse } from "@/legacy/backend/errors";
 import { getAPIServiceClient } from "@/legacy/backend/graphql";
 import {
   canVerifyForAction,
@@ -10,13 +11,12 @@ import {
   AppModel,
   NullifierModel,
 } from "@/legacy/lib/models";
-import { NextApiRequest, NextApiResponse } from "next";
 import { CanUserVerifyType, EngineType } from "@/legacy/lib/types";
-import { runCors } from "@/legacy/backend/cors";
-import { errorNotAllowed, errorResponse } from "@/legacy/backend/errors";
-import * as yup from "yup";
 import { generateExternalNullifier } from "@/lib/hashing";
 import { getCDNImageUrl } from "@/lib/utils";
+import { ApolloError, gql } from "@apollo/client";
+import { NextApiRequest, NextApiResponse } from "next";
+import * as yup from "yup";
 
 type _Nullifier = Pick<
   NullifierModel,
@@ -225,6 +225,7 @@ export default async function handlePrecheck(
     verified_app_logo: logo_img_url,
     actions: rawAppValues.actions,
   };
+
   // ANCHOR: If the action doesn't exist, create it
   if (!app.actions.length) {
     if (action === null) {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Links/page/LinksForm/graphql/client/update-app-links.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Links/page/LinksForm/graphql/client/update-app-links.generated.ts
@@ -9,6 +9,7 @@ export type UpdateAppLinksInfoMutationVariables = Types.Exact<{
   integration_url: Types.Scalars["String"];
   app_website_url: Types.Scalars["String"];
   source_code_url: Types.Scalars["String"];
+  world_app_button_text: Types.Scalars["String"];
 }>;
 
 export type UpdateAppLinksInfoMutation = {
@@ -25,6 +26,7 @@ export const UpdateAppLinksInfoDocument = gql`
     $integration_url: String!
     $app_website_url: String!
     $source_code_url: String!
+    $world_app_button_text: String!
   ) {
     update_app_metadata_by_pk(
       pk_columns: { id: $app_metadata_id }
@@ -32,6 +34,7 @@ export const UpdateAppLinksInfoDocument = gql`
         integration_url: $integration_url
         app_website_url: $app_website_url
         source_code_url: $source_code_url
+        world_app_button_text: $world_app_button_text
       }
     ) {
       id
@@ -60,6 +63,7 @@ export type UpdateAppLinksInfoMutationFn = Apollo.MutationFunction<
  *      integration_url: // value for 'integration_url'
  *      app_website_url: // value for 'app_website_url'
  *      source_code_url: // value for 'source_code_url'
+ *      world_app_button_text: // value for 'world_app_button_text'
  *   },
  * });
  */

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Links/page/LinksForm/graphql/client/update-app-links.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Links/page/LinksForm/graphql/client/update-app-links.graphql
@@ -3,6 +3,7 @@ mutation UpdateAppLinksInfo(
   $integration_url: String!
   $app_website_url: String!
   $source_code_url: String!
+  $world_app_button_text: String!
 ) {
   update_app_metadata_by_pk(
     pk_columns: { id: $app_metadata_id }
@@ -10,6 +11,7 @@ mutation UpdateAppLinksInfo(
       integration_url: $integration_url
       app_website_url: $app_website_url
       source_code_url: $source_code_url
+      world_app_button_text: $world_app_button_text
     }
   ) {
     id

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Links/page/LinksForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Links/page/LinksForm/index.tsx
@@ -42,6 +42,10 @@ const schema = yup.object().shape({
       excludeEmptyString: true,
     })
     .optional(),
+  world_app_button_text: yup
+    .string()
+    .max(25, "Content cannot exceed 25 characters")
+    .optional(),
 });
 
 type LinksFormValues = yup.Asserts<typeof schema>;
@@ -78,6 +82,7 @@ export const LinksForm = (props: LinksFormProps) => {
       integration_url: appMetadata?.integration_url,
       app_website_url: appMetadata?.app_website_url,
       source_code_url: appMetadata?.source_code_url,
+      world_app_button_text: appMetadata?.world_app_button_text,
     },
   });
   // Used to update the fields when view mode is change
@@ -86,11 +91,13 @@ export const LinksForm = (props: LinksFormProps) => {
       integration_url: appMetadata?.integration_url,
       app_website_url: appMetadata?.app_website_url,
       source_code_url: appMetadata?.source_code_url,
+      world_app_button_text: appMetadata?.world_app_button_text,
     });
   }, [
     appMetadata?.app_website_url,
     appMetadata?.integration_url,
     appMetadata?.source_code_url,
+    appMetadata?.world_app_button_text,
     reset,
   ]);
 
@@ -104,6 +111,7 @@ export const LinksForm = (props: LinksFormProps) => {
             integration_url: values.integration_url,
             app_website_url: values.app_website_url ?? "",
             source_code_url: values.source_code_url ?? "",
+            world_app_button_text: values.world_app_button_text ?? "",
           },
 
           refetchQueries: [
@@ -160,6 +168,13 @@ export const LinksForm = (props: LinksFormProps) => {
           disabled={!isEditable || !isEnoughPermissions}
           placeholder="https://"
           register={register("source_code_url")}
+        />
+        <Input
+          label="World App Button Text"
+          errors={errors.world_app_button_text}
+          disabled={!isEditable || !isEnoughPermissions}
+          placeholder="Use Integration"
+          register={register("world_app_button_text")}
         />
       </div>
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Links/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Links/page/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import clsx from "clsx";
+import { SizingWrapper } from "@/components/SizingWrapper";
 import { useAtom } from "jotai";
 import Error from "next/error";
 import { useMemo } from "react";
@@ -9,7 +9,6 @@ import { FormSkeleton } from "../../PageComponents/AppTopBar/FormSkeleton";
 import { useFetchAppMetadataQuery } from "../../graphql/client/fetch-app-metadata.generated";
 import { viewModeAtom } from "../../layout/ImagesProvider";
 import { LinksForm } from "./LinksForm";
-import { SizingWrapper } from "@/components/SizingWrapper";
 
 type AppProfileLinksProps = {
   params: Record<string, string> | null | undefined;

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/StoreInfo/page/UpdateStoreInfoForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/StoreInfo/page/UpdateStoreInfoForm/index.tsx
@@ -24,7 +24,7 @@ import { useUpdateAppStoreInfoMutation } from "../graphql/client/update-store-in
 const schema = yup.object().shape({
   world_app_description: yup
     .string()
-    .max(50, "World app description cannot exceed 50 characters")
+    .max(35, "World app description cannot exceed 35 characters")
     .optional(),
   description_overview: yup
     .string()
@@ -253,7 +253,7 @@ export const UpdateStoreInfoForm = (props: UpdateStoreInfoFormProps) => {
                 <span style={{ color: "red" }}>*</span>
               </>
             }
-            maxLength={50}
+            maxLength={35}
             errors={errors.world_app_description}
             disabled={!isEditable || !isEnoughPermissions}
             placeholder="This description will be shown inside of World App."
@@ -261,7 +261,7 @@ export const UpdateStoreInfoForm = (props: UpdateStoreInfoFormProps) => {
             addOnRight={
               <RemainingCharacters
                 text={watch("world_app_description")}
-                maxChars={50}
+                maxChars={35}
               />
             }
           />

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/graphql/client/fetch-app-metadata.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/graphql/client/fetch-app-metadata.generated.ts
@@ -28,6 +28,7 @@ export type FetchAppMetadataQuery = {
       world_app_description: string;
       category: string;
       is_developer_allow_listing: boolean;
+      world_app_button_text: string;
       integration_url: string;
       app_website_url: string;
       source_code_url: string;
@@ -47,6 +48,7 @@ export type FetchAppMetadataQuery = {
       world_app_description: string;
       category: string;
       is_developer_allow_listing: boolean;
+      world_app_button_text: string;
       integration_url: string;
       app_website_url: string;
       source_code_url: string;
@@ -75,6 +77,7 @@ export const FetchAppMetadataDocument = gql`
         world_app_description
         category
         is_developer_allow_listing
+        world_app_button_text
         integration_url
         app_website_url
         source_code_url
@@ -95,6 +98,7 @@ export const FetchAppMetadataDocument = gql`
         world_app_description
         category
         is_developer_allow_listing
+        world_app_button_text
         integration_url
         app_website_url
         source_code_url

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/graphql/client/fetch-app-metadata.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/graphql/client/fetch-app-metadata.graphql
@@ -15,6 +15,7 @@ query FetchAppMetadata($id: String!) {
       world_app_description
       category
       is_developer_allow_listing
+      world_app_button_text
       integration_url
       app_website_url
       source_code_url
@@ -35,6 +36,7 @@ query FetchAppMetadata($id: String!) {
       world_app_description
       category
       is_developer_allow_listing
+      world_app_button_text
       integration_url
       app_website_url
       source_code_url

--- a/web/tests/api/public/app.test.ts
+++ b/web/tests/api/public/app.test.ts
@@ -24,6 +24,8 @@ jest.mock(
             integration_url: "https://example.com/integration",
             app_website_url: "https://example.com",
             source_code_url: "https://github.com/example/app",
+            description:
+              '{"description_overview":"fewf","description_how_it_works":"few","description_connect":"fewf"}',
             app: {
               team: {
                 name: "Example Team",
@@ -63,6 +65,11 @@ describe("/api/public/app/[app_id]", () => {
         app_website_url: "https://example.com",
         source_code_url: "https://github.com/example/app",
         team_name: "Example Team",
+        description: {
+          description_overview: "fewf",
+          description_how_it_works: "few",
+          description_connect: "fewf",
+        },
       },
     });
   });

--- a/web/tests/api/public/apps.test.ts
+++ b/web/tests/api/public/apps.test.ts
@@ -75,7 +75,7 @@ describe("/api/public/apps", () => {
     );
     const response = await GET(request);
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ apps: [] });
+    expect(await response.json()).toEqual({ apps: [], featured: [] });
   });
 
   test("should return 200 with non-empty rankings for valid platform and country parameters", async () => {
@@ -95,6 +95,14 @@ describe("/api/public/apps", () => {
             logo_img_url: "logo.png",
             hero_image_url: "hero1.png",
             showcase_img_urls: ["showcase1.png"],
+            category: "social",
+            world_app_button_text: "random",
+            world_app_description: "random",
+            description: {
+              how_it_works: "23423",
+              how_to_connect: "4fwfewf",
+              overview: "random string",
+            },
             app: {
               team: {
                 name: "Example Team",
@@ -107,6 +115,14 @@ describe("/api/public/apps", () => {
             logo_img_url: "logo.png",
             hero_image_url: "hero.png",
             showcase_img_urls: ["showcase1.png", "showcase2.png"],
+            category: "social",
+            world_app_button_text: "random",
+            world_app_description: "random",
+            description: {
+              how_it_works: "fwefw",
+              how_to_connect: "fewfw",
+              overview: "fwefew",
+            },
             app: {
               team: {
                 name: "Example Team",
@@ -118,11 +134,19 @@ describe("/api/public/apps", () => {
             name: "Test App3",
             logo_img_url: "logo.png",
             hero_image_url: "hero.png",
+            world_app_button_text: "random",
+            world_app_description: "random",
             showcase_img_urls: [
               "showcase1.png",
               "showcase2.png",
               "showcase3.png",
             ],
+            category: "social",
+            description: {
+              how_it_works: "random",
+              how_to_connect: "random",
+              overview: "random",
+            },
             app: {
               team: {
                 name: "Example Team",
@@ -145,17 +169,26 @@ describe("/api/public/apps", () => {
     const response = await GET(request);
 
     expect(await response.json()).toEqual({
+      featured: [],
       apps: [
         {
           app_id: "2",
           name: "Test App2",
           logo_img_url: "https://cdn.test.com/2/logo.png",
           hero_image_url: "https://cdn.test.com/2/hero.png",
+          category: "world_id_partner_category_social",
+          description: {
+            how_it_works: "world_id_partner_2_description_how_it_works",
+            how_to_connect: "world_id_partner_2_description_connect",
+            overview: "world_id_partner_2_description_overview",
+          },
           showcase_img_urls: [
             "https://cdn.test.com/2/showcase1.png",
             "https://cdn.test.com/2/showcase2.png",
           ],
           team_name: "Example Team",
+          world_app_button_text: "world_id_partner_2_world_app_button_text",
+          world_app_description: "world_id_partner_2_world_app_description",
         },
         {
           app_id: "1",
@@ -164,6 +197,14 @@ describe("/api/public/apps", () => {
           hero_image_url: "https://cdn.test.com/1/hero1.png",
           showcase_img_urls: ["https://cdn.test.com/1/showcase1.png"],
           team_name: "Example Team",
+          category: "world_id_partner_category_social",
+          description: {
+            how_it_works: "world_id_partner_1_description_how_it_works",
+            how_to_connect: "world_id_partner_1_description_connect",
+            overview: "world_id_partner_1_description_overview",
+          },
+          world_app_button_text: "world_id_partner_1_world_app_button_text",
+          world_app_description: "world_id_partner_1_world_app_description",
         },
         {
           app_id: "3",
@@ -175,7 +216,15 @@ describe("/api/public/apps", () => {
             "https://cdn.test.com/3/showcase2.png",
             "https://cdn.test.com/3/showcase3.png",
           ],
+          category: "world_id_partner_category_social",
+          description: {
+            how_it_works: "world_id_partner_3_description_how_it_works",
+            how_to_connect: "world_id_partner_3_description_connect",
+            overview: "world_id_partner_3_description_overview",
+          },
           team_name: "Example Team",
+          world_app_button_text: "world_id_partner_3_world_app_button_text",
+          world_app_description: "world_id_partner_3_world_app_description",
         },
       ],
     });


### PR DESCRIPTION
### Changes
- Add new field `world_app_button_text` that lets dev specify text they want show in the app default is use integration
- added new permission for reviewer role to update verified apps. This is set so we can remove apps from the app store via setting the `is_reviewer_app_store_approved` flag
- Add localise strings to platform=app
- Updated the return to include featured apps
- Update JSON to now parse the description when returning see spec for new format. 
- App and web return types are different
- Add the new button text field to links section
- Reduced world app description length to 35