### PR TITLE
WID-1047 Hasura Backend Changes for App Rating

### DIFF
--- a/hasura/metadata/databases/default/tables/public_app_metadata.yaml
+++ b/hasura/metadata/databases/default/tables/public_app_metadata.yaml
@@ -5,6 +5,13 @@ object_relationships:
   - name: app
     using:
       foreign_key_constraint_on: app_id
+computed_fields:
+  - name: app_rating
+    definition:
+      function:
+        name: compute_average_rating
+        schema: public
+    comment: A computed field that returns the rating of an app
 insert_permissions:
   - role: api_key
     permission:
@@ -122,6 +129,8 @@ select_permissions:
         - world_app_button_text
         - whitelisted_addresses
         - app_mode
+      computed_fields:
+        - app_rating
       filter:
         verification_status:
           _neq: unverified
@@ -150,6 +159,8 @@ select_permissions:
         - whitelisted_addresses
         - world_app_button_text
         - world_app_description
+      computed_fields:
+        - app_rating
       filter: {}
   - role: user
     permission:
@@ -179,6 +190,8 @@ select_permissions:
         - whitelisted_addresses
         - world_app_button_text
         - world_app_description
+      computed_fields:
+        - app_rating
       filter:
         app:
           team:

--- a/hasura/metadata/databases/default/tables/public_app_reviews.yaml
+++ b/hasura/metadata/databases/default/tables/public_app_reviews.yaml
@@ -1,0 +1,31 @@
+table:
+  name: app_reviews
+  schema: public
+insert_permissions:
+  - role: service
+    permission:
+      check: {}
+      columns:
+        - nullifier_hash
+        - app_id
+        - country
+        - rating
+select_permissions:
+  - role: service
+    permission:
+      columns:
+        - id
+        - nullifier_hash
+        - app_id
+        - country
+        - rating
+        - updated_at
+      filter: {}
+update_permissions:
+  - role: service
+    permission:
+      columns:
+        - rating
+        - updated_at
+      filter: {}
+      check: {}

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -4,6 +4,7 @@
 - "!include public_app.yaml"
 - "!include public_app_metadata.yaml"
 - "!include public_app_rankings.yaml"
+- "!include public_app_reviews.yaml"
 - "!include public_app_stats_returning.yaml"
 - "!include public_auth_code.yaml"
 - "!include public_cache.yaml"

--- a/hasura/migrations/default/1718063882069_create_table_public_app_reviews/down.sql
+++ b/hasura/migrations/default/1718063882069_create_table_public_app_reviews/down.sql
@@ -1,0 +1,5 @@
+DROP FUNCTION compute_average_rating (app_metadata_row app_metadata);
+
+DROP TRIGGER IF EXISTS "set_public_app_reviews_updated_at" ON "public"."app_reviews";
+
+DROP TABLE "public"."app_reviews";

--- a/hasura/migrations/default/1718063882069_create_table_public_app_reviews/up.sql
+++ b/hasura/migrations/default/1718063882069_create_table_public_app_reviews/up.sql
@@ -1,0 +1,25 @@
+CREATE TABLE
+    "public"."app_reviews" (
+        "id" varchar NOT NULL UNIQUE DEFAULT gen_random_friendly_id ('reviews'),
+        "nullifier_hash" text NOT NULL,
+        "app_id" varchar NOT NULL,
+        "country" varchar NOT NULL,
+        "rating" integer NOT NULL,
+        "created_at" timestamptz NOT NULL DEFAULT now (),
+        "updated_at" timestamptz NOT NULL DEFAULT now (),
+        PRIMARY KEY ("id"),
+        FOREIGN KEY ("app_id") REFERENCES "public"."app" ("id") ON UPDATE restrict ON DELETE cascade,
+        UNIQUE ("nullifier_hash")
+    );
+
+CREATE TRIGGER "set_public_app_reviews_updated_at" BEFORE
+UPDATE ON "public"."app_reviews" FOR EACH ROW EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at" ();
+
+COMMENT ON TRIGGER "set_public_app_reviews_updated_at" ON "public"."app_reviews" IS 'trigger to set value of column "updated_at" to current timestamp on row update';
+
+CREATE FUNCTION compute_average_rating(app_metadata_row app_metadata)
+RETURNS numeric AS $$
+    SELECT AVG(rating)
+    FROM "public"."app_reviews"
+    WHERE app_id = app_metadata_row.app_id
+$$ LANGUAGE sql STABLE;

