### PR TITLE
feat: static kiosk link

### DIFF
--- a/web/app/(portal)/kiosk/[appId]/[actionId]/page.tsx
+++ b/web/app/(portal)/kiosk/[appId]/[actionId]/page.tsx
@@ -1,0 +1,13 @@
+import { generateMetaTitle } from "@/lib/genarate-title";
+import { ActionIdKioskPage } from "@/scenes/Portal/Kiosk";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: generateMetaTitle({ left: "Kiosk" }),
+  appleWebApp: {
+    title: "World ID Kiosk",
+    statusBarStyle: "black-translucent",
+  },
+};
+
+export default ActionIdKioskPage;

--- a/web/scenes/Portal/Kiosk/index.tsx
+++ b/web/scenes/Portal/Kiosk/index.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { SizingWrapper } from "@/components/SizingWrapper";
+import { VerificationLevel } from "@worldcoin/idkit-core";
+import { useSearchParams } from "next/navigation";
+import { ActiveKioskPage } from "../Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/ActiveKiosk";
+import { useGetKioskActionQuery } from "../Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/graphql/client/get-kiosk-action.generated";
+
+type ActionIdKioskPageProps = {
+  params: Record<string, string> | null | undefined;
+};
+export const ActionIdKioskPage = (props: ActionIdKioskPageProps) => {
+  const { params } = props;
+  const searchParams = useSearchParams();
+
+  const verificationLevel = searchParams?.get(
+    "verification-level",
+  ) as VerificationLevel;
+
+  const appId = params?.appId as `app_${string}`;
+  const actionId = params?.actionId as `action_${string}`;
+
+  const { data } = useGetKioskActionQuery({
+    variables: {
+      action_id: actionId,
+      app_id: appId,
+    },
+  });
+
+  return (
+    <SizingWrapper gridClassName="order-2 pt-6 md:pt-10">
+      {data && (
+        <ActiveKioskPage
+          params={params}
+          data={data}
+          toggleKiosk={() => true}
+          verificationLevel={verificationLevel}
+        />
+      )}
+    </SizingWrapper>
+  );
+};


### PR DESCRIPTION
Creates a kiosk page that can be shared at a static URL, and is compatible with Apple's "Add to Home Screen" functionality.

Primary purpose is to support kiosks on iPads.