### PR TITLE
Allow unverified apps to test notifications

### DIFF
--- a/web/api/v2/minikit/send-notification/graphql/fetch-metadata.generated.ts
+++ b/web/api/v2/minikit/send-notification/graphql/fetch-metadata.generated.ts
@@ -17,6 +17,7 @@ export type GetAppMetadataQuery = {
     is_reviewer_app_store_approved: boolean;
     is_allowed_unlimited_notifications?: boolean | null;
     max_notifications_per_day?: number | null;
+    verification_status: string;
     app: { __typename?: "app"; team: { __typename?: "team"; id: string } };
   }>;
 };
@@ -24,17 +25,14 @@ export type GetAppMetadataQuery = {
 export const GetAppMetadataDocument = gql`
   query GetAppMetadata($app_id: String!) {
     app_metadata(
-      where: {
-        app_id: { _eq: $app_id }
-        verification_status: { _eq: "verified" }
-        app: { is_banned: { _eq: false } }
-      }
+      where: { app_id: { _eq: $app_id }, app: { is_banned: { _eq: false } } }
     ) {
       name
       app_id
       is_reviewer_app_store_approved
       is_allowed_unlimited_notifications
       max_notifications_per_day
+      verification_status
       app {
         team {
           id

--- a/web/api/v2/minikit/send-notification/graphql/fetch-metadata.graphql
+++ b/web/api/v2/minikit/send-notification/graphql/fetch-metadata.graphql
@@ -1,16 +1,13 @@
 query GetAppMetadata($app_id: String!) {
   app_metadata(
-    where: {
-      app_id: { _eq: $app_id }
-      verification_status: { _eq: "verified" }
-      app: { is_banned: { _eq: false } }
-    }
+    where: { app_id: { _eq: $app_id }, app: { is_banned: { _eq: false } } }
   ) {
     name
     app_id
     is_reviewer_app_store_approved
     is_allowed_unlimited_notifications
     max_notifications_per_day
+    verification_status
     app {
       team {
         id


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description
Allow an unverified app to send notifications up to 40 per 4 hours to do testing

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
