### PR TITLE
Set working corepack version to fix docker CI

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,13 +7,20 @@ FROM base AS deps
 RUN apk update && apk add --no-cache libc6-compat
 WORKDIR /app
 
+# Install specific version of corepack to fix signature verification issues
+RUN npm install -g corepack@0.31.0 && corepack --version
+
 # Install dependencies based on the preferred package manager
 COPY package.json pnpm-lock.yaml ./
 RUN corepack enable pnpm && pnpm i --frozen-lockfile
+
 # Server depencies are runtime depencies required for running the Node.JS server, bundled separately
 # this includes logging dependencies
 FROM base AS server_deps
 WORKDIR /app
+
+# Install specific version of corepack in this stage
+RUN npm install -g corepack@0.31.0 && corepack --version
 
 # TODO: Can be further optimized to remove next peer dependency
 RUN corepack enable pnpm && pnpm i next-logger@5.0.0 pino@9.2.0 dd-trace@5.12.0
@@ -23,6 +30,9 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+
+# Install specific version of corepack in builder stage
+RUN npm install -g corepack@0.31.0 && corepack --version
 
 # Temporary env vars required for building
 ARG ASSETS_S3_BUCKET_NAME=""
@@ -43,7 +53,7 @@ ENV HASURA_GRAPHQL_JWT_SECRET '{"key": "unsafe_AnEsZxveGsAWoENHGAnEsZxveGsAvxgMt
 ENV CLOUDFRONT_DISTRIBUTION_ID=${CLOUDFRONT_DISTRIBUTION_ID}
 ENV JWT_ISSUER invalid.localhost
 
-RUN corepack enable pnpm && pnpm run build;
+RUN corepack enable pnpm && pnpm run build
 
 # Production image, copy all the files and run next
 FROM base AS runner

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,7 +7,7 @@ FROM base AS deps
 RUN apk update && apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Install specific version of corepack to fix signature verification issues
+# Install working version of corepack
 RUN npm install -g corepack@0.31.0 && corepack --version
 
 # Install dependencies based on the preferred package manager
@@ -19,7 +19,7 @@ RUN corepack enable pnpm && pnpm i --frozen-lockfile
 FROM base AS server_deps
 WORKDIR /app
 
-# Install specific version of corepack in this stage
+# Install working version of corepack
 RUN npm install -g corepack@0.31.0 && corepack --version
 
 # TODO: Can be further optimized to remove next peer dependency
@@ -31,7 +31,7 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# Install specific version of corepack in builder stage
+# Install working version of corepack
 RUN npm install -g corepack@0.31.0 && corepack --version
 
 # Temporary env vars required for building


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [X] Bug Fix
- [ ] QA Tests

## Description

https://github.com/nodejs/corepack/pull/614
https://github.com/stackblitz-labs/bolt.diy/issues/1250

Default corepack version was failing due to signature verification.

Pinned a working corepack version to fix docker build  GH Action.

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
