### PR TITLE
fix: provide compatibility layer for report form

### DIFF
--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -64,6 +64,12 @@ type Mutation {
   ): ResetClientOutput
 }
 
+type Mutation {
+  tmp_insert_app_report(
+    input: TmpInsertAppReport!
+  ): TmpInsertAppReportOutput
+}
+
 type Query {
   upload_image(
     app_id: String!
@@ -94,6 +100,13 @@ input UploadImageInput {
   team_id: String!
   image_type: String!
   content_type_ending: String!
+}
+
+input TmpInsertAppReport {
+  app_id: String!
+  user_id: String!
+  reporter_email: String!
+  details: String!
 }
 
 type ResetClientOutput {
@@ -166,5 +179,9 @@ type ValidateLocalisationOutput {
 
 type BanAppOutput {
   success: Boolean
+}
+
+type TmpInsertAppReportOutput {
+  success: Boolean!
 }
 

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -126,6 +126,16 @@ actions:
       - role: api_key
       - role: user
     comment: Reset the client secret for a Sign in with World ID application
+  - name: tmp_insert_app_report
+    definition:
+      kind: synchronous
+      handler: '{{NEXT_API_URL}}/hasura/tmp-insert-app-report'
+      headers:
+        - name: Authorization
+          value: INTERNAL_ENDPOINTS_SECRET
+    permissions:
+      - role: reviewer
+    comment: temporary backward-compatibility layer for the old report form
   - name: upload_image
     definition:
       kind: ""
@@ -184,6 +194,7 @@ custom_types:
   enums: []
   input_objects:
     - name: UploadImageInput
+    - name: TmpInsertAppReport
   objects:
     - name: ResetClientOutput
     - name: ResetAPIOutput
@@ -201,4 +212,5 @@ custom_types:
     - name: CreateNewDraftOutput
     - name: ValidateLocalisationOutput
     - name: BanAppOutput
+    - name: TmpInsertAppReportOutput
   scalars: []

--- a/web/api/hasura/tmp-insert-app-report/graphql/create-app-report.generated.ts
+++ b/web/api/hasura/tmp-insert-app-report/graphql/create-app-report.generated.ts
@@ -1,0 +1,78 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type CreateAppReportMutationVariables = Types.Exact<{
+  app_id: Types.Scalars["String"]["input"];
+  user_id: Types.Scalars["String"]["input"];
+  reporter_email: Types.Scalars["String"]["input"];
+  details?: Types.InputMaybe<Types.Scalars["String"]["input"]>;
+}>;
+
+export type CreateAppReportMutation = {
+  __typename?: "mutation_root";
+  insert_app_report?: { __typename: "app_report_mutation_response" } | null;
+};
+
+export const CreateAppReportDocument = gql`
+  mutation CreateAppReport(
+    $app_id: String!
+    $user_id: String!
+    $reporter_email: String!
+    $details: String
+  ) {
+    insert_app_report(
+      objects: [
+        {
+          app_id: $app_id
+          user_id: $user_id
+          reporter_email: $reporter_email
+          details: $details
+        }
+      ]
+    ) {
+      __typename
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    CreateAppReport(
+      variables: CreateAppReportMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CreateAppReportMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateAppReportMutation>(
+            CreateAppReportDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "CreateAppReport",
+        "mutation",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/hasura/tmp-insert-app-report/graphql/create-app-report.graphql
+++ b/web/api/hasura/tmp-insert-app-report/graphql/create-app-report.graphql
@@ -1,0 +1,19 @@
+mutation CreateAppReport(
+  $app_id: String!
+  $user_id: String!
+  $reporter_email: String!
+  $details: String
+) {
+  insert_app_report(
+    objects: [
+      {
+        app_id: $app_id
+        user_id: $user_id
+        reporter_email: $reporter_email
+        details: $details
+      }
+    ]
+  ) {
+    __typename
+  }
+}

--- a/web/api/hasura/tmp-insert-app-report/index.ts
+++ b/web/api/hasura/tmp-insert-app-report/index.ts
@@ -1,0 +1,87 @@
+import { errorHasuraQuery } from "@/api/helpers/errors";
+import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { protectInternalEndpoint } from "@/api/helpers/utils";
+import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
+import { logger } from "@/lib/logger";
+import { NextRequest, NextResponse } from "next/server";
+import * as yup from "yup";
+import { getSdk as getCreateAppSdk } from "./graphql/create-app-report.generated";
+
+export const schema = yup.object({
+  app_id: yup.string().required("App ID is required"),
+  user_id: yup.string().required("User ID is required"),
+  reporter_email: yup.string().required("Reporter email is required"),
+  details: yup.string().nullable(),
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    if (!protectInternalEndpoint(req)) {
+      return errorHasuraQuery({
+        req,
+        detail: "Internal endpoint",
+        code: "internal_endpoint",
+      });
+    }
+
+    const body = await req.json();
+
+    if (body?.action.name !== "create_app_report") {
+      return errorHasuraQuery({
+        req,
+        detail: "Invalid action.",
+        code: "invalid_action",
+      });
+    }
+
+    if (
+      !["reviewer", "admin"].includes(body.session_variables["x-hasura-role"])
+    ) {
+      logger.error("Unauthorized access."),
+        { role: body.session_variables["x-hasura-role"] };
+      return errorHasuraQuery({ req });
+    }
+
+    const { isValid, parsedParams } = await validateRequestSchema({
+      value: body.input.input,
+      schema,
+    });
+
+    if (!isValid || !parsedParams) {
+      return errorHasuraQuery({
+        req,
+        detail: "Invalid request body.",
+        code: "invalid_request",
+      });
+    }
+
+    const client = await getAPIServiceGraphqlClient();
+
+    const { insert_app_report } = await getCreateAppSdk(client).CreateAppReport(
+      {
+        app_id: parsedParams.app_id,
+        user_id: parsedParams.user_id,
+        reporter_email: parsedParams.reporter_email,
+        details: parsedParams.details,
+      },
+    );
+
+    if (!insert_app_report) {
+      return errorHasuraQuery({
+        req,
+        detail: "Failed to create app report",
+        code: "create_app_report_failed",
+      });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error("Error creating app report", { error });
+
+    return errorHasuraQuery({
+      req,
+      detail: "Unable to create app report",
+      code: "internal_error",
+    });
+  }
+};

--- a/web/app/api/hasura/tmp-insert-app-report/route.ts
+++ b/web/app/api/hasura/tmp-insert-app-report/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "@/api/hasura/tmp-insert-app-report";


### PR DESCRIPTION
This is needed so that there aren't any interruptions in the app reporting flow. Other PR introduces breaking changes, which would result in rejected inserts. This ensures that reports always go through in the transition period