### PR TITLE
add instrumentation file

### DIFF
--- a/web/@types/global.d.ts
+++ b/web/@types/global.d.ts
@@ -1,0 +1,7 @@
+import { Redis, Cluster as RedisCluster } from "ioredis";
+
+type Messages = typeof en;
+
+declare global {
+  var RedisClient: Redis | RedisCluster | undefined;
+}

--- a/web/api/helpers/app-rating/index.ts
+++ b/web/api/helpers/app-rating/index.ts
@@ -1,5 +1,4 @@
 "use server";
-import { createRedisClient } from "@/lib/redis";
 import { getAPIServiceGraphqlClient } from "../graphql";
 import { getSdk as getAppRatingSdk } from "./graphql/get-app-rating.generated";
 
@@ -8,11 +7,11 @@ export async function getAppRating(appId: string): Promise<number> {
   const redisKey = `app:${appId}:rating`;
   const lockKey = `lock:${appId}:rating`;
 
-  const redis = createRedisClient({
-    url: process.env.REDIS_URL!,
-    password: process.env.REDIS_PASSWORD!,
-    username: process.env.REDIS_USERNAME!,
-  });
+  const redis = global.RedisClient;
+
+  if (!redis) {
+    throw new Error("Redis client not found");
+  }
 
   try {
     // Try to get from cache first

--- a/web/instrumentation.ts
+++ b/web/instrumentation.ts
@@ -1,0 +1,34 @@
+export async function register() {
+  console.log("🛠️ Starting Instrumentation registration...");
+
+  try {
+    if (
+      typeof window === "undefined" &&
+      process.env.NEXT_RUNTIME === "nodejs"
+    ) {
+      const { createRedisClient } = await import("./lib/redis");
+
+      if (
+        !process.env.REDIS_URL ||
+        !process.env.REDIS_USERNAME ||
+        !process.env.REDIS_PASSWORD
+      ) {
+        return console.error(
+          "🔴 Missing Redis configuration in instrumentation.ts",
+        );
+      }
+
+      const redis = createRedisClient({
+        url: process.env.REDIS_URL,
+        password: process.env.REDIS_PASSWORD,
+        username: process.env.REDIS_USERNAME,
+      });
+
+      global.RedisClient = redis;
+    }
+  } catch (error) {
+    return console.error("🔴 Instrumentation registration error: ", error);
+  }
+
+  console.log("✅ Instrumentation registration complete.");
+}

--- a/web/jest.setup.ts
+++ b/web/jest.setup.ts
@@ -1,3 +1,4 @@
+import IORedis from "ioredis-mock";
 import { setConfig } from "next/config";
 import "whatwg-fetch";
 
@@ -8,6 +9,12 @@ setConfig({
     ),
   ),
 });
