### PR TITLE
Add Ratings External Nullifier to App Directory

### DIFF
--- a/web/api/v2/app/submit-app-review/index.ts
+++ b/web/api/v2/app/submit-app-review/index.ts
@@ -2,9 +2,10 @@ import { errorResponse } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { verifyProof } from "@/api/helpers/verify";
+import { generateExternalNullifier } from "@/lib/hashing";
 import { logger } from "@/lib/logger";
 import { AppErrorCodes, VerificationLevel } from "@worldcoin/idkit-core";
-import { hashToField, packAndEncode } from "@worldcoin/idkit-core/hashing";
+import { hashToField } from "@worldcoin/idkit-core/hashing";
 import { NextRequest, NextResponse } from "next/server";
 import * as yup from "yup";
 import { getSdk as upsertAppReview } from "./graphql/upsert-app-review.generated";
@@ -41,9 +42,9 @@ export const POST = async (req: NextRequest) => {
 
   // Fix the signal hash to be empty string
   const signalHash = hashToField(parsedParams.rating.toString());
-  const external_nullifier = packAndEncode([
-    ["uint256", hashToField(`${parsedParams.app_id}_app_review`).hash],
-  ]);
+  const external_nullifier = generateExternalNullifier(
+    `${parsedParams.app_id}_app_review`,
+  );
 
   const { error, success } = await verifyProof(
     {

--- a/web/lib/hashing.ts
+++ b/web/lib/hashing.ts
@@ -16,7 +16,7 @@ export const generateExternalNullifier = (
 
   return packAndEncode([
     ["uint256", hashToField(app_id).hash],
-  ...action.types.map(
+    ...action.types.map(
       (type, index) =>
         [type, (action as AbiEncodedValue).values[index]] as [string, unknown],
     ),

--- a/web/lib/hashing.ts
+++ b/web/lib/hashing.ts
@@ -8,15 +8,15 @@ import {
 } from "@worldcoin/idkit-core/hashing";
 
 export const generateExternalNullifier = (
-  app_id: IDKitConfig["app_id"],
-  action: IDKitConfig["action"],
+  app_id: string,
+  action?: IDKitConfig["action"],
 ): HashFunctionOutput => {
   if (!action) return packAndEncode([["uint256", hashToField(app_id).hash]]);
   if (typeof action === "string") action = solidityEncode(["string"], [action]);
 
   return packAndEncode([
     ["uint256", hashToField(app_id).hash],
-    ...action.types.map(
+  ...action.types.map(
       (type, index) =>
         [type, (action as AbiEncodedValue).values[index]] as [string, unknown],
     ),

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -7,6 +7,7 @@ import {
   PHONE_SEQUENCER,
   PHONE_SEQUENCER_STAGING,
 } from "./constants";
+import { generateExternalNullifier } from "./hashing";
 import {
   AppLocaliseKeys,
   AppStatsReturnType,
@@ -216,6 +217,9 @@ export const formatAppMetadata = (
       appMetadata.app_id,
       AppLocaliseKeys.world_app_description,
     ),
+    ratings_external_nullifier: generateExternalNullifier(
+      `${appMetadata.app_id}_app_review`,
+    ).digest,
     category: [
       {
         name: appMetadata.category,

--- a/web/tests/api/v2/public/apps/app.test.ts
+++ b/web/tests/api/v2/public/apps/app.test.ts
@@ -78,6 +78,8 @@ describe("/api/public/app/[app_id]", () => {
         team_name: "Example Team",
         whitelisted_addresses: ["0x1234", "0x5678"],
         app_mode: "mini-app",
+        ratings_external_nullifier:
+          "0x00051f128f73eec6f444e98dca57697f9cce04fb3f2e0e63dea5351ccde35b8e",
         support_email: "andy@gmail.com",
         supported_countries: ["us"],
         supported_languages: ["en", "es"],
@@ -169,6 +171,8 @@ describe("/api/public/app/[app_id]", () => {
         integration_url: "worldapp://test",
         app_website_url: "https://example.com",
         source_code_url: "https://github.com/example/app",
+        ratings_external_nullifier:
+          "0x00ca597c4f12f9f85a633bb04cfdc877af7c2d91a6c1c7fe45031b495a227a58",
         support_email: "andy@gmail.com",
         supported_countries: ["us"],
         supported_languages: ["en", "es"],

--- a/web/tests/api/v2/public/apps/apps-metadata.test.ts
+++ b/web/tests/api/v2/public/apps/apps-metadata.test.ts
@@ -193,6 +193,8 @@ describe("/api/v2/public/apps", () => {
           {
             app_id: "1",
             name: "Test App",
+            ratings_external_nullifier:
+              "0x00051f128f73eec6f444e98dca57697f9cce04fb3f2e0e63dea5351ccde35b8e",
             logo_img_url: "https://cdn.test.com/1/logo.png",
             hero_image_url: "https://cdn.test.com/1/hero1.png",
             showcase_img_urls: ["https://cdn.test.com/1/showcase1.png"],
@@ -232,6 +234,8 @@ describe("/api/v2/public/apps", () => {
           {
             app_id: "2",
             name: "Test App2",
+            ratings_external_nullifier:
+              "0x00fc298ff1e90b9bcbd7635266377d41b389cf96426db379b5871dd85a837020",
             logo_img_url: "https://cdn.test.com/2/logo.png",
             hero_image_url: "https://cdn.test.com/2/hero.png",
             category: [
@@ -276,6 +280,8 @@ describe("/api/v2/public/apps", () => {
             name: "Test App3",
             logo_img_url: "https://cdn.test.com/3/logo.png",
             hero_image_url: "https://cdn.test.com/3/hero.png",
+            ratings_external_nullifier:
+              "0x00a8ca23f766684e799bbbf19666342bb13b830c80aba71b9e25036990b539f1",
             showcase_img_urls: [
               "https://cdn.test.com/3/showcase1.png",
               "https://cdn.test.com/3/showcase2.png",
@@ -414,6 +420,8 @@ describe("/api/v2/public/apps", () => {
             support_email: "andy@gmail.com",
             supported_countries: ["us"],
             supported_languages: ["en", "es"],
+            ratings_external_nullifier:
+              "0x00ca597c4f12f9f85a633bb04cfdc877af7c2d91a6c1c7fe45031b495a227a58",
             app_rating: 3.4,
             unique_users: 0,
             whitelisted_addresses: ["0x1234", "0x5678"],


### PR DESCRIPTION
Right now the app cannot generate external nullifiers. We could add the logic to oxide but this is a one off instance and we need to do that in wallet kit anyways. External nullifier is not a secret value and can be calculated so it's fine to just return it in the directory