### PR TITLE
Feat: Transaction Endpoint for Mini Apps

### DIFF
--- a/web/api/v2/minikit/transaction/[transaction_id]/graphql/fetch-api-key.generated.ts
+++ b/web/api/v2/minikit/transaction/[transaction_id]/graphql/fetch-api-key.generated.ts
@@ -1,0 +1,76 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient } from "graphql-request";
+import { GraphQLClientRequestHeaders } from "graphql-request/build/cjs/types";
+import gql from "graphql-tag";
+export type FetchApiKeyQueryVariables = Types.Exact<{
+  id: Types.Scalars["String"];
+  appId: Types.Scalars["String"];
+}>;
+
+export type FetchApiKeyQuery = {
+  __typename?: "query_root";
+  api_key_by_pk?: {
+    __typename?: "api_key";
+    id: string;
+    api_key: string;
+    is_active: boolean;
+    team: {
+      __typename?: "team";
+      id: string;
+      apps: Array<{ __typename?: "app"; id: string }>;
+    };
+  } | null;
+};
+
+export const FetchApiKeyDocument = gql`
+  query FetchAPIKey($id: String!, $appId: String!) {
+    api_key_by_pk(id: $id) {
+      id
+      api_key
+      is_active
+      team {
+        id
+        apps(where: { id: { _eq: $appId } }) {
+          id
+        }
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchAPIKey(
+      variables: FetchApiKeyQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchApiKeyQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchApiKeyQuery>(FetchApiKeyDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        "FetchAPIKey",
+        "query",
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/v2/minikit/transaction/[transaction_id]/graphql/fetch-api-key.gql
+++ b/web/api/v2/minikit/transaction/[transaction_id]/graphql/fetch-api-key.gql
@@ -1,0 +1,13 @@
+query FetchAPIKey($id: String!, $appId: String!) {
+  api_key_by_pk(id: $id) {
+    id
+    api_key
+    is_active
+    team {
+      id
+      apps(where: { id: { _eq: $appId } }) {
+        id
+      }
+    }
+  }
+}

--- a/web/api/v2/minikit/transaction/[transaction_id]/route.ts
+++ b/web/api/v2/minikit/transaction/[transaction_id]/route.ts
@@ -1,0 +1,111 @@
+import { errorResponse } from "@/api/helpers/errors";
+import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { verifyHashedSecret } from "@/api/helpers/utils";
+import { NextRequest, NextResponse } from "next/server";
+import { getSdk as fetchApiKeySdk } from "./graphql/fetch-api-key.generated";
+
+export const GET = async (
+  req: NextRequest,
+  { params: routeParams }: { params: { transaction_id: string } },
+) => {
+  const api_key = req.headers.get("authorization")?.split(" ")[1];
+  const { searchParams } = new URL(req.url);
+
+  if (!api_key) {
+    return errorResponse({
+      statusCode: 401,
+      code: "unauthorized",
+      detail: "API key is required.",
+      attribute: "api_key",
+      req,
+    });
+  }
+
+  const appId = searchParams.get("app_id");
+  if (!appId) {
+    return errorResponse({
+      statusCode: 400,
+      code: "invalid_request",
+      detail: "App ID is required.",
+      attribute: "app_id",
+      req,
+    });
+  }
+
+  const transactionId = routeParams.transaction_id;
+  const keyValue = api_key.replace(/^api_/, "");
+  const base64ApiKey = Buffer.from(keyValue, "base64").toString("utf8");
+  const [id, secret] = base64ApiKey.split(":");
+  const serviceClient = await getAPIServiceGraphqlClient();
+
+  const { api_key_by_pk } = await fetchApiKeySdk(serviceClient).FetchAPIKey({
+    id,
+    appId: appId,
+  });
+
+  if (!api_key_by_pk) {
+    return errorResponse({
+      statusCode: 404,
+      code: "not_found",
+      detail: "API key not found.",
+      attribute: "api_key",
+      req,
+    });
+  }
+
+  if (!api_key_by_pk.is_active) {
+    return errorResponse({
+      statusCode: 400,
+      code: "api_key_inactive",
+      detail: "API key is inactive.",
+      attribute: "api_key",
+      req,
+    });
+  }
+
+  if (!api_key_by_pk.team.apps.some((a) => a.id === appId)) {
+    return errorResponse({
+      statusCode: 403,
+      code: "invalid_app",
+      detail: "API key is not valid for this app.",
+      attribute: "api_key",
+      req,
+    });
+  }
+
+  const isAPIKeyValid = verifyHashedSecret(
+    api_key_by_pk.id,
+    secret,
+    api_key_by_pk.api_key,
+  );
+
+  if (!isAPIKeyValid) {
+    return errorResponse({
+      statusCode: 403,
+      code: "invalid_api_key",
+      detail: "API key is not valid.",
+      attribute: "api_key",
+      req,
+    });
+  }
+
+  const res = await fetch(
+    `${process.env.NEXT_SERVER_INTERNAL_PAYMENTS_ENDPOINT}?miniapp-id=${appId}&transaction-id=${transactionId}`,
+    {
+      method: "GET",
+    },
+  );
+
+  if (!res.ok) {
+    return errorResponse({
+      statusCode: res.status,
+      code: "internal_server_error",
+      detail: "Failed to fetch transaction data.",
+      attribute: "transaction",
+      req,
+    });
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: 200 });
+};

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/index.ts
@@ -15,13 +15,13 @@ export const getTransactionData = async (
       method: "GET",
     });
 
+    const data = await response.json();
     if (!response.ok) {
       throw new Error(
-        `Failed to fetch transaction data. Status: ${response.status}`,
+        `Failed to fetch transaction data. Status: ${response.status}. Error: ${data}`,
       );
     }
 
-    const data = await response.json();
     console.log(data); // Keep for now since we can only test on staging
     return data;
   } catch (error) {

--- a/web/tests/api/v2/minikit-transaction.test.ts
+++ b/web/tests/api/v2/minikit-transaction.test.ts
@@ -1,0 +1,247 @@
+import { GET } from "@/api/v2/minikit/transaction/[transaction_id]/route";
+import { generateHashedSecret } from "@/legacy/backend/utils";
+import { NextRequest } from "next/server";
+
+// #region Mocks
+const FetchAPIKey = jest.fn();
+
+jest.mock("../../../lib/logger", () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock(
+  "../../../api/v2/minikit/transaction/[transaction_id]/graphql/fetch-api-key.generated",
+  () => ({
+    getSdk: () => ({
+      FetchAPIKey,
+    }),
+  }),
+);
+
+const transaction = {
+  transactionId: "txn_123456789",
+  transactionHash: "0xabc123def456",
+  transactionStatus: "completed",
+  referenceId: "ref_987654321",
+  miniappId: "miniapp_001",
+  updatedAt: new Date().toISOString(),
+  network: "optimism",
+  fromWalletAddress: "0x123456789abcdef",
+  recipientAddress: "0x987654321fedcba",
+  inputToken: "USDC",
+  inputTokenAmount: "15000000",
+};
+
+// #endregion
+
+// #region Test Data
+const getUrl = (transaction_id: string, app_id?: string) => {
+  if (!app_id) {
+    return new URL(
+      `/api/v2/minikit/transaction/${transaction_id}`,
+      "http://localhost:3000",
+    );
+  }
+  return new URL(
+    `/api/v2/minikit/transaction/${transaction_id}?app_id=${app_id}`,
+    "http://localhost:3000",
+  );
+};
+
+const createMockRequest = (params: {
+  url: URL | RequestInfo;
+  api_key: string;
+}) => {
+  const { url, api_key } = params;
+  return new NextRequest(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `ApiKey ${api_key}`,
+    },
+  });
+};
+
+const validApiKeyId = "key_667f5fbd4ad943622b4b2d3eb258f89c";
+const testHashedSecret = generateHashedSecret(validApiKeyId);
+
+const apiKeyValue = Buffer.from(`${validApiKeyId}:${testHashedSecret.secret}`)
+  .toString("base64")
+  .replace(/=/g, "");
+
+const validApiKeyResponse = {
+  api_key_by_pk: {
+    id: validApiKeyId,
+    api_key: testHashedSecret.hashed_secret,
+    is_active: true,
+    team: {
+      id: "team_dd2ecd36c6c45f645e8e5d9a31abdee1",
+      apps: [{ id: "app_staging_9cdd0a714aec9ed17dca660bc9ffe72a" }],
+    },
+  },
+};
+
+const validAppId = validApiKeyResponse.api_key_by_pk.team.apps[0].id;
+const validTransactionId = "transaction_123";
+const validApiKey = `api_${apiKeyValue}`;
+
+// #endregion
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: jest.fn(() => Promise.resolve({})),
+    ok: true,
+    status: 200,
+  }),
+) as jest.Mock;
+
+const mockFetch = (params: {
+  body: Record<string, any>;
+  ok: boolean;
+  status: number;
+  text?: string;
+}) => {
+  (fetch as jest.Mock).mockImplementationOnce(() =>
+    Promise.resolve({
+      json: jest.fn(() => Promise.resolve(params.body)),
+      text: jest.fn(() => Promise.resolve(params.text ?? "")),
+      ok: params.ok,
+      status: params.status,
+    }),
+  );
+};
+
+// #region Success cases tests
+describe("/api/v2/minikit/transaction/transaction_id [success cases]", () => {
+  it("can fetch a transaction", async () => {
+    const mockReq = createMockRequest({
+      url: getUrl(validTransactionId, validAppId),
+      api_key: validApiKey,
+    });
+
+    const ctx = { params: { transaction_id: validTransactionId } };
+    FetchAPIKey.mockResolvedValue(validApiKeyResponse);
+
+    mockFetch({
+      body: transaction,
+      ok: true,
+      status: 200,
+    });
+
+    const res = await GET(mockReq, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body).toEqual(transaction);
+  });
+});
+// #endregion
+
+// #region Error cases tests
+describe("/api/v2/minikit/transaction/transaction_id [error cases]", () => {
+  it("returns 401 if no api key is provided", async () => {
+    const mockReq = createMockRequest({
+      url: getUrl(validTransactionId, validAppId),
+      api_key: "",
+    });
+
+    const ctx = { params: { transaction_id: validTransactionId } };
+    FetchAPIKey.mockResolvedValue(validApiKeyResponse);
+
+    const res = await GET(mockReq, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 if api key not exists", async () => {
+    const mockReq = createMockRequest({
+      url: getUrl(validTransactionId, validAppId),
+      api_key: (Math.random() * 10 ** 10).toFixed(),
+    });
+
+    const ctx = { params: { transaction_id: validTransactionId } };
+    FetchAPIKey.mockResolvedValue({});
+
+    const res = await GET(mockReq, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 if token is invalid or old", async () => {
+    const testHashedSecretLocal = generateHashedSecret("app_123");
+
+    const apiKeyValueLocal = Buffer.from(
+      `${"app_123"}:${testHashedSecretLocal.secret}`,
+    )
+      .toString("base64")
+      .replace(/=/g, "");
+
+    const mockReq = createMockRequest({
+      url: getUrl(validTransactionId, validAppId),
+      api_key: `api_${apiKeyValueLocal}`,
+    });
+
+    const ctx = { params: { transaction_id: validTransactionId } };
+    FetchAPIKey.mockResolvedValue(validApiKeyResponse);
+
+    const res = await GET(mockReq, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 if api key is not valid for the app", async () => {
+    const mockReq = createMockRequest({
+      url: getUrl(validTransactionId, "app_1234"),
+      api_key: validApiKey,
+    });
+
+    const ctx = { params: { transaction_id: validTransactionId } };
+    FetchAPIKey.mockResolvedValue(validApiKeyResponse);
+
+    const res = await GET(mockReq, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 if api key is inactive", async () => {
+    const mockReq = createMockRequest({
+      url: getUrl(validTransactionId, validAppId),
+      api_key: validApiKey,
+    });
+
+    const ctx = { params: { transaction_id: validTransactionId } };
+    FetchAPIKey.mockResolvedValue({
+      ...validApiKeyResponse,
+      api_key_by_pk: { ...validApiKeyResponse.api_key_by_pk, is_active: false },
+    });
+
+    const res = await GET(mockReq, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 if appId is not provided", async () => {
+    const mockReq = createMockRequest({
+      url: getUrl(validTransactionId),
+      api_key: validApiKey,
+    });
+
+    const ctx = { params: { transaction_id: validTransactionId } };
+    FetchAPIKey.mockResolvedValue(validApiKeyResponse);
+
+    const res = await GET(mockReq, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 if appId is empty", async () => {
+    const mockReq = createMockRequest({
+      url: getUrl(validTransactionId, ""),
+      api_key: validApiKey,
+    });
+
+    const ctx = { params: { transaction_id: validTransactionId } };
+    FetchAPIKey.mockResolvedValue(validApiKeyResponse);
+
+    const res = await GET(mockReq, ctx);
+    expect(res.status).toBe(400);
+  });
+});
+// #endregion

--- a/web/tests/api/v2/minikit-transaction.test.ts
+++ b/web/tests/api/v2/minikit-transaction.test.ts
@@ -60,7 +60,7 @@ const createMockRequest = (params: {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `ApiKey ${api_key}`,
+      Authorization: `Bearer ${api_key}`,
     },
   });
 };
@@ -126,7 +126,7 @@ describe("/api/v2/minikit/transaction/transaction_id [success cases]", () => {
     FetchAPIKey.mockResolvedValue(validApiKeyResponse);
 
     mockFetch({
-      body: transaction,
+      body: [transaction],
       ok: true,
       status: 200,
     });
@@ -135,7 +135,7 @@ describe("/api/v2/minikit/transaction/transaction_id [success cases]", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
 
-    expect(body).toEqual(transaction);
+    expect(body).toEqual([transaction]);
   });
 });
 // #endregion


### PR DESCRIPTION
This endpoint is used by web2 apps to confirm the transaction was successfully mined on chain. Developers will use their api key in the dev portal in order to call this endpoint. Developers will only be able to see transaction data for apps that they own the API key for. 

Developers will call this via `developer.worldcoin.org/v1/minikit/transactions/transaction_id?app_id=12312`.
Upon successful completion this will return a singular transaction object back to the user in the form of 
[transaction_data]