### PR TITLE
[Fix] Dev portal next js migration errors

### DIFF
--- a/web/api/prod/internal/v1/transactions/index.ts
+++ b/web/api/prod/internal/v1/transactions/index.ts
@@ -18,11 +18,12 @@ export const GET = async () => {
     } catch (error) {
       data = null;
     }
+    const headers = Object.fromEntries(response.headers.entries());
 
     return new NextResponse(JSON.stringify(data), {
       status: response.status,
       statusText: response.statusText,
-      headers: response.headers,
+      headers: headers,
     });
   } catch (error) {
     if (error instanceof Error) {

--- a/web/lib/logger.ts
+++ b/web/lib/logger.ts
@@ -63,7 +63,10 @@ async function requestFormatter(req: NextApiRequest | IncomingMessage) {
     return {};
   }
 
-  const ip = req.socket.remoteAddress;
+  const ip =
+    req.socket?.remoteAddress ||
+    req.headers["x-forwarded-for"] ||
+    "IP not available";
   const url = req.url?.replace(/\?.*$/, "");
   const method = req.method;
   const userAgent = req.headers["user-agent"];


### PR DESCRIPTION
Lots of errors triggering on call alerts. i think this has to do with the upgrade to next js and the new endpoint

`Part terminated early due to unexpected end of multipart data` `Cannot read properties of undefined (reading 'remoteAddress')`

Header one was cause of this https://app.datadoghq.com/logs?query=env%3Aproduction%20app%3Adeveloper-portal%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAY9OGcXSNrkiQgAAAAAAAAAYAAAAAEFZOU9HY2lGQUFCSElScGxhNDJWQ3dBQQAAACQAAAAAMDE4ZjRlMjYtOGI1ZS00N2QxLThhN2YtN2ZiMzMxMWI1OGE5&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1715002035421&to_ts=1715016435421&live=true

I can't tell where it's coming from since our log traces are bad