### PR TITLE
fix: en lang refetch

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
@@ -255,10 +255,6 @@ export const AppStoreForm = (props: {
       await saveLocalisation();
     }
 
-    if (supportedLanguages.length === 0) {
-      return;
-    }
-
     const currentLocaleIdx = supportedLanguages.indexOf(locale);
     const nextLocaleIdx = currentLocaleIdx + 1;
     const nextLocale = supportedLanguages[nextLocaleIdx];
@@ -279,10 +275,6 @@ export const AppStoreForm = (props: {
   const handleSelectPreviousLocalisation = useCallback(async () => {
     if (isDirty) {
       await saveLocalisation();
-    }
-
-    if (supportedLanguages.length === 0) {
-      return;
     }
 
     const currentLocaleIdx = supportedLanguages.indexOf(locale);

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
@@ -194,7 +194,7 @@ export const AppStoreForm = (props: {
       // if locale is en, set the data on app_metadata directly
       if (locale === "en") {
         await validateAndUpdateAppLocaleInfoServerSide(commonProperties);
-        refetchLocalisation();
+        await refetchLocalisation();
         return;
       }
 
@@ -255,6 +255,10 @@ export const AppStoreForm = (props: {
       await saveLocalisation();
     }
 
+    if (supportedLanguages.length === 0) {
+      return;
+    }
+
     const currentLocaleIdx = supportedLanguages.indexOf(locale);
     const nextLocaleIdx = currentLocaleIdx + 1;
     const nextLocale = supportedLanguages[nextLocaleIdx];
@@ -275,6 +279,10 @@ export const AppStoreForm = (props: {
   const handleSelectPreviousLocalisation = useCallback(async () => {
     if (isDirty) {
       await saveLocalisation();
+    }
+
+    if (supportedLanguages.length === 0) {
+      return;
     }
 
     const currentLocaleIdx = supportedLanguages.indexOf(locale);


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

await the refetch to prevent showing stale data - if for example going english -> spanish -> back to english the form could show stale english translation

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
