### PR TITLE
fix: prevent OIDC /token endpoint race condition

### DIFF
--- a/web/pages/api/v1/oidc/token.ts
+++ b/web/pages/api/v1/oidc/token.ts
@@ -51,7 +51,13 @@ const deleteAuthCodeQuery = gql`
         auth_code: { _eq: $auth_code }
       }
     ) {
-      affected_rows
+      nullifier_hash
+      verification_level
+      scope
+      code_challenge
+      code_challenge_method
+      redirect_uri
+      nonce
     }
   }
 `;
@@ -158,7 +164,7 @@ export default async function handleOIDCToken(
       >
     >;
   }>({
-    mutation: findAuthCodeQuery,
+    mutation: deleteAuthCodeQuery,
     variables: {
       auth_code,
       app_id,
@@ -255,15 +261,6 @@ export default async function handleOIDCToken(
     ...jwk,
     scope: code.scope,
     nonce: code.nonce,
-  });
-
-  await client.mutate({
-    mutation: deleteAuthCodeQuery,
-    variables: {
-      auth_code,
-      app_id,
-      now,
-    },
   });
 
   return res.status(200).json({

--- a/web/pages/api/v1/oidc/token.ts
+++ b/web/pages/api/v1/oidc/token.ts
@@ -14,30 +14,6 @@ import { createHash, timingSafeEqual } from "crypto";
 import { NextApiRequest, NextApiResponse } from "next";
 import * as yup from "yup";
 
-const findAuthCodeQuery = gql`
-  query FindAuthCode(
-    $auth_code: String!
-    $app_id: String!
-    $now: timestamptz!
-  ) {
-    auth_code(
-      where: {
-        app_id: { _eq: $app_id }
-        expires_at: { _gt: $now }
-        auth_code: { _eq: $auth_code }
-      }
-    ) {
-      nullifier_hash
-      verification_level
-      scope
-      code_challenge
-      code_challenge_method
-      redirect_uri
-      nonce
-    }
-  }
-`;
-
 const deleteAuthCodeQuery = gql`
   mutation DeleteAuthCode(
     $auth_code: String!

--- a/web/tests/integration/oidc/token.test.ts
+++ b/web/tests/integration/oidc/token.test.ts
@@ -318,12 +318,12 @@ describe("/api/v1/oidc/token", () => {
       error_description: "Missing code verifier.",
     });
 
-    // Verify that the auth code is not deleted
+    // Verify that the auth code is deleted
     const result = await integrationDBExecuteQuery(
       "SELECT id FROM auth_code WHERE app_id = $1 AND auth_code = $2",
       [app_id, "83a313c5939399ba017d2381"],
     );
-    expect(result.rowCount).toEqual(1);
+    expect(result.rowCount).toEqual(0);
   });
 
   test("error when PKCE not expected", async () => {
@@ -369,12 +369,12 @@ describe("/api/v1/oidc/token", () => {
       error_description: "Code verifier was not expected.",
     });
 
-    // Verify that the auth code is not deleted
+    // Verify that the auth code is deleted
     const result = await integrationDBExecuteQuery(
       "SELECT id FROM auth_code WHERE app_id = $1 AND auth_code = $2",
       [app_id, "83a313c5939399ba017d2381"],
     );
-    expect(result.rowCount).toEqual(1);
+    expect(result.rowCount).toEqual(0);
   });
 
   test("properly sets CORS headers", async () => {


### PR DESCRIPTION
Uses one atomic GraphQL mutation to return and delete the `auth_code` when accessing the OIDC `/token` endpoint.
completes sec-697
Not yet tested.