### PR TITLE
small improvement to links

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Setup/page/SetupForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Profile/Setup/page/SetupForm/index.tsx
@@ -133,10 +133,10 @@ export const SetupForm = (props: LinksFormProps) => {
       app_mode: appMetadata?.app_mode === "mini-app" ? true : false,
       support_link: appMetadata?.support_link.includes("https://")
         ? appMetadata?.support_link
-        : undefined,
+        : "",
       support_email: appMetadata?.support_link.includes("@")
         ? appMetadata?.support_link.replace("mailto:", "")
-        : undefined,
+        : "",
       supported_countries: appMetadata?.supported_countries ?? [],
       supported_languages: appMetadata?.supported_languages ?? [],
       is_whitelist_disabled: !Boolean(appMetadata?.whitelisted_addresses),


### PR DESCRIPTION
Previously the support link would not go to null if you toggled between the approve and original version which was visually confusing