### PR TITLE
Fix: Update view permissions and filter keys

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/graphql/client/fetch-keys.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/graphql/client/fetch-keys.generated.ts
@@ -4,7 +4,9 @@ import * as Types from "@/graphql/graphql";
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
 const defaultOptions = {} as const;
-export type FetchKeysQueryVariables = Types.Exact<{ [key: string]: never }>;
+export type FetchKeysQueryVariables = Types.Exact<{
+  teamId: Types.Scalars["String"];
+}>;
 
 export type FetchKeysQuery = {
   __typename?: "query_root";
@@ -20,8 +22,11 @@ export type FetchKeysQuery = {
 };
 
 export const FetchKeysDocument = gql`
-  query FetchKeys {
-    api_key(order_by: { created_at: asc }) {
+  query FetchKeys($teamId: String!) {
+    api_key(
+      order_by: { created_at: asc }
+      where: { team_id: { _eq: $teamId } }
+    ) {
       id
       team_id
       created_at
@@ -44,14 +49,12 @@ export const FetchKeysDocument = gql`
  * @example
  * const { data, loading, error } = useFetchKeysQuery({
  *   variables: {
+ *      teamId: // value for 'teamId'
  *   },
  * });
  */
 export function useFetchKeysQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    FetchKeysQuery,
-    FetchKeysQueryVariables
-  >,
+  baseOptions: Apollo.QueryHookOptions<FetchKeysQuery, FetchKeysQueryVariables>,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<FetchKeysQuery, FetchKeysQueryVariables>(

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/graphql/client/fetch-keys.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/graphql/client/fetch-keys.graphql
@@ -1,5 +1,5 @@
-query FetchKeys {
-  api_key(order_by: { created_at: asc }) {
+query FetchKeys($teamId: String!) {
+  api_key(order_by: { created_at: asc }, where: { team_id: { _eq: $teamId } }) {
     id
     team_id
     created_at

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/index.tsx
@@ -1,5 +1,8 @@
 "use client";
 import { DecoratedButton } from "@/components/DecoratedButton";
+import { PlusIcon } from "@/components/Icons/PlusIcon";
+import { Section } from "@/components/Section";
+import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { useState } from "react";
 import Skeleton from "react-loading-skeleton";
@@ -7,9 +10,6 @@ import { TeamProfile } from "../../common/TeamProfile";
 import { ApiKeysTable } from "./ApiKeyTable";
 import { CreateKeyModal } from "./CreateKeyModal";
 import { useFetchKeysQuery } from "./graphql/client/fetch-keys.generated";
-import { SizingWrapper } from "@/components/SizingWrapper";
-import { PlusIcon } from "@/components/Icons/PlusIcon";
-import { Section } from "@/components/Section";
 
 type TeamApiKeysPageProps = {
   params: Record<string, string> | null | undefined;
@@ -19,7 +19,9 @@ export const TeamApiKeysPage = (props: TeamApiKeysPageProps) => {
   const { params } = props;
   const teamId = params?.teamId;
   const [showCreateKeyModal, setShowCreateKeyModal] = useState(false);
-  const { data, loading } = useFetchKeysQuery();
+  const { data, loading } = useFetchKeysQuery({
+    variables: { teamId: teamId ?? "" },
+  });
 
   const apiKeys = data?.api_key;
   return (

--- a/web/scenes/Portal/Teams/TeamId/Team/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/layout/index.tsx
@@ -28,7 +28,7 @@ export const TeamIdLayout = async (props: TeamIdLayoutProps) => {
   const ownerAndAdminPermission = checkUserPermissions(
     user,
     params.teamId ?? "",
-    [Role_Enum.Owner],
+    [Role_Enum.Owner, Role_Enum.Admin],
   );
 
   return (


### PR DESCRIPTION
Previously we were not filtering keys by team such that you could see keys for other teams that you were part of