### PR TITLE
Disable Delete Sign in Action

### DIFF
--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   postgres_test:
     image: postgres:14

--- a/hasura/metadata/databases/default/tables/public_action.yaml
+++ b/hasura/metadata/databases/default/tables/public_action.yaml
@@ -218,17 +218,20 @@ delete_permissions:
   - role: user
     permission:
       filter:
-        app:
-          team:
-            memberships:
-              _and:
-                - user_id:
-                    _eq: X-Hasura-User-Id
-                - _or:
-                    - role:
-                        _eq: OWNER
-                    - role:
-                        _eq: ADMIN
+        _and:
+          - action:
+              _neq: ""
+          - app:
+              team:
+                memberships:
+                  _and:
+                    - user_id:
+                        _eq: X-Hasura-User-Id
+                    - _or:
+                        - role:
+                            _eq: OWNER
+                        - role:
+                            _eq: ADMIN
 event_triggers:
   - name: generate_external_nullifier
     definition:


### PR DESCRIPTION
We don't have a restriction on deletion for sign in with world id. This fixes that. While this security wise doesn't cause an impact it does create a functionality bug where if you delete the sign in action then the page wont' load