--- a/web/api/public/app/[app_id]/graphql/get-app-metadata.generated.ts
+++ b/web/api/public/app/[app_id]/graphql/get-app-metadata.generated.ts
@@ -26,7 +26,7 @@ export type GetAppMetadataQuery = {
     integration_url: string;
     app_website_url: string;
     source_code_url: string;
-    support_email?: string | null;
+    support_email: string;
     supported_countries?: any | null;
     supported_languages?: any | null;
     app: {

--- a/web/api/public/apps/graphql/get-app-metadata.generated.ts
+++ b/web/api/public/apps/graphql/get-app-metadata.generated.ts
@@ -30,7 +30,7 @@ export type GetAppMetadataQuery = {
     integration_url: string;
     app_website_url: string;
     source_code_url: string;
-    support_email?: string | null;
+    support_email: string;
     supported_countries?: any | null;
     supported_languages?: any | null;
     app: {
@@ -54,7 +54,7 @@ export type GetAppMetadataQuery = {
     integration_url: string;
     app_website_url: string;
     source_code_url: string;
-    support_email?: string | null;
+    support_email: string;
     supported_countries?: any | null;
     supported_languages?: any | null;
     app: {

--- a/web/graphql/graphql.schema.json
+++ b/web/graphql/graphql.schema.json
@@ -11788,6 +11788,18 @@
             "deprecationReason": null
           },
           {
+            "name": "app_rating",
+            "description": "A computed field that returns the rating of an app",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "numeric",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "app_website_url",
             "description": null,
             "args": [],
@@ -12060,9 +12072,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -12490,6 +12506,18 @@
         "description": "aggregate fields of \"app_metadata\"",
         "fields": [
           {
+            "name": "avg",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_metadata_avg_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "count",
             "description": null,
             "args": [
@@ -12557,6 +12585,90 @@
             "type": {
               "kind": "OBJECT",
               "name": "app_metadata_min_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_metadata_stddev_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_pop",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_metadata_stddev_pop_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_samp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_metadata_stddev_samp_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sum",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_metadata_sum_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_pop",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_metadata_var_pop_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_samp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_metadata_var_samp_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "variance",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_metadata_variance_fields",
               "ofType": null
             },
             "isDeprecated": false,
@@ -12663,6 +12775,29 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "app_metadata_avg_fields",
+        "description": "aggregate avg on columns",
+        "fields": [
+          {
+            "name": "app_rating",
+            "description": "A computed field that returns the rating of an app",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "numeric",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "app_metadata_bool_exp",
         "description": "Boolean expression to filter rows from the table \"app_metadata\". All fields are combined with a logical 'AND'.",
@@ -12750,6 +12885,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_rating",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "numeric_comparison_exp",
               "ofType": null
             },
             "defaultValue": null,
@@ -13491,6 +13638,18 @@
             "deprecationReason": null
           },
           {
+            "name": "app_rating",
+            "description": "A computed field that returns the rating of an app",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "numeric",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "app_website_url",
             "description": null,
             "args": [],
@@ -13987,6 +14146,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_rating",
+            "description": "A computed field that returns the rating of an app",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "numeric",
               "ofType": null
             },
             "isDeprecated": false,
@@ -14611,6 +14782,18 @@
           },
           {
             "name": "app_mode",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_rating",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -15562,6 +15745,75 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "app_metadata_stddev_fields",
+        "description": "aggregate stddev on columns",
+        "fields": [
+          {
+            "name": "app_rating",
+            "description": "A computed field that returns the rating of an app",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "numeric",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_metadata_stddev_pop_fields",
+        "description": "aggregate stddev_pop on columns",
+        "fields": [
+          {
+            "name": "app_rating",
+            "description": "A computed field that returns the rating of an app",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "numeric",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_metadata_stddev_samp_fields",
+        "description": "aggregate stddev_samp on columns",
+        "fields": [
+          {
+            "name": "app_rating",
+            "description": "A computed field that returns the rating of an app",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "numeric",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "app_metadata_stream_cursor_input",
         "description": "Streaming cursor of the table \"app_metadata\"",
@@ -15948,6 +16200,29 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "app_metadata_sum_fields",
+        "description": "aggregate sum on columns",
+        "fields": [
+          {
+            "name": "app_rating",
+            "description": "A computed field that returns the rating of an app",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "numeric",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "app_metadata_update_column",
         "description": "update columns of table \"app_metadata\"",
@@ -16162,6 +16437,75 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_metadata_var_pop_fields",
+        "description": "aggregate var_pop on columns",
+        "fields": [
+          {
+            "name": "app_rating",
+            "description": "A computed field that returns the rating of an app",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "numeric",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_metadata_var_samp_fields",
+        "description": "aggregate var_samp on columns",
+        "fields": [
+          {
+            "name": "app_rating",
+            "description": "A computed field that returns the rating of an app",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "numeric",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_metadata_variance_fields",
+        "description": "aggregate variance on columns",
+        "fields": [
+          {
+            "name": "app_rating",
+            "description": "A computed field that returns the rating of an app",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "numeric",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -17750,6 +18094,1640 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews",
+        "description": "columns and relationships of \"app_reviews\"",
+        "fields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews_aggregate",
+        "description": "aggregated selection of \"app_reviews\"",
+        "fields": [
+          {
+            "name": "aggregate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_aggregate_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "app_reviews",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews_aggregate_fields",
+        "description": "aggregate fields of \"app_reviews\"",
+        "fields": [
+          {
+            "name": "avg",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_avg_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count",
+            "description": null,
+            "args": [
+              {
+                "name": "columns",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "app_reviews_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "distinct",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_max_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_min_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_stddev_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_pop",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_stddev_pop_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_samp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_stddev_samp_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sum",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_sum_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_pop",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_var_pop_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_samp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_var_samp_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "variance",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_variance_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews_avg_fields",
+        "description": "aggregate avg on columns",
+        "fields": [
+          {
+            "name": "rating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "app_reviews_bool_exp",
+        "description": "Boolean expression to filter rows from the table \"app_reviews\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "app_reviews_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "app_reviews_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "app_reviews_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rating",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "app_reviews_constraint",
+        "description": "unique or primary key constraints on table \"app_reviews\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "app_reviews_nullifier_hash_key",
+            "description": "unique or primary key constraint on columns \"nullifier_hash\"",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_reviews_pkey",
+            "description": "unique or primary key constraint on columns \"id\"",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "app_reviews_inc_input",
+        "description": "input type for incrementing numeric columns in table \"app_reviews\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "rating",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "app_reviews_insert_input",
+        "description": "input type for inserting data into table \"app_reviews\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rating",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews_max_fields",
+        "description": "aggregate max on columns",
+        "fields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews_min_fields",
+        "description": "aggregate min on columns",
+        "fields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews_mutation_response",
+        "description": "response of any mutation on the table \"app_reviews\"",
+        "fields": [
+          {
+            "name": "affected_rows",
+            "description": "number of rows affected by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "returning",
+            "description": "data from the rows affected by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "app_reviews",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "app_reviews_on_conflict",
+        "description": "on_conflict condition type for table \"app_reviews\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "constraint",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "app_reviews_constraint",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_columns",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "app_reviews_update_column",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": "[]",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "app_reviews_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "app_reviews_order_by",
+        "description": "Ordering options when selecting data from \"app_reviews\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rating",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "app_reviews_pk_columns_input",
+        "description": "primary key columns input for table: app_reviews",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "app_reviews_select_column",
+        "description": "select columns of table \"app_reviews\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "app_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rating",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "app_reviews_set_input",
+        "description": "input type for updating data in table \"app_reviews\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rating",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews_stddev_fields",
+        "description": "aggregate stddev on columns",
+        "fields": [
+          {
+            "name": "rating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews_stddev_pop_fields",
+        "description": "aggregate stddev_pop on columns",
+        "fields": [
+          {
+            "name": "rating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews_stddev_samp_fields",
+        "description": "aggregate stddev_samp on columns",
+        "fields": [
+          {
+            "name": "rating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "app_reviews_stream_cursor_input",
+        "description": "Streaming cursor of the table \"app_reviews\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "initial_value",
+            "description": "Stream column input with initial value",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "app_reviews_stream_cursor_value_input",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ordering",
+            "description": "cursor ordering",
+            "type": {
+              "kind": "ENUM",
+              "name": "cursor_ordering",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "app_reviews_stream_cursor_value_input",
+        "description": "Initial value of the column from where the streaming should start",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rating",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews_sum_fields",
+        "description": "aggregate sum on columns",
+        "fields": [
+          {
+            "name": "rating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "app_reviews_update_column",
+        "description": "update columns of table \"app_reviews\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "app_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rating",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "app_reviews_updates",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_inc",
+            "description": "increments the numeric columns with given value of the filtered values",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "app_reviews_inc_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_set",
+            "description": "sets the columns of the filtered rows to the given values",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "app_reviews_set_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": "filter the rows which have to be updated",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "app_reviews_bool_exp",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews_var_pop_fields",
+        "description": "aggregate var_pop on columns",
+        "fields": [
+          {
+            "name": "rating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews_var_samp_fields",
+        "description": "aggregate var_samp on columns",
+        "fields": [
+          {
+            "name": "rating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "app_reviews_variance_fields",
+        "description": "aggregate variance on columns",
+        "fields": [
+          {
+            "name": "rating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -27732,6 +29710,64 @@
             "deprecationReason": null
           },
           {
+            "name": "delete_app_reviews",
+            "description": "delete data from the table: \"app_reviews\"",
+            "args": [
+              {
+                "name": "where",
+                "description": "filter the rows which have to be deleted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "app_reviews_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "delete_app_reviews_by_pk",
+            "description": "delete single row from the table: \"app_reviews\"",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "delete_app_stats_returning",
             "description": "delete data from the table: \"app_stats_returning\"",
             "args": [
@@ -28933,6 +30969,96 @@
             "type": {
               "kind": "OBJECT",
               "name": "app_rankings",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insert_app_reviews",
+            "description": "insert data into the table: \"app_reviews\"",
+            "args": [
+              {
+                "name": "objects",
+                "description": "the rows to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "app_reviews_insert_input",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "on_conflict",
+                "description": "upsert condition",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "app_reviews_on_conflict",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insert_app_reviews_one",
+            "description": "insert a single row into the table: \"app_reviews\"",
+            "args": [
+              {
+                "name": "object",
+                "description": "the row to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "app_reviews_insert_input",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "on_conflict",
+                "description": "upsert condition",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "app_reviews_on_conflict",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews",
               "ofType": null
             },
             "isDeprecated": false,
@@ -30847,6 +32973,153 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "app_rankings_mutation_response",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_app_reviews",
+            "description": "update data of the table: \"app_reviews\"",
+            "args": [
+              {
+                "name": "_inc",
+                "description": "increments the numeric columns with given value of the filtered values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "app_reviews_inc_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_set",
+                "description": "sets the columns of the filtered rows to the given values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "app_reviews_set_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows which have to be updated",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "app_reviews_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_app_reviews_by_pk",
+            "description": "update single row of the table: \"app_reviews\"",
+            "args": [
+              {
+                "name": "_inc",
+                "description": "increments the numeric columns with given value of the filtered values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "app_reviews_inc_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_set",
+                "description": "sets the columns of the filtered rows to the given values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "app_reviews_set_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pk_columns",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "app_reviews_pk_columns_input",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_app_reviews_many",
+            "description": "update multiples rows of table: \"app_reviews\"",
+            "args": [
+              {
+                "name": "updates",
+                "description": "updates to execute, in order",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "app_reviews_updates",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "app_reviews_mutation_response",
                 "ofType": null
               }
             },
@@ -36541,6 +38814,229 @@
             "type": {
               "kind": "OBJECT",
               "name": "app_rankings",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_reviews",
+            "description": "fetch data from the table: \"app_reviews\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "app_reviews_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "app_reviews_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "app_reviews_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "app_reviews",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_reviews_aggregate",
+            "description": "fetch aggregated fields from the table: \"app_reviews\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "app_reviews_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "app_reviews_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "app_reviews_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "app_reviews_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_reviews_by_pk",
+            "description": "fetch data from the table: \"app_reviews\" using primary key columns",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews",
               "ofType": null
             },
             "isDeprecated": false,
@@ -43717,6 +46213,302 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "app_rankings",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_reviews",
+            "description": "fetch data from the table: \"app_reviews\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "app_reviews_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "app_reviews_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "app_reviews_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "app_reviews",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_reviews_aggregate",
+            "description": "fetch aggregated fields from the table: \"app_reviews\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "app_reviews_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "app_reviews_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "app_reviews_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "app_reviews_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_reviews_by_pk",
+            "description": "fetch data from the table: \"app_reviews\" using primary key columns",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "app_reviews",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_reviews_stream",
+            "description": "fetch data from the table in a streaming manner: \"app_reviews\"",
+            "args": [
+              {
+                "name": "batch_size",
+                "description": "maximum number of rows returned in a single batch",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "cursor",
+                "description": "cursor to stream the results returned by the query",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "app_reviews_stream_cursor_input",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "app_reviews_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "app_reviews",
                     "ofType": null
                   }
                 }

--- a/web/graphql/graphql.ts
+++ b/web/graphql/graphql.ts
@@ -1547,6 +1547,8 @@ export type App_Metadata = {
   app: App;
   app_id: Scalars["String"];
   app_mode: Scalars["String"];
+  /** A computed field that returns the rating of an app */
+  app_rating?: Maybe<Scalars["numeric"]>;
   app_website_url: Scalars["String"];
   category: Scalars["String"];
   created_at: Scalars["timestamptz"];
@@ -1564,7 +1566,7 @@ export type App_Metadata = {
   reviewed_by: Scalars["String"];
   showcase_img_urls?: Maybe<Scalars["_text"]>;
   source_code_url: Scalars["String"];
-  support_email?: Maybe<Scalars["String"]>;
+  support_email: Scalars["String"];
   supported_countries?: Maybe<Scalars["_text"]>;
   supported_languages?: Maybe<Scalars["_text"]>;
   updated_at: Scalars["timestamptz"];
@@ -1612,9 +1614,17 @@ export type App_Metadata_Aggregate_Bool_Exp_Count = {
 /** aggregate fields of "app_metadata" */
 export type App_Metadata_Aggregate_Fields = {
   __typename?: "app_metadata_aggregate_fields";
+  avg?: Maybe<App_Metadata_Avg_Fields>;
   count: Scalars["Int"];
   max?: Maybe<App_Metadata_Max_Fields>;
   min?: Maybe<App_Metadata_Min_Fields>;
+  stddev?: Maybe<App_Metadata_Stddev_Fields>;
+  stddev_pop?: Maybe<App_Metadata_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<App_Metadata_Stddev_Samp_Fields>;
+  sum?: Maybe<App_Metadata_Sum_Fields>;
+  var_pop?: Maybe<App_Metadata_Var_Pop_Fields>;
+  var_samp?: Maybe<App_Metadata_Var_Samp_Fields>;
+  variance?: Maybe<App_Metadata_Variance_Fields>;
 };
 
 /** aggregate fields of "app_metadata" */
@@ -1637,6 +1647,13 @@ export type App_Metadata_Arr_Rel_Insert_Input = {
   on_conflict?: InputMaybe<App_Metadata_On_Conflict>;
 };
 
+/** aggregate avg on columns */
+export type App_Metadata_Avg_Fields = {
+  __typename?: "app_metadata_avg_fields";
+  /** A computed field that returns the rating of an app */
+  app_rating?: Maybe<Scalars["numeric"]>;
+};
+
 /** Boolean expression to filter rows from the table "app_metadata". All fields are combined with a logical 'AND'. */
 export type App_Metadata_Bool_Exp = {
   _and?: InputMaybe<Array<App_Metadata_Bool_Exp>>;
@@ -1645,6 +1662,7 @@ export type App_Metadata_Bool_Exp = {
   app?: InputMaybe<App_Bool_Exp>;
   app_id?: InputMaybe<String_Comparison_Exp>;
   app_mode?: InputMaybe<String_Comparison_Exp>;
+  app_rating?: InputMaybe<Numeric_Comparison_Exp>;
   app_website_url?: InputMaybe<String_Comparison_Exp>;
   category?: InputMaybe<String_Comparison_Exp>;
   created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
@@ -1721,6 +1739,8 @@ export type App_Metadata_Max_Fields = {
   __typename?: "app_metadata_max_fields";
   app_id?: Maybe<Scalars["String"]>;
   app_mode?: Maybe<Scalars["String"]>;
+  /** A computed field that returns the rating of an app */
+  app_rating?: Maybe<Scalars["numeric"]>;
   app_website_url?: Maybe<Scalars["String"]>;
   category?: Maybe<Scalars["String"]>;
   created_at?: Maybe<Scalars["timestamptz"]>;
@@ -1770,6 +1790,8 @@ export type App_Metadata_Min_Fields = {
   __typename?: "app_metadata_min_fields";
   app_id?: Maybe<Scalars["String"]>;
   app_mode?: Maybe<Scalars["String"]>;
+  /** A computed field that returns the rating of an app */
+  app_rating?: Maybe<Scalars["numeric"]>;
   app_website_url?: Maybe<Scalars["String"]>;
   category?: Maybe<Scalars["String"]>;
   created_at?: Maybe<Scalars["timestamptz"]>;
@@ -1835,6 +1857,7 @@ export type App_Metadata_Order_By = {
   app?: InputMaybe<App_Order_By>;
   app_id?: InputMaybe<Order_By>;
   app_mode?: InputMaybe<Order_By>;
+  app_rating?: InputMaybe<Order_By>;
   app_website_url?: InputMaybe<Order_By>;
   category?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
@@ -1984,6 +2007,27 @@ export type App_Metadata_Set_Input = {
   world_app_description?: InputMaybe<Scalars["String"]>;
 };
 
+/** aggregate stddev on columns */
+export type App_Metadata_Stddev_Fields = {
+  __typename?: "app_metadata_stddev_fields";
+  /** A computed field that returns the rating of an app */
+  app_rating?: Maybe<Scalars["numeric"]>;
+};
+
+/** aggregate stddev_pop on columns */
+export type App_Metadata_Stddev_Pop_Fields = {
+  __typename?: "app_metadata_stddev_pop_fields";
+  /** A computed field that returns the rating of an app */
+  app_rating?: Maybe<Scalars["numeric"]>;
+};
+
+/** aggregate stddev_samp on columns */
+export type App_Metadata_Stddev_Samp_Fields = {
+  __typename?: "app_metadata_stddev_samp_fields";
+  /** A computed field that returns the rating of an app */
+  app_rating?: Maybe<Scalars["numeric"]>;
+};
+
 /** Streaming cursor of the table "app_metadata" */
 export type App_Metadata_Stream_Cursor_Input = {
   /** Stream column input with initial value */
@@ -2022,6 +2066,13 @@ export type App_Metadata_Stream_Cursor_Value_Input = {
   whitelisted_addresses?: InputMaybe<Scalars["_text"]>;
   world_app_button_text?: InputMaybe<Scalars["String"]>;
   world_app_description?: InputMaybe<Scalars["String"]>;
+};
+
+/** aggregate sum on columns */
+export type App_Metadata_Sum_Fields = {
+  __typename?: "app_metadata_sum_fields";
+  /** A computed field that returns the rating of an app */
+  app_rating?: Maybe<Scalars["numeric"]>;
 };
 
 /** update columns of table "app_metadata" */
@@ -2089,6 +2140,27 @@ export type App_Metadata_Updates = {
   _set?: InputMaybe<App_Metadata_Set_Input>;
   /** filter the rows which have to be updated */
   where: App_Metadata_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type App_Metadata_Var_Pop_Fields = {
+  __typename?: "app_metadata_var_pop_fields";
+  /** A computed field that returns the rating of an app */
+  app_rating?: Maybe<Scalars["numeric"]>;
+};
+
+/** aggregate var_samp on columns */
+export type App_Metadata_Var_Samp_Fields = {
+  __typename?: "app_metadata_var_samp_fields";
+  /** A computed field that returns the rating of an app */
+  app_rating?: Maybe<Scalars["numeric"]>;
+};
+
+/** aggregate variance on columns */
+export type App_Metadata_Variance_Fields = {
+  __typename?: "app_metadata_variance_fields";
+  /** A computed field that returns the rating of an app */
+  app_rating?: Maybe<Scalars["numeric"]>;
 };
 
 /** aggregate min on columns */
@@ -2322,6 +2394,264 @@ export type App_Rankings_Updates = {
   _set?: InputMaybe<App_Rankings_Set_Input>;
   /** filter the rows which have to be updated */
   where: App_Rankings_Bool_Exp;
+};
+
+/** columns and relationships of "app_reviews" */
+export type App_Reviews = {
+  __typename?: "app_reviews";
+  app_id: Scalars["String"];
+  country: Scalars["String"];
+  created_at: Scalars["timestamptz"];
+  id: Scalars["String"];
+  nullifier_hash: Scalars["String"];
+  rating: Scalars["Int"];
+  updated_at: Scalars["timestamptz"];
+};
+
+/** aggregated selection of "app_reviews" */
+export type App_Reviews_Aggregate = {
+  __typename?: "app_reviews_aggregate";
+  aggregate?: Maybe<App_Reviews_Aggregate_Fields>;
+  nodes: Array<App_Reviews>;
+};
+
+/** aggregate fields of "app_reviews" */
+export type App_Reviews_Aggregate_Fields = {
+  __typename?: "app_reviews_aggregate_fields";
+  avg?: Maybe<App_Reviews_Avg_Fields>;
+  count: Scalars["Int"];
+  max?: Maybe<App_Reviews_Max_Fields>;
+  min?: Maybe<App_Reviews_Min_Fields>;
+  stddev?: Maybe<App_Reviews_Stddev_Fields>;
+  stddev_pop?: Maybe<App_Reviews_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<App_Reviews_Stddev_Samp_Fields>;
+  sum?: Maybe<App_Reviews_Sum_Fields>;
+  var_pop?: Maybe<App_Reviews_Var_Pop_Fields>;
+  var_samp?: Maybe<App_Reviews_Var_Samp_Fields>;
+  variance?: Maybe<App_Reviews_Variance_Fields>;
+};
+
+/** aggregate fields of "app_reviews" */
+export type App_Reviews_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<App_Reviews_Select_Column>>;
+  distinct?: InputMaybe<Scalars["Boolean"]>;
+};
+
+/** aggregate avg on columns */
+export type App_Reviews_Avg_Fields = {
+  __typename?: "app_reviews_avg_fields";
+  rating?: Maybe<Scalars["Float"]>;
+};
+
+/** Boolean expression to filter rows from the table "app_reviews". All fields are combined with a logical 'AND'. */
+export type App_Reviews_Bool_Exp = {
+  _and?: InputMaybe<Array<App_Reviews_Bool_Exp>>;
+  _not?: InputMaybe<App_Reviews_Bool_Exp>;
+  _or?: InputMaybe<Array<App_Reviews_Bool_Exp>>;
+  app_id?: InputMaybe<String_Comparison_Exp>;
+  country?: InputMaybe<String_Comparison_Exp>;
+  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  id?: InputMaybe<String_Comparison_Exp>;
+  nullifier_hash?: InputMaybe<String_Comparison_Exp>;
+  rating?: InputMaybe<Int_Comparison_Exp>;
+  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "app_reviews" */
+export enum App_Reviews_Constraint {
+  /** unique or primary key constraint on columns "nullifier_hash" */
+  AppReviewsNullifierHashKey = "app_reviews_nullifier_hash_key",
+  /** unique or primary key constraint on columns "id" */
+  AppReviewsPkey = "app_reviews_pkey",
+}
+
+/** input type for incrementing numeric columns in table "app_reviews" */
+export type App_Reviews_Inc_Input = {
+  rating?: InputMaybe<Scalars["Int"]>;
+};
+
+/** input type for inserting data into table "app_reviews" */
+export type App_Reviews_Insert_Input = {
+  app_id?: InputMaybe<Scalars["String"]>;
+  country?: InputMaybe<Scalars["String"]>;
+  created_at?: InputMaybe<Scalars["timestamptz"]>;
+  id?: InputMaybe<Scalars["String"]>;
+  nullifier_hash?: InputMaybe<Scalars["String"]>;
+  rating?: InputMaybe<Scalars["Int"]>;
+  updated_at?: InputMaybe<Scalars["timestamptz"]>;
+};
+
+/** aggregate max on columns */
+export type App_Reviews_Max_Fields = {
+  __typename?: "app_reviews_max_fields";
+  app_id?: Maybe<Scalars["String"]>;
+  country?: Maybe<Scalars["String"]>;
+  created_at?: Maybe<Scalars["timestamptz"]>;
+  id?: Maybe<Scalars["String"]>;
+  nullifier_hash?: Maybe<Scalars["String"]>;
+  rating?: Maybe<Scalars["Int"]>;
+  updated_at?: Maybe<Scalars["timestamptz"]>;
+};
+
+/** aggregate min on columns */
+export type App_Reviews_Min_Fields = {
+  __typename?: "app_reviews_min_fields";
+  app_id?: Maybe<Scalars["String"]>;
+  country?: Maybe<Scalars["String"]>;
+  created_at?: Maybe<Scalars["timestamptz"]>;
+  id?: Maybe<Scalars["String"]>;
+  nullifier_hash?: Maybe<Scalars["String"]>;
+  rating?: Maybe<Scalars["Int"]>;
+  updated_at?: Maybe<Scalars["timestamptz"]>;
+};
+
+/** response of any mutation on the table "app_reviews" */
+export type App_Reviews_Mutation_Response = {
+  __typename?: "app_reviews_mutation_response";
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars["Int"];
+  /** data from the rows affected by the mutation */
+  returning: Array<App_Reviews>;
+};
+
+/** on_conflict condition type for table "app_reviews" */
+export type App_Reviews_On_Conflict = {
+  constraint: App_Reviews_Constraint;
+  update_columns?: Array<App_Reviews_Update_Column>;
+  where?: InputMaybe<App_Reviews_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "app_reviews". */
+export type App_Reviews_Order_By = {
+  app_id?: InputMaybe<Order_By>;
+  country?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  nullifier_hash?: InputMaybe<Order_By>;
+  rating?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: app_reviews */
+export type App_Reviews_Pk_Columns_Input = {
+  id: Scalars["String"];
+};
+
+/** select columns of table "app_reviews" */
+export enum App_Reviews_Select_Column {
+  /** column name */
+  AppId = "app_id",
+  /** column name */
+  Country = "country",
+  /** column name */
+  CreatedAt = "created_at",
+  /** column name */
+  Id = "id",
+  /** column name */
+  NullifierHash = "nullifier_hash",
+  /** column name */
+  Rating = "rating",
+  /** column name */
+  UpdatedAt = "updated_at",
+}
+
+/** input type for updating data in table "app_reviews" */
+export type App_Reviews_Set_Input = {
+  app_id?: InputMaybe<Scalars["String"]>;
+  country?: InputMaybe<Scalars["String"]>;
+  created_at?: InputMaybe<Scalars["timestamptz"]>;
+  id?: InputMaybe<Scalars["String"]>;
+  nullifier_hash?: InputMaybe<Scalars["String"]>;
+  rating?: InputMaybe<Scalars["Int"]>;
+  updated_at?: InputMaybe<Scalars["timestamptz"]>;
+};
+
+/** aggregate stddev on columns */
+export type App_Reviews_Stddev_Fields = {
+  __typename?: "app_reviews_stddev_fields";
+  rating?: Maybe<Scalars["Float"]>;
+};
+
+/** aggregate stddev_pop on columns */
+export type App_Reviews_Stddev_Pop_Fields = {
+  __typename?: "app_reviews_stddev_pop_fields";
+  rating?: Maybe<Scalars["Float"]>;
+};
+
+/** aggregate stddev_samp on columns */
+export type App_Reviews_Stddev_Samp_Fields = {
+  __typename?: "app_reviews_stddev_samp_fields";
+  rating?: Maybe<Scalars["Float"]>;
+};
+
+/** Streaming cursor of the table "app_reviews" */
+export type App_Reviews_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: App_Reviews_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type App_Reviews_Stream_Cursor_Value_Input = {
+  app_id?: InputMaybe<Scalars["String"]>;
+  country?: InputMaybe<Scalars["String"]>;
+  created_at?: InputMaybe<Scalars["timestamptz"]>;
+  id?: InputMaybe<Scalars["String"]>;
+  nullifier_hash?: InputMaybe<Scalars["String"]>;
+  rating?: InputMaybe<Scalars["Int"]>;
+  updated_at?: InputMaybe<Scalars["timestamptz"]>;
+};
+
+/** aggregate sum on columns */
+export type App_Reviews_Sum_Fields = {
+  __typename?: "app_reviews_sum_fields";
+  rating?: Maybe<Scalars["Int"]>;
+};
+
+/** update columns of table "app_reviews" */
+export enum App_Reviews_Update_Column {
+  /** column name */
+  AppId = "app_id",
+  /** column name */
+  Country = "country",
+  /** column name */
+  CreatedAt = "created_at",
+  /** column name */
+  Id = "id",
+  /** column name */
+  NullifierHash = "nullifier_hash",
+  /** column name */
+  Rating = "rating",
+  /** column name */
+  UpdatedAt = "updated_at",
+}
+
+export type App_Reviews_Updates = {
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<App_Reviews_Inc_Input>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<App_Reviews_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: App_Reviews_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type App_Reviews_Var_Pop_Fields = {
+  __typename?: "app_reviews_var_pop_fields";
+  rating?: Maybe<Scalars["Float"]>;
+};
+
+/** aggregate var_samp on columns */
+export type App_Reviews_Var_Samp_Fields = {
+  __typename?: "app_reviews_var_samp_fields";
+  rating?: Maybe<Scalars["Float"]>;
+};
+
+/** aggregate variance on columns */
+export type App_Reviews_Variance_Fields = {
+  __typename?: "app_reviews_variance_fields";
+  rating?: Maybe<Scalars["Float"]>;
 };
 
 /** select columns of table "app" */
@@ -3834,6 +4164,10 @@ export type Mutation_Root = {
   delete_app_rankings?: Maybe<App_Rankings_Mutation_Response>;
   /** delete single row from the table: "app_rankings" */
   delete_app_rankings_by_pk?: Maybe<App_Rankings>;
+  /** delete data from the table: "app_reviews" */
+  delete_app_reviews?: Maybe<App_Reviews_Mutation_Response>;
+  /** delete single row from the table: "app_reviews" */
+  delete_app_reviews_by_pk?: Maybe<App_Reviews>;
   /** delete data from the table: "app_stats_returning" */
   delete_app_stats_returning?: Maybe<App_Stats_Returning_Mutation_Response>;
   /** delete single row from the table: "app_stats_returning" */
@@ -3903,6 +4237,10 @@ export type Mutation_Root = {
   insert_app_rankings?: Maybe<App_Rankings_Mutation_Response>;
   /** insert a single row into the table: "app_rankings" */
   insert_app_rankings_one?: Maybe<App_Rankings>;
+  /** insert data into the table: "app_reviews" */
+  insert_app_reviews?: Maybe<App_Reviews_Mutation_Response>;
+  /** insert a single row into the table: "app_reviews" */
+  insert_app_reviews_one?: Maybe<App_Reviews>;
   /** insert data into the table: "app_stats_returning" */
   insert_app_stats_returning?: Maybe<App_Stats_Returning_Mutation_Response>;
   /** insert a single row into the table: "app_stats_returning" */
@@ -3995,6 +4333,12 @@ export type Mutation_Root = {
   update_app_rankings_many?: Maybe<
     Array<Maybe<App_Rankings_Mutation_Response>>
   >;
+  /** update data of the table: "app_reviews" */
+  update_app_reviews?: Maybe<App_Reviews_Mutation_Response>;
+  /** update single row of the table: "app_reviews" */
+  update_app_reviews_by_pk?: Maybe<App_Reviews>;
+  /** update multiples rows of table: "app_reviews" */
+  update_app_reviews_many?: Maybe<Array<Maybe<App_Reviews_Mutation_Response>>>;
   /** update data of the table: "app_stats_returning" */
   update_app_stats_returning?: Maybe<App_Stats_Returning_Mutation_Response>;
   /** update single row of the table: "app_stats_returning" */
@@ -4124,6 +4468,16 @@ export type Mutation_RootDelete_App_RankingsArgs = {
 
 /** mutation root */
 export type Mutation_RootDelete_App_Rankings_By_PkArgs = {
+  id: Scalars["String"];
+};
+
+/** mutation root */
+export type Mutation_RootDelete_App_ReviewsArgs = {
+  where: App_Reviews_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootDelete_App_Reviews_By_PkArgs = {
   id: Scalars["String"];
 };
 
@@ -4312,6 +4666,18 @@ export type Mutation_RootInsert_App_RankingsArgs = {
 export type Mutation_RootInsert_App_Rankings_OneArgs = {
   object: App_Rankings_Insert_Input;
   on_conflict?: InputMaybe<App_Rankings_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_App_ReviewsArgs = {
+  objects: Array<App_Reviews_Insert_Input>;
+  on_conflict?: InputMaybe<App_Reviews_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_App_Reviews_OneArgs = {
+  object: App_Reviews_Insert_Input;
+  on_conflict?: InputMaybe<App_Reviews_On_Conflict>;
 };
 
 /** mutation root */
@@ -4568,6 +4934,25 @@ export type Mutation_RootUpdate_App_Rankings_By_PkArgs = {
 /** mutation root */
 export type Mutation_RootUpdate_App_Rankings_ManyArgs = {
   updates: Array<App_Rankings_Updates>;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_App_ReviewsArgs = {
+  _inc?: InputMaybe<App_Reviews_Inc_Input>;
+  _set?: InputMaybe<App_Reviews_Set_Input>;
+  where: App_Reviews_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_App_Reviews_By_PkArgs = {
+  _inc?: InputMaybe<App_Reviews_Inc_Input>;
+  _set?: InputMaybe<App_Reviews_Set_Input>;
+  pk_columns: App_Reviews_Pk_Columns_Input;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_App_Reviews_ManyArgs = {
+  updates: Array<App_Reviews_Updates>;
 };
 
 /** mutation root */
@@ -5204,6 +5589,12 @@ export type Query_Root = {
   app_rankings_aggregate: App_Rankings_Aggregate;
   /** fetch data from the table: "app_rankings" using primary key columns */
   app_rankings_by_pk?: Maybe<App_Rankings>;
+  /** fetch data from the table: "app_reviews" */
+  app_reviews: Array<App_Reviews>;
+  /** fetch aggregated fields from the table: "app_reviews" */
+  app_reviews_aggregate: App_Reviews_Aggregate;
+  /** fetch data from the table: "app_reviews" using primary key columns */
+  app_reviews_by_pk?: Maybe<App_Reviews>;
   /** execute function "app_stats" which returns "app_stats_returning" */
   app_stats: Array<App_Stats_Returning>;
   /** execute function "app_stats" and query aggregates on result of table type "app_stats_returning" */
@@ -5418,6 +5809,26 @@ export type Query_RootApp_Rankings_AggregateArgs = {
 };
 
 export type Query_RootApp_Rankings_By_PkArgs = {
+  id: Scalars["String"];
+};
+
+export type Query_RootApp_ReviewsArgs = {
+  distinct_on?: InputMaybe<Array<App_Reviews_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  offset?: InputMaybe<Scalars["Int"]>;
+  order_by?: InputMaybe<Array<App_Reviews_Order_By>>;
+  where?: InputMaybe<App_Reviews_Bool_Exp>;
+};
+
+export type Query_RootApp_Reviews_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<App_Reviews_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  offset?: InputMaybe<Scalars["Int"]>;
+  order_by?: InputMaybe<Array<App_Reviews_Order_By>>;
+  where?: InputMaybe<App_Reviews_Bool_Exp>;
+};
+
+export type Query_RootApp_Reviews_By_PkArgs = {
   id: Scalars["String"];
 };
 
@@ -6102,6 +6513,14 @@ export type Subscription_Root = {
   app_rankings_by_pk?: Maybe<App_Rankings>;
   /** fetch data from the table in a streaming manner: "app_rankings" */
   app_rankings_stream: Array<App_Rankings>;
+  /** fetch data from the table: "app_reviews" */
+  app_reviews: Array<App_Reviews>;
+  /** fetch aggregated fields from the table: "app_reviews" */
+  app_reviews_aggregate: App_Reviews_Aggregate;
+  /** fetch data from the table: "app_reviews" using primary key columns */
+  app_reviews_by_pk?: Maybe<App_Reviews>;
+  /** fetch data from the table in a streaming manner: "app_reviews" */
+  app_reviews_stream: Array<App_Reviews>;
   /** execute function "app_stats" which returns "app_stats_returning" */
   app_stats: Array<App_Stats_Returning>;
   /** execute function "app_stats" and query aggregates on result of table type "app_stats_returning" */
@@ -6364,6 +6783,32 @@ export type Subscription_RootApp_Rankings_StreamArgs = {
   batch_size: Scalars["Int"];
   cursor: Array<InputMaybe<App_Rankings_Stream_Cursor_Input>>;
   where?: InputMaybe<App_Rankings_Bool_Exp>;
+};
+
+export type Subscription_RootApp_ReviewsArgs = {
+  distinct_on?: InputMaybe<Array<App_Reviews_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  offset?: InputMaybe<Scalars["Int"]>;
+  order_by?: InputMaybe<Array<App_Reviews_Order_By>>;
+  where?: InputMaybe<App_Reviews_Bool_Exp>;
+};
+
+export type Subscription_RootApp_Reviews_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<App_Reviews_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  offset?: InputMaybe<Scalars["Int"]>;
+  order_by?: InputMaybe<Array<App_Reviews_Order_By>>;
+  where?: InputMaybe<App_Reviews_Bool_Exp>;
+};
+
+export type Subscription_RootApp_Reviews_By_PkArgs = {
+  id: Scalars["String"];
+};
+
+export type Subscription_RootApp_Reviews_StreamArgs = {
+  batch_size: Scalars["Int"];
+  cursor: Array<InputMaybe<App_Reviews_Stream_Cursor_Input>>;
+  where?: InputMaybe<App_Reviews_Bool_Exp>;
 };
 
 export type Subscription_RootApp_StatsArgs = {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/graphql/client/fetch-app-metadata.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/graphql/client/fetch-app-metadata.generated.ts
@@ -37,7 +37,7 @@ export type FetchAppMetadataQuery = {
       verification_status: string;
       app_mode: string;
       whitelisted_addresses?: any | null;
-      support_email?: string | null;
+      support_email: string;
       supported_countries?: any | null;
       supported_languages?: any | null;
     }>;
@@ -62,7 +62,7 @@ export type FetchAppMetadataQuery = {
       verification_status: string;
       app_mode: string;
       whitelisted_addresses?: any | null;
-      support_email?: string | null;
+      support_email: string;
       supported_countries?: any | null;
       supported_languages?: any | null;
     }>;


### PR DESCRIPTION
This PR adds the hasura migration and permissions for app rating
- Creates the new `app_reviews` table
- Adds a computed field `app_rating` to `app_metadata`
- Adds permissions for service role to modify and read the value
- Add permission for service role to insert new app_ratings as well as update the rating