### PR TITLE
Fix: Hasura Actions GET -> POST

### DIFF
--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -17,13 +17,9 @@ actions:
         - name: Authorization
           value_from_env: INTERNAL_ENDPOINTS_SECRET
       request_transform:
-        method: GET
+        method: POST
         query_params:
           app_id: '{{$body.input.app_id}}'
-        request_headers:
-          add_headers: {}
-          remove_headers:
-            - content-type
         template_engine: Kriti
         version: 2
     permissions:
@@ -37,13 +33,9 @@ actions:
         - name: Authorization
           value_from_env: INTERNAL_ENDPOINTS_SECRET
       request_transform:
-        method: GET
+        method: POST
         query_params:
           app_id: '{{$body.input.app_id}}'
-        request_headers:
-          add_headers: {}
-          remove_headers:
-            - content-type
         template_engine: Kriti
         version: 2
     permissions:
@@ -57,15 +49,11 @@ actions:
         - name: Authorization
           value_from_env: INTERNAL_ENDPOINTS_SECRET
       request_transform:
-        method: GET
+        method: POST
         query_params:
           app_id: '{{$body.input.app_id}}'
           content_type_ending: '{{$body.input.content_type_ending}}'
           image_type: '{{$body.input.image_type}}'
-        request_headers:
-          add_headers: {}
-          remove_headers:
-            - content-type
         template_engine: Kriti
         version: 2
     permissions:
@@ -111,15 +99,11 @@ actions:
         - name: Authorization
           value_from_env: INTERNAL_ENDPOINTS_SECRET
       request_transform:
-        method: GET
+        method: POST
         query_params:
           app_id: '{{$body.input.app_id}}'
           content_type_ending: '{{$body.input.content_type_ending}}'
           image_type: '{{$body.input.image_type}}'
-        request_headers:
-          add_headers: {}
-          remove_headers:
-            - content-type
         template_engine: Kriti
         version: 2
     permissions:

--- a/hasura/metadata/databases/default/tables/public_action.yaml
+++ b/hasura/metadata/databases/default/tables/public_action.yaml
@@ -37,7 +37,6 @@ insert_permissions:
       columns:
         - action
         - app_id
-        - creation_mode
         - description
         - external_nullifier
         - kiosk_enabled
@@ -91,7 +90,6 @@ select_permissions:
         - max_accounts_per_user
         - max_verifications
         - name
-        - status
         - updated_at
       filter:
         app:

--- a/hasura/metadata/databases/default/tables/public_nullifier.yaml
+++ b/hasura/metadata/databases/default/tables/public_nullifier.yaml
@@ -22,7 +22,6 @@ select_permissions:
         - created_at
         - id
         - nullifier_hash
-        - uses
       filter:
         action:
           app:

--- a/web/legacy/api/images/get_app_review_images.ts
+++ b/web/legacy/api/images/get_app_review_images.ts
@@ -30,6 +30,8 @@ const schema = yup.object({
  * @param req
  * @param res
  */
+
+// TODO: When we migrate this to new API, should convert to GET
 export const handleGetAppReviewImages = async (
   req: NextApiRequest,
   res: NextApiResponse,
@@ -47,11 +49,11 @@ export const handleGetAppReviewImages = async (
       return;
     }
 
-    if (req.method !== "GET") {
+    if (req.method !== "POST") {
       return errorNotAllowed(req.method, res, req);
     }
 
-    const body = JSON.parse(req.body);
+    const body = req.body;
 
     if (body?.action.name !== "get_app_review_images") {
       return errorHasuraQuery({

--- a/web/legacy/api/images/get_uploaded_image.ts
+++ b/web/legacy/api/images/get_uploaded_image.ts
@@ -22,6 +22,8 @@ type RequestQueryParams = {
  * @param req
  * @param res
  */
+
+// TODO: When we migrate this to new API, should convert to GET
 export const handleImageGet = async (
   req: NextApiRequest,
   res: NextApiResponse,
@@ -31,11 +33,11 @@ export const handleImageGet = async (
       return;
     }
 
-    if (!req.method || req.method !== "GET") {
+    if (!req.method || req.method !== "POST") {
       return errorNotAllowed(req.method, res, req);
     }
 
-    const body = JSON.parse(req.body);
+    const body = req.body;
     if (body?.action.name !== "get_uploaded_image") {
       return errorHasuraQuery({
         res,

--- a/web/legacy/api/images/upload_image_url.ts
+++ b/web/legacy/api/images/upload_image_url.ts
@@ -18,6 +18,8 @@ type RequestQueryParams = {
  * @param req
  * @param res
  */
+
+// TODO: When we migrate this to new API, should convert to GET
 export const handleImageUpload = async (
   req: NextApiRequest,
   res: NextApiResponse,
@@ -27,10 +29,10 @@ export const handleImageUpload = async (
       return;
     }
 
-    if (req.method !== "GET") {
+    if (req.method !== "POST") {
       return errorNotAllowed(req.method, res, req);
     }
-    const body = JSON.parse(req.body);
+    const body = req.body;
     if (body?.action.name !== "upload_image") {
       return errorHasuraQuery({
         res,


### PR DESCRIPTION
Currently Hasura actions are GET requests but they contain body. This is casuing datadog to spasm for good reason. I will move them to GET requests but we should do that when migrating the endpoints out of legacy. This is a temp fix for now to make them post requests.