### PR TITLE
Temp check sign in ip

### DIFF
--- a/web/pages/api/v1/oidc/validate.ts
+++ b/web/pages/api/v1/oidc/validate.ts
@@ -22,6 +22,10 @@ export default async function handleOIDCValidate(
   if (!req.method || !["POST"].includes(req.method)) {
     return errorNotAllowed(req.method, res, req);
   }
+  if (process.env.NEXT_PUBLIC_APP_ENV === "staging") {
+    console.log(req.headers["x-forwarded-for"]); // This is the IP address of the client
+    console.log(req.headers["X-Forwarded-For"]); // This is the IP address of the client
+  }
 
   const { isValid, parsedParams, handleError } = await validateRequestSchema({
     schema,


### PR DESCRIPTION
Check the sign in ip since the sign in server is getting rate limited by our blanked rule. We will add an exception for it so it doesn't go down during high usage like with DSCVR this past week