+
+// Create the mock Redis client
+const redisMock = new IORedis();
+
+// Set the global mock
+global.RedisClient = redisMock;
 
 export const MOCKED_GENERAL_SECRET_KEY =
   "0xsuperSecretKey99994ab56046d4d97695b9999999";

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -11,6 +11,11 @@ const publicAppURL =
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
+
+  experimental: {
+    instrumentationHook: true,
+  },
+
   output: "standalone",
   images: {
     remotePatterns: [

--- a/web/pages/api/v1/oidc/authorize.ts
+++ b/web/pages/api/v1/oidc/authorize.ts
@@ -19,7 +19,6 @@ import { validateRequestSchema } from "@/legacy/backend/utils";
 import { verifyProof } from "@/legacy/backend/verify";
 import { logger } from "@/legacy/lib/logger";
 import { OIDCFlowType, OIDCResponseType } from "@/legacy/lib/types";
-import { createRedisClient } from "@/lib/redis";
 import { captureEvent } from "@/services/posthogClient";
 import { gql } from "@apollo/client";
 import { VerificationLevel } from "@worldcoin/idkit-core";
@@ -98,32 +97,20 @@ export default async function handleOIDCAuthorize(
     return errorNotAllowed(req.method, res, req);
   }
 
-  let redis;
+  const redis = global.RedisClient;
+
+  if (!redis) {
+    return errorResponse(
+      res,
+      500,
+      "internal_server_error",
+      "Redis client not found",
+      "server",
+      req,
+    );
+  }
 
   try {
-    // Initial validations...
-    if (!process.env.REDIS_URL || !process.env.REDIS_USERNAME) {
-      return errorResponse(
-        res,
-        500,
-        "missing_redis_config",
-        "Missing ENV variables.",
-        "INVALID_CONFIG",
-        req,
-      );
-    }
-
-    if (process.env.NODE_ENV !== "development" && !process.env.REDIS_USERNAME) {
-      return errorResponse(
-        res,
-        500,
-        "missing_redis_config",
-        "Missing ENV variables.",
-        "INVALID_CONFIG",
-        req,
-      );
-    }
-
     const { isValid, parsedParams, handleError } = await validateRequestSchema({
       schema,
       value: req.body,
@@ -224,12 +211,6 @@ export default async function handleOIDCAuthorize(
         req,
       );
     }
-
-    redis = createRedisClient({
-      url: process.env.REDIS_URL,
-      password: process.env.REDIS_PASSWORD,
-      username: process.env.REDIS_USERNAME,
-    });
 
     // Anchor: Check the proof hasn't been replayed
     const hashedProof = createHash("sha256").update(proof).digest("hex");

--- a/web/tests/api/oidc/authorize.test.ts
+++ b/web/tests/api/oidc/authorize.test.ts
@@ -5,7 +5,6 @@ import {
   insertAuthCodeQuery,
 } from "@/legacy/backend/oidc";
 import { OIDCResponseType } from "@/legacy/lib/types";
-import { createRedisClient } from "@/lib/redis";
 import handleOIDCAuthorize from "@/pages/api/v1/oidc/authorize";
 import { createPublicKey } from "crypto";
 import dayjs from "dayjs";
@@ -25,15 +24,6 @@ jest.mock("legacy/backend/kms", () =>
 jest.mock("legacy/backend/jwks", () =>
   require("tests/api/__mocks__/jwks.mock.ts"),
 );
-
-jest.mock("ioredis", () => {
-  const ioredisMock = jest.requireActual("ioredis-mock");
-  return {
-    __esModule: true,
-    Redis: ioredisMock,
-    Cluster: ioredisMock.Cluster,
-  };
-});
 
 const fetchAppQueryResponse = () => ({
   data: {
@@ -74,6 +64,8 @@ jest.mock(
 );
 
 beforeEach(async () => {
+  await global.RedisClient?.flushall();
+
   when(requestReturnFn)
     .calledWith(
       expect.objectContaining({
@@ -108,14 +100,6 @@ beforeEach(async () => {
     .mockImplementation((args) => ({
       data: { insert_auth_code_one: { auth_code: args.variables.auth_code } },
     }));
-
-  const redis = createRedisClient({
-    url: process.env.REDIS_URL!,
-    password: process.env.REDIS_PASSWORD,
-    username: process.env.REDIS_USERNAME!,
-  });
-
-  await redis.flushall();
 });
 
 beforeAll(() => {

--- a/web/tests/integration/oidc/authorize.test.ts
+++ b/web/tests/integration/oidc/authorize.test.ts
@@ -1,5 +1,4 @@
 import { OIDCErrorCodes } from "@/legacy/backend/oidc";
-import { createRedisClient } from "@/lib/redis";
 import handleOIDCAuthorize from "@/pages/api/v1/oidc/authorize";
 import { createHash } from "crypto";
 import fetchMock from "jest-fetch-mock";
@@ -10,24 +9,9 @@ import { validSemaphoreProofMock } from "tests/api/__mocks__/sequencer.mock";
 import { integrationDBClean, integrationDBExecuteQuery } from "../setup";
 import { testGetDefaultApp } from "../test-utils";
 
-jest.mock("ioredis", () => {
-  const ioredisMock = jest.requireActual("ioredis-mock");
-  return {
-    __esModule: true,
-    Redis: ioredisMock,
-    Cluster: ioredisMock.Cluster,
-  };
-});
-
 beforeEach(async () => {
   await integrationDBClean();
-  const redis = createRedisClient({
-    url: process.env.REDIS_URL!,
-    password: process.env.REDIS_PASSWORD,
-    username: process.env.REDIS_USERNAME!,
-  });
-
-  await redis.flushall();
+  await global.RedisClient?.flushall();
 });
 
 beforeAll(() => {


### PR DESCRIPTION
This PR adds redis client usage with instrumentation file.

Instrumentation file docs: 
https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation

Shortly (but read the doc), we use `register()` inside the instrumentation file to execute Redis client creation only once on the application starting after the build. Then, we store the Redis client instance globally to access it everywhere. 

### TODO 
- PR is not finished. We should apply global client everywhere where we are using redis client.