### PR TITLE
[Fix] precheck blocking empty string

### DIFF
--- a/web/pages/api/v1/precheck/[app_id].ts
+++ b/web/pages/api/v1/precheck/[app_id].ts
@@ -104,11 +104,7 @@ const appPrecheckQuery = gql`
 `;
 
 const schema = yup.object().shape({
-  action: yup
-    .string()
-    .strict()
-    .required("This attribute is required")
-    .default(""),
+  action: yup.string().strict().default(""),
 
   nullifier_hash: yup
     .string()


### PR DESCRIPTION
Required was blocking sign in with world id precheck causing things to fail. Removing required since we default to empty string