### PR TITLE
Fix new users stat

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/getAccumulativeTransactionData.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/getAccumulativeTransactionData.ts
@@ -22,6 +22,8 @@ const calculateUSDAmount = (
 const safelyAdd = (a: number, b: number) =>
   (a * 10 ** 18 + b * 10 ** 18) / 10 ** 18;
 
+const roundToTwoDecimals = (num: number) => Math.round(num * 100) / 100;
+
 export const getAccumulativeTransactionData = async (
   appId: string,
 ): Promise<{
@@ -124,7 +126,7 @@ export const getAccumulativeTransactionData = async (
 
     return {
       accumulativeTransactions,
-      accumulatedTokenAmountUSD,
+      accumulatedTokenAmountUSD: roundToTwoDecimals(accumulatedTokenAmountUSD),
     };
   } catch (error) {
     if (error instanceof Error) {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/StatCards/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/StatCards/index.tsx
@@ -39,18 +39,18 @@ export const StatCards = ({ appId }: { appId: string }) => {
   const { metrics: appMetrics, loading: isMetricsLoading } =
     useGetMetrics(appId);
 
-  const impressionsTotal = appMetrics?.impressions;
-  const impressionsLast7Days = appMetrics?.impressions_7days;
+  const impressionsTotal = appMetrics?.total_impressions;
+  const impressionsLast7Days = appMetrics?.total_impressions_last_7_days;
   const impressionsPercentageChange = calculatePercentChange(
     impressionsTotal,
     impressionsLast7Days,
   );
 
   const uniqueUsers = appMetrics?.unique_users;
-  const uniqueUsersLast7Days = appMetrics?.unique_users_7days;
+  const uniqueUsersLast7Days = appMetrics?.unique_users_last_7_days;
 
-  const usersTotal = appMetrics?.users;
-  const usersLast7Days = appMetrics?.users_7days;
+  const usersTotal = appMetrics?.total_users;
+  const usersLast7Days = appMetrics?.total_users_last_7_days;
 
   const newUsersLast7Days = appMetrics?.new_users_last_7_days;
 
@@ -73,16 +73,6 @@ export const StatCards = ({ appId }: { appId: string }) => {
           />
           <StatCard
             mainColorClassName="bg-blue-500"
-            title="New users"
-            value={resolveStatValue({
-              allTimeValue: uniqueUsers,
-              weekValue: newUsersLast7Days,
-              timespanValue,
-            })}
-            isLoading={isMetricsLoading}
-          />
-          <StatCard
-            mainColorClassName="bg-blue-500"
             title="Sessions"
             value={resolveStatValue({
               allTimeValue: usersTotal,
@@ -101,6 +91,18 @@ export const StatCards = ({ appId }: { appId: string }) => {
             })}
             isLoading={isMetricsLoading}
           />
+          {timespanValue === "week" && (
+            <StatCard
+              mainColorClassName="bg-blue-500"
+              title="New users"
+              value={resolveStatValue({
+                allTimeValue: uniqueUsers,
+                weekValue: newUsersLast7Days,
+                timespanValue,
+              })}
+              isLoading={isMetricsLoading}
+            />
+          )}
         </div>
       </div>
     </>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/StatCards/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/StatCards/index.tsx
@@ -5,8 +5,8 @@ import { Timespan, TimespanSelector } from "../TimespanSelector";
 import { useGetMetrics } from "./use-get-metrics";
 
 export const timespans: Timespan[] = [
-  { label: "All time", value: "all-time" },
   { label: "Weekly", value: "week" },
+  { label: "All time", value: "all-time" },
 ];
 
 export const timespanAtom = atom(timespans[0]);
@@ -75,7 +75,7 @@ export const StatCards = ({ appId }: { appId: string }) => {
             mainColorClassName="bg-blue-500"
             title="New users"
             value={resolveStatValue({
-              allTimeValue: usersTotal,
+              allTimeValue: uniqueUsers,
               weekValue: newUsersLast7Days,
               timespanValue,
             })}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/server/index.ts
@@ -1,12 +1,12 @@
 "use server";
 
 export type AppMetricsData = {
-  impressions: number | null;
-  impressions_7days: number | null;
-  users: number | null;
-  users_7days: number | null;
+  total_impressions: number | null;
+  total_impressions_last_7_days: number | null;
+  total_users: number | null;
+  total_users_last_7_days: number | null;
   unique_users: number | null;
-  unique_users_7days: number | null;
+  unique_users_last_7_days: number | null;
   new_users_last_7_days: number | null;
   appRanking: `${number} / ${number}` | "-- / --";
 };
@@ -37,12 +37,12 @@ export const getAppMetricsData = async (
 
   if (!appMetrics) {
     return {
-      impressions: 0,
-      impressions_7days: 0,
-      users: 0,
-      users_7days: 0,
+      total_impressions: 0,
+      total_impressions_last_7_days: 0,
+      total_users: 0,
+      total_users_last_7_days: 0,
       unique_users: 0,
-      unique_users_7days: 0,
+      unique_users_last_7_days: 0,
       new_users_last_7_days: 0,
       appRanking: "-- / --",
     };
@@ -53,12 +53,12 @@ export const getAppMetricsData = async (
   const appRanking = `${appIndex + 1} / ${totalApps}` as const;
 
   return {
-    impressions: appMetrics.total_impressions,
-    impressions_7days: appMetrics.total_impressions_last_7_days,
-    users: appMetrics.total_users,
-    users_7days: appMetrics.total_users_last_7_days,
+    total_impressions: appMetrics.total_impressions,
+    total_impressions_last_7_days: appMetrics.total_impressions_last_7_days,
+    total_users: appMetrics.total_users,
+    total_users_last_7_days: appMetrics.total_users_last_7_days,
     unique_users: appMetrics.unique_users,
-    unique_users_7days: appMetrics.unique_users_last_7_days,
+    unique_users_last_7_days: appMetrics.unique_users_last_7_days,
     new_users_last_7_days: appMetrics.new_users_last_7_days,
     appRanking,
   };


### PR DESCRIPTION
This fixes two things, first of all the transaction amount is in USD and had 3 decimals, rounded to 2 now.

Secondly, switched up the default dashboard selector from all time to weekly. All time new users = all time users (we already show that), so maybe let's show meaningful data? The drawback is a smaller number...

<img width="910" alt="Screenshot 2024-10-23 at 17 54 45" src="https://github.com/user-attachments/assets/7047dc1e-609b-49d1-af97-a808076e5440">

<img width="905" alt="Screenshot 2024-10-23 at 17 54 39" src="https://github.com/user-attachments/assets/aad1f464-437c-4f6d-b6d5-c9c9e152865e">

