### PR TITLE
fix: use predefined regexes for notifications too

### DIFF
--- a/web/api/v2/minikit/send-notification/index.ts
+++ b/web/api/v2/minikit/send-notification/index.ts
@@ -3,6 +3,10 @@ import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { verifyHashedSecret } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { logger } from "@/lib/logger";
+import {
+  allowedCommonCharactersRegex,
+  allowedTitleCharactersRegex,
+} from "@/lib/schema";
 import { createSignedFetcher } from "aws-sigv4-fetch";
 import { GraphQLClient } from "graphql-request";
 import { NextRequest, NextResponse } from "next/server";
@@ -28,7 +32,7 @@ const sendNotificationBodySchema = yup.object({
     .required()
     .max(200)
     .matches(
-      /^[\p{L}\p{N}\p{Z}\p{Sc}\.\-%!&]+$/u,
+      allowedCommonCharactersRegex,
       "Message can only contain letters, numbers, punctuation, and spaces",
     ),
   title: yup
@@ -37,7 +41,7 @@ const sendNotificationBodySchema = yup.object({
     .optional()
     .max(30)
     .matches(
-      /^[\p{L}\p{N}\p{Z}\p{Sc}\.\-%!&]+$/u,
+      allowedTitleCharactersRegex,
       "Title can only contain letters, numbers, punctuation, and spaces",
     ),
   mini_app_path: yup.string().strict().required(),


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

It was reported on telegram that some messages don't pass validation
```
that and languages that don't use letters. korean, japanese, hindi, chinese, etc
```
it's the same problem we had before with app names and descriptions. I think we should have the same rules for both actually, quite permissive style wise, with "dangerous" characters excluded ( `{}\ )

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
