### PR TITLE
Fix: Pass through of API keys

### DIFF
--- a/web/pages/api/v1/graphql.ts
+++ b/web/pages/api/v1/graphql.ts
@@ -65,6 +65,9 @@ export default async function handleGraphQL(
       "Authorization",
       `Bearer ${await generateAPIKeyJWT(response.data.api_key[0].team_id)}`,
     );
+  } else if (authorization) {
+    // If we get a service key or reviewer key in the authorization header, pass it through
+    headers.append("authorization", `Bearer ${authorization}`);
   }
 
   let body: string | undefined = undefined;


### PR DESCRIPTION
We are firewall blocking requests now, so we should have a pass through of valid authorization headers. Currently if someone has a valid JWT for the service or reviewer role they are hitting hasura directly. We are changing access to now not allow public access so they will need to go through this api