### PR TITLE
Cloudfront cache

### DIFF
--- a/web/api/v2/public/apps/index.ts
+++ b/web/api/v2/public/apps/index.ts
@@ -192,11 +192,19 @@ export const GET = async (request: NextRequest) => {
     return app;
   });
 
-  return NextResponse.json({
-    app_rankings: {
-      top_apps: rankApps(formattedTopApps, metricsData),
-      highlights: rankApps(highlightedApps, metricsData),
+  return NextResponse.json(
+    {
+      app_rankings: {
+        top_apps: rankApps(formattedTopApps, metricsData),
+        highlights: rankApps(highlightedApps, metricsData),
+      },
+      categories: getAllLocalisedCategories(locale), // TODO: Localise
     },
-    categories: getAllLocalisedCategories(locale), // TODO: Localise
-  });
+    {
+      headers: {
+        // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html#ExpirationDownloadDist
+        "Cache-Control": "public, max-age=86400, stale-while-error=86400",
+      },
+    },
+  );
 };

--- a/web/api/v2/public/apps/index.ts
+++ b/web/api/v2/public/apps/index.ts
@@ -203,7 +203,7 @@ export const GET = async (request: NextRequest) => {
     {
       headers: {
         // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html#ExpirationDownloadDist
-        "Cache-Control": "public, max-age=86400, stale-while-error=86400",
+        "Cache-Control": "public, max-age=86400, stale-if-error=86400",
       },
     },
   );

--- a/web/api/v2/public/apps/index.ts
+++ b/web/api/v2/public/apps/index.ts
@@ -203,6 +203,7 @@ export const GET = async (request: NextRequest) => {
     {
       headers: {
         // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html#ExpirationDownloadDist
+        // https://aws.amazon.com/about-aws/whats-new/2023/05/amazon-cloudfront-stale-while-revalidate-stale-if-error-cache-control-directives/
         "Cache-Control": "public, max-age=86400, stale-if-error=86400",
       },
     },


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

This will cause CloudFront to serve cached data, when developer portal returns an error. Even if it's after ttl

To test I guess the easiest would be to block prod transition, merge this, invalidate cache, merge another PR that makes this error always and see if CF serves it correctly. Let's coordinate this on merge @andy-t-wang 

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
