### PR TITLE
fix: return cache if error for individual apps too

### DIFF
--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -120,6 +120,9 @@ export async function GET(
     { app_data: formattedMetadata },
     {
       status: 200,
+      headers: {
+        "Cache-Control": "public, max-age=86400, stale-if-error=86400",
+      },
     },
   );
 }


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

This is exactly what i did in public/apps, as in it will return stale cached data from cloudfront if developer portal errors

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
