### PR TITLE
feat: switch from RS256 to PS256 for OIDC JWT

### DIFF
--- a/web/api/helpers/jwks/index.ts
+++ b/web/api/helpers/jwks/index.ts
@@ -67,7 +67,7 @@ export const retrieveJWK = async (kid: string) => {
 };
 
 /**
- * Generates an RS256 asymmetric key pair in JWK format
+ * Generates a PS256 asymmetric key pair in JWK format
  * @returns
  */
 export const generateJWK = async (): Promise<CreateJWKResult> => {

--- a/web/api/helpers/jwts.ts
+++ b/web/api/helpers/jwts.ts
@@ -264,7 +264,7 @@ export const generateOIDCJWT = async ({
   // Sign the JWT with a KMS managed key
   const client = await getKMSClient();
   const header = {
-    alg: "RS256",
+    alg: "PS256",
     typ: "JWT",
     kid,
   };
@@ -293,7 +293,7 @@ export const verifyOIDCJWT = async (
 
   const { payload } = await jose.jwtVerify(
     token,
-    await jose.importJWK(public_jwk, "RS256"),
+    await jose.importJWK(public_jwk, "PS256"),
     {
       issuer: JWT_ISSUER,
     },

--- a/web/api/helpers/kms.ts
+++ b/web/api/helpers/kms.ts
@@ -100,7 +100,7 @@ export const signJWTWithKMSKey = async (
         KeyId: kms_id,
         Message: Buffer.from(encodedHeaderPayload),
         MessageType: "RAW",
-        SigningAlgorithm: "RSASSA_PKCS1_V1_5_SHA_256",
+        SigningAlgorithm: "RSASSA_PSS_SHA_256",
       }),
     );
 

--- a/web/legacy/backend/jwks.ts
+++ b/web/legacy/backend/jwks.ts
@@ -1,11 +1,11 @@
+import { JWK_TIME_TO_LIVE, JWK_TTL_USABLE } from "@/legacy/lib/constants";
+import { logger } from "@/legacy/lib/logger";
+import { JWKModel } from "@/legacy/lib/models";
 import { gql } from "@apollo/client";
 import { createPublicKey } from "crypto";
 import dayjs from "dayjs";
-import { JWKModel } from "@/legacy/lib/models";
 import { getAPIServiceClient } from "./graphql";
 import { createKMSKey, getKMSClient, scheduleKeyDeletion } from "./kms";
-import { JWK_TIME_TO_LIVE, JWK_TTL_USABLE } from "@/legacy/lib/constants";
-import { logger } from "@/legacy/lib/logger";
 
 export type CreateJWKResult = {
   keyId: string;
@@ -126,7 +126,7 @@ export const fetchActiveJWK = async () => {
 };
 
 /**
- * Generates an RS256 asymmetric key pair in JWK format
+ * Generates a PS256 asymmetric key pair in JWK format
  * @returns
  */
 export const generateJWK = async (): Promise<CreateJWKResult> => {

--- a/web/legacy/backend/jwts.ts
+++ b/web/legacy/backend/jwts.ts
@@ -264,7 +264,7 @@ export const generateOIDCJWT = async ({
   // Sign the JWT with a KMS managed key
   const client = await getKMSClient();
   const header = {
-    alg: "RS256",
+    alg: "PS256",
     typ: "JWT",
     kid,
   };
@@ -293,7 +293,7 @@ export const verifyOIDCJWT = async (
 
   const { payload } = await jose.jwtVerify(
     token,
-    await jose.importJWK(public_jwk, "RS256"),
+    await jose.importJWK(public_jwk, "PS256"),
     {
       issuer: JWT_ISSUER,
     },

--- a/web/legacy/backend/kms.ts
+++ b/web/legacy/backend/kms.ts
@@ -2,6 +2,7 @@
  * Contains all functions for interacting with Amazon KMS
  */
 
+import { logger } from "@/legacy/lib/logger";
 import {
   CreateKeyCommand,
   DescribeKeyCommand,
@@ -13,7 +14,6 @@ import {
 } from "@aws-sdk/client-kms";
 import { base64url } from "jose";
 import { retrieveJWK } from "./jwks";
-import { logger } from "@/legacy/lib/logger";
 
 export type CreateKeyResult =
   | {
@@ -93,7 +93,7 @@ export const signJWTWithKMSKey = async (
         KeyId: kms_id,
         Message: Buffer.from(encodedHeaderPayload),
         MessageType: "RAW",
-        SigningAlgorithm: "RSASSA_PKCS1_V1_5_SHA_256",
+        SigningAlgorithm: "RSASSA_PSS_SHA_256",
       }),
     );
 

--- a/web/tests/api/__mocks__/kms.mock.ts
+++ b/web/tests/api/__mocks__/kms.mock.ts
@@ -1,4 +1,9 @@
-import { createPrivateKey, createPublicKey, createSign } from "crypto";
+import {
+  constants,
+  createPrivateKey,
+  createPublicKey,
+  createSign,
+} from "crypto";
 import { privateJwk, publicJwk } from "./jwk";
 
 module.exports = {
@@ -12,7 +17,13 @@ module.exports = {
       const sign = createSign("RSA-SHA256");
       sign.update(Buffer.from(signCommand.input.Message));
       return {
-        Signature: new Uint8Array(sign.sign(key).buffer),
+        Signature: new Uint8Array(
+          sign.sign({
+            key: key,
+            padding: constants.RSA_PKCS1_PSS_PADDING,
+            saltLength: constants.RSA_PSS_SALTLEN_DIGEST,
+          }).buffer,
+        ),
       };
     }),
   })),

--- a/web/tests/api/oidc/authorize.test.ts
+++ b/web/tests/api/oidc/authorize.test.ts
@@ -1,6 +1,3 @@
-import { when } from "jest-when";
-import fetchMock from "jest-fetch-mock";
-import { createMocks } from "node-mocks-http";
 import {
   OIDCErrorCodes,
   OIDCScopes,
@@ -9,13 +6,16 @@ import {
 } from "@/legacy/backend/oidc";
 import { OIDCResponseType } from "@/legacy/lib/types";
 import handleOIDCAuthorize from "@/pages/api/v1/oidc/authorize";
-import { validSemaphoreProofMock } from "../__mocks__/sequencer.mock";
-import { semaphoreProofParamsMock } from "../__mocks__/proof.mock";
-import { jwtVerify } from "jose";
-import { publicJwk } from "../__mocks__/jwk";
 import { createPublicKey } from "crypto";
 import dayjs from "dayjs";
+import fetchMock from "jest-fetch-mock";
+import { when } from "jest-when";
+import { jwtVerify } from "jose";
 import { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { publicJwk } from "../__mocks__/jwk";
+import { semaphoreProofParamsMock } from "../__mocks__/proof.mock";
+import { validSemaphoreProofMock } from "../__mocks__/sequencer.mock";
 
 jest.mock("legacy/backend/kms", () =>
   require("tests/api/__mocks__/kms.mock.ts"),
@@ -255,7 +255,7 @@ describe("/api/v1/oidc/authorize [implicit flow]", () => {
     const { protectedHeader, payload } = await jwtVerify(jwt, publicKey);
 
     expect(protectedHeader).toEqual({
-      alg: "RS256",
+      alg: "PS256",
       kid: "kid_my_test_key",
       typ: "JWT",
     });
@@ -316,7 +316,7 @@ describe("/api/v1/oidc/authorize [hybrid flow]", () => {
     const { protectedHeader, payload } = await jwtVerify(jwt, publicKey);
 
     expect(protectedHeader).toEqual({
-      alg: "RS256",
+      alg: "PS256",
       kid: "kid_my_test_key",
       typ: "JWT",
     });

--- a/web/tests/integration/oidc/token.test.ts
+++ b/web/tests/integration/oidc/token.test.ts
@@ -140,7 +140,7 @@ describe("/api/v1/oidc/token", () => {
 
     const { payload } = await jose.jwtVerify(
       access_token,
-      await jose.importJWK(publicJwk, "RS256"),
+      await jose.importJWK(publicJwk, "PS256"),
       {
         issuer: process.env.JWT_ISSUER,
       },


### PR DESCRIPTION
Updates JWTs used in Sign In with World ID to use PS256 instead of RS256 for signing. No changes made to key generation logic, as both RS256 and PS256 use RSA keys. Must be tested in staging before deploying to production.

Not intended to impact Hasura JWT authentication.