### PR TITLE
DEV 1261: Support app metatada id in deeplinking and public app endpoint

### DIFF
--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -89,7 +89,9 @@ export async function GET(
   } else if (app_metadata.length > 1) {
     // If no specific metadata found by id, check for reviewer approved version
     const approvedMetadata = app_metadata.find(
-      (meta) => meta.is_reviewer_world_app_approved,
+      (meta) =>
+        meta.is_reviewer_world_app_approved &&
+        meta.verification_status === "verified",
     );
     if (approvedMetadata) {
       parsedAppMetadata = approvedMetadata;

--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -77,12 +77,10 @@ export async function GET(
 
   // Get query param for specific metadata if provided
   const { searchParams } = new URL(request.url);
-  const app_metadata_id = searchParams.get("app_metadata_id");
+  const draft_id = searchParams.get("draft_id");
 
-  if (app_metadata_id) {
-    const metadataById = app_metadata.find(
-      (meta) => meta.id === app_metadata_id,
-    );
+  if (draft_id) {
+    const metadataById = app_metadata.find((meta) => meta.id === draft_id);
     if (metadataById) {
       parsedAppMetadata = metadataById;
     }

--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -74,24 +74,26 @@ export async function GET(
 
   let parsedAppMetadata = app_metadata[0];
   const nativeAppMetadata = NativeApps[process.env.NEXT_PUBLIC_APP_ENV];
-  if (app_metadata.length > 1) {
-    app_metadata.reduce((acc, current) => {
-      if (current.is_reviewer_world_app_approved) {
-        parsedAppMetadata = current;
-      }
-      return acc;
-    }, null);
-  }
 
-  /**
-   * Temporary: Testing staging feature for mini apps
-   */
+  // Get query param for specific metadata if provided
   const { searchParams } = new URL(request.url);
   const app_metadata_id = searchParams.get("app_metadata_id");
-  if (process.env.NEXT_PUBLIC_APP_ENV !== "production" && app_metadata_id) {
-    parsedAppMetadata =
-      app_metadata.find((meta) => meta.id === app_metadata_id) ??
-      parsedAppMetadata;
+
+  if (app_metadata_id) {
+    const metadataById = app_metadata.find(
+      (meta) => meta.id === app_metadata_id,
+    );
+    if (metadataById) {
+      parsedAppMetadata = metadataById;
+    }
+  } else if (app_metadata.length > 1) {
+    // If no specific metadata found by id, check for reviewer approved version
+    const approvedMetadata = app_metadata.find(
+      (meta) => meta.is_reviewer_world_app_approved,
+    );
+    if (approvedMetadata) {
+      parsedAppMetadata = approvedMetadata;
+    }
   }
 
   let formattedMetadata = await formatAppMetadata(

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/QrQuickAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/QrQuickAction/index.tsx
@@ -22,7 +22,6 @@ export const QrQuickAction = (props: {
   showDeveloperFlag: boolean;
 }) => {
   const { url, showDeveloperFlag } = props;
-  // const { app_id, app_metadata_id } = props;
   const [qrCodeDataURL, setQrCodeDataURL] = useState<string | null>(null);
 
   useEffect(() => {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/QrQuickAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/QrQuickAction/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { CopyButton } from "@/components/CopyButton";
 import { FlaskIcon } from "@/components/Icons/FlaskIcon";
+import { Notification } from "@/components/Notification";
 import { QuickAction } from "@/components/QuickAction";
 import Image from "next/image";
 import QRCode from "qrcode";
@@ -17,16 +18,12 @@ const getQRCode = async (url: string): Promise<string | null> => {
 };
 
 export const QrQuickAction = (props: {
-  app_id: string;
-  app_metadata_id: string;
+  url: string;
+  showDeveloperFlag: boolean;
 }) => {
-  const { app_id, app_metadata_id } = props;
+  const { url, showDeveloperFlag } = props;
+  // const { app_id, app_metadata_id } = props;
   const [qrCodeDataURL, setQrCodeDataURL] = useState<string | null>(null);
-
-  let url = `https://worldcoin.org/mini-app?app_id=${app_id}`;
-  if (process.env.NEXT_PUBLIC_APP_ENV !== "production" && app_metadata_id) {
-    url += `&app_metadata_id=${app_metadata_id}`;
-  }
 
   useEffect(() => {
     getQRCode(url).then(setQrCodeDataURL);
@@ -37,21 +34,36 @@ export const QrQuickAction = (props: {
   }
 
   return (
-    <QuickAction
-      type="button"
-      description="Scan this, or copy the link"
-      icon={<FlaskIcon />}
-      hideArrow
-      iconRight={
-        <CopyButton
-          fieldName="Miniapp URL"
-          fieldValue={url}
-          className="flex items-center justify-center rounded-full border p-2 !pr-2 text-blue-500"
-        />
-      }
-      title="See your mini app"
-    >
-      <Image src={qrCodeDataURL} width={200} height={200} alt="QR Code" />
-    </QuickAction>
+    <div className="grid gap-y-2">
+      {showDeveloperFlag && (
+        <Notification variant="warning">
+          <div className="text-sm">
+            <h3 className="font-medium text-yellow-800">Developer Preview</h3>
+            <div className="mt-2 text-yellow-700">
+              This link/QR code is for testing purposes only and will be deleted
+              after the app is verified.
+            </div>
+          </div>
+        </Notification>
+      )}
+      <div className="flex justify-center">
+        <QuickAction
+          type="button"
+          description="Scan this, or copy the link"
+          icon={<FlaskIcon />}
+          hideArrow
+          iconRight={
+            <CopyButton
+              fieldName="Miniapp URL"
+              fieldValue={url}
+              className="flex items-center justify-center rounded-full border p-2 !pr-2 text-blue-500"
+            />
+          }
+          title="See your mini app"
+        >
+          <Image src={qrCodeDataURL} width={200} height={200} alt="QR Code" />
+        </QuickAction>
+      </div>
+    </div>
   );
 };

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
@@ -105,7 +105,7 @@ export const BasicInformation = (props: {
     let url = `https://worldcoin.org/mini-app?app_id=${appId}`;
     let showDeveloperFlag = appMetaData?.verification_status !== "verified";
     if (showDeveloperFlag) {
-      url += `&app_metadata_id=${appMetaData?.id}`;
+      url += `&draft_id=${appMetaData?.id}`;
     }
     return { url, showDeveloperFlag };
   }, [appId, appMetaData]);

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
@@ -30,7 +30,7 @@ export const BasicInformation = (props: {
   app: FetchAppMetadataQuery["app"][0];
   teamName: string;
 }) => {
-  const { appId, teamId, app, teamName } = props;
+  const { appId, teamId, app } = props;
   const { refetch: refetchAppMetadata } =
     useRefetchQueries<FetchAppMetadataQueryVariables>(
       FetchAppMetadataDocument,
@@ -101,6 +101,15 @@ export const BasicInformation = (props: {
     [appMetaData?.id, refetchAppMetadata],
   );
 
+  const { url, showDeveloperFlag } = useMemo(() => {
+    let url = `https://worldcoin.org/mini-app?app_id=${appId}`;
+    let showDeveloperFlag = appMetaData?.verification_status !== "verified";
+    if (showDeveloperFlag) {
+      url += `&app_metadata_id=${appMetaData?.id}`;
+    }
+    return { url, showDeveloperFlag };
+  }, [appId, appMetaData]);
+
   return (
     <div className="grid max-w-[580px] grid-cols-1fr/auto">
       <div className="">
@@ -158,7 +167,7 @@ export const BasicInformation = (props: {
           </DecoratedButton>
         </form>
         <div className="mt-7 flex justify-center sm:justify-start">
-          <QrQuickAction app_id={appId} app_metadata_id={appMetaData?.id} />
+          <QrQuickAction url={url} showDeveloperFlag={showDeveloperFlag} />
         </div>
       </div>
     </div>

--- a/web/tests/api/v2/public/apps/app.test.ts
+++ b/web/tests/api/v2/public/apps/app.test.ts
@@ -299,4 +299,281 @@ describe("/api/public/app/[app_id]", () => {
       },
     });
   });
+
+  describe("App metadata selection logic", () => {
+    // beforeEach(() => {
+    //   process.env.NEXT_PUBLIC_APP_ENV = "development";
+    //   process.env.NEXT_PUBLIC_METRICS_SERVICE_ENDPOINT = "http://metrics";
+    //   process.env.NEXT_PUBLIC_IMAGES_CDN_URL = "http://cdn";
+    //   global.fetch = jest.fn(() =>
+    //     Promise.resolve({
+    //       status: 200,
+    //       json: () => Promise.resolve({ stats: "data" }),
+    //     }),
+    //   ) as jest.Mock;
+    // });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test("should select metadata by app_metadata_id when provided", async () => {
+      jest.mocked(getAppMetadataSdk).mockImplementation(() => ({
+        GetAppMetadata: jest.fn().mockResolvedValue({
+          app_metadata: [
+            {
+              id: "1",
+              name: "Example App",
+              app_id: "1",
+              short_name: "test",
+              logo_img_url: "logo.png",
+              showcase_img_urls: ["showcase1.png", "showcase2.png"],
+              hero_image_url: "hero.png",
+              world_app_description:
+                "This is an example app designed to showcase the capabilities of our platform.",
+              world_app_button_text: "Use Integration",
+              category: "Productivity",
+              description:
+                '{"description_overview":"fewf","description_how_it_works":"few","description_connect":"fewf"}',
+              integration_url: "https://example.com/integration",
+              app_website_url: "https://example.com",
+              source_code_url: "https://github.com/example/app",
+              whitelisted_addresses: ["0x1234", "0x5678"],
+              app_mode: "mini-app",
+              support_link: "takis@gmail.com",
+              supported_countries: ["us"],
+              associated_domains: ["https://worldcoin.org"],
+              contracts: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
+              permit2_tokens: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
+              supported_languages: ["en", "es"],
+              verification_status: "verified",
+              is_allowed_unlimited_notifications: false,
+              max_notifications_per_day: 10,
+              is_reviewer_world_app_approved: true,
+              app: {
+                team: {
+                  name: "Example Team",
+                },
+                rating_sum: 10,
+                rating_count: 3,
+              },
+            },
+            {
+              id: "2",
+              name: "Example App",
+              app_id: "1",
+              short_name: "test",
+              logo_img_url: "logo.png",
+              showcase_img_urls: ["showcase1.png", "showcase2.png"],
+              hero_image_url: "hero.png",
+              world_app_description:
+                "This is an example app designed to showcase the capabilities of our platform.",
+              world_app_button_text: "Use Integration",
+              category: "Productivity",
+              description:
+                '{"description_overview":"fewf","description_how_it_works":"few","description_connect":"fewf"}',
+              integration_url: "https://example.com/integration-unverified",
+              app_website_url: "https://example.com",
+              source_code_url: "https://github.com/example/app",
+              whitelisted_addresses: ["0x1234", "0x5678"],
+              app_mode: "mini-app",
+              support_link: "takis@gmail.com",
+              supported_countries: ["us"],
+              associated_domains: ["https://worldcoin.org"],
+              contracts: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
+              permit2_tokens: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
+              supported_languages: ["en", "es"],
+              is_reviewer_world_app_approved: false,
+              verification_status: "unverified",
+              is_allowed_unlimited_notifications: false,
+              max_notifications_per_day: 10,
+              app: {
+                team: {
+                  name: "Example Team",
+                },
+                rating_sum: 10,
+                rating_count: 3,
+              },
+            },
+          ],
+        }),
+      }));
+
+      const request = new NextRequest(
+        "https://cdn.test.com/api/public/app/test-app?app_metadata_id=2",
+        {
+          headers: {
+            host: "cdn.test.com",
+          },
+        },
+      );
+      const response = await GET(request, { params: { app_id: "test-app" } });
+      const data = await response.json();
+      expect(data.app_data.name).toBe("Example App");
+      expect(data.app_data.app_rating).toBe(3.33);
+      expect(data.app_data.integration_url).toBe(
+        "https://example.com/integration-unverified",
+      );
+    });
+
+    test("should select reviewer approved metadata when no app_metadata_id provided", async () => {
+      jest.mocked(getAppMetadataSdk).mockImplementation(() => ({
+        GetAppMetadata: jest.fn().mockResolvedValue({
+          app_metadata: [
+            {
+              id: "1",
+              name: "Example App",
+              app_id: "1",
+              short_name: "test",
+              logo_img_url: "logo.png",
+              showcase_img_urls: ["showcase1.png", "showcase2.png"],
+              hero_image_url: "hero.png",
+              world_app_description:
+                "This is an example app designed to showcase the capabilities of our platform.",
+              world_app_button_text: "Use Integration",
+              category: "Productivity",
+              description:
+                '{"description_overview":"fewf","description_how_it_works":"few","description_connect":"fewf"}',
+              integration_url: "https://example.com/integration",
+              app_website_url: "https://example.com",
+              source_code_url: "https://github.com/example/app",
+              whitelisted_addresses: ["0x1234", "0x5678"],
+              app_mode: "mini-app",
+              support_link: "takis@gmail.com",
+              supported_countries: ["us"],
+              associated_domains: ["https://worldcoin.org"],
+              contracts: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
+              permit2_tokens: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
+              supported_languages: ["en", "es"],
+              verification_status: "verified",
+              is_allowed_unlimited_notifications: false,
+              max_notifications_per_day: 10,
+              is_reviewer_world_app_approved: true,
+              app: {
+                team: {
+                  name: "Example Team",
+                },
+                rating_sum: 10,
+                rating_count: 3,
+              },
+            },
+            {
+              id: "2",
+              name: "Example App",
+              app_id: "1",
+              short_name: "test",
+              logo_img_url: "logo.png",
+              showcase_img_urls: ["showcase1.png", "showcase2.png"],
+              hero_image_url: "hero.png",
+              world_app_description:
+                "This is an example app designed to showcase the capabilities of our platform.",
+              world_app_button_text: "Use Integration",
+              category: "Productivity",
+              description:
+                '{"description_overview":"fewf","description_how_it_works":"few","description_connect":"fewf"}',
+              integration_url: "https://example.com/integration-unverified",
+              app_website_url: "https://example.com",
+              source_code_url: "https://github.com/example/app",
+              whitelisted_addresses: ["0x1234", "0x5678"],
+              app_mode: "mini-app",
+              support_link: "takis@gmail.com",
+              supported_countries: ["us"],
+              associated_domains: ["https://worldcoin.org"],
+              contracts: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
+              permit2_tokens: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
+              supported_languages: ["en", "es"],
+              is_reviewer_world_app_approved: false,
+              verification_status: "unverified",
+              is_allowed_unlimited_notifications: false,
+              max_notifications_per_day: 10,
+              app: {
+                team: {
+                  name: "Example Team",
+                },
+                rating_sum: 10,
+                rating_count: 3,
+              },
+            },
+          ],
+        }),
+      }));
+
+      const request = new NextRequest(
+        "https://cdn.test.com/api/public/app/test-app",
+        {
+          headers: {
+            host: "cdn.test.com",
+          },
+        },
+      );
+      const response = await GET(request, { params: { app_id: "test-app" } });
+      const data = await response.json();
+      expect(data.app_data.name).toBe("Example App");
+      expect(data.app_data.app_rating).toBe(3.33);
+      expect(data.app_data.integration_url).toBe(
+        "https://example.com/integration",
+      );
+    });
+
+    test("should fallback to first metadata when app_metadata_id is invalid", async () => {
+      jest.mocked(getAppMetadataSdk).mockImplementation(() => ({
+        GetAppMetadata: jest.fn().mockResolvedValue({
+          app_metadata: [
+            {
+              id: "1",
+              name: "Example App",
+              app_id: "1",
+              short_name: "test",
+              logo_img_url: "logo.png",
+              showcase_img_urls: ["showcase1.png", "showcase2.png"],
+              hero_image_url: "hero.png",
+              world_app_description:
+                "This is an example app designed to showcase the capabilities of our platform.",
+              world_app_button_text: "Use Integration",
+              category: "Productivity",
+              description:
+                '{"description_overview":"fewf","description_how_it_works":"few","description_connect":"fewf"}',
+              integration_url: "https://example.com/integration",
+              app_website_url: "https://example.com",
+              source_code_url: "https://github.com/example/app",
+              whitelisted_addresses: ["0x1234", "0x5678"],
+              app_mode: "mini-app",
+              support_link: "andy@gmail.com",
+              supported_countries: ["us"],
+              associated_domains: ["https://worldcoin.org"],
+              contracts: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
+              permit2_tokens: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
+              supported_languages: ["en", "es"],
+              verification_status: "verified",
+              is_allowed_unlimited_notifications: false,
+              max_notifications_per_day: 10,
+              app: {
+                team: {
+                  name: "Example Team",
+                },
+                rating_sum: 10,
+                rating_count: 3,
+              },
+            },
+          ],
+        }),
+      }));
+
+      const request = new NextRequest(
+        "https://cdn.test.com/api/public/app/test-app?app_metadata_id=non-existent",
+        {
+          headers: {
+            host: "cdn.test.com",
+          },
+        },
+      );
+      const response = await GET(request, { params: { app_id: "test-app" } });
+      const data = await response.json();
+      expect(data.app_data.name).toBe("Example App");
+      expect(data.app_data.app_rating).toBe(3.33);
+      expect(data.app_data.integration_url).toBe(
+        "https://example.com/integration",
+      );
+    });
+  });
 });

--- a/web/tests/api/v2/public/apps/app.test.ts
+++ b/web/tests/api/v2/public/apps/app.test.ts
@@ -305,7 +305,7 @@ describe("/api/public/app/[app_id]", () => {
       jest.clearAllMocks();
     });
 
-    test("should select metadata by app_metadata_id when provided", async () => {
+    test("should select metadata by draft_id when provided", async () => {
       jest.mocked(getAppMetadataSdk).mockImplementation(() => ({
         GetAppMetadata: jest.fn().mockResolvedValue({
           app_metadata: [
@@ -388,7 +388,7 @@ describe("/api/public/app/[app_id]", () => {
       }));
 
       const request = new NextRequest(
-        "https://cdn.test.com/api/public/app/test-app?app_metadata_id=2",
+        "https://cdn.test.com/api/public/app/test-app?draft_id=2",
         {
           headers: {
             host: "cdn.test.com",
@@ -404,7 +404,7 @@ describe("/api/public/app/[app_id]", () => {
       );
     });
 
-    test("should select reviewer approved metadata when no app_metadata_id provided", async () => {
+    test("should select reviewer approved metadata when no draft_id provided", async () => {
       jest.mocked(getAppMetadataSdk).mockImplementation(() => ({
         GetAppMetadata: jest.fn().mockResolvedValue({
           app_metadata: [
@@ -503,7 +503,7 @@ describe("/api/public/app/[app_id]", () => {
       );
     });
 
-    test("should fallback to first metadata when app_metadata_id is invalid", async () => {
+    test("should fallback to first metadata when draft_id is invalid", async () => {
       jest.mocked(getAppMetadataSdk).mockImplementation(() => ({
         GetAppMetadata: jest.fn().mockResolvedValue({
           app_metadata: [
@@ -548,7 +548,7 @@ describe("/api/public/app/[app_id]", () => {
       }));
 
       const request = new NextRequest(
-        "https://cdn.test.com/api/public/app/test-app?app_metadata_id=non-existent",
+        "https://cdn.test.com/api/public/app/test-app?draft_id=non-existent",
         {
           headers: {
             host: "cdn.test.com",

--- a/web/tests/api/v2/public/apps/app.test.ts
+++ b/web/tests/api/v2/public/apps/app.test.ts
@@ -301,18 +301,6 @@ describe("/api/public/app/[app_id]", () => {
   });
 
   describe("App metadata selection logic", () => {
-    // beforeEach(() => {
-    //   process.env.NEXT_PUBLIC_APP_ENV = "development";
-    //   process.env.NEXT_PUBLIC_METRICS_SERVICE_ENDPOINT = "http://metrics";
-    //   process.env.NEXT_PUBLIC_IMAGES_CDN_URL = "http://cdn";
-    //   global.fetch = jest.fn(() =>
-    //     Promise.resolve({
-    //       status: 200,
-    //       json: () => Promise.resolve({ stats: "data" }),
-    //     }),
-    //   ) as jest.Mock;
-    // });
-
     afterEach(() => {
       jest.clearAllMocks();
     });


### PR DESCRIPTION
## PR Type

- [X] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

This PR:
- Add support `app_metadata_id` query param in `/public/app/{app_id}` endpoint.
- Update QR code action to include `app_metadata_id`  used for deeplinking
- Add a warning message for draft version qr code/urls

![MiniAppQrCode-Approved](https://github.com/user-attachments/assets/d8fe2174-65b1-48ad-b3a5-6cfb0dade1fe)
![MiniAppQrCode-Draft](https://github.com/user-attachments/assets/5eebab16-2b7a-4fbd-b9e7-9910e39754fb)


## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.

## Depedencies
Wait for mobile work to suport these changes, otherwise the warning message above the QR code will confuse developers.

