### PR TITLE
Improve api keys

### DIFF
--- a/web/components/CopyButton/index.tsx
+++ b/web/components/CopyButton/index.tsx
@@ -9,8 +9,9 @@ export const CopyButton = (props: {
   fieldName: string;
   fieldValue: string;
   className?: string;
+  disabled?: boolean;
 }) => {
-  const { fieldName, fieldValue, className } = props;
+  const { fieldName, fieldValue, className, disabled } = props;
   const [isCopied, setIsCopied] = useState<boolean>(false);
 
   const copyToClipboard = (event: any) => {
@@ -28,6 +29,7 @@ export const CopyButton = (props: {
       type="button"
       onClick={copyToClipboard}
       className={clsx("pr-4", className)}
+      disabled={disabled}
     >
       {isCopied ? (
         <CopyCheckIcon className={clsx("size-5 text-grey-900")} />

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/index.tsx
@@ -85,7 +85,7 @@ export const AppIdLayout = async (props: AppIdLayoutProps) => {
               underlined
               segment={"API Keys"}
             >
-              <Typography variant={TYPOGRAPHY.R4}>Api Keys</Typography>
+              <Typography variant={TYPOGRAPHY.R4}>API Keys</Typography>
             </Tab>
           </Tabs>
         </SizingWrapper>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/index.tsx
@@ -79,6 +79,14 @@ export const AppIdLayout = async (props: AppIdLayoutProps) => {
             >
               <Typography variant={TYPOGRAPHY.R4}>Transactions</Typography>
             </Tab>
+
+            <Tab
+              href={`/teams/${params!.teamId}/api-keys`}
+              underlined
+              segment={"API Keys"}
+            >
+              <Typography variant={TYPOGRAPHY.R4}>Api Keys</Typography>
+            </Tab>
           </Tabs>
         </SizingWrapper>
       </div>

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
@@ -125,11 +125,13 @@ export const ApiKeyRow = (props: {
 
           <CopyButton
             className={clsx(
-              "cursor-pointer !p-0 opacity-0 transition-opacity duration-300",
+              "cursor-default !p-0 opacity-0 transition-opacity duration-300",
               {
-                "sm:opacity-0 sm:group-hover:opacity-100": secretKey,
+                "cursor-pointer sm:opacity-0 sm:group-hover:opacity-100":
+                  secretKey,
               },
             )}
+            disabled={!secretKey}
             fieldValue={secretKey ?? ""}
             fieldName="API Key"
           />

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
@@ -118,12 +118,14 @@ export const ApiKeyRow = (props: {
             as="div"
             className="truncate md:!leading-6"
           >
-            {secretKey ?? "api_" + btoa(apiKey.id).substring(0, 15) + "..."}
+            {secretKey
+              ? "api_" + btoa(apiKey.id).substring(0, 20) + "......"
+              : "Reset to view"}
           </Typography>
 
           <CopyButton
             className={clsx(
-              "cursor-pointer !p-0 transition-opacity duration-300 ",
+              "cursor-pointer !p-0 opacity-0 transition-opacity duration-300",
               {
                 "sm:opacity-0 sm:group-hover:opacity-100": secretKey,
               },


### PR DESCRIPTION
<img width="1988" alt="Screenshot 2024-07-22 at 12 34 09 PM" src="https://github.com/user-attachments/assets/3f6c9e1d-efc0-44a7-9295-2fcc62fc7230">
<img width="2032" alt="Screenshot 2024-07-22 at 12 37 35 PM" src="https://github.com/user-attachments/assets/5d478fb2-7e5a-4fef-a884-15101e2bd656">

Improves the api keys flow. Makes it so it's clear you need to reset the key and also makes it easier to find the keys by adding to top nav since we are using api keys more now