### PR TITLE
Support app_metadata_id in qr codes and get app endpoint

### DIFF
--- a/web/api/v2/public/app/[app_id]/graphql/get-app-metadata.generated.ts
+++ b/web/api/v2/public/app/[app_id]/graphql/get-app-metadata.generated.ts
@@ -13,6 +13,7 @@ export type GetAppMetadataQuery = {
   __typename?: "query_root";
   app_metadata: Array<{
     __typename?: "app_metadata";
+    id: string;
     name: string;
     short_name: string;
     app_id: string;
@@ -61,6 +62,7 @@ export const GetAppMetadataDocument = gql`
     app_metadata(
       where: { app_id: { _eq: $app_id }, app: { is_banned: { _eq: false } } }
     ) {
+      id
       name
       short_name
       app_id

--- a/web/api/v2/public/app/[app_id]/graphql/get-app-metadata.graphql
+++ b/web/api/v2/public/app/[app_id]/graphql/get-app-metadata.graphql
@@ -2,6 +2,7 @@ query GetAppMetadata($app_id: String!, $locale: String!) {
   app_metadata(
     where: { app_id: { _eq: $app_id }, app: { is_banned: { _eq: false } } }
   ) {
+    id
     name
     short_name
     app_id

--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -83,6 +83,17 @@ export async function GET(
     }, null);
   }
 
+  /**
+   * Temporary: Testing staging feature for mini apps
+   */
+  const { searchParams } = new URL(request.url);
+  const app_metadata_id = searchParams.get("app_metadata_id");
+  if (process.env.NEXT_PUBLIC_APP_ENV !== "production" && app_metadata_id) {
+    parsedAppMetadata =
+      app_metadata.find((meta) => meta.id === app_metadata_id) ??
+      parsedAppMetadata;
+  }
+
   let formattedMetadata = await formatAppMetadata(
     { ...parsedAppMetadata },
     metricsData,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/QrQuickAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/QrQuickAction/index.tsx
@@ -16,11 +16,17 @@ const getQRCode = async (url: string): Promise<string | null> => {
   }
 };
 
-export const QrQuickAction = (props: { app_id: string }) => {
-  const { app_id } = props;
+export const QrQuickAction = (props: {
+  app_id: string;
+  app_metadata_id: string;
+}) => {
+  const { app_id, app_metadata_id } = props;
   const [qrCodeDataURL, setQrCodeDataURL] = useState<string | null>(null);
 
-  const url = `https://worldcoin.org/mini-app?app_id=${app_id}`;
+  let url = `https://worldcoin.org/mini-app?app_id=${app_id}`;
+  if (process.env.NEXT_PUBLIC_APP_ENV !== "production" && app_metadata_id) {
+    url += `&app_metadata_id=${app_metadata_id}`;
+  }
 
   useEffect(() => {
     getQRCode(url).then(setQrCodeDataURL);

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
@@ -158,7 +158,7 @@ export const BasicInformation = (props: {
           </DecoratedButton>
         </form>
         <div className="mt-7 flex justify-center sm:justify-start">
-          <QrQuickAction app_id={appId} />
+          <QrQuickAction app_id={appId} app_metadata_id={appMetaData?.id} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

This PR adds some code for staging and dev, to support `appMetadataId` in:
- QR code
- Public app endpoint

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
