### PR TITLE
fix: add an optional country param

### DIFF
--- a/web/api/v2/public/apps/index.ts
+++ b/web/api/v2/public/apps/index.ts
@@ -27,6 +27,7 @@ const queryParamsSchema = yup.object({
     .string()
     .oneOf(["mini-app", "external", "native"])
     .notRequired(),
+  country: yup.string().notRequired(),
 });
 
 export const GET = async (request: NextRequest) => {
@@ -64,8 +65,14 @@ export const GET = async (request: NextRequest) => {
     return handleError(request);
   }
   const headers = request.headers;
-  const country = headers.get("CloudFront-Viewer-Country");
   const locale = parseLocale(headers.get("x-accept-language") ?? "");
+  let country: string | null = null;
+
+  if (parsedParams.country) {
+    country = parsedParams.country;
+  } else {
+    country = headers.get("CloudFront-Viewer-Country");
+  }
 
   const { page, limit } = parsedParams;
   const client = await getAPIServiceGraphqlClient();


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

When requesting this from server side, there's no way to specify the correct country (to filter out apps). This adds a query param that allows a country code to be specified (ISO 3166-1 alpha-2)

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
