### PR TITLE
fix: add localisation arrows, save on change

### DIFF
--- a/web/components/TextArea/index.tsx
+++ b/web/components/TextArea/index.tsx
@@ -73,7 +73,7 @@ export const TextArea = memo(function TextArea(props: TextAreaInterface) {
   );
 
   return (
-    <div className={"inline-grid font-gta"}>
+    <div className={"inline-grid w-full font-gta"}>
       <fieldset
         className={twMerge(
           clsx("group relative grid pb-2", parentClassNames),

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
@@ -76,15 +76,18 @@ export const AppStoreForm = (props: {
     { data: localisedData, refetch: refetchLocalisation },
   ] = useFetchLocalisationLazyQuery();
 
-  const updateLocalisation = async (locale: string) => {
-    await getLocalisationText({
-      variables: {
-        id: appMetadata.id,
-        locale: locale,
-      },
-    });
-    setLocale(locale);
-  };
+  const updateLocalisation = useCallback(
+    async (locale: string) => {
+      await getLocalisationText({
+        variables: {
+          id: appMetadata.id,
+          locale: locale,
+        },
+      });
+      setLocale(locale);
+    },
+    [appMetadata.id, getLocalisationText],
+  );
 
   const isEnoughPermissions = useMemo(() => {
     return checkUserPermissions(user, teamId ?? "", [
@@ -295,7 +298,7 @@ export const AppStoreForm = (props: {
     name: "supported_languages",
   });
 
-  const handleSelectNextLocalisation = async () => {
+  const handleSelectNextLocalisation = useCallback(async () => {
     if (isDirty) {
       await saveLocalisation();
     }
@@ -309,9 +312,15 @@ export const AppStoreForm = (props: {
       const firstLocale = supportedLanguages[0];
       return updateLocalisation(firstLocale);
     }
-  };
+  }, [
+    isDirty,
+    locale,
+    saveLocalisation,
+    supportedLanguages,
+    updateLocalisation,
+  ]);
 
-  const handleSelectPreviousLocalisation = async () => {
+  const handleSelectPreviousLocalisation = useCallback(async () => {
     if (isDirty) {
       await saveLocalisation();
     }
@@ -325,7 +334,13 @@ export const AppStoreForm = (props: {
       const lastLocale = supportedLanguages[supportedLanguages.length - 1];
       return updateLocalisation(lastLocale);
     }
-  };
+  }, [
+    isDirty,
+    locale,
+    saveLocalisation,
+    supportedLanguages,
+    updateLocalisation,
+  ]);
 
   return (
     <div className="grid max-w-[580px] grid-cols-1fr/auto">

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
@@ -1,6 +1,8 @@
 import { CategorySelector } from "@/components/Category";
 import { CountryBadge } from "@/components/CountryBadge";
 import { DecoratedButton } from "@/components/DecoratedButton";
+import { ChevronLeftIcon } from "@/components/Icons/ChevronLeftIcon";
+import { ChevronRightIcon } from "@/components/Icons/ChevronRightIcon";
 import { Input } from "@/components/Input";
 import { Radio } from "@/components/Radio";
 import { SelectMultiple } from "@/components/SelectMultiple";
@@ -108,13 +110,7 @@ export const AppStoreForm = (props: {
     reset,
     watch,
     getValues,
-    formState: {
-      errors,
-      isDirty,
-      isSubmitSuccessful,
-      isSubmitting,
-      isSubmitted,
-    },
+    formState: { errors, isDirty, isSubmitted },
   } = useForm<AppStoreLocalisedForm>({
     resolver: yupResolver(schema),
     mode: "onChange",
@@ -235,6 +231,7 @@ export const AppStoreForm = (props: {
           },
         },
       });
+      refetchLocalisation();
     }
   }, [
     appMetadata?.id,
@@ -297,6 +294,38 @@ export const AppStoreForm = (props: {
     control,
     name: "supported_languages",
   });
+
+  const handleSelectNextLocalisation = async () => {
+    if (isDirty) {
+      await saveLocalisation();
+    }
+
+    const currentLocaleIdx = supportedLanguages.indexOf(locale);
+    const nextLocaleIdx = currentLocaleIdx + 1;
+    const nextLocale = supportedLanguages[nextLocaleIdx];
+    if (nextLocale) {
+      return updateLocalisation(nextLocale);
+    } else {
+      const firstLocale = supportedLanguages[0];
+      return updateLocalisation(firstLocale);
+    }
+  };
+
+  const handleSelectPreviousLocalisation = async () => {
+    if (isDirty) {
+      await saveLocalisation();
+    }
+
+    const currentLocaleIdx = supportedLanguages.indexOf(locale);
+    const previousLocaleIdx = currentLocaleIdx - 1;
+    const previousLocale = supportedLanguages[previousLocaleIdx];
+    if (previousLocale) {
+      return updateLocalisation(previousLocale);
+    } else {
+      const lastLocale = supportedLanguages[supportedLanguages.length - 1];
+      return updateLocalisation(lastLocale);
+    }
+  };
 
   return (
     <div className="grid max-w-[580px] grid-cols-1fr/auto">
@@ -469,6 +498,12 @@ export const AppStoreForm = (props: {
               render={({ field }) => (
                 <SelectMultiple
                   values={field.value}
+                  items={languages}
+                  label=""
+                  disabled={!isEditable || !isEnoughPermissions}
+                  errors={errors.supported_languages}
+                  showSelectedList
+                  searchPlaceholder="Start by typing language..."
                   onRemove={async (value) => {
                     field.onChange(
                       field.value?.filter((v) => v !== value) ?? [],
@@ -491,10 +526,6 @@ export const AppStoreForm = (props: {
                       ],
                     });
                   }}
-                  items={languages}
-                  label=""
-                  disabled={!isEditable || !isEnoughPermissions}
-                  errors={errors.supported_languages}
                   selectAll={() => {
                     const languageValues = languages.map((c) => c.value);
                     addLocaleMutation({
@@ -530,8 +561,6 @@ export const AppStoreForm = (props: {
                       ],
                     });
                   }}
-                  showSelectedList
-                  searchPlaceholder="Start by typing language..."
                 >
                   {(item, index) => (
                     <SelectMultiple.Item
@@ -572,7 +601,6 @@ export const AppStoreForm = (props: {
               )}
             />
           </div>
-
           <div className="flex flex-wrap gap-2">
             {supportedLanguages?.map((lang, index) => {
               const language = languageMap[lang as keyof typeof languageMap];
@@ -603,65 +631,74 @@ export const AppStoreForm = (props: {
               );
             })}
           </div>
-
-          <Input
-            register={register("name")}
-            errors={errors.name}
-            label="App name"
-            disabled={!isEditable || !isEnoughPermissions}
-            required
-            placeholder="Enter your App Name"
-            maxLength={50}
-            addOnRight={
-              <RemainingCharacters text={watch("name")} maxChars={50} />
-            }
-          />
-
-          <Input
-            register={register("short_name")}
-            errors={errors.short_name}
-            label="Short name"
-            disabled={!isEditable || !isEnoughPermissions}
-            required
-            placeholder="Enter your short app name"
-            maxLength={10}
-            addOnRight={
-              <RemainingCharacters text={watch("short_name")} maxChars={10} />
-            }
-          />
-
-          <Input
-            register={register("world_app_description")}
-            errors={errors.world_app_description}
-            label="App tag line"
-            disabled={!isEditable || !isEnoughPermissions}
-            required
-            placeholder="Short app store tagline"
-            maxLength={35}
-            addOnRight={
-              <RemainingCharacters
-                text={watch("world_app_description")}
-                maxChars={35}
+          <div className="flex flex-row items-center">
+            <button type="button" onClick={handleSelectPreviousLocalisation}>
+              <ChevronLeftIcon className="mr-2 size-8" />
+            </button>
+            <div>
+              <Input
+                register={register("name")}
+                errors={errors.name}
+                label="App name"
+                disabled={!isEditable || !isEnoughPermissions}
+                required
+                placeholder="Enter your App Name"
+                maxLength={50}
+                addOnRight={
+                  <RemainingCharacters text={watch("name")} maxChars={50} />
+                }
               />
-            }
-          />
-
-          <TextArea
-            label="Overview"
-            required
-            rows={5}
-            maxLength={1500}
-            errors={errors.description_overview}
-            disabled={!isEditable || !isEnoughPermissions}
-            addOn={
-              <RemainingCharacters
-                text={watch("description_overview")}
-                maxChars={1500}
+              <Input
+                register={register("short_name")}
+                errors={errors.short_name}
+                label="Short name"
+                disabled={!isEditable || !isEnoughPermissions}
+                required
+                placeholder="Enter your short app name"
+                maxLength={10}
+                addOnRight={
+                  <RemainingCharacters
+                    text={watch("short_name")}
+                    maxChars={10}
+                  />
+                }
               />
-            }
-            placeholder="Give an overview of your app to potential users. What does it do? Why should they use it?"
-            register={register("description_overview")}
-          />
+              <Input
+                register={register("world_app_description")}
+                errors={errors.world_app_description}
+                label="App tag line"
+                disabled={!isEditable || !isEnoughPermissions}
+                required
+                placeholder="Short app store tagline"
+                maxLength={35}
+                addOnRight={
+                  <RemainingCharacters
+                    text={watch("world_app_description")}
+                    maxChars={35}
+                  />
+                }
+              />
+              <TextArea
+                label="Overview"
+                required
+                rows={5}
+                maxLength={1500}
+                errors={errors.description_overview}
+                disabled={!isEditable || !isEnoughPermissions}
+                addOn={
+                  <RemainingCharacters
+                    text={watch("description_overview")}
+                    maxChars={1500}
+                  />
+                }
+                placeholder="Give an overview of your app to potential users. What does it do? Why should they use it?"
+                register={register("description_overview")}
+              />
+            </div>
+            <button type="button" onClick={handleSelectNextLocalisation}>
+              <ChevronRightIcon className="ml-2 size-8" />
+            </button>
+          </div>
 
           <DecoratedButton
             type="submit"


### PR DESCRIPTION
<img width="566" alt="Screenshot 2024-11-15 at 21 51 13" src="https://github.com/user-attachments/assets/9b157e10-3574-4958-8b84-71617c21031e">

arrows allow to switch left to right & vice versa, wrapping from last to first & vice versa
on top of that they indicate that there's some switching to be done - users will hopefully instinctively know how localisations work

edit: Most importantly, localisations are now saved between switches, so no data loss