### PR TITLE
Improve native app endpoint

### DIFF
--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -1,5 +1,5 @@
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
-import { NativeApps } from "@/lib/constants";
+import { NativeAppToAppIdMapping, NativeApps } from "@/lib/constants";
 import { formatAppMetadata, isValidHostName } from "@/lib/utils";
 import { NextResponse } from "next/server";
 import { getSdk as getAppMetadataSdk } from "./graphql/get-app-metadata.generated";
@@ -15,8 +15,6 @@ export async function GET(
   request: Request,
   { params }: { params: { app_id: string } },
 ) {
-  const app_id = params.app_id;
-
   if (!process.env.APP_ENV) {
     return NextResponse.json(
       {
@@ -24,6 +22,13 @@ export async function GET(
       },
       { status: 400 },
     );
+  }
+
+  let app_id = params.app_id;
+
+  // Native Apps have substituted app_ids so we pull their constant ID to get the metadata
+  if (app_id in NativeAppToAppIdMapping[process.env.APP_ENV]) {
+    app_id = NativeAppToAppIdMapping[process.env.APP_ENV][app_id];
   }
 
   const client = await getAPIServiceGraphqlClient();

--- a/web/lib/constants.ts
+++ b/web/lib/constants.ts
@@ -57,18 +57,35 @@ export const Categories: Array<{ name: string; lokalise_key: string }> = [
   { name: "Other", lokalise_key: "world_id_partner_category_other" },
 ];
 
-export const NativeApps: Record<string, NativeAppsMap> = {
-  dev: {},
+export const NativeAppToAppIdMapping: Record<string, Record<string, string>> = {
+  dev: {
+    TEST_APP: "app_test_123",
+  },
   staging: {
-    app_staging_44e711bce52215150d0a7f31af4f4f33: {
+    grants: "app_staging_44e711bce52215150d0a7f31af4f4f33",
+    invites: "app_staging_fb0465348ceb59cba6202685cbdc4120",
+    network: "app_staging_44210a8be72aa299410be44232b1ea57",
+  },
+  production: {},
+};
+
+export const NativeApps: Record<string, NativeAppsMap> = {
+  dev: {
+    app_test_123: {
+      app_id: "TEST_APP",
+      integration_url: "worldapp://test",
+    },
+  },
+  staging: {
+    [NativeAppToAppIdMapping.staging.grants]: {
       app_id: "grants",
       integration_url: "worldapp://grants",
     },
-    app_staging_fb0465348ceb59cba6202685cbdc4120: {
+    [NativeAppToAppIdMapping.staging.invites]: {
       app_id: "invites",
       integration_url: "worldapp://invites",
     },
-    app_staging_44210a8be72aa299410be44232b1ea57: {
+    [NativeAppToAppIdMapping.staging.network]: {
       app_id: "network",
       integration_url: "worldapp://network",
     },

--- a/web/tests/api/v2/public/apps/app.test.ts
+++ b/web/tests/api/v2/public/apps/app.test.ts
@@ -2,6 +2,7 @@ import { GET } from "@/api/v2/public/app/[app_id]";
 import { AppLocaliseKeys } from "@/lib/types";
 import { createLocaliseCategory, createLocaliseField } from "@/lib/utils";
 import { NextRequest } from "next/server";
+import { getSdk as getAppMetadataSdk } from "../../../../../api/v2/public/app/[app_id]/graphql/get-app-metadata.generated";
 
 // Mock the external dependencies
 jest.mock("@/api/helpers/graphql", () => ({
@@ -48,7 +49,7 @@ jest.mock(
 );
 
 describe("/api/public/app/[app_id]", () => {
-  test("Should return correct value", async () => {
+  test("Returns correct value for valid app", async () => {
     const request = new NextRequest("https://cdn.test.com/api/public/app/1", {
       headers: {
         host: "cdn.test.com",
@@ -102,6 +103,104 @@ describe("/api/public/app/[app_id]", () => {
         ),
         world_app_description: createLocaliseField(
           "1",
+          AppLocaliseKeys.world_app_description,
+        ),
+      },
+    });
+  });
+
+  test("Implements native app correctly", async () => {
+    const request = new NextRequest(
+      "https://cdn.test.com/api/v2/public/app/TEST_APP",
+      {
+        headers: {
+          host: "cdn.test.com",
+        },
+      },
+    );
+
+    jest.mocked(getAppMetadataSdk).mockImplementation(() => ({
+      GetAppMetadata: jest.fn().mockResolvedValue({
+        app_metadata: [
+          {
+            name: "Example App",
+            app_id: "app_test_123",
+            logo_img_url: "logo.png",
+            showcase_img_urls: ["showcase1.png", "showcase2.png"],
+            hero_image_url: "hero.png",
+            world_app_description:
+              "This is an example app designed to showcase the capabilities of our platform.",
+            world_app_button_text: "Use Integration",
+            category: "social",
+            description:
+              '{"description_overview":"fewf","description_how_it_works":"few","description_connect":"fewf"}',
+            integration_url: "https://example.com/integration",
+            app_website_url: "https://example.com",
+            source_code_url: "https://github.com/example/app",
+            whitelisted_addresses: ["0x1234", "0x5678"],
+            app_mode: "mini-app",
+            support_email: "andy@gmail.com",
+            supported_countries: ["us"],
+            supported_languages: ["en", "es"],
+            app_rating: 3.4,
+            app: {
+              team: {
+                name: "Example Team",
+              },
+            },
+          },
+        ],
+      }),
+    }));
+
+    const response = await GET(request, { params: { app_id: "TEST_APP" } });
+    expect(await response.json()).toEqual({
+      app_data: {
+        name: "Example App",
+        app_id: "TEST_APP",
+        logo_img_url: "https://cdn.test.com/app_test_123/logo.png",
+        hero_image_url: "https://cdn.test.com/app_test_123/hero.png",
+        showcase_img_urls: [
+          "https://cdn.test.com/app_test_123/showcase1.png",
+          "https://cdn.test.com/app_test_123/showcase2.png",
+        ],
+        team_name: "Example Team",
+        app_mode: "native",
+        integration_url: "worldapp://test",
+        app_website_url: "https://example.com",
+        source_code_url: "https://github.com/example/app",
+        support_email: "andy@gmail.com",
+        supported_countries: ["us"],
+        supported_languages: ["en", "es"],
+        app_rating: 3.4,
+        unique_users: 0,
+        whitelisted_addresses: ["0x1234", "0x5678"],
+        category: [
+          {
+            name: "social",
+            lokalise_key: "world_id_partner_category_social",
+          },
+        ],
+        description: {
+          how_it_works: createLocaliseField(
+            "app_test_123",
+            AppLocaliseKeys.description_how_it_works,
+          ),
+          how_to_connect: createLocaliseField(
+            "app_test_123",
+            AppLocaliseKeys.description_connect,
+          ),
+          overview: createLocaliseField(
+            "app_test_123",
+            AppLocaliseKeys.description_overview,
+          ),
+        },
+        world_app_button_text: createLocaliseField(
+          "app_test_123",
+          AppLocaliseKeys.world_app_button_text,
+        ),
+        world_app_description: createLocaliseField(
+          "app_test_123",
           AppLocaliseKeys.world_app_description,
         ),
       },

--- a/web/tests/api/v2/public/apps/apps-metadata.test.ts
+++ b/web/tests/api/v2/public/apps/apps-metadata.test.ts
@@ -344,4 +344,136 @@ describe("/api/v2/public/apps", () => {
       ],
     });
   });
+
+  test("Native Apps", async () => {
+    jest.mocked(getHighlightsSdk).mockImplementation(() => ({
+      GetHighlights: jest.fn().mockResolvedValue({
+        app_rankings: [{ rankings: [] }],
+      }),
+    }));
+
+    jest.mocked(getAppsSdk).mockImplementation(() => ({
+      GetApps: jest.fn().mockResolvedValue({
+        top_apps: [
+          {
+            name: "Example App",
+            app_id: "TEST_APP_ID",
+            logo_img_url: "logo.png",
+            showcase_img_urls: ["showcase1.png", "showcase2.png"],
+            hero_image_url: "hero.png",
+            world_app_description:
+              "This is an example app designed to showcase the capabilities of our platform.",
+            world_app_button_text: "Use Integration",
+            category: "social",
+            description:
+              '{"description_overview":"fewf","description_how_it_works":"few","description_connect":"fewf"}',
+            integration_url: "https://example.com/integration",
+            app_website_url: "https://example.com",
+            source_code_url: "https://github.com/example/app",
+            whitelisted_addresses: ["0x1234", "0x5678"],
+            app_mode: "mini-app",
+            support_email: "andy@gmail.com",
+            supported_countries: ["us"],
+            supported_languages: ["en", "es"],
+            app_rating: 3.4,
+            app: {
+              team: {
+                name: "Example Team",
+              },
+            },
+          },
+        ],
+        highlights: [],
+      }),
+    }));
+    const request = new NextRequest("https://cdn.test.com/api/v2/public/apps", {
+      headers: {
+        host: "cdn.test.com",
+      },
+    });
+    const response = await GET(request);
+
+    expect(await response.json()).toEqual({
+      app_rankings: {
+        top_apps: [
+          {
+            name: "Example App",
+            app_id: "Test",
+            logo_img_url: "https://cdn.test.com/TEST_APP_ID/logo.png",
+            hero_image_url: "https://cdn.test.com/TEST_APP_ID/hero.png",
+            showcase_img_urls: [
+              "https://cdn.test.com/TEST_APP_ID/showcase1.png",
+              "https://cdn.test.com/TEST_APP_ID/showcase2.png",
+            ],
+            team_name: "Example Team",
+            app_mode: "native",
+            integration_url: "worldapp://test",
+            app_website_url: "https://example.com",
+            source_code_url: "https://github.com/example/app",
+            support_email: "andy@gmail.com",
+            supported_countries: ["us"],
+            supported_languages: ["en", "es"],
+            app_rating: 3.4,
+            unique_users: 0,
+            whitelisted_addresses: ["0x1234", "0x5678"],
+            category: [
+              {
+                name: "social",
+                lokalise_key: "world_id_partner_category_social",
+              },
+            ],
+            description: {
+              how_it_works: createLocaliseField(
+                "TEST_APP_ID",
+                AppLocaliseKeys.description_how_it_works,
+              ),
+              how_to_connect: createLocaliseField(
+                "TEST_APP_ID",
+                AppLocaliseKeys.description_connect,
+              ),
+              overview: createLocaliseField(
+                "TEST_APP_ID",
+                AppLocaliseKeys.description_overview,
+              ),
+            },
+            world_app_button_text: createLocaliseField(
+              "TEST_APP_ID",
+              AppLocaliseKeys.world_app_button_text,
+            ),
+            world_app_description: createLocaliseField(
+              "TEST_APP_ID",
+              AppLocaliseKeys.world_app_description,
+            ),
+          },
+        ],
+        highlights: [],
+      },
+      categories: [
+        {
+          name: "Social",
+          lokalise_key: "world_id_partner_category_social",
+        },
+        {
+          name: "Gaming",
+          lokalise_key: "world_id_partner_category_gaming",
+        },
+        {
+          name: "Business",
+          lokalise_key: "world_id_partner_category_business",
+        },
+        {
+          name: "Finance",
+          lokalise_key: "world_id_partner_category_finance",
+        },
+        {
+          name: "Productivity",
+          lokalise_key: "world_id_partner_category_productivity",
+        },
+        {
+          name: "Other",
+          lokalise_key: "world_id_partner_category_other",
+        },
+      ],
+    });
+  });
 });

--- a/web/tests/api/v2/public/apps/apps-metadata.test.ts
+++ b/web/tests/api/v2/public/apps/apps-metadata.test.ts
@@ -357,7 +357,7 @@ describe("/api/v2/public/apps", () => {
         top_apps: [
           {
             name: "Example App",
-            app_id: "TEST_APP_ID",
+            app_id: "app_test_123",
             logo_img_url: "logo.png",
             showcase_img_urls: ["showcase1.png", "showcase2.png"],
             hero_image_url: "hero.png",
@@ -398,12 +398,12 @@ describe("/api/v2/public/apps", () => {
         top_apps: [
           {
             name: "Example App",
-            app_id: "Test",
-            logo_img_url: "https://cdn.test.com/TEST_APP_ID/logo.png",
-            hero_image_url: "https://cdn.test.com/TEST_APP_ID/hero.png",
+            app_id: "TEST_APP",
+            logo_img_url: "https://cdn.test.com/app_test_123/logo.png",
+            hero_image_url: "https://cdn.test.com/app_test_123/hero.png",
             showcase_img_urls: [
-              "https://cdn.test.com/TEST_APP_ID/showcase1.png",
-              "https://cdn.test.com/TEST_APP_ID/showcase2.png",
+              "https://cdn.test.com/app_test_123/showcase1.png",
+              "https://cdn.test.com/app_test_123/showcase2.png",
             ],
             team_name: "Example Team",
             app_mode: "native",
@@ -424,24 +424,24 @@ describe("/api/v2/public/apps", () => {
             ],
             description: {
               how_it_works: createLocaliseField(
-                "TEST_APP_ID",
+                "app_test_123",
                 AppLocaliseKeys.description_how_it_works,
               ),
               how_to_connect: createLocaliseField(
-                "TEST_APP_ID",
+                "app_test_123",
                 AppLocaliseKeys.description_connect,
               ),
               overview: createLocaliseField(
-                "TEST_APP_ID",
+                "app_test_123",
                 AppLocaliseKeys.description_overview,
               ),
             },
             world_app_button_text: createLocaliseField(
-              "TEST_APP_ID",
+              "app_test_123",
               AppLocaliseKeys.world_app_button_text,
             ),
             world_app_description: createLocaliseField(
-              "TEST_APP_ID",
+              "app_test_123",
               AppLocaliseKeys.world_app_description,
             ),
           },


### PR DESCRIPTION
App endpoint for v2 has native apps that we change the `app_id` for. This improves the test coverage for this case as well as makes it able to handle passing in the subbed app_id since the app won't know the actual app_id