### PR TITLE
Add `draft_id` to response

### DIFF
--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -102,6 +102,14 @@ export async function GET(
     locale,
   );
 
+  // Add the draft_id to the response if it exists in the parsed metadata
+  if (parsedAppMetadata.id === draft_id) {
+    formattedMetadata = {
+      ...formattedMetadata,
+      draft_id: draft_id,
+    };
+  }
+
   if (formattedMetadata.app_id in nativeAppMetadata) {
     const nativeAppItem = nativeAppMetadata[formattedMetadata.app_id];
 

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -247,6 +247,7 @@ export type AppStoreFormattedFields = Omit<
     how_it_works: string;
     how_to_connect: string;
   };
+  draft_id?: string;
 };
 
 type NativeApp = {

--- a/web/tests/api/v2/public/apps/app.test.ts
+++ b/web/tests/api/v2/public/apps/app.test.ts
@@ -402,6 +402,7 @@ describe("/api/public/app/[app_id]", () => {
       expect(data.app_data.integration_url).toBe(
         "https://example.com/integration-unverified",
       );
+      expect(data.app_data.draft_id).toBe("2");
     });
 
     test("should select reviewer approved metadata when no draft_id provided", async () => {
@@ -501,6 +502,7 @@ describe("/api/public/app/[app_id]", () => {
       expect(data.app_data.integration_url).toBe(
         "https://example.com/integration",
       );
+      expect(data.app_data.draft_id).toBeUndefined();
     });
 
     test("should fallback to first metadata when draft_id is invalid", async () => {
@@ -562,6 +564,7 @@ describe("/api/public/app/[app_id]", () => {
       expect(data.app_data.integration_url).toBe(
         "https://example.com/integration",
       );
+      expect(data.app_data.draft_id).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

This PR adds `draft_id` to `/app` endpoint. It only does this if the respective app has draft metadata based on the `draft_id` query param.

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
