### PR TITLE
DEV 1377: Override top apps with draft data

### DIFF
--- a/web/api/v2/public/apps/graphql/get-draft-metadata.generated.ts
+++ b/web/api/v2/public/apps/graphql/get-draft-metadata.generated.ts
@@ -1,0 +1,154 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type GetDraftMetadataQueryVariables = Types.Exact<{
+  draft_ids?: Types.InputMaybe<
+    Array<Types.Scalars["String"]["input"]> | Types.Scalars["String"]["input"]
+  >;
+  locale: Types.Scalars["String"]["input"];
+}>;
+
+export type GetDraftMetadataQuery = {
+  __typename?: "query_root";
+  draft_metadata: Array<{
+    __typename?: "app_metadata";
+    id: string;
+    name: string;
+    short_name: string;
+    app_id: string;
+    logo_img_url: string;
+    showcase_img_urls?: Array<string> | null;
+    hero_image_url: string;
+    world_app_description: string;
+    world_app_button_text: string;
+    whitelisted_addresses?: Array<string> | null;
+    app_mode: string;
+    description: string;
+    category: string;
+    integration_url: string;
+    app_website_url: string;
+    source_code_url: string;
+    support_link: string;
+    supported_countries?: Array<string> | null;
+    supported_languages?: Array<string> | null;
+    associated_domains?: Array<string> | null;
+    contracts?: Array<string> | null;
+    permit2_tokens?: Array<string> | null;
+    can_import_all_contacts: boolean;
+    is_reviewer_world_app_approved: boolean;
+    verification_status: string;
+    is_allowed_unlimited_notifications?: boolean | null;
+    max_notifications_per_day?: number | null;
+    localisations: Array<{
+      __typename?: "localisations";
+      name: string;
+      world_app_button_text: string;
+      world_app_description: string;
+      short_name: string;
+      description: string;
+    }>;
+    app: {
+      __typename?: "app";
+      rating_count: number;
+      rating_sum: number;
+      is_banned: boolean;
+      created_at: string;
+      updated_at: string;
+      team: { __typename?: "team"; name?: string | null; id: string };
+    };
+  }>;
+};
+
+export const GetDraftMetadataDocument = gql`
+  query GetDraftMetadata($draft_ids: [String!], $locale: String!) {
+    draft_metadata: app_metadata(where: { id: { _in: $draft_ids } }) {
+      id
+      name
+      short_name
+      app_id
+      logo_img_url
+      showcase_img_urls
+      hero_image_url
+      world_app_description
+      world_app_button_text
+      whitelisted_addresses
+      app_mode
+      description
+      category
+      integration_url
+      app_website_url
+      source_code_url
+      support_link
+      supported_countries
+      supported_languages
+      associated_domains
+      contracts
+      permit2_tokens
+      can_import_all_contacts
+      is_reviewer_world_app_approved
+      verification_status
+      is_allowed_unlimited_notifications
+      max_notifications_per_day
+      localisations(where: { locale: { _eq: $locale } }) {
+        name
+        world_app_button_text
+        world_app_description
+        short_name
+        description
+      }
+      app {
+        team {
+          name
+          id
+        }
+        rating_count
+        rating_sum
+        is_banned
+        created_at
+        updated_at
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    GetDraftMetadata(
+      variables: GetDraftMetadataQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetDraftMetadataQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetDraftMetadataQuery>(
+            GetDraftMetadataDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "GetDraftMetadata",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/v2/public/apps/graphql/get-draft-metadata.graphql
+++ b/web/api/v2/public/apps/graphql/get-draft-metadata.graphql
@@ -1,0 +1,49 @@
+query GetDraftMetadata($draft_ids: [String!], $locale: String!) {
+  draft_metadata: app_metadata(where: { id: { _in: $draft_ids } }) {
+    id
+    name
+    short_name
+    app_id
+    logo_img_url
+    showcase_img_urls
+    hero_image_url
+    world_app_description
+    world_app_button_text
+    whitelisted_addresses
+    app_mode
+    description
+    category
+    integration_url
+    app_website_url
+    source_code_url
+    support_link
+    supported_countries
+    supported_languages
+    associated_domains
+    contracts
+    permit2_tokens
+    can_import_all_contacts
+    is_reviewer_world_app_approved
+    verification_status
+    is_allowed_unlimited_notifications
+    max_notifications_per_day
+    localisations(where: { locale: { _eq: $locale } }) {
+      name
+      world_app_button_text
+      world_app_description
+      short_name
+      description
+    }
+    app {
+      team {
+        name
+        id
+      }
+      rating_count
+      rating_sum
+      is_banned
+      created_at
+      updated_at
+    }
+  }
+}

--- a/web/tests/api/v2/public/apps/apps.test.ts
+++ b/web/tests/api/v2/public/apps/apps.test.ts
@@ -93,7 +93,6 @@ describe("/api/v2/public/apps", () => {
     expect(await response.json()).toEqual({
       app_rankings: { top_apps: [], highlights: [] },
       categories: Categories,
-      draft_apps: [],
     });
   });
 
@@ -325,7 +324,6 @@ describe("/api/v2/public/apps", () => {
         ],
       },
       categories: Categories,
-      draft_apps: [],
     });
   });
 
@@ -437,7 +435,6 @@ describe("/api/v2/public/apps", () => {
         highlights: [],
       },
       categories: Categories,
-      draft_apps: [],
     });
   });
 
@@ -454,50 +451,37 @@ describe("/api/v2/public/apps", () => {
           highlights: [],
         }),
       }));
-      jest.mocked(getAppsSdk).mockImplementation(() => ({
-        GetApps: jest.fn().mockResolvedValue({
-          top_apps: [],
-        }),
-      }));
     });
 
-    test("should return draft metadata when draft_ids array contains one valid id", async () => {
-      jest.mocked(getDraftMetadataSdk).mockImplementation(() => ({
-        GetDraftMetadata: jest.fn().mockResolvedValue({
-          draft_metadata: [
+    test("should override top app with draft metadata when draft_id matches", async () => {
+      // Mock top apps with two metadata rows for the same app
+      jest.mocked(getAppsSdk).mockImplementation(() => ({
+        GetApps: jest.fn().mockResolvedValue({
+          top_apps: [
             {
-              id: "draft1",
-              name: "Draft App 1",
+              id: "1",
+              name: "Original App",
               app_id: "app1",
               short_name: "test",
               logo_img_url: "logo.png",
-              showcase_img_urls: ["showcase1.png", "showcase2.png"],
+              showcase_img_urls: ["showcase1.png"],
               hero_image_url: "hero.png",
-              world_app_description: "Draft description",
-              world_app_button_text: "Use Draft",
+              world_app_description: "Original description",
+              world_app_button_text: "Use Original",
               category: "Productivity",
               description:
-                '{"description_overview":"draft","description_how_it_works":"draft","description_connect":"draft"}',
-              integration_url: "https://example.com/draft",
+                '{"description_overview":"original","description_how_it_works":"original","description_connect":"original"}',
+              integration_url: "https://example.com/original",
               app_website_url: "https://example.com",
               source_code_url: "https://github.com/example/app",
               whitelisted_addresses: ["0x1234"],
               app_mode: "mini-app",
-              support_link: "draft@example.com",
+              support_link: "support@example.com",
               supported_countries: ["us"],
-              associated_domains: ["https://draft.org"],
-              contracts: ["0x1234"],
-              permit2_tokens: ["0x1234"],
-              supported_languages: ["en"],
-              verification_status: "unverified",
-              is_allowed_unlimited_notifications: true,
-              max_notifications_per_day: 5,
-              is_reviewer_world_app_approved: false,
+              verification_status: "verified",
               app: {
-                team: {
-                  name: "Draft Team",
-                },
-                rating_sum: 5,
+                team: { name: "Original Team" },
+                rating_sum: 10,
                 rating_count: 2,
               },
             },
@@ -505,105 +489,34 @@ describe("/api/v2/public/apps", () => {
         }),
       }));
 
-      const request = new NextRequest(
-        "https://cdn.test.com/api/v2/public/apps?draft_ids=draft1",
-        {
-          headers: {
-            host: "cdn.test.com",
-          },
-        },
-      );
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(data.draft_apps).toHaveLength(1);
-      expect(data.draft_apps[0]).toMatchObject({
-        name: "Draft App 1",
-        app_id: "app1",
-        integration_url: "https://example.com/draft",
-        verification_status: "unverified",
-        logo_img_url: "https://cdn.test.com/unverified/app1/logo.png",
-        hero_image_url: "https://cdn.test.com/unverified/app1/hero.png",
-        showcase_img_urls: [
-          "https://cdn.test.com/unverified/app1/showcase1.png",
-          "https://cdn.test.com/unverified/app1/showcase2.png",
-        ],
-      });
-    });
-
-    test("should handle multiple draft_ids with mix of existing and non-existing ids", async () => {
+      // Mock draft metadata
       jest.mocked(getDraftMetadataSdk).mockImplementation(() => ({
         GetDraftMetadata: jest.fn().mockResolvedValue({
           draft_metadata: [
             {
               id: "draft1",
-              name: "Draft App 1",
+              name: "Draft Version",
               app_id: "app1",
-              short_name: "test",
-              logo_img_url: "logo.png",
-              showcase_img_urls: ["showcase1.png", "showcase2.png"],
-              hero_image_url: "hero.png",
+              short_name: "test-draft",
+              logo_img_url: "logo-draft.png",
+              showcase_img_urls: ["showcase-draft.png"],
+              hero_image_url: "hero-draft.png",
               world_app_description: "Draft description",
               world_app_button_text: "Use Draft",
-              category: "Productivity",
+              category: "Social",
               description:
                 '{"description_overview":"draft","description_how_it_works":"draft","description_connect":"draft"}',
-              integration_url: "https://example.com/draft1",
-              app_website_url: "https://example.com",
-              source_code_url: "https://github.com/example/app",
-              whitelisted_addresses: ["0x1234"],
+              integration_url: "https://example.com/draft",
+              app_website_url: "https://example.com/draft",
+              source_code_url: "https://github.com/example/draft",
+              whitelisted_addresses: ["0x5678"],
               app_mode: "mini-app",
               support_link: "draft@example.com",
               supported_countries: ["us"],
-              associated_domains: ["https://draft.org"],
-              contracts: ["0x1234"],
-              permit2_tokens: ["0x1234"],
-              supported_languages: ["en"],
               verification_status: "unverified",
-              is_allowed_unlimited_notifications: true,
-              max_notifications_per_day: 5,
-              is_reviewer_world_app_approved: false,
               app: {
-                team: {
-                  name: "Draft Team 1",
-                },
-                rating_sum: 5,
-                rating_count: 2,
-              },
-            },
-            {
-              id: "draft2",
-              name: "Draft App 2",
-              app_id: "app2",
-              short_name: "test",
-              logo_img_url: "logo.png",
-              showcase_img_urls: ["showcase1.png", "showcase2.png"],
-              hero_image_url: "hero.png",
-              world_app_description: "Draft description",
-              world_app_button_text: "Use Draft",
-              category: "Productivity",
-              description:
-                '{"description_overview":"draft","description_how_it_works":"draft","description_connect":"draft"}',
-              integration_url: "https://example.com/draft2",
-              app_website_url: "https://example.com",
-              source_code_url: "https://github.com/example/app",
-              whitelisted_addresses: ["0x1234"],
-              app_mode: "mini-app",
-              support_link: "draft@example.com",
-              supported_countries: ["us"],
-              associated_domains: ["https://draft.org"],
-              contracts: ["0x1234"],
-              permit2_tokens: ["0x1234"],
-              supported_languages: ["en"],
-              verification_status: "unverified",
-              is_allowed_unlimited_notifications: true,
-              max_notifications_per_day: 5,
-              is_reviewer_world_app_approved: false,
-              app: {
-                team: {
-                  name: "Draft Team 2",
-                },
-                rating_sum: 8,
+                team: { name: "Draft Team" },
+                rating_sum: 15,
                 rating_count: 3,
               },
             },
@@ -612,7 +525,7 @@ describe("/api/v2/public/apps", () => {
       }));
 
       const request = new NextRequest(
-        "https://cdn.test.com/api/v2/public/apps?draft_ids=draft1,draft2,non_existent_draft",
+        "https://cdn.test.com/api/v2/public/apps?override_top_apps_by_draft_ids=draft1",
         {
           headers: {
             host: "cdn.test.com",
@@ -622,34 +535,89 @@ describe("/api/v2/public/apps", () => {
       const response = await GET(request);
       const data = await response.json();
 
-      expect(data.draft_apps).toHaveLength(2);
-      expect(data.draft_apps).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            name: "Draft App 1",
-            app_id: "app1",
-            integration_url: "https://example.com/draft1",
-            logo_img_url: "https://cdn.test.com/unverified/app1/logo.png",
-          }),
-          expect.objectContaining({
-            name: "Draft App 2",
-            app_id: "app2",
-            integration_url: "https://example.com/draft2",
-            logo_img_url: "https://cdn.test.com/unverified/app2/logo.png",
-          }),
-        ]),
-      );
+      expect(data.app_rankings.top_apps).toHaveLength(1);
+      expect(data.app_rankings.top_apps[0]).toMatchObject({
+        name: "Draft Version",
+        app_id: "app1",
+        integration_url: "https://example.com/draft",
+        logo_img_url: "https://cdn.test.com/unverified/app1/logo-draft.png",
+        team_name: "Draft Team",
+      });
     });
 
-    test("should return empty drafts array when no draft_ids match", async () => {
+    test("should use original metadata when draft_id doesn't match", async () => {
+      // Mock top apps with original metadata
+      jest.mocked(getAppsSdk).mockImplementation(() => ({
+        GetApps: jest.fn().mockResolvedValue({
+          top_apps: [
+            {
+              id: "1",
+              name: "Original App",
+              app_id: "app1",
+              short_name: "test",
+              logo_img_url: "logo.png",
+              showcase_img_urls: ["showcase1.png"],
+              hero_image_url: "hero.png",
+              world_app_description: "Original description",
+              world_app_button_text: "Use Original",
+              category: "Productivity",
+              description:
+                '{"description_overview":"original","description_how_it_works":"original","description_connect":"original"}',
+              integration_url: "https://example.com/original",
+              app_website_url: "https://example.com",
+              source_code_url: "https://github.com/example/app",
+              whitelisted_addresses: ["0x1234"],
+              app_mode: "mini-app",
+              support_link: "support@example.com",
+              supported_countries: ["us"],
+              verification_status: "verified",
+              app: {
+                team: { name: "Original Team" },
+                rating_sum: 10,
+                rating_count: 2,
+              },
+            },
+          ],
+        }),
+      }));
+
+      // Mock draft metadata with non-matching draft
       jest.mocked(getDraftMetadataSdk).mockImplementation(() => ({
         GetDraftMetadata: jest.fn().mockResolvedValue({
-          draft_metadata: [],
+          draft_metadata: [
+            {
+              id: "draft2",
+              name: "Different Draft",
+              app_id: "app2",
+              short_name: "test-draft",
+              logo_img_url: "logo-draft.png",
+              showcase_img_urls: ["showcase-draft.png"],
+              hero_image_url: "hero-draft.png",
+              world_app_description: "Draft description",
+              world_app_button_text: "Use Draft",
+              category: "Social",
+              description:
+                '{"description_overview":"draft","description_how_it_works":"draft","description_connect":"draft"}',
+              integration_url: "https://example.com/draft",
+              app_website_url: "https://example.com/draft",
+              source_code_url: "https://github.com/example/draft",
+              whitelisted_addresses: ["0x5678"],
+              app_mode: "mini-app",
+              support_link: "draft@example.com",
+              supported_countries: ["us"],
+              verification_status: "unverified",
+              app: {
+                team: { name: "Draft Team" },
+                rating_sum: 15,
+                rating_count: 3,
+              },
+            },
+          ],
         }),
       }));
 
       const request = new NextRequest(
-        "https://cdn.test.com/api/v2/public/apps?draft_ids=non_existent1,non_existent2",
+        "https://cdn.test.com/api/v2/public/apps?override_top_apps_by_draft_ids=draft2",
         {
           headers: {
             host: "cdn.test.com",
@@ -659,7 +627,14 @@ describe("/api/v2/public/apps", () => {
       const response = await GET(request);
       const data = await response.json();
 
-      expect(data.draft_apps).toEqual([]);
+      expect(data.app_rankings.top_apps).toHaveLength(1);
+      expect(data.app_rankings.top_apps[0]).toMatchObject({
+        name: "Original App",
+        app_id: "app1",
+        integration_url: "https://example.com/original",
+        logo_img_url: "https://cdn.test.com/app1/logo.png",
+        team_name: "Original Team",
+      });
     });
   });
 });

--- a/web/tests/api/v2/public/apps/apps.test.ts
+++ b/web/tests/api/v2/public/apps/apps.test.ts
@@ -3,6 +3,7 @@ import { Categories } from "@/lib/constants";
 import { NextRequest } from "next/server";
 import { getSdk as getAppsSdk } from "../../../../../api/v2/public/apps/graphql/get-app-rankings.generated";
 import { getSdk as getWebHighlightsSdk } from "../../../../../api/v2/public/apps/graphql/get-app-web-highlights.generated";
+import { getSdk as getDraftMetadataSdk } from "../../../../../api/v2/public/apps/graphql/get-draft-metadata.generated";
 import { getSdk as getHighlightsSdk } from "../../../../../api/v2/public/apps/graphql/get-highlighted-apps.generated";
 
 // Mock the external dependencies
@@ -38,6 +39,17 @@ jest.mock(
     getSdk: jest.fn(() => ({
       GetHighlights: jest.fn().mockResolvedValue({
         highlights: [],
+      }),
+    })),
+  }),
+);
+
+jest.mock(
+  "../../../../../api/v2/public/apps/graphql/get-draft-metadata.generated",
+  () => ({
+    getSdk: jest.fn(() => ({
+      GetDraftMetadata: jest.fn().mockResolvedValue({
+        draft_metadata: [],
       }),
     })),
   }),
@@ -81,6 +93,7 @@ describe("/api/v2/public/apps", () => {
     expect(await response.json()).toEqual({
       app_rankings: { top_apps: [], highlights: [] },
       categories: Categories,
+      draft_apps: [],
     });
   });
 
@@ -312,6 +325,7 @@ describe("/api/v2/public/apps", () => {
         ],
       },
       categories: Categories,
+      draft_apps: [],
     });
   });
 
@@ -423,6 +437,229 @@ describe("/api/v2/public/apps", () => {
         highlights: [],
       },
       categories: Categories,
+      draft_apps: [],
+    });
+  });
+
+  describe("Draft metadata handling", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.mocked(getWebHighlightsSdk).mockImplementation(() => ({
+        GetHighlights: jest.fn().mockResolvedValue({
+          app_rankings: [{ rankings: [] }],
+        }),
+      }));
+      jest.mocked(getHighlightsSdk).mockImplementation(() => ({
+        GetHighlights: jest.fn().mockResolvedValue({
+          highlights: [],
+        }),
+      }));
+      jest.mocked(getAppsSdk).mockImplementation(() => ({
+        GetApps: jest.fn().mockResolvedValue({
+          top_apps: [],
+        }),
+      }));
+    });
+
+    test("should return draft metadata when draft_ids array contains one valid id", async () => {
+      jest.mocked(getDraftMetadataSdk).mockImplementation(() => ({
+        GetDraftMetadata: jest.fn().mockResolvedValue({
+          draft_metadata: [
+            {
+              id: "draft1",
+              name: "Draft App 1",
+              app_id: "app1",
+              short_name: "test",
+              logo_img_url: "logo.png",
+              showcase_img_urls: ["showcase1.png", "showcase2.png"],
+              hero_image_url: "hero.png",
+              world_app_description: "Draft description",
+              world_app_button_text: "Use Draft",
+              category: "Productivity",
+              description:
+                '{"description_overview":"draft","description_how_it_works":"draft","description_connect":"draft"}',
+              integration_url: "https://example.com/draft",
+              app_website_url: "https://example.com",
+              source_code_url: "https://github.com/example/app",
+              whitelisted_addresses: ["0x1234"],
+              app_mode: "mini-app",
+              support_link: "draft@example.com",
+              supported_countries: ["us"],
+              associated_domains: ["https://draft.org"],
+              contracts: ["0x1234"],
+              permit2_tokens: ["0x1234"],
+              supported_languages: ["en"],
+              verification_status: "unverified",
+              is_allowed_unlimited_notifications: true,
+              max_notifications_per_day: 5,
+              is_reviewer_world_app_approved: false,
+              app: {
+                team: {
+                  name: "Draft Team",
+                },
+                rating_sum: 5,
+                rating_count: 2,
+              },
+            },
+          ],
+        }),
+      }));
+
+      const request = new NextRequest(
+        "https://cdn.test.com/api/v2/public/apps?draft_ids=draft1",
+        {
+          headers: {
+            host: "cdn.test.com",
+          },
+        },
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data.draft_apps).toHaveLength(1);
+      expect(data.draft_apps[0]).toMatchObject({
+        name: "Draft App 1",
+        app_id: "app1",
+        integration_url: "https://example.com/draft",
+        verification_status: "unverified",
+        logo_img_url: "https://cdn.test.com/unverified/app1/logo.png",
+        hero_image_url: "https://cdn.test.com/unverified/app1/hero.png",
+        showcase_img_urls: [
+          "https://cdn.test.com/unverified/app1/showcase1.png",
+          "https://cdn.test.com/unverified/app1/showcase2.png",
+        ],
+      });
+    });
+
+    test("should handle multiple draft_ids with mix of existing and non-existing ids", async () => {
+      jest.mocked(getDraftMetadataSdk).mockImplementation(() => ({
+        GetDraftMetadata: jest.fn().mockResolvedValue({
+          draft_metadata: [
+            {
+              id: "draft1",
+              name: "Draft App 1",
+              app_id: "app1",
+              short_name: "test",
+              logo_img_url: "logo.png",
+              showcase_img_urls: ["showcase1.png", "showcase2.png"],
+              hero_image_url: "hero.png",
+              world_app_description: "Draft description",
+              world_app_button_text: "Use Draft",
+              category: "Productivity",
+              description:
+                '{"description_overview":"draft","description_how_it_works":"draft","description_connect":"draft"}',
+              integration_url: "https://example.com/draft1",
+              app_website_url: "https://example.com",
+              source_code_url: "https://github.com/example/app",
+              whitelisted_addresses: ["0x1234"],
+              app_mode: "mini-app",
+              support_link: "draft@example.com",
+              supported_countries: ["us"],
+              associated_domains: ["https://draft.org"],
+              contracts: ["0x1234"],
+              permit2_tokens: ["0x1234"],
+              supported_languages: ["en"],
+              verification_status: "unverified",
+              is_allowed_unlimited_notifications: true,
+              max_notifications_per_day: 5,
+              is_reviewer_world_app_approved: false,
+              app: {
+                team: {
+                  name: "Draft Team 1",
+                },
+                rating_sum: 5,
+                rating_count: 2,
+              },
+            },
+            {
+              id: "draft2",
+              name: "Draft App 2",
+              app_id: "app2",
+              short_name: "test",
+              logo_img_url: "logo.png",
+              showcase_img_urls: ["showcase1.png", "showcase2.png"],
+              hero_image_url: "hero.png",
+              world_app_description: "Draft description",
+              world_app_button_text: "Use Draft",
+              category: "Productivity",
+              description:
+                '{"description_overview":"draft","description_how_it_works":"draft","description_connect":"draft"}',
+              integration_url: "https://example.com/draft2",
+              app_website_url: "https://example.com",
+              source_code_url: "https://github.com/example/app",
+              whitelisted_addresses: ["0x1234"],
+              app_mode: "mini-app",
+              support_link: "draft@example.com",
+              supported_countries: ["us"],
+              associated_domains: ["https://draft.org"],
+              contracts: ["0x1234"],
+              permit2_tokens: ["0x1234"],
+              supported_languages: ["en"],
+              verification_status: "unverified",
+              is_allowed_unlimited_notifications: true,
+              max_notifications_per_day: 5,
+              is_reviewer_world_app_approved: false,
+              app: {
+                team: {
+                  name: "Draft Team 2",
+                },
+                rating_sum: 8,
+                rating_count: 3,
+              },
+            },
+          ],
+        }),
+      }));
+
+      const request = new NextRequest(
+        "https://cdn.test.com/api/v2/public/apps?draft_ids=draft1,draft2,non_existent_draft",
+        {
+          headers: {
+            host: "cdn.test.com",
+          },
+        },
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data.draft_apps).toHaveLength(2);
+      expect(data.draft_apps).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "Draft App 1",
+            app_id: "app1",
+            integration_url: "https://example.com/draft1",
+            logo_img_url: "https://cdn.test.com/unverified/app1/logo.png",
+          }),
+          expect.objectContaining({
+            name: "Draft App 2",
+            app_id: "app2",
+            integration_url: "https://example.com/draft2",
+            logo_img_url: "https://cdn.test.com/unverified/app2/logo.png",
+          }),
+        ]),
+      );
+    });
+
+    test("should return empty drafts array when no draft_ids match", async () => {
+      jest.mocked(getDraftMetadataSdk).mockImplementation(() => ({
+        GetDraftMetadata: jest.fn().mockResolvedValue({
+          draft_metadata: [],
+        }),
+      }));
+
+      const request = new NextRequest(
+        "https://cdn.test.com/api/v2/public/apps?draft_ids=non_existent1,non_existent2",
+        {
+          headers: {
+            host: "cdn.test.com",
+          },
+        },
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data.draft_apps).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

This PR adds `override_top_apps_by_draft_ids` query param to `/public/apps` endpoint.

This is part of enabling "staging" mode for mini-apps, if a top app matches one of the given draft ids it will be returned with the draft metadata instead.

**Note:** A `draft_id` represents an `app_metadata_id` for context PTAL: #1145

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [X] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [X] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
