### PR TITLE
fix: invite same email to the multiple teams

### DIFF
--- a/web/legacy/api/_invite-team-members/graphql/fetchInvites.generated.ts
+++ b/web/legacy/api/_invite-team-members/graphql/fetchInvites.generated.ts
@@ -10,7 +10,12 @@ export type FetchInvitesQueryVariables = Types.Exact<{
 
 export type FetchInvitesQuery = {
   __typename?: "query_root";
-  invite: Array<{ __typename?: "invite"; id: string; email: string }>;
+  invite: Array<{
+    __typename?: "invite";
+    id: string;
+    email: string;
+    team_id: string;
+  }>;
 };
 
 export const FetchInvitesDocument = gql`
@@ -18,6 +23,7 @@ export const FetchInvitesDocument = gql`
     invite(where: { email: { _in: $emails } }) {
       id
       email
+      team_id
     }
   }
 `;

--- a/web/legacy/api/_invite-team-members/graphql/fetchInvites.gql
+++ b/web/legacy/api/_invite-team-members/graphql/fetchInvites.gql
@@ -2,5 +2,6 @@ query FetchInvites($emails: [String!]!) {
   invite(where: { email: { _in: $emails } }) {
     id
     email
+    team_id
   }
 }

--- a/web/legacy/api/_invite-team-members/graphql/getUserAndTeamMemberships.generated.ts
+++ b/web/legacy/api/_invite-team-members/graphql/getUserAndTeamMemberships.generated.ts
@@ -21,6 +21,7 @@ export type GetUserAndTeamMembershipsQuery = {
   membership: Array<{
     __typename?: "membership";
     user: { __typename?: "user"; email?: string | null };
+    team: { __typename?: "team"; id: string; name?: string | null };
   }>;
 };
 
@@ -46,6 +47,10 @@ export const GetUserAndTeamMembershipsDocument = gql`
     membership(where: { team_id: { _eq: $team_id } }) {
       user {
         email
+      }
+      team {
+        id
+        name
       }
     }
   }

--- a/web/legacy/api/_invite-team-members/graphql/getUserAndTeamMemberships.graphql
+++ b/web/legacy/api/_invite-team-members/graphql/getUserAndTeamMemberships.graphql
@@ -17,5 +17,9 @@ query GetUserAndTeamMemberships($team_id: String!, $user_id: String!) {
     user {
       email
     }
+    team {
+      id
+      name
+    }
   }
 }

--- a/web/legacy/api/_invite-team-members/index.ts
+++ b/web/legacy/api/_invite-team-members/index.ts
@@ -122,22 +122,22 @@ export const handleInvite = async (
     emails,
   });
 
-  const invitesToUpdate = fetchInvitesResult.invite.filter((invite) => {
-    return emails.includes(invite.email);
+  const existingInvites = fetchInvitesResult.invite.filter((invite) => {
+    return emails.includes(invite.email) && invite.team_id === teamId;
   });
 
   const emailsToCreate = emails.filter((email: string) => {
-    return !invitesToUpdate.some((invite) => invite.email === email);
+    return !existingInvites.some((invite) => invite.email === email);
   });
 
   let updatedInvites: NonNullable<
     UpdateInvitesExpirationMutation["invites"]
   >["returning"] = [];
 
-  if (invitesToUpdate.length > 0) {
+  if (existingInvites.length > 0) {
     const updateExpirationResult = await getSdk(client).UpdateInvitesExpiration(
       {
-        ids: invitesToUpdate.map((invite) => invite.id),
+        ids: existingInvites.map((invite) => invite.id),
         expires_at: dayjs().add(7, "days").toISOString(),
       },
     );

--- a/web/legacy/api/_invite-team-members/index.ts
+++ b/web/legacy/api/_invite-team-members/index.ts
@@ -90,6 +90,10 @@ export const handleInvite = async (
 
   const invitingUser = query.user[0];
 
+  const invitingUsersMembership = query.membership.find(
+    (membership) => membership.team.id === teamId,
+  );
+
   if (!invitingUser?.id) {
     logger.warn(
       "User or team not found. User may not have permissions for this team.",
@@ -209,7 +213,9 @@ export const handleInvite = async (
       invitingUser.name || invitingUser.email || "Someone",
     );
 
-    const team = DOMPurify.sanitize(invitingUser.team?.name || "their team");
+    const team = DOMPurify.sanitize(
+      invitingUsersMembership?.team.name || "their team",
+    );
     const to = DOMPurify.sanitize(invite.email);
 
     promises.push(

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/InviteTeamMemberDialog/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/InviteTeamMemberDialog/index.tsx
@@ -11,9 +11,9 @@ import { atom, useAtom } from "jotai";
 import { useParams } from "next/navigation";
 import { useCallback } from "react";
 import { toast } from "react-toastify";
+import { FetchTeamMembersDocument } from "../graphql/client/fetch-team-members.generated";
 import { useInviteTeamMembersMutation } from "../graphql/client/invite-team-members.generated";
 import { EmailsInput } from "./EmailsInput";
-import { FetchTeamMembersDocument } from "../graphql/client/fetch-team-members.generated";
 
 export const inviteTeamMemberDialogAtom = atom(false);
 export const emailsInputAtom = atom<string[]>([]);


### PR DESCRIPTION
This should fix the invites bug when you have incorrect behavior if you invite the same email to different teams. 

Problem: 
- Logic is so that if a user sends an email that is already in the invite list we should just update the existing one instead of creating a new one with the same email. 
- The issue was the condition that filters existing emails. The condition didn't check the `teamId` and as a result, if you already have an invite to team A, when you try to create an invite to team B, an invite to team A will be selected as an "invite to update", but not as an "invite to create".


PR also fixes incorrect team names in the invite email

---

Screencast updated:

https://github.com/worldcoin/developer-portal/assets/89008845/92752b3f-f089-4205-bb71-4f64a6a8dad6


