### PR TITLE
Fix visual bug on safari

### DIFF
--- a/web/components/Category/index.tsx
+++ b/web/components/Category/index.tsx
@@ -53,13 +53,16 @@ export const CategorySelector = (props: {
         !disabled,
     },
   );
-  const labelClassNames = clsx("ml-4 px-0.5 peer-focus:text-blue-500", {
-    "text-grey-400 peer-focus:text-blue-500 group-hover:text-grey-700":
-      !errors && !disabled,
-    "text-system-error-500 peer-focus:text-system-error-500":
-      errors && !disabled,
-    "text-grey-400": disabled,
-  });
+  const labelClassNames = clsx(
+    "ml-4 whitespace-nowrap px-0.5 peer-focus:text-blue-500",
+    {
+      "text-grey-400 peer-focus:text-blue-500 group-hover:text-grey-700":
+        !errors && !disabled,
+      "text-system-error-500 peer-focus:text-system-error-500":
+        errors && !disabled,
+      "text-grey-400": disabled,
+    },
+  );
 
   const handleSelect = useCallback(
     (newValue: number) => {

--- a/web/components/Input/index.tsx
+++ b/web/components/Input/index.tsx
@@ -95,7 +95,11 @@ export const Input = memo(function Input(props: InputInterface) {
         <div className="flex items-center">{addOnRight && addOnRight}</div>
 
         {label && (
-          <legend className={twMerge(clsx("select-none", labelClassNames))}>
+          <legend
+            className={twMerge(
+              clsx("select-none whitespace-nowrap", labelClassNames),
+            )}
+          >
             {label}{" "}
             {required && <span className="text-system-error-500">*</span>}
           </legend>

--- a/web/components/SelectMultiple/index.tsx
+++ b/web/components/SelectMultiple/index.tsx
@@ -112,15 +112,18 @@ export const SelectMultiple = <T extends FieldValues>(
     [items, search],
   );
 
-  const labelClassNames = clsx("ml-2 text-sm peer-focus:text-blue-500", {
-    "text-grey-400 peer-focus:text-blue-500 group-hover:text-grey-700":
-      !errors && !disabled,
-    "text-system-error-500 peer-focus:text-system-error-500":
-      errors && !disabled,
-    "text-grey-400": disabled,
-    "px-0": label == "",
-    "px-0.5": label != "",
-  });
+  const labelClassNames = clsx(
+    "ml-2 whitespace-nowrap text-sm peer-focus:text-blue-500",
+    {
+      "text-grey-400 peer-focus:text-blue-500 group-hover:text-grey-700":
+        !errors && !disabled,
+      "text-system-error-500 peer-focus:text-system-error-500":
+        errors && !disabled,
+      "text-grey-400": disabled,
+      "px-0": label == "",
+      "px-0.5": label != "",
+    },
+  );
 
   const fieldsetClassName = clsx(
     "overflow-hidden rounded-lg border bg-grey-0 text-base text-grey-700 md:text-sm",

--- a/web/components/TextArea/index.tsx
+++ b/web/components/TextArea/index.tsx
@@ -61,7 +61,7 @@ export const TextArea = memo(function TextArea(props: TextAreaInterface) {
   );
 
   const labelClassNames = clsx(
-    "ml-2 px-[2px] text-sm peer-focus:text-blue-500",
+    "ml-2 whitespace-nowrap px-[2px] text-sm peer-focus:text-blue-500",
     {
       "text-grey-400 peer-focus:text-blue-500 group-hover:text-grey-700":
         !errors && !disabled,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/MaxVerificationsSelector/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/MaxVerificationsSelector/index.tsx
@@ -57,10 +57,14 @@ export const MaxVerificationsSelector = (props: {
         true,
     },
   );
-  const labelClassNames = clsx("ml-4 px-[2px] peer-focus:text-blue-500", {
-    "text-grey-400 peer-focus:text-blue-500 group-hover:text-grey-700": !errors,
-    "text-system-error-500 peer-focus:text-system-error-500": errors,
-  });
+  const labelClassNames = clsx(
+    "ml-4 whitespace-nowrap px-[2px] peer-focus:text-blue-500",
+    {
+      "text-grey-400 peer-focus:text-blue-500 group-hover:text-grey-700":
+        !errors,
+      "text-system-error-500 peer-focus:text-system-error-500": errors,
+    },
+  );
 
   const handleSelect = useCallback(
     (newValue: number) => {


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description
Visual bug on safari where these values were wrapping and making the fields look bad

<img width="671" alt="IMG_3220" src="https://github.com/user-attachments/assets/4b9bbcdd-42fc-42cc-9e91-56224861ab68" />


## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
