### PR TITLE
remove use of status in sequencer response

### DIFF
--- a/web/api/helpers/verify.ts
+++ b/web/api/helpers/verify.ts
@@ -262,18 +262,7 @@ export const verifyProof = async (
     }
   }
 
-  const result = await response.json();
-  const status = result.status === "mined" ? "on-chain" : "pending";
-
-  if (!status) {
-    logger.error("Unexpected response received from sequencer.", {
-      result,
-      sequencerUrl,
-    });
-    throw new Error("Unexpected response received from sequencer.");
-  }
-
-  return { success: true, status };
+  return { success: true };
 };
 
 /**

--- a/web/legacy/backend/verify.ts
+++ b/web/legacy/backend/verify.ts
@@ -379,16 +379,5 @@ export const verifyProof = async (
     }
   }
 
-  const result = await response.json();
-  const status = result.status === "mined" ? "on-chain" : "pending";
-
-  if (!status) {
-    logger.error("Unexpected response received from sequencer.", {
-      result,
-      sequencerUrl,
-    });
-    throw new Error("Unexpected response received from sequencer.");
-  }
-
-  return { success: true, status };
+  return { success: true };
 };


### PR DESCRIPTION
From the protocol team:
> We should also remove the explicit use of status field from the response and rely on HTTPS status codes.