### PR TITLE
fix: handle hex strings shorter than 64 characters (excluding 0x)

### DIFF
--- a/web/api/helpers/verify.ts
+++ b/web/api/helpers/verify.ts
@@ -100,7 +100,10 @@ export const parseProofInputs = (params: IInputParams) => {
 
   try {
     nullifier_hash = (
-      abi.decode(["uint256"], params.nullifier_hash)[0] as BigNumber
+      abi.decode(
+        ["uint256"],
+        `0x${params.nullifier_hash.slice(2).padStart(64, "0")}`,
+      )[0] as BigNumber
     ).toHexString();
   } catch (error) {
     logger.error("Error create nullifier hash", { error });
@@ -117,7 +120,10 @@ export const parseProofInputs = (params: IInputParams) => {
 
   try {
     merkle_root = (
-      abi.decode(["uint256"], params.merkle_root)[0] as BigNumber
+      abi.decode(
+        ["uint256"],
+        `0x${params.merkle_root.slice(2).padStart(64, "0")}`,
+      )[0] as BigNumber
     ).toHexString();
   } catch (error) {
     logger.error("Error create merkle root", { error });
@@ -134,7 +140,10 @@ export const parseProofInputs = (params: IInputParams) => {
 
   try {
     external_nullifier = (
-      abi.decode(["uint256"], params.external_nullifier)[0] as BigNumber
+      abi.decode(
+        ["uint256"],
+        `0x${params.external_nullifier.slice(2).padStart(64, "0")}`,
+      )[0] as BigNumber
     ).toHexString();
   } catch (error) {
     logger.error("Error create external nullifier", { error });
@@ -151,7 +160,10 @@ export const parseProofInputs = (params: IInputParams) => {
 
   try {
     signal_hash = (
-      abi.decode(["uint256"], params.signal_hash)[0] as BigNumber
+      abi.decode(
+        ["uint256"],
+        `0x${params.signal_hash.slice(2).padStart(64, "0")}`,
+      )[0] as BigNumber
     ).toHexString();
   } catch (error) {
     logger.error("Error create signal hash", { error });


### PR DESCRIPTION
Handles inputs to proof verification shorter than 64 hex characters for `nullifier_hash`, `merkle_root`, `external_nullifier`, and `signal_hash`.

As these are all outputs of a hash function, there's no guarantee that the output is above a certain value, and we shouldn't expect to receive hex strings pre-padded.

This issue was identified during testing of an unrelated Android bug, where the `merkle_root` was valid, but only 63 hex characters long.

For the above-named inputs, this PR slices off `0x` from the string, pads the hex string with `0` up to 64 characters, and adds the `0x` back, then attempts to parse the hex string as a `uint256`.