### PR TITLE
Add webhook configuration to incognito actions config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ test-results/
 # misc
 .DS_Store
 *.pem
+.idea/
 
 # debug
 pnpm-debug.log*

--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ cd web/
 cp .env.test .env
 ```
 
+**Note:** You may also have to overwrite the `.env.local` file if one exists. 
+
 2. Edit any environment variables for which you have real credentials.
 3. AWS access (for KMS) is required to run the Developer Portal locally. KMS is used to sign/encrypt, particularly for Sign in with World ID. You will need to have AWS credentials in your env with relevant permissions to run KMS. Here is an [IAM sample policy](aws-role-sample-policy.json) for this.
    1. If you are a core contributor with AWS access to TFH, follow the instructions [here](https://github.com/worldcoin/developer-portal-deployment#local-development) instead.
+
 
 ### Starting the app
 

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -136,6 +136,11 @@ enum IllegalContentCategoryEnum {
   OTHER
 }
 
+enum ActionFlowEnum {
+  VERIFY
+  PARTNER
+}
+
 input UploadImageInput {
   app_id: String!
   team_id: String!

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -136,9 +136,9 @@ enum IllegalContentCategoryEnum {
   OTHER
 }
 
-enum ActionFlowEnum {
+enum AppFlowOnCompleteEnum {
+  NONE,
   VERIFY
-  PARTNER
 }
 
 input UploadImageInput {

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -271,6 +271,14 @@ custom_types:
         - description: null
           is_deprecated: null
           value: OTHER
+    - name: ActionFlowEnum
+      values:
+        - description: null
+          is_deprecated: null
+          value: VERIFY
+        - description: null
+          is_deprecated: null
+          value: PARTNER
   input_objects:
     - name: UploadImageInput
     - name: CreateAppReportInput
@@ -299,4 +307,4 @@ custom_types:
     - name: FinishAppReportOutput
     - name: TmpInsertAppReportOutput
     - name: ConcludeAppReportInvestigationOutput
-  scalars: []
+  scalars: [ ]

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -271,14 +271,14 @@ custom_types:
         - description: null
           is_deprecated: null
           value: OTHER
-    - name: ActionFlowEnum
+    - name: AppFlowOnCompleteEnum
       values:
         - description: null
           is_deprecated: null
-          value: VERIFY
+          value: NONE
         - description: null
           is_deprecated: null
-          value: PARTNER
+          value: VERIFY
   input_objects:
     - name: UploadImageInput
     - name: CreateAppReportInput

--- a/hasura/metadata/databases/default/tables/public_action.yaml
+++ b/hasura/metadata/databases/default/tables/public_action.yaml
@@ -44,7 +44,7 @@ insert_permissions:
         - max_accounts_per_user
         - max_verifications
         - name
-        - flow
+        - app_flow_on_complete
         - webhook_pem
         - webhook_uri
   - role: service
@@ -59,7 +59,7 @@ insert_permissions:
         - max_accounts_per_user
         - max_verifications
         - name
-        - flow
+        - app_flow_on_complete
         - webhook_pem
         - webhook_uri
 select_permissions:
@@ -79,7 +79,7 @@ select_permissions:
         - name
         - status
         - updated_at
-        - flow
+        - app_flow_on_complete
         - webhook_pem
         - webhook_uri
       computed_fields:
@@ -106,7 +106,7 @@ select_permissions:
         - privacy_policy_uri
         - status
         - terms_uri
-        - flow
+        - app_flow_on_complete
         - webhook_uri
         - webhook_pem
       computed_fields:
@@ -137,7 +137,7 @@ select_permissions:
         - status
         - terms_uri
         - updated_at
-        - flow
+        - app_flow_on_complete
         - webhook_uri
         - webhook_pem
       filter:
@@ -155,7 +155,7 @@ update_permissions:
         - max_accounts_per_user
         - max_verifications
         - name
-        - flow
+        - app_flow_on_complete
         - webhook_pem
         - webhook_uri
       filter:
@@ -183,7 +183,7 @@ update_permissions:
         - privacy_policy_uri
         - status
         - terms_uri
-        - flow
+        - app_flow_on_complete
         - webhook_uri
         - webhook_pem
       filter:

--- a/hasura/metadata/databases/default/tables/public_action.yaml
+++ b/hasura/metadata/databases/default/tables/public_action.yaml
@@ -95,6 +95,8 @@ select_permissions:
         - privacy_policy_uri
         - status
         - terms_uri
+        - webhook_uri
+        - webhook_pem
       computed_fields:
         - redirect_count
       filter:
@@ -123,6 +125,8 @@ select_permissions:
         - status
         - terms_uri
         - updated_at
+        - webhook_uri
+        - webhook_pem
       filter:
         app:
           team:
@@ -163,6 +167,8 @@ update_permissions:
         - privacy_policy_uri
         - status
         - terms_uri
+        - webhook_uri
+        - webhook_pem
       filter:
         app:
           team:

--- a/hasura/metadata/databases/default/tables/public_action.yaml
+++ b/hasura/metadata/databases/default/tables/public_action.yaml
@@ -44,6 +44,7 @@ insert_permissions:
         - max_accounts_per_user
         - max_verifications
         - name
+        - flow
         - webhook_pem
         - webhook_uri
   - role: service
@@ -58,6 +59,7 @@ insert_permissions:
         - max_accounts_per_user
         - max_verifications
         - name
+        - flow
         - webhook_pem
         - webhook_uri
 select_permissions:
@@ -77,6 +79,7 @@ select_permissions:
         - name
         - status
         - updated_at
+        - flow
         - webhook_pem
         - webhook_uri
       computed_fields:
@@ -103,6 +106,7 @@ select_permissions:
         - privacy_policy_uri
         - status
         - terms_uri
+        - flow
         - webhook_uri
         - webhook_pem
       computed_fields:
@@ -133,6 +137,7 @@ select_permissions:
         - status
         - terms_uri
         - updated_at
+        - flow
         - webhook_uri
         - webhook_pem
       filter:
@@ -150,6 +155,7 @@ update_permissions:
         - max_accounts_per_user
         - max_verifications
         - name
+        - flow
         - webhook_pem
         - webhook_uri
       filter:
@@ -177,6 +183,7 @@ update_permissions:
         - privacy_policy_uri
         - status
         - terms_uri
+        - flow
         - webhook_uri
         - webhook_pem
       filter:

--- a/hasura/metadata/databases/default/tables/public_action.yaml
+++ b/hasura/metadata/databases/default/tables/public_action.yaml
@@ -35,50 +35,52 @@ insert_permissions:
           team_id:
             _eq: X-Hasura-Team-Id
       columns:
-        - name
-        - description
         - action
-        - external_nullifier
         - app_id
+        - creation_mode
+        - description
+        - external_nullifier
+        - kiosk_enabled
         - max_accounts_per_user
         - max_verifications
-        - creation_mode
-        - kiosk_enabled
-        - webhook_uri
+        - name
         - webhook_pem
+        - webhook_uri
   - role: service
     permission:
       check: {}
       columns:
+        - action
         - app_id
+        - creation_mode
         - description
         - external_nullifier
         - max_accounts_per_user
         - max_verifications
         - name
-        - action
-        - creation_mode
-        - webhook_uri
         - webhook_pem
+        - webhook_uri
 select_permissions:
   - role: api_key
     permission:
       columns:
-        - id
-        - created_at
-        - updated_at
-        - name
-        - description
         - action
-        - external_nullifier
         - app_id
+        - created_at
+        - creation_mode
+        - description
+        - external_nullifier
+        - id
+        - kiosk_enabled
         - max_accounts_per_user
         - max_verifications
-        - creation_mode
-        - kiosk_enabled
+        - name
         - status
-        - webhook_uri
+        - updated_at
         - webhook_pem
+        - webhook_uri
+      computed_fields:
+        - redirect_count
       filter:
         app:
           team_id:
@@ -148,6 +150,8 @@ update_permissions:
         - max_accounts_per_user
         - max_verifications
         - name
+        - webhook_pem
+        - webhook_uri
       filter:
         app:
           team_id:

--- a/hasura/metadata/databases/default/tables/public_action.yaml
+++ b/hasura/metadata/databases/default/tables/public_action.yaml
@@ -44,6 +44,8 @@ insert_permissions:
         - max_verifications
         - creation_mode
         - kiosk_enabled
+        - webhook_uri
+        - webhook_pem
   - role: service
     permission:
       check: {}
@@ -56,6 +58,8 @@ insert_permissions:
         - name
         - action
         - creation_mode
+        - webhook_uri
+        - webhook_pem
 select_permissions:
   - role: api_key
     permission:
@@ -73,6 +77,8 @@ select_permissions:
         - creation_mode
         - kiosk_enabled
         - status
+        - webhook_uri
+        - webhook_pem
       filter:
         app:
           team_id:

--- a/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/down.sql
+++ b/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/down.sql
@@ -1,2 +1,6 @@
-alter table "public"."action" drop column "webhook_uri";
-alter table "public"."action" drop column "webhook_pem";
+ALTER TABLE public.action
+DROP COLUMN webhook_uri,
+  DROP COLUMN webhook_pem,
+  DROP COLUMN flow;
+
+DROP TYPE action_flow_enum;

--- a/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/down.sql
+++ b/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/down.sql
@@ -1,4 +1,2 @@
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- alter table "public"."action" add column "webhook_uri" text
---  null;
+alter table "public"."action" drop column "webhook_uri";
+alter table "public"."action" drop column "webhook_pem";

--- a/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/down.sql
+++ b/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/down.sql
@@ -1,6 +1,6 @@
 ALTER TABLE public.action
 DROP COLUMN webhook_uri,
   DROP COLUMN webhook_pem,
-  DROP COLUMN flow;
+  DROP COLUMN app_flow_on_complete;
 
-DROP TYPE action_flow_enum;
+DROP TYPE app_flow_on_complete;

--- a/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/down.sql
+++ b/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."action" add column "webhook_uri" text
+--  null;

--- a/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/up.sql
+++ b/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/up.sql
@@ -3,3 +3,6 @@ alter table "public"."action" add column "webhook_uri" text
 
 alter table "public"."action" add column "webhook_pem" text
  null;
+
+comment on column "public"."action"."webhook_pem" is E'PEM used to encrypt the payload sent to the webhook_uri';
+comment on column "public"."action"."webhook_uri" is E'uri to send a payload to the webhook, encrypted by the webhook_pem';

--- a/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/up.sql
+++ b/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/up.sql
@@ -1,8 +1,9 @@
-alter table "public"."action" add column "webhook_uri" text
- null;
+CREATE TYPE action_flow_enum AS ENUM ('VERIFY', 'PARTNER');
 
-alter table "public"."action" add column "webhook_pem" text
- null;
+ALTER TABLE public.action
+    ADD COLUMN webhook_uri TEXT,
+    ADD COLUMN webhook_pem TEXT,
+    ADD COLUMN flow action_flow_enum;
 
-comment on column "public"."action"."webhook_pem" is E'PEM used to encrypt the payload sent to the webhook_uri';
-comment on column "public"."action"."webhook_uri" is E'uri to send a payload to the webhook, encrypted by the webhook_pem';
+COMMENT ON COLUMN public.action.webhook_uri IS 'URI to send a payload to the webhook, encrypted by the webhook_pem';
+COMMENT ON COLUMN public.action.webhook_pem IS 'PEM used to encrypt the payload sent to the webhook_uri';

--- a/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/up.sql
+++ b/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/up.sql
@@ -1,9 +1,9 @@
-CREATE TYPE action_flow_enum AS ENUM ('VERIFY', 'PARTNER');
+CREATE TYPE app_flow_on_complete_enum AS ENUM ('NONE', 'VERIFY');
 
 ALTER TABLE public.action
     ADD COLUMN webhook_uri TEXT,
     ADD COLUMN webhook_pem TEXT,
-    ADD COLUMN flow action_flow_enum;
+    ADD COLUMN app_flow_on_complete app_flow_on_complete_enum;
 
 COMMENT ON COLUMN public.action.webhook_uri IS 'URI to send a payload to the webhook, encrypted by the webhook_pem';
 COMMENT ON COLUMN public.action.webhook_pem IS 'PEM used to encrypt the payload sent to the webhook_uri';

--- a/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/up.sql
+++ b/hasura/migrations/default/1739394725314_alter_table_public_action_add_column_webhook_uri_pem/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."action" add column "webhook_uri" text
+ null;
+
+alter table "public"."action" add column "webhook_pem" text
+ null;

--- a/web/.env.test
+++ b/web/.env.test
@@ -9,6 +9,7 @@ NEXT_PUBLIC_METRICS_SERVICE_ENDPOINT="https://metrics.worldcoin.org/miniapps"
 # Hasura <> Next App connection
 HASURA_GRAPHQL_JWT_SECRET='{"key": "unsafe_AnEsZxveGsAWoENHGAnEsZxveGsAvxgMtDq9UxgTsDq9UxgTsNHGWoENIoJ", "type": "HS512"}'
 INTERNAL_ENDPOINTS_SECRET=internal_endpoint_test_key
+HASURA_GRAPHQL_ADMIN_SECRET=secret!
 
 # PostHog
 NEXT_PUBLIC_POSTHOG_API_KEY=

--- a/web/components/Input/index.tsx
+++ b/web/components/Input/index.tsx
@@ -16,8 +16,10 @@ interface InputInterface extends InputHTMLAttributes<HTMLInputElement> {
   addOnRight?: React.ReactElement;
   className?: string;
   selectOptions?: { value: string; label: string }[];
-  onChange?: (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
-  type?: 'text' | 'select' | 'number' | 'password';
+  onChange?: (
+    event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => void;
+  type?: "text" | "select" | "number" | "password";
 }
 
 export const Input = memo(function Input(props: InputInterface) {
@@ -33,7 +35,7 @@ export const Input = memo(function Input(props: InputInterface) {
     addOnRight,
     disabled,
     selectOptions,
-    type = 'text',
+    type = "text",
     ...restProps
   } = props;
 
@@ -74,7 +76,7 @@ export const Input = memo(function Input(props: InputInterface) {
 
   return (
     <div className={"inline-grid w-full font-gta transition-colors"}>
-      {type === 'select' ? (
+      {type === "select" ? (
         <div className="space-y-1">
           {label && (
             <label className={clsx(labelClassNames)}>
@@ -92,11 +94,11 @@ export const Input = memo(function Input(props: InputInterface) {
                 "border-system-error-500": errors && !disabled,
                 "bg-grey-50 text-grey-400": disabled,
                 "hover:border-grey-700": !disabled,
-              }
+              },
             )}
             disabled={disabled}
           >
-            {selectOptions?.map(option => (
+            {selectOptions?.map((option) => (
               <option key={option.value} value={option.value}>
                 {option.label}
               </option>
@@ -104,11 +106,16 @@ export const Input = memo(function Input(props: InputInterface) {
           </select>
         </div>
       ) : (
-        <fieldset className={twMerge(clsx(
-          "group grid grid-cols-auto/1fr/auto pb-2 transition-colors",
-          { "py-2": !label },
-          parentClassNames
-        ), className)}>
+        <fieldset
+          className={twMerge(
+            clsx(
+              "group grid grid-cols-auto/1fr/auto pb-2 transition-colors",
+              { "py-2": !label },
+              parentClassNames,
+            ),
+            className,
+          )}
+        >
           <div className="flex items-center">{addOnLeft && addOnLeft}</div>
 
           <input

--- a/web/components/Input/index.tsx
+++ b/web/components/Input/index.tsx
@@ -4,7 +4,7 @@ import { InputHTMLAttributes, memo } from "react";
 import { FieldError, UseFormRegisterReturn } from "react-hook-form";
 import { twMerge } from "tailwind-merge";
 
-export interface InputInterface extends InputHTMLAttributes<HTMLInputElement> {
+interface InputInterface extends InputHTMLAttributes<HTMLInputElement> {
   register?: UseFormRegisterReturn;
   required?: boolean;
   currentValue?: string;

--- a/web/components/Input/index.tsx
+++ b/web/components/Input/index.tsx
@@ -4,7 +4,7 @@ import { InputHTMLAttributes, memo } from "react";
 import { FieldError, UseFormRegisterReturn } from "react-hook-form";
 import { twMerge } from "tailwind-merge";
 
-interface InputInterface extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputInterface extends InputHTMLAttributes<HTMLInputElement> {
   register?: UseFormRegisterReturn;
   required?: boolean;
   currentValue?: string;
@@ -15,6 +15,9 @@ interface InputInterface extends InputHTMLAttributes<HTMLInputElement> {
   addOnLeft?: React.ReactElement;
   addOnRight?: React.ReactElement;
   className?: string;
+  selectOptions?: { value: string; label: string }[];
+  onChange?: (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
+  type?: 'text' | 'select' | 'number' | 'password';
 }
 
 export const Input = memo(function Input(props: InputInterface) {
@@ -29,6 +32,8 @@ export const Input = memo(function Input(props: InputInterface) {
     addOnLeft,
     addOnRight,
     disabled,
+    selectOptions,
+    type = 'text',
     ...restProps
   } = props;
 
@@ -69,42 +74,67 @@ export const Input = memo(function Input(props: InputInterface) {
 
   return (
     <div className={"inline-grid w-full font-gta transition-colors"}>
-      <fieldset
-        className={twMerge(
-          clsx(
-            "group grid grid-cols-auto/1fr/auto pb-2 transition-colors",
-            { "py-2": !label },
-            parentClassNames,
-          ),
-
-          typeof className === "string" ? className : undefined,
-        )}
-      >
-        <div className="flex items-center">{addOnLeft && addOnLeft}</div>
-
-        <input
-          {...register}
-          {...restProps}
-          className={clsx(inputClassNames)}
-          placeholder={placeholder}
-          disabled={disabled}
-          required={required}
-          aria-invalid={errors ? "true" : "false"}
-        />
-
-        <div className="flex items-center">{addOnRight && addOnRight}</div>
-
-        {label && (
-          <legend
-            className={twMerge(
-              clsx("select-none whitespace-nowrap", labelClassNames),
+      {type === 'select' ? (
+        <div className="space-y-1">
+          {label && (
+            <label className={clsx(labelClassNames)}>
+              {label}
+              {required && <span className="text-system-error-500">*</span>}
+            </label>
+          )}
+          <select
+            value={props.currentValue}
+            onChange={props.onChange}
+            className={clsx(
+              "w-full rounded-lg border border-grey-200 bg-grey-0 p-2 text-grey-700",
+              "focus:border-blue-500 focus:outline-none",
+              {
+                "border-system-error-500": errors && !disabled,
+                "bg-grey-50 text-grey-400": disabled,
+                "hover:border-grey-700": !disabled,
+              }
             )}
+            disabled={disabled}
           >
-            {label}{" "}
-            {required && <span className="text-system-error-500">*</span>}
-          </legend>
-        )}
-      </fieldset>
+            {selectOptions?.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : (
+        <fieldset className={twMerge(clsx(
+          "group grid grid-cols-auto/1fr/auto pb-2 transition-colors",
+          { "py-2": !label },
+          parentClassNames
+        ), className)}>
+          <div className="flex items-center">{addOnLeft && addOnLeft}</div>
+
+          <input
+            {...register}
+            {...restProps}
+            className={clsx(inputClassNames)}
+            placeholder={placeholder}
+            disabled={disabled}
+            required={required}
+            aria-invalid={errors ? "true" : "false"}
+          />
+
+          <div className="flex items-center">{addOnRight && addOnRight}</div>
+
+          {label && (
+            <legend
+              className={twMerge(
+                clsx("select-none whitespace-nowrap", labelClassNames),
+              )}
+            >
+              {label}{" "}
+              {required && <span className="text-system-error-500">*</span>}
+            </legend>
+          )}
+        </fieldset>
+      )}
 
       <div className={clsx("flex w-full flex-col px-2")}>
         {helperText && (

--- a/web/components/Input/index.tsx
+++ b/web/components/Input/index.tsx
@@ -15,11 +15,9 @@ interface InputInterface extends InputHTMLAttributes<HTMLInputElement> {
   addOnLeft?: React.ReactElement;
   addOnRight?: React.ReactElement;
   className?: string;
-  selectOptions?: { value: string; label: string }[];
   onChange?: (
     event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
   ) => void;
-  type?: "text" | "select" | "number" | "password";
 }
 
 export const Input = memo(function Input(props: InputInterface) {
@@ -34,8 +32,6 @@ export const Input = memo(function Input(props: InputInterface) {
     addOnLeft,
     addOnRight,
     disabled,
-    selectOptions,
-    type = "text",
     ...restProps
   } = props;
 
@@ -76,72 +72,37 @@ export const Input = memo(function Input(props: InputInterface) {
 
   return (
     <div className={"inline-grid w-full font-gta transition-colors"}>
-      {type === "select" ? (
-        <div className="space-y-1">
-          {label && (
-            <label className={clsx(labelClassNames)}>
-              {label}
-              {required && <span className="text-system-error-500">*</span>}
-            </label>
-          )}
-          <select
-            value={props.currentValue}
-            onChange={props.onChange}
-            className={clsx(
-              "w-full rounded-lg border border-grey-200 bg-grey-0 p-2 text-grey-700",
-              "focus:border-blue-500 focus:outline-none",
-              {
-                "border-system-error-500": errors && !disabled,
-                "bg-grey-50 text-grey-400": disabled,
-                "hover:border-grey-700": !disabled,
-              },
-            )}
-            disabled={disabled}
-          >
-            {selectOptions?.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </div>
-      ) : (
-        <fieldset
-          className={twMerge(
-            clsx(
-              "group grid grid-cols-auto/1fr/auto pb-2 transition-colors",
-              { "py-2": !label },
-              parentClassNames,
-            ),
-            className,
-          )}
-        >
-          <div className="flex items-center">{addOnLeft && addOnLeft}</div>
-
-          <input
-            {...register}
-            {...restProps}
-            className={clsx(inputClassNames)}
-            placeholder={placeholder}
-            disabled={disabled}
-            required={required}
-            aria-invalid={errors ? "true" : "false"}
-          />
-
-          <div className="flex items-center">{addOnRight && addOnRight}</div>
-
-          {label && (
-            <legend
-              className={twMerge(
-                clsx("select-none whitespace-nowrap", labelClassNames),
-              )}
-            >
-              {label}{" "}
-              {required && <span className="text-system-error-500">*</span>}
-            </legend>
-          )}
-        </fieldset>
+      {label && (
+        <label className={clsx(labelClassNames)}>
+          {label}
+          {required && <span className="text-system-error-500">*</span>}
+        </label>
       )}
+
+      <fieldset
+        className={twMerge(
+          clsx(
+            "group grid grid-cols-auto/1fr/auto pb-2 transition-colors",
+            { "py-2": !label },
+            parentClassNames,
+          ),
+          className,
+        )}
+      >
+        <div className="flex items-center">{addOnLeft && addOnLeft}</div>
+
+        <input
+          {...register}
+          {...restProps}
+          className={clsx(inputClassNames)}
+          placeholder={placeholder}
+          disabled={disabled}
+          required={required}
+          aria-invalid={errors ? "true" : "false"}
+        />
+
+        <div className="flex items-center">{addOnRight && addOnRight}</div>
+      </fieldset>
 
       <div className={clsx("flex w-full flex-col px-2")}>
         {helperText && (

--- a/web/components/Input/index.tsx
+++ b/web/components/Input/index.tsx
@@ -15,9 +15,6 @@ interface InputInterface extends InputHTMLAttributes<HTMLInputElement> {
   addOnLeft?: React.ReactElement;
   addOnRight?: React.ReactElement;
   className?: string;
-  onChange?: (
-    event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
-  ) => void;
 }
 
 export const Input = memo(function Input(props: InputInterface) {
@@ -72,13 +69,6 @@ export const Input = memo(function Input(props: InputInterface) {
 
   return (
     <div className={"inline-grid w-full font-gta transition-colors"}>
-      {label && (
-        <label className={clsx(labelClassNames)}>
-          {label}
-          {required && <span className="text-system-error-500">*</span>}
-        </label>
-      )}
-
       <fieldset
         className={twMerge(
           clsx(
@@ -86,7 +76,8 @@ export const Input = memo(function Input(props: InputInterface) {
             { "py-2": !label },
             parentClassNames,
           ),
-          className,
+
+          typeof className === "string" ? className : undefined,
         )}
       >
         <div className="flex items-center">{addOnLeft && addOnLeft}</div>
@@ -102,6 +93,17 @@ export const Input = memo(function Input(props: InputInterface) {
         />
 
         <div className="flex items-center">{addOnRight && addOnRight}</div>
+
+        {label && (
+          <legend
+            className={twMerge(
+              clsx("select-none whitespace-nowrap", labelClassNames),
+            )}
+          >
+            {label}{" "}
+            {required && <span className="text-system-error-500">*</span>}
+          </legend>
+        )}
       </fieldset>
 
       <div className={clsx("flex w-full flex-col px-2")}>

--- a/web/components/Toggle/index.tsx
+++ b/web/components/Toggle/index.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import clsx from "clsx";
+import { useState } from "react";
+
+type ToggleProps = {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  className?: string;
+  disabled?: boolean;
+};
+
+export const Toggle = (props: ToggleProps) => {
+  const { checked, onChange, className, disabled } = props;
+  const [isChecked, setIsChecked] = useState(checked);
+
+  const handleToggle = () => {
+    if (disabled) return;
+    const newState = !isChecked;
+    setIsChecked(newState);
+    onChange(newState);
+  };
+
+  return (
+    <button
+      type="button"
+      className={clsx(
+        "relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
+        {
+          "bg-blue-500": isChecked,
+          "bg-grey-200": !isChecked,
+          "cursor-not-allowed opacity-50": disabled,
+        },
+        className,
+      )}
+      role="switch"
+      aria-checked={isChecked}
+      disabled={disabled}
+      onClick={handleToggle}
+    >
+      <span
+        className={clsx(
+          "pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
+          {
+            "translate-x-5": isChecked,
+            "translate-x-0": !isChecked,
+          },
+        )}
+      />
+    </button>
+  );
+}; 

--- a/web/components/Toggle/index.tsx
+++ b/web/components/Toggle/index.tsx
@@ -25,7 +25,7 @@ export const Toggle = (props: ToggleProps) => {
     <button
       type="button"
       className={clsx(
-        "relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
+        "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
         {
           "bg-blue-500": isChecked,
           "bg-grey-200": !isChecked,
@@ -40,7 +40,7 @@ export const Toggle = (props: ToggleProps) => {
     >
       <span
         className={clsx(
-          "pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
+          "pointer-events-none inline-block size-5 rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
           {
             "translate-x-5": isChecked,
             "translate-x-0": !isChecked,
@@ -49,4 +49,4 @@ export const Toggle = (props: ToggleProps) => {
       />
     </button>
   );
-}; 
+};

--- a/web/graphql-codegen.schema.js
+++ b/web/graphql-codegen.schema.js
@@ -7,7 +7,7 @@ dotenv.config({ path: `.env.local`, override: true });
 module.exports = {
   schema: [
     {
-      [process.env.NEXT_PUBLIC_GRAPHQL_API_URL]: {
+      ["http://localhost:8080/v1/graphql"]: {
         headers: {
           "x-hasura-admin-secret": process.env.HASURA_GRAPHQL_ADMIN_SECRET,
         },

--- a/web/graphql-codegen.schema.js
+++ b/web/graphql-codegen.schema.js
@@ -7,7 +7,7 @@ dotenv.config({ path: `.env.local`, override: true });
 module.exports = {
   schema: [
     {
-      ["http://localhost:8080/v1/graphql"]: {
+      [process.env.NEXT_PUBLIC_GRAPHQL_API_URL]: {
         headers: {
           "x-hasura-admin-secret": process.env.HASURA_GRAPHQL_ADMIN_SECRET,
         },

--- a/web/graphql/graphql.schema.json
+++ b/web/graphql/graphql.schema.json
@@ -2611,6 +2611,18 @@
             "deprecationReason": null
           },
           {
+            "name": "app_flow_on_complete",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "app_flow_on_complete_enum",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "app_id",
             "description": null,
             "args": [],
@@ -2702,18 +2714,6 @@
                 "name": "String",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "flow",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "action_flow_enum",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -4118,6 +4118,18 @@
             "deprecationReason": null
           },
           {
+            "name": "app_flow_on_complete",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "app_flow_on_complete_enum_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "app_id",
             "description": null,
             "type": {
@@ -4183,18 +4195,6 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "flow",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "action_flow_enum_comparison_exp",
               "ofType": null
             },
             "defaultValue": null,
@@ -4428,151 +4428,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "SCALAR",
-        "name": "action_flow_enum",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "action_flow_enum_comparison_exp",
-        "description": "Boolean expression to compare columns of type \"action_flow_enum\". All fields are combined with logical 'AND'.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "_eq",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "action_flow_enum",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_gt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "action_flow_enum",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_gte",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "action_flow_enum",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_in",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "action_flow_enum",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_is_null",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_lt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "action_flow_enum",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_lte",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "action_flow_enum",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_neq",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "action_flow_enum",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_nin",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "action_flow_enum",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "INPUT_OBJECT",
         "name": "action_inc_input",
         "description": "input type for incrementing numeric columns in table \"action\"",
@@ -4631,6 +4486,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "app_obj_rel_insert_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_flow_on_complete",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "app_flow_on_complete_enum",
               "ofType": null
             },
             "defaultValue": null,
@@ -4703,18 +4570,6 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "flow",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "action_flow_enum",
               "ofType": null
             },
             "defaultValue": null,
@@ -4900,6 +4755,18 @@
             "deprecationReason": null
           },
           {
+            "name": "app_flow_on_complete",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "app_flow_on_complete_enum",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "app_id",
             "description": null,
             "args": [],
@@ -4966,18 +4833,6 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "flow",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "action_flow_enum",
               "ofType": null
             },
             "isDeprecated": false,
@@ -5140,6 +4995,18 @@
             "deprecationReason": null
           },
           {
+            "name": "app_flow_on_complete",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "app_id",
             "description": null,
             "type": {
@@ -5202,18 +5069,6 @@
           {
             "name": "external_nullifier",
             "description": "Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs.",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "flow",
-            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
@@ -5366,6 +5221,18 @@
             "deprecationReason": null
           },
           {
+            "name": "app_flow_on_complete",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "app_flow_on_complete_enum",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "app_id",
             "description": null,
             "args": [],
@@ -5432,18 +5299,6 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "flow",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "action_flow_enum",
               "ofType": null
             },
             "isDeprecated": false,
@@ -5606,6 +5461,18 @@
             "deprecationReason": null
           },
           {
+            "name": "app_flow_on_complete",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "app_id",
             "description": null,
             "type": {
@@ -5668,18 +5535,6 @@
           {
             "name": "external_nullifier",
             "description": "Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs.",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "flow",
-            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
@@ -5998,6 +5853,18 @@
             "deprecationReason": null
           },
           {
+            "name": "app_flow_on_complete",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "app_id",
             "description": null,
             "type": {
@@ -6059,18 +5926,6 @@
           },
           {
             "name": "external_nullifier",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "flow",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -6296,6 +6151,12 @@
             "deprecationReason": null
           },
           {
+            "name": "app_flow_on_complete",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "app_id",
             "description": "column name",
             "isDeprecated": false,
@@ -6327,12 +6188,6 @@
           },
           {
             "name": "external_nullifier",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "flow",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -6459,6 +6314,18 @@
             "deprecationReason": null
           },
           {
+            "name": "app_flow_on_complete",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "app_flow_on_complete_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "app_id",
             "description": null,
             "type": {
@@ -6524,18 +6391,6 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "flow",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "action_flow_enum",
               "ofType": null
             },
             "defaultValue": null,
@@ -8482,6 +8337,18 @@
             "deprecationReason": null
           },
           {
+            "name": "app_flow_on_complete",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "app_flow_on_complete_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "app_id",
             "description": null,
             "type": {
@@ -8547,18 +8414,6 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "flow",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "action_flow_enum",
               "ofType": null
             },
             "defaultValue": null,
@@ -8799,6 +8654,12 @@
             "deprecationReason": null
           },
           {
+            "name": "app_flow_on_complete",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "app_id",
             "description": "column name",
             "isDeprecated": false,
@@ -8830,12 +8691,6 @@
           },
           {
             "name": "external_nullifier",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "flow",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -12801,6 +12656,151 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "app_flow_on_complete_enum",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "app_flow_on_complete_enum_comparison_exp",
+        "description": "Boolean expression to compare columns of type \"app_flow_on_complete_enum\". All fields are combined with logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_eq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "app_flow_on_complete_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "app_flow_on_complete_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "app_flow_on_complete_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "app_flow_on_complete_enum",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_is_null",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "app_flow_on_complete_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "app_flow_on_complete_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_neq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "app_flow_on_complete_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_nin",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "app_flow_on_complete_enum",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
         "possibleTypes": null
       },
       {

--- a/web/graphql/graphql.schema.json
+++ b/web/graphql/graphql.schema.json
@@ -2707,6 +2707,22 @@
             "deprecationReason": null
           },
           {
+            "name": "flow",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "action_flow_enum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "args": [],
@@ -3256,7 +3272,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
+            "description": "URI to send a payload to the webhook, encrypted by the webhook_pem",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4178,6 +4194,18 @@
             "deprecationReason": null
           },
           {
+            "name": "flow",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "action_flow_enum_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "type": {
@@ -4404,6 +4432,151 @@
         "possibleTypes": null
       },
       {
+        "kind": "SCALAR",
+        "name": "action_flow_enum",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "action_flow_enum_comparison_exp",
+        "description": "Boolean expression to compare columns of type \"action_flow_enum\". All fields are combined with logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_eq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "action_flow_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "action_flow_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "action_flow_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "action_flow_enum",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_is_null",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "action_flow_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "action_flow_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_neq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "action_flow_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_nin",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "action_flow_enum",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "action_inc_input",
         "description": "input type for incrementing numeric columns in table \"action\"",
@@ -4534,6 +4707,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "flow",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "action_flow_enum",
               "ofType": null
             },
             "defaultValue": null,
@@ -4686,7 +4871,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
+            "description": "URI to send a payload to the webhook, encrypted by the webhook_pem",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -4785,6 +4970,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "flow",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "action_flow_enum",
               "ofType": null
             },
             "isDeprecated": false,
@@ -4912,7 +5109,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
+            "description": "URI to send a payload to the webhook, encrypted by the webhook_pem",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5019,6 +5216,18 @@
             "deprecationReason": null
           },
           {
+            "name": "flow",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "type": {
@@ -5128,7 +5337,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
+            "description": "URI to send a payload to the webhook, encrypted by the webhook_pem",
             "type": {
               "kind": "ENUM",
               "name": "order_by",
@@ -5227,6 +5436,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "flow",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "action_flow_enum",
               "ofType": null
             },
             "isDeprecated": false,
@@ -5354,7 +5575,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
+            "description": "URI to send a payload to the webhook, encrypted by the webhook_pem",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5451,6 +5672,18 @@
           {
             "name": "external_nullifier",
             "description": "Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs.",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "flow",
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
@@ -5570,7 +5803,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
+            "description": "URI to send a payload to the webhook, encrypted by the webhook_pem",
             "type": {
               "kind": "ENUM",
               "name": "order_by",
@@ -5841,6 +6074,18 @@
             "deprecationReason": null
           },
           {
+            "name": "flow",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "type": {
@@ -6091,6 +6336,12 @@
             "deprecationReason": null
           },
           {
+            "name": "flow",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": "column name",
             "isDeprecated": false,
@@ -6284,6 +6535,18 @@
             "deprecationReason": null
           },
           {
+            "name": "flow",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "action_flow_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "type": {
@@ -6405,7 +6668,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
+            "description": "URI to send a payload to the webhook, encrypted by the webhook_pem",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8295,6 +8558,18 @@
             "deprecationReason": null
           },
           {
+            "name": "flow",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "action_flow_enum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "type": {
@@ -8416,7 +8691,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
+            "description": "URI to send a payload to the webhook, encrypted by the webhook_pem",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8559,6 +8834,12 @@
           },
           {
             "name": "external_nullifier",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "flow",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null

--- a/web/graphql/graphql.schema.json
+++ b/web/graphql/graphql.schema.json
@@ -2711,13 +2711,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "action_flow_enum",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "action_flow_enum",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/web/graphql/graphql.schema.json
+++ b/web/graphql/graphql.schema.json
@@ -3244,7 +3244,7 @@
           },
           {
             "name": "webhook_pem",
-            "description": null,
+            "description": "PEM used to encrypt the payload sent to the webhook_uri",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3256,7 +3256,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": null,
+            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4674,7 +4674,7 @@
           },
           {
             "name": "webhook_pem",
-            "description": null,
+            "description": "PEM used to encrypt the payload sent to the webhook_uri",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -4686,7 +4686,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": null,
+            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -4900,7 +4900,7 @@
           },
           {
             "name": "webhook_pem",
-            "description": null,
+            "description": "PEM used to encrypt the payload sent to the webhook_uri",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4912,7 +4912,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": null,
+            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5116,7 +5116,7 @@
           },
           {
             "name": "webhook_pem",
-            "description": null,
+            "description": "PEM used to encrypt the payload sent to the webhook_uri",
             "type": {
               "kind": "ENUM",
               "name": "order_by",
@@ -5128,7 +5128,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": null,
+            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
             "type": {
               "kind": "ENUM",
               "name": "order_by",
@@ -5342,7 +5342,7 @@
           },
           {
             "name": "webhook_pem",
-            "description": null,
+            "description": "PEM used to encrypt the payload sent to the webhook_uri",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5354,7 +5354,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": null,
+            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5558,7 +5558,7 @@
           },
           {
             "name": "webhook_pem",
-            "description": null,
+            "description": "PEM used to encrypt the payload sent to the webhook_uri",
             "type": {
               "kind": "ENUM",
               "name": "order_by",
@@ -5570,7 +5570,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": null,
+            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
             "type": {
               "kind": "ENUM",
               "name": "order_by",
@@ -6393,7 +6393,7 @@
           },
           {
             "name": "webhook_pem",
-            "description": null,
+            "description": "PEM used to encrypt the payload sent to the webhook_uri",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -6405,7 +6405,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": null,
+            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8404,7 +8404,7 @@
           },
           {
             "name": "webhook_pem",
-            "description": null,
+            "description": "PEM used to encrypt the payload sent to the webhook_uri",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8416,7 +8416,7 @@
           },
           {
             "name": "webhook_uri",
-            "description": null,
+            "description": "uri to send a payload to the webhook, encrypted by the webhook_pem",
             "type": {
               "kind": "SCALAR",
               "name": "String",

--- a/web/graphql/graphql.schema.json
+++ b/web/graphql/graphql.schema.json
@@ -3241,6 +3241,30 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "webhook_pem",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_uri",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -4320,6 +4344,30 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "webhook_pem",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_uri",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -4623,6 +4671,30 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "webhook_pem",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_uri",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -4825,6 +4897,30 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "webhook_pem",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_uri",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -5008,6 +5104,30 @@
           },
           {
             "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_pem",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_uri",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5219,6 +5339,30 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "webhook_pem",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_uri",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -5402,6 +5546,30 @@
           },
           {
             "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_pem",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_uri",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5815,6 +5983,30 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "webhook_pem",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_uri",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -5948,6 +6140,18 @@
           },
           {
             "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_pem",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_uri",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -6181,6 +6385,30 @@
             "type": {
               "kind": "SCALAR",
               "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_pem",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_uri",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -8173,6 +8401,30 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "webhook_pem",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_uri",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -8361,6 +8613,18 @@
           },
           {
             "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_pem",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook_uri",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null

--- a/web/graphql/graphql.ts
+++ b/web/graphql/graphql.ts
@@ -260,7 +260,7 @@ export type Action = {
   description: Scalars["String"]["output"];
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier: Scalars["String"]["output"];
-  flow: Scalars["action_flow_enum"]["output"];
+  flow?: Maybe<Scalars["action_flow_enum"]["output"]>;
   id: Scalars["String"]["output"];
   kiosk_enabled: Scalars["Boolean"]["output"];
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */

--- a/web/graphql/graphql.ts
+++ b/web/graphql/graphql.ts
@@ -26,7 +26,7 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean };
   Int: { input: number; output: number };
   Float: { input: number; output: number };
-  action_flow_enum: { input: unknown; output: unknown };
+  app_flow_on_complete_enum: { input: unknown; output: unknown };
   illegal_content_category_enum: { input: unknown; output: unknown };
   jsonb: { input: any; output: any };
   numeric: { input: number; output: number };
@@ -253,6 +253,7 @@ export type Action = {
   action: Scalars["String"]["output"];
   /** An object relationship */
   app: App;
+  app_flow_on_complete?: Maybe<Scalars["app_flow_on_complete_enum"]["output"]>;
   app_id: Scalars["String"]["output"];
   client_secret: Scalars["String"]["output"];
   created_at: Scalars["timestamptz"]["output"];
@@ -260,7 +261,6 @@ export type Action = {
   description: Scalars["String"]["output"];
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier: Scalars["String"]["output"];
-  flow?: Maybe<Scalars["action_flow_enum"]["output"]>;
   id: Scalars["String"]["output"];
   kiosk_enabled: Scalars["Boolean"]["output"];
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
@@ -429,13 +429,13 @@ export type Action_Bool_Exp = {
   _or?: InputMaybe<Array<Action_Bool_Exp>>;
   action?: InputMaybe<String_Comparison_Exp>;
   app?: InputMaybe<App_Bool_Exp>;
+  app_flow_on_complete?: InputMaybe<App_Flow_On_Complete_Enum_Comparison_Exp>;
   app_id?: InputMaybe<String_Comparison_Exp>;
   client_secret?: InputMaybe<String_Comparison_Exp>;
   created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
   creation_mode?: InputMaybe<String_Comparison_Exp>;
   description?: InputMaybe<String_Comparison_Exp>;
   external_nullifier?: InputMaybe<String_Comparison_Exp>;
-  flow?: InputMaybe<Action_Flow_Enum_Comparison_Exp>;
   id?: InputMaybe<String_Comparison_Exp>;
   kiosk_enabled?: InputMaybe<Boolean_Comparison_Exp>;
   max_accounts_per_user?: InputMaybe<Int_Comparison_Exp>;
@@ -464,19 +464,6 @@ export enum Action_Constraint {
   ActionPkey = "action_pkey",
 }
 
-/** Boolean expression to compare columns of type "action_flow_enum". All fields are combined with logical 'AND'. */
-export type Action_Flow_Enum_Comparison_Exp = {
-  _eq?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
-  _gt?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
-  _gte?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
-  _in?: InputMaybe<Array<Scalars["action_flow_enum"]["input"]>>;
-  _is_null?: InputMaybe<Scalars["Boolean"]["input"]>;
-  _lt?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
-  _lte?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
-  _neq?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
-  _nin?: InputMaybe<Array<Scalars["action_flow_enum"]["input"]>>;
-};
-
 /** input type for incrementing numeric columns in table "action" */
 export type Action_Inc_Input = {
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
@@ -490,6 +477,9 @@ export type Action_Insert_Input = {
   /** Raw action value as passed by the dev to IDKit. */
   action?: InputMaybe<Scalars["String"]["input"]>;
   app?: InputMaybe<App_Obj_Rel_Insert_Input>;
+  app_flow_on_complete?: InputMaybe<
+    Scalars["app_flow_on_complete_enum"]["input"]
+  >;
   app_id?: InputMaybe<Scalars["String"]["input"]>;
   client_secret?: InputMaybe<Scalars["String"]["input"]>;
   created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
@@ -497,7 +487,6 @@ export type Action_Insert_Input = {
   description?: InputMaybe<Scalars["String"]["input"]>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: InputMaybe<Scalars["String"]["input"]>;
-  flow?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
   id?: InputMaybe<Scalars["String"]["input"]>;
   kiosk_enabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
@@ -523,6 +512,7 @@ export type Action_Max_Fields = {
   __typename?: "action_max_fields";
   /** Raw action value as passed by the dev to IDKit. */
   action?: Maybe<Scalars["String"]["output"]>;
+  app_flow_on_complete?: Maybe<Scalars["app_flow_on_complete_enum"]["output"]>;
   app_id?: Maybe<Scalars["String"]["output"]>;
   client_secret?: Maybe<Scalars["String"]["output"]>;
   created_at?: Maybe<Scalars["timestamptz"]["output"]>;
@@ -530,7 +520,6 @@ export type Action_Max_Fields = {
   description?: Maybe<Scalars["String"]["output"]>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: Maybe<Scalars["String"]["output"]>;
-  flow?: Maybe<Scalars["action_flow_enum"]["output"]>;
   id?: Maybe<Scalars["String"]["output"]>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
   max_accounts_per_user?: Maybe<Scalars["Int"]["output"]>;
@@ -554,6 +543,7 @@ export type Action_Max_Fields = {
 export type Action_Max_Order_By = {
   /** Raw action value as passed by the dev to IDKit. */
   action?: InputMaybe<Order_By>;
+  app_flow_on_complete?: InputMaybe<Order_By>;
   app_id?: InputMaybe<Order_By>;
   client_secret?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
@@ -561,7 +551,6 @@ export type Action_Max_Order_By = {
   description?: InputMaybe<Order_By>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: InputMaybe<Order_By>;
-  flow?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
   max_accounts_per_user?: InputMaybe<Order_By>;
@@ -584,6 +573,7 @@ export type Action_Min_Fields = {
   __typename?: "action_min_fields";
   /** Raw action value as passed by the dev to IDKit. */
   action?: Maybe<Scalars["String"]["output"]>;
+  app_flow_on_complete?: Maybe<Scalars["app_flow_on_complete_enum"]["output"]>;
   app_id?: Maybe<Scalars["String"]["output"]>;
   client_secret?: Maybe<Scalars["String"]["output"]>;
   created_at?: Maybe<Scalars["timestamptz"]["output"]>;
@@ -591,7 +581,6 @@ export type Action_Min_Fields = {
   description?: Maybe<Scalars["String"]["output"]>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: Maybe<Scalars["String"]["output"]>;
-  flow?: Maybe<Scalars["action_flow_enum"]["output"]>;
   id?: Maybe<Scalars["String"]["output"]>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
   max_accounts_per_user?: Maybe<Scalars["Int"]["output"]>;
@@ -615,6 +604,7 @@ export type Action_Min_Fields = {
 export type Action_Min_Order_By = {
   /** Raw action value as passed by the dev to IDKit. */
   action?: InputMaybe<Order_By>;
+  app_flow_on_complete?: InputMaybe<Order_By>;
   app_id?: InputMaybe<Order_By>;
   client_secret?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
@@ -622,7 +612,6 @@ export type Action_Min_Order_By = {
   description?: InputMaybe<Order_By>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: InputMaybe<Order_By>;
-  flow?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
   max_accounts_per_user?: InputMaybe<Order_By>;
@@ -667,13 +656,13 @@ export type Action_On_Conflict = {
 export type Action_Order_By = {
   action?: InputMaybe<Order_By>;
   app?: InputMaybe<App_Order_By>;
+  app_flow_on_complete?: InputMaybe<Order_By>;
   app_id?: InputMaybe<Order_By>;
   client_secret?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
   creation_mode?: InputMaybe<Order_By>;
   description?: InputMaybe<Order_By>;
   external_nullifier?: InputMaybe<Order_By>;
-  flow?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   kiosk_enabled?: InputMaybe<Order_By>;
   max_accounts_per_user?: InputMaybe<Order_By>;
@@ -700,6 +689,8 @@ export enum Action_Select_Column {
   /** column name */
   Action = "action",
   /** column name */
+  AppFlowOnComplete = "app_flow_on_complete",
+  /** column name */
   AppId = "app_id",
   /** column name */
   ClientSecret = "client_secret",
@@ -711,8 +702,6 @@ export enum Action_Select_Column {
   Description = "description",
   /** column name */
   ExternalNullifier = "external_nullifier",
-  /** column name */
-  Flow = "flow",
   /** column name */
   Id = "id",
   /** column name */
@@ -753,6 +742,9 @@ export enum Action_Select_Column_Action_Aggregate_Bool_Exp_Bool_Or_Arguments_Col
 export type Action_Set_Input = {
   /** Raw action value as passed by the dev to IDKit. */
   action?: InputMaybe<Scalars["String"]["input"]>;
+  app_flow_on_complete?: InputMaybe<
+    Scalars["app_flow_on_complete_enum"]["input"]
+  >;
   app_id?: InputMaybe<Scalars["String"]["input"]>;
   client_secret?: InputMaybe<Scalars["String"]["input"]>;
   created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
@@ -760,7 +752,6 @@ export type Action_Set_Input = {
   description?: InputMaybe<Scalars["String"]["input"]>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: InputMaybe<Scalars["String"]["input"]>;
-  flow?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
   id?: InputMaybe<Scalars["String"]["input"]>;
   kiosk_enabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
@@ -1087,6 +1078,9 @@ export type Action_Stream_Cursor_Input = {
 export type Action_Stream_Cursor_Value_Input = {
   /** Raw action value as passed by the dev to IDKit. */
   action?: InputMaybe<Scalars["String"]["input"]>;
+  app_flow_on_complete?: InputMaybe<
+    Scalars["app_flow_on_complete_enum"]["input"]
+  >;
   app_id?: InputMaybe<Scalars["String"]["input"]>;
   client_secret?: InputMaybe<Scalars["String"]["input"]>;
   created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
@@ -1094,7 +1088,6 @@ export type Action_Stream_Cursor_Value_Input = {
   description?: InputMaybe<Scalars["String"]["input"]>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: InputMaybe<Scalars["String"]["input"]>;
-  flow?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
   id?: InputMaybe<Scalars["String"]["input"]>;
   kiosk_enabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
@@ -1137,6 +1130,8 @@ export enum Action_Update_Column {
   /** column name */
   Action = "action",
   /** column name */
+  AppFlowOnComplete = "app_flow_on_complete",
+  /** column name */
   AppId = "app_id",
   /** column name */
   ClientSecret = "client_secret",
@@ -1148,8 +1143,6 @@ export enum Action_Update_Column {
   Description = "description",
   /** column name */
   ExternalNullifier = "external_nullifier",
-  /** column name */
-  Flow = "flow",
   /** column name */
   Id = "id",
   /** column name */
@@ -1698,6 +1691,19 @@ export enum App_Constraint {
   /** unique or primary key constraint on columns "id" */
   AppPkey = "app_pkey",
 }
+
+/** Boolean expression to compare columns of type "app_flow_on_complete_enum". All fields are combined with logical 'AND'. */
+export type App_Flow_On_Complete_Enum_Comparison_Exp = {
+  _eq?: InputMaybe<Scalars["app_flow_on_complete_enum"]["input"]>;
+  _gt?: InputMaybe<Scalars["app_flow_on_complete_enum"]["input"]>;
+  _gte?: InputMaybe<Scalars["app_flow_on_complete_enum"]["input"]>;
+  _in?: InputMaybe<Array<Scalars["app_flow_on_complete_enum"]["input"]>>;
+  _is_null?: InputMaybe<Scalars["Boolean"]["input"]>;
+  _lt?: InputMaybe<Scalars["app_flow_on_complete_enum"]["input"]>;
+  _lte?: InputMaybe<Scalars["app_flow_on_complete_enum"]["input"]>;
+  _neq?: InputMaybe<Scalars["app_flow_on_complete_enum"]["input"]>;
+  _nin?: InputMaybe<Array<Scalars["app_flow_on_complete_enum"]["input"]>>;
+};
 
 /** input type for incrementing numeric columns in table "app" */
 export type App_Inc_Input = {

--- a/web/graphql/graphql.ts
+++ b/web/graphql/graphql.ts
@@ -281,6 +281,10 @@ export type Action = {
   status: Scalars["String"]["output"];
   terms_uri?: Maybe<Scalars["String"]["output"]>;
   updated_at: Scalars["timestamptz"]["output"];
+  /** PEM used to encrypt the payload sent to the webhook_uri */
+  webhook_pem?: Maybe<Scalars["String"]["output"]>;
+  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  webhook_uri?: Maybe<Scalars["String"]["output"]>;
 };
 
 /** columns and relationships of "action" */
@@ -443,6 +447,8 @@ export type Action_Bool_Exp = {
   status?: InputMaybe<String_Comparison_Exp>;
   terms_uri?: InputMaybe<String_Comparison_Exp>;
   updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  webhook_pem?: InputMaybe<String_Comparison_Exp>;
+  webhook_uri?: InputMaybe<String_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "action" */
@@ -489,6 +495,10 @@ export type Action_Insert_Input = {
   status?: InputMaybe<Scalars["String"]["input"]>;
   terms_uri?: InputMaybe<Scalars["String"]["input"]>;
   updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  /** PEM used to encrypt the payload sent to the webhook_uri */
+  webhook_pem?: InputMaybe<Scalars["String"]["input"]>;
+  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  webhook_uri?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 /** aggregate max on columns */
@@ -516,6 +526,10 @@ export type Action_Max_Fields = {
   status?: Maybe<Scalars["String"]["output"]>;
   terms_uri?: Maybe<Scalars["String"]["output"]>;
   updated_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  /** PEM used to encrypt the payload sent to the webhook_uri */
+  webhook_pem?: Maybe<Scalars["String"]["output"]>;
+  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  webhook_uri?: Maybe<Scalars["String"]["output"]>;
 };
 
 /** order by max() on columns of table "action" */
@@ -540,6 +554,10 @@ export type Action_Max_Order_By = {
   status?: InputMaybe<Order_By>;
   terms_uri?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
+  /** PEM used to encrypt the payload sent to the webhook_uri */
+  webhook_pem?: InputMaybe<Order_By>;
+  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  webhook_uri?: InputMaybe<Order_By>;
 };
 
 /** aggregate min on columns */
@@ -567,6 +585,10 @@ export type Action_Min_Fields = {
   status?: Maybe<Scalars["String"]["output"]>;
   terms_uri?: Maybe<Scalars["String"]["output"]>;
   updated_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  /** PEM used to encrypt the payload sent to the webhook_uri */
+  webhook_pem?: Maybe<Scalars["String"]["output"]>;
+  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  webhook_uri?: Maybe<Scalars["String"]["output"]>;
 };
 
 /** order by min() on columns of table "action" */
@@ -591,6 +613,10 @@ export type Action_Min_Order_By = {
   status?: InputMaybe<Order_By>;
   terms_uri?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
+  /** PEM used to encrypt the payload sent to the webhook_uri */
+  webhook_pem?: InputMaybe<Order_By>;
+  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  webhook_uri?: InputMaybe<Order_By>;
 };
 
 /** response of any mutation on the table "action" */
@@ -638,6 +664,8 @@ export type Action_Order_By = {
   status?: InputMaybe<Order_By>;
   terms_uri?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
+  webhook_pem?: InputMaybe<Order_By>;
+  webhook_uri?: InputMaybe<Order_By>;
 };
 
 /** primary key columns input for table: action */
@@ -679,6 +707,10 @@ export enum Action_Select_Column {
   TermsUri = "terms_uri",
   /** column name */
   UpdatedAt = "updated_at",
+  /** column name */
+  WebhookPem = "webhook_pem",
+  /** column name */
+  WebhookUri = "webhook_uri",
 }
 
 /** select "action_aggregate_bool_exp_bool_and_arguments_columns" columns of table "action" */
@@ -716,6 +748,10 @@ export type Action_Set_Input = {
   status?: InputMaybe<Scalars["String"]["input"]>;
   terms_uri?: InputMaybe<Scalars["String"]["input"]>;
   updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  /** PEM used to encrypt the payload sent to the webhook_uri */
+  webhook_pem?: InputMaybe<Scalars["String"]["input"]>;
+  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  webhook_uri?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type Action_Stats_Args = {
@@ -1045,6 +1081,10 @@ export type Action_Stream_Cursor_Value_Input = {
   status?: InputMaybe<Scalars["String"]["input"]>;
   terms_uri?: InputMaybe<Scalars["String"]["input"]>;
   updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  /** PEM used to encrypt the payload sent to the webhook_uri */
+  webhook_pem?: InputMaybe<Scalars["String"]["input"]>;
+  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  webhook_uri?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 /** aggregate sum on columns */
@@ -1100,6 +1140,10 @@ export enum Action_Update_Column {
   TermsUri = "terms_uri",
   /** column name */
   UpdatedAt = "updated_at",
+  /** column name */
+  WebhookPem = "webhook_pem",
+  /** column name */
+  WebhookUri = "webhook_uri",
 }
 
 export type Action_Updates = {

--- a/web/graphql/graphql.ts
+++ b/web/graphql/graphql.ts
@@ -26,6 +26,7 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean };
   Int: { input: number; output: number };
   Float: { input: number; output: number };
+  action_flow_enum: { input: unknown; output: unknown };
   illegal_content_category_enum: { input: unknown; output: unknown };
   jsonb: { input: any; output: any };
   numeric: { input: number; output: number };
@@ -259,6 +260,7 @@ export type Action = {
   description: Scalars["String"]["output"];
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier: Scalars["String"]["output"];
+  flow: Scalars["action_flow_enum"]["output"];
   id: Scalars["String"]["output"];
   kiosk_enabled: Scalars["Boolean"]["output"];
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
@@ -283,7 +285,7 @@ export type Action = {
   updated_at: Scalars["timestamptz"]["output"];
   /** PEM used to encrypt the payload sent to the webhook_uri */
   webhook_pem?: Maybe<Scalars["String"]["output"]>;
-  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  /** URI to send a payload to the webhook, encrypted by the webhook_pem */
   webhook_uri?: Maybe<Scalars["String"]["output"]>;
 };
 
@@ -433,6 +435,7 @@ export type Action_Bool_Exp = {
   creation_mode?: InputMaybe<String_Comparison_Exp>;
   description?: InputMaybe<String_Comparison_Exp>;
   external_nullifier?: InputMaybe<String_Comparison_Exp>;
+  flow?: InputMaybe<Action_Flow_Enum_Comparison_Exp>;
   id?: InputMaybe<String_Comparison_Exp>;
   kiosk_enabled?: InputMaybe<Boolean_Comparison_Exp>;
   max_accounts_per_user?: InputMaybe<Int_Comparison_Exp>;
@@ -461,6 +464,19 @@ export enum Action_Constraint {
   ActionPkey = "action_pkey",
 }
 
+/** Boolean expression to compare columns of type "action_flow_enum". All fields are combined with logical 'AND'. */
+export type Action_Flow_Enum_Comparison_Exp = {
+  _eq?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
+  _gt?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
+  _gte?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
+  _in?: InputMaybe<Array<Scalars["action_flow_enum"]["input"]>>;
+  _is_null?: InputMaybe<Scalars["Boolean"]["input"]>;
+  _lt?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
+  _lte?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
+  _neq?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
+  _nin?: InputMaybe<Array<Scalars["action_flow_enum"]["input"]>>;
+};
+
 /** input type for incrementing numeric columns in table "action" */
 export type Action_Inc_Input = {
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
@@ -481,6 +497,7 @@ export type Action_Insert_Input = {
   description?: InputMaybe<Scalars["String"]["input"]>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: InputMaybe<Scalars["String"]["input"]>;
+  flow?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
   id?: InputMaybe<Scalars["String"]["input"]>;
   kiosk_enabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
@@ -497,7 +514,7 @@ export type Action_Insert_Input = {
   updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   /** PEM used to encrypt the payload sent to the webhook_uri */
   webhook_pem?: InputMaybe<Scalars["String"]["input"]>;
-  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  /** URI to send a payload to the webhook, encrypted by the webhook_pem */
   webhook_uri?: InputMaybe<Scalars["String"]["input"]>;
 };
 
@@ -513,6 +530,7 @@ export type Action_Max_Fields = {
   description?: Maybe<Scalars["String"]["output"]>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: Maybe<Scalars["String"]["output"]>;
+  flow?: Maybe<Scalars["action_flow_enum"]["output"]>;
   id?: Maybe<Scalars["String"]["output"]>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
   max_accounts_per_user?: Maybe<Scalars["Int"]["output"]>;
@@ -528,7 +546,7 @@ export type Action_Max_Fields = {
   updated_at?: Maybe<Scalars["timestamptz"]["output"]>;
   /** PEM used to encrypt the payload sent to the webhook_uri */
   webhook_pem?: Maybe<Scalars["String"]["output"]>;
-  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  /** URI to send a payload to the webhook, encrypted by the webhook_pem */
   webhook_uri?: Maybe<Scalars["String"]["output"]>;
 };
 
@@ -543,6 +561,7 @@ export type Action_Max_Order_By = {
   description?: InputMaybe<Order_By>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: InputMaybe<Order_By>;
+  flow?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
   max_accounts_per_user?: InputMaybe<Order_By>;
@@ -556,7 +575,7 @@ export type Action_Max_Order_By = {
   updated_at?: InputMaybe<Order_By>;
   /** PEM used to encrypt the payload sent to the webhook_uri */
   webhook_pem?: InputMaybe<Order_By>;
-  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  /** URI to send a payload to the webhook, encrypted by the webhook_pem */
   webhook_uri?: InputMaybe<Order_By>;
 };
 
@@ -572,6 +591,7 @@ export type Action_Min_Fields = {
   description?: Maybe<Scalars["String"]["output"]>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: Maybe<Scalars["String"]["output"]>;
+  flow?: Maybe<Scalars["action_flow_enum"]["output"]>;
   id?: Maybe<Scalars["String"]["output"]>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
   max_accounts_per_user?: Maybe<Scalars["Int"]["output"]>;
@@ -587,7 +607,7 @@ export type Action_Min_Fields = {
   updated_at?: Maybe<Scalars["timestamptz"]["output"]>;
   /** PEM used to encrypt the payload sent to the webhook_uri */
   webhook_pem?: Maybe<Scalars["String"]["output"]>;
-  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  /** URI to send a payload to the webhook, encrypted by the webhook_pem */
   webhook_uri?: Maybe<Scalars["String"]["output"]>;
 };
 
@@ -602,6 +622,7 @@ export type Action_Min_Order_By = {
   description?: InputMaybe<Order_By>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: InputMaybe<Order_By>;
+  flow?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
   max_accounts_per_user?: InputMaybe<Order_By>;
@@ -615,7 +636,7 @@ export type Action_Min_Order_By = {
   updated_at?: InputMaybe<Order_By>;
   /** PEM used to encrypt the payload sent to the webhook_uri */
   webhook_pem?: InputMaybe<Order_By>;
-  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  /** URI to send a payload to the webhook, encrypted by the webhook_pem */
   webhook_uri?: InputMaybe<Order_By>;
 };
 
@@ -652,6 +673,7 @@ export type Action_Order_By = {
   creation_mode?: InputMaybe<Order_By>;
   description?: InputMaybe<Order_By>;
   external_nullifier?: InputMaybe<Order_By>;
+  flow?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   kiosk_enabled?: InputMaybe<Order_By>;
   max_accounts_per_user?: InputMaybe<Order_By>;
@@ -689,6 +711,8 @@ export enum Action_Select_Column {
   Description = "description",
   /** column name */
   ExternalNullifier = "external_nullifier",
+  /** column name */
+  Flow = "flow",
   /** column name */
   Id = "id",
   /** column name */
@@ -736,6 +760,7 @@ export type Action_Set_Input = {
   description?: InputMaybe<Scalars["String"]["input"]>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: InputMaybe<Scalars["String"]["input"]>;
+  flow?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
   id?: InputMaybe<Scalars["String"]["input"]>;
   kiosk_enabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
@@ -750,7 +775,7 @@ export type Action_Set_Input = {
   updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   /** PEM used to encrypt the payload sent to the webhook_uri */
   webhook_pem?: InputMaybe<Scalars["String"]["input"]>;
-  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  /** URI to send a payload to the webhook, encrypted by the webhook_pem */
   webhook_uri?: InputMaybe<Scalars["String"]["input"]>;
 };
 
@@ -1069,6 +1094,7 @@ export type Action_Stream_Cursor_Value_Input = {
   description?: InputMaybe<Scalars["String"]["input"]>;
   /** Encoded and hashed value of app_id and action. Determines scope for uniqueness. Used for Semaphore ZKPs. */
   external_nullifier?: InputMaybe<Scalars["String"]["input"]>;
+  flow?: InputMaybe<Scalars["action_flow_enum"]["input"]>;
   id?: InputMaybe<Scalars["String"]["input"]>;
   kiosk_enabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** Only for Sign in with World ID. Determines the maximum number of accounts a single person can have for the respective app. */
@@ -1083,7 +1109,7 @@ export type Action_Stream_Cursor_Value_Input = {
   updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   /** PEM used to encrypt the payload sent to the webhook_uri */
   webhook_pem?: InputMaybe<Scalars["String"]["input"]>;
-  /** uri to send a payload to the webhook, encrypted by the webhook_pem */
+  /** URI to send a payload to the webhook, encrypted by the webhook_pem */
   webhook_uri?: InputMaybe<Scalars["String"]["input"]>;
 };
 
@@ -1122,6 +1148,8 @@ export enum Action_Update_Column {
   Description = "description",
   /** column name */
   ExternalNullifier = "external_nullifier",
+  /** column name */
+  Flow = "flow",
   /** column name */
   Id = "id",
   /** column name */

--- a/web/package.json
+++ b/web/package.json
@@ -134,5 +134,6 @@
     "test:unit": "jest tests/unit",
     "typecheck": "tsc"
   },
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
 }

--- a/web/pages/api/v1/precheck/[app_id].ts
+++ b/web/pages/api/v1/precheck/[app_id].ts
@@ -94,7 +94,7 @@ const appPrecheckQuery = gql`
         status
         privacy_policy_uri
         terms_uri
-        flow
+        app_flow_on_complete
         webhook_uri
         webhook_pem
         nullifiers(where: { nullifier_hash: { _eq: $nullifier_hash } }) {

--- a/web/pages/api/v1/precheck/[app_id].ts
+++ b/web/pages/api/v1/precheck/[app_id].ts
@@ -94,6 +94,8 @@ const appPrecheckQuery = gql`
         status
         privacy_policy_uri
         terms_uri
+        webhook_uri
+        webhook_pem
         nullifiers(where: { nullifier_hash: { _eq: $nullifier_hash } }) {
           uses
           nullifier_hash

--- a/web/pages/api/v1/precheck/[app_id].ts
+++ b/web/pages/api/v1/precheck/[app_id].ts
@@ -94,6 +94,7 @@ const appPrecheckQuery = gql`
         status
         privacy_policy_uri
         terms_uri
+        flow
         webhook_uri
         webhook_pem
         nullifiers(where: { nullifier_hash: { _eq: $nullifier_hash } }) {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/graphql/client/get-kiosk-action.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/graphql/client/get-kiosk-action.generated.ts
@@ -20,6 +20,8 @@ export type GetKioskActionQuery = {
     name: string;
     max_verifications: number;
     kiosk_enabled: boolean;
+    webhook_uri?: string | null;
+    webhook_pem?: string | null;
   }>;
   app_metadata: Array<{ __typename?: "app_metadata"; logo_img_url: string }>;
 };
@@ -34,6 +36,8 @@ export const GetKioskActionDocument = gql`
       name
       max_verifications
       kiosk_enabled
+      webhook_uri
+      webhook_pem
     }
     app_metadata(
       where: {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/graphql/client/get-kiosk-action.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/graphql/client/get-kiosk-action.generated.ts
@@ -20,7 +20,7 @@ export type GetKioskActionQuery = {
     name: string;
     max_verifications: number;
     kiosk_enabled: boolean;
-    flow?: unknown | null;
+    app_flow_on_complete?: unknown | null;
     webhook_uri?: string | null;
     webhook_pem?: string | null;
   }>;
@@ -37,7 +37,7 @@ export const GetKioskActionDocument = gql`
       name
       max_verifications
       kiosk_enabled
-      flow
+      app_flow_on_complete
       webhook_uri
       webhook_pem
     }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/graphql/client/get-kiosk-action.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/graphql/client/get-kiosk-action.generated.ts
@@ -20,6 +20,7 @@ export type GetKioskActionQuery = {
     name: string;
     max_verifications: number;
     kiosk_enabled: boolean;
+    flow?: unknown | null;
     webhook_uri?: string | null;
     webhook_pem?: string | null;
   }>;
@@ -36,6 +37,7 @@ export const GetKioskActionDocument = gql`
       name
       max_verifications
       kiosk_enabled
+      flow
       webhook_uri
       webhook_pem
     }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/graphql/client/get-kiosk-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/graphql/client/get-kiosk-action.graphql
@@ -7,6 +7,7 @@ query GetKioskAction($action_id: String!, $app_id: String!) {
     name
     max_verifications
     kiosk_enabled
+    flow
     webhook_uri
     webhook_pem
   }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/graphql/client/get-kiosk-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/graphql/client/get-kiosk-action.graphql
@@ -7,7 +7,7 @@ query GetKioskAction($action_id: String!, $app_id: String!) {
     name
     max_verifications
     kiosk_enabled
-    flow
+    app_flow_on_complete
     webhook_uri
     webhook_pem
   }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/graphql/client/get-kiosk-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/graphql/client/get-kiosk-action.graphql
@@ -7,6 +7,8 @@ query GetKioskAction($action_id: String!, $app_id: String!) {
     name
     max_verifications
     kiosk_enabled
+    webhook_uri
+    webhook_pem
   }
   app_metadata(
     where: {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/graphql/client/update-action.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/graphql/client/update-action.generated.ts
@@ -18,6 +18,7 @@ export type UpdateActionMutation = {
     description: string;
     max_verifications: number;
     status: string;
+    flow?: unknown | null;
     webhook_uri?: string | null;
     webhook_pem?: string | null;
   } | null;
@@ -31,6 +32,7 @@ export const UpdateActionDocument = gql`
       description
       max_verifications
       status
+      flow
       webhook_uri
       webhook_pem
     }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/graphql/client/update-action.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/graphql/client/update-action.generated.ts
@@ -18,7 +18,7 @@ export type UpdateActionMutation = {
     description: string;
     max_verifications: number;
     status: string;
-    flow?: unknown | null;
+    app_flow_on_complete?: unknown | null;
     webhook_uri?: string | null;
     webhook_pem?: string | null;
   } | null;
@@ -32,7 +32,7 @@ export const UpdateActionDocument = gql`
       description
       max_verifications
       status
-      flow
+      app_flow_on_complete
       webhook_uri
       webhook_pem
     }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/graphql/client/update-action.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/graphql/client/update-action.generated.ts
@@ -18,6 +18,8 @@ export type UpdateActionMutation = {
     description: string;
     max_verifications: number;
     status: string;
+    webhook_uri?: string | null;
+    webhook_pem?: string | null;
   } | null;
 };
 
@@ -29,6 +31,8 @@ export const UpdateActionDocument = gql`
       description
       max_verifications
       status
+      webhook_uri
+      webhook_pem
     }
   }
 `;

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/graphql/client/update-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/graphql/client/update-action.graphql
@@ -5,6 +5,7 @@ mutation UpdateAction($id: String!, $input: action_set_input) {
     description
     max_verifications
     status
+    flow
     webhook_uri
     webhook_pem
   }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/graphql/client/update-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/graphql/client/update-action.graphql
@@ -5,5 +5,7 @@ mutation UpdateAction($id: String!, $input: action_set_input) {
     description
     max_verifications
     status
+    webhook_uri
+    webhook_pem
   }
 }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/graphql/client/update-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/graphql/client/update-action.graphql
@@ -5,7 +5,7 @@ mutation UpdateAction($id: String!, $input: action_set_input) {
     description
     max_verifications
     status
-    flow
+    app_flow_on_complete
     webhook_uri
     webhook_pem
   }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
@@ -243,6 +243,6 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
 
 // e.g. "VERIFY" -> "Verify", "PARTNER" -> "Partner"
 const formatFlowType = (flow: string | null | undefined) => {
-  if (!flow) return '';
+  if (!flow) return "";
   return flow.charAt(0).toUpperCase() + flow.slice(1).toLowerCase();
 };

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
@@ -14,22 +14,40 @@ import { GetActionNameDocument } from "../../Components/ActionsHeader/graphql/cl
 import { GetSingleActionQuery } from "../page/graphql/client/get-single-action.generated";
 import { useUpdateActionMutation } from "./graphql/client/update-action.generated";
 
-const updateActionSchema = yup.object({
-  name: yup.string().required("This field is required"),
-  description: yup.string().required(),
-  action: yup.string().required("This field is required"),
-  maxVerifications: yup
-    .number()
-    .typeError("Max verifications must be a number")
-    .required("This field is required"),
-  webhook_uri: yup.string().optional().url("Must be a valid URL"),
-  webhook_pem: yup.string().when("webhook_uri", {
-    is: (value: string) => !!value,
-    then: (schema) =>
-      schema.required("PEM is required when a webhook URL is provided"),
-    otherwise: (schema) => schema.optional(),
-  }),
-});
+const rsaPublicKeyRegex =
+  /^-----BEGIN RSA PUBLIC KEY-----\s+([A-Za-z0-9+/=\s]+)-----END RSA PUBLIC KEY-----\s*$/;
+
+const updateActionSchema = yup
+  .object({
+    name: yup.string().required("This field is required"),
+    description: yup.string().required(),
+    action: yup.string().required("This field is required"),
+    maxVerifications: yup
+      .number()
+      .typeError("Max verifications must be a number")
+      .required("This field is required"),
+    webhook_uri: yup.string().optional().url("Must be a valid URL"),
+    webhook_pem: yup.string().optional().matches(rsaPublicKeyRegex, {
+      message:
+        "Must be a valid RSA public key in PEM format (BEGIN/END lines, base64 data).",
+      excludeEmptyString: true,
+    }),
+  })
+  .test(
+    "webhook-fields",
+    "Both webhook URL and PEM must be provided or removed",
+    function (values) {
+      const { webhook_uri, webhook_pem } = values;
+      if (!!webhook_uri !== !!webhook_pem) {
+        const errorPath = !webhook_uri ? "webhook_uri" : "webhook_pem";
+        return this.createError({
+          path: errorPath,
+          message: "Both webhook URL and PEM must be provided or removed",
+        });
+      }
+      return true;
+    },
+  );
 
 export type NewActionFormValues = yup.Asserts<typeof updateActionSchema>;
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
@@ -22,6 +22,13 @@ const updateActionSchema = yup.object({
     .number()
     .typeError("Max verifications must be a number")
     .required("This field is required"),
+  webhook_uri: yup.string().optional().url("Must be a valid URL"),
+  webhook_pem: yup.string().when("webhook_uri", {
+    is: (value: string) => !!value,
+    then: (schema) =>
+      schema.required("PEM is required when a webhook URL is provided"),
+    otherwise: (schema) => schema.optional(),
+  }),
 });
 
 export type NewActionFormValues = yup.Asserts<typeof updateActionSchema>;
@@ -47,6 +54,8 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
       description: action.description,
       action: action.action,
       maxVerifications: action.max_verifications,
+      webhook_uri: action.webhook_uri ?? undefined,
+      webhook_pem: action.webhook_pem ?? undefined,
     },
   });
 
@@ -62,6 +71,8 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
               name: values.name,
               description: values.description,
               max_verifications: values.maxVerifications,
+              webhook_uri: values.webhook_uri,
+              webhook_pem: values.webhook_pem,
             },
           },
           refetchQueries: [GetActionNameDocument],
@@ -157,6 +168,24 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
             }}
           />
         )}
+
+        <Input
+          register={register("webhook_uri")}
+          errors={errors.webhook_uri}
+          label="Webhook URL"
+          placeholder="https://your-webhook-endpoint.com"
+          helperText="Enter the full URL where webhook payloads will be sent. Must start with 'https://'."
+          className="h-16"
+        />
+
+        <Input
+          register={register("webhook_pem")}
+          errors={errors.webhook_pem}
+          label="Webhook PEM"
+          placeholder={`-----BEGIN RSA PUBLIC KEY-----\nMII... (your key here) ...AB\n-----END RSA PUBLIC KEY-----`}
+          helperText="Enter the full RSA public key in PEM format, including 'BEGIN' and 'END' lines."
+          className="h-16"
+        />
 
         <div className="flex w-full justify-start">
           <DecoratedButton

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
@@ -9,6 +9,7 @@ import { useCallback } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import * as yup from "yup";
+import { FlowTypeSelector } from "../../../page/CreateActionModal/FlowTypeSelector";
 import { MaxVerificationsSelector } from "../../../page/CreateActionModal/MaxVerificationsSelector";
 import { GetActionNameDocument } from "../../Components/ActionsHeader/graphql/client/get-action-name.generated";
 import { GetSingleActionQuery } from "../page/graphql/client/get-single-action.generated";
@@ -131,7 +132,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
           label="Action Name"
           placeholder="Anonymous Vote #12"
           required
-          className="h-16"
+          className="h-12"
         />
         <Input
           register={register("description")}
@@ -140,7 +141,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
           placeholder="Cast your vote on proposal #102"
           helperText="Tell your users what the action is for."
           required
-          className="h-16"
+          className="h-12"
         />
 
         <Input
@@ -156,7 +157,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
               fieldValue={watch("action")}
             />
           }
-          className="h-16 text-grey-400"
+          className="h-12 text-grey-400"
         />
 
         <Input
@@ -170,7 +171,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
               fieldValue={action.app_id}
             />
           }
-          className="h-16 text-grey-400"
+          className="h-12 text-grey-400"
         />
 
         {action.app.engine !== EngineType.OnChain && (
@@ -194,12 +195,13 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
           />
         )}
 
-        <Input
+        <FlowTypeSelector
+          value={action.flow as "VERIFY" | "PARTNER"}
+          onChange={() => { }}
           label="Flow"
-          disabled
-          value={formatFlowType(action.flow?.toString())}
-          className="h-16"
           helperText="The flow type for this action"
+          className="text-grey-400"
+          disabled
         />
 
         {action.flow === "PARTNER" && (
@@ -210,7 +212,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
               label="Webhook URL"
               placeholder="https://your-webhook-endpoint.com"
               helperText="Enter the full URL where webhook payloads will be sent. Must start with 'https://'."
-              className="h-16"
+              className="h-12"
             />
 
             <Input
@@ -219,7 +221,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
               label="Webhook PEM"
               placeholder={`-----BEGIN RSA PUBLIC KEY-----\nMII... (your key here) ...AB\n-----END RSA PUBLIC KEY-----`}
               helperText="Enter the full RSA public key in PEM format, including 'BEGIN' and 'END' lines."
-              className="h-16"
+              className="h-12"
             />
           </>
         )}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
@@ -82,14 +82,20 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
       action: action.action,
       max_verifications: action.max_verifications,
       app_flow_on_complete: action.app_flow_on_complete as "NONE" | "VERIFY",
-      webhook_uri: action.app_flow_on_complete === "VERIFY" ? action.webhook_uri ?? undefined : undefined,
-      webhook_pem: action.app_flow_on_complete === "VERIFY" ? action.webhook_pem ?? undefined : undefined,
+      webhook_uri:
+        action.app_flow_on_complete === "VERIFY"
+          ? action.webhook_uri ?? undefined
+          : undefined,
+      webhook_pem:
+        action.app_flow_on_complete === "VERIFY"
+          ? action.webhook_pem ?? undefined
+          : undefined,
     },
   });
 
   const [updateActionQuery, { loading }] = useUpdateActionMutation();
   const [showAdvancedConfig, setShowAdvancedConfig] = useState(
-    action.app_flow_on_complete === "VERIFY"
+    action.app_flow_on_complete === "VERIFY",
   );
 
   const appFlowOnComplete = watch("app_flow_on_complete");
@@ -129,7 +135,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
         toast.error(
           error instanceof Error
             ? error.message
-            : "Error occurred while updating action."
+            : "Error occurred while updating action.",
         );
       }
     },
@@ -226,7 +232,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
           </div>
 
           {showAdvancedConfig && (
-            <div className="space-y-6 pl-4 border-l-2 border-grey-100">
+            <div className="space-y-6 border-l-2 border-grey-100 pl-4">
               <Controller
                 name="app_flow_on_complete"
                 control={control}
@@ -243,7 +249,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
               />
 
               {watch("app_flow_on_complete") === "VERIFY" && (
-                <div className="space-y-6 pl-4 border-l-2 border-grey-100">
+                <div className="space-y-6 border-l-2 border-grey-100 pl-4">
                   <Input
                     register={register("webhook_uri")}
                     errors={errors.webhook_uri}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
@@ -132,7 +132,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
           label="Action Name"
           placeholder="Anonymous Vote #12"
           required
-          className="h-12"
+          className="h-16"
         />
         <Input
           register={register("description")}
@@ -141,7 +141,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
           placeholder="Cast your vote on proposal #102"
           helperText="Tell your users what the action is for."
           required
-          className="h-12"
+          className="h-16"
         />
 
         <Input
@@ -157,7 +157,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
               fieldValue={watch("action")}
             />
           }
-          className="h-12 text-grey-400"
+          className="h-16 text-grey-400"
         />
 
         <Input
@@ -171,7 +171,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
               fieldValue={action.app_id}
             />
           }
-          className="h-12 text-grey-400"
+          className="h-16 text-grey-400"
         />
 
         {action.app.engine !== EngineType.OnChain && (
@@ -197,7 +197,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
 
         <FlowTypeSelector
           value={action.flow as "VERIFY" | "PARTNER"}
-          onChange={() => { }}
+          onChange={() => {}}
           label="Flow"
           helperText="The flow type for this action"
           className="text-grey-400"
@@ -212,7 +212,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
               label="Webhook URL"
               placeholder="https://your-webhook-endpoint.com"
               helperText="Enter the full URL where webhook payloads will be sent. Must start with 'https://'."
-              className="h-12"
+              className="h-16"
             />
 
             <Input
@@ -221,7 +221,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
               label="Webhook PEM"
               placeholder={`-----BEGIN RSA PUBLIC KEY-----\nMII... (your key here) ...AB\n-----END RSA PUBLIC KEY-----`}
               helperText="Enter the full RSA public key in PEM format, including 'BEGIN' and 'END' lines."
-              className="h-12"
+              className="h-16"
             />
           </>
         )}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/graphql/client/get-single-action.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/graphql/client/get-single-action.generated.ts
@@ -18,7 +18,7 @@ export type GetSingleActionQuery = {
     description: string;
     name: string;
     max_verifications: number;
-    flow?: unknown | null;
+    app_flow_on_complete?: unknown | null;
     webhook_uri?: string | null;
     webhook_pem?: string | null;
     app: {
@@ -39,7 +39,7 @@ export const GetSingleActionDocument = gql`
       description
       name
       max_verifications
-      flow
+      app_flow_on_complete
       webhook_uri
       webhook_pem
       app {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/graphql/client/get-single-action.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/graphql/client/get-single-action.generated.ts
@@ -18,6 +18,7 @@ export type GetSingleActionQuery = {
     description: string;
     name: string;
     max_verifications: number;
+    flow?: unknown | null;
     webhook_uri?: string | null;
     webhook_pem?: string | null;
     app: {
@@ -38,6 +39,7 @@ export const GetSingleActionDocument = gql`
       description
       name
       max_verifications
+      flow
       webhook_uri
       webhook_pem
       app {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/graphql/client/get-single-action.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/graphql/client/get-single-action.generated.ts
@@ -18,6 +18,8 @@ export type GetSingleActionQuery = {
     description: string;
     name: string;
     max_verifications: number;
+    webhook_uri?: string | null;
+    webhook_pem?: string | null;
     app: {
       __typename?: "app";
       id: string;
@@ -36,6 +38,8 @@ export const GetSingleActionDocument = gql`
       description
       name
       max_verifications
+      webhook_uri
+      webhook_pem
       app {
         id
         is_staging

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/graphql/client/get-single-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/graphql/client/get-single-action.graphql
@@ -6,6 +6,8 @@ query GetSingleAction($action_id: String!) {
     description
     name
     max_verifications
+    webhook_uri
+    webhook_pem
     app {
       id
       is_staging

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/graphql/client/get-single-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/graphql/client/get-single-action.graphql
@@ -6,7 +6,7 @@ query GetSingleAction($action_id: String!) {
     description
     name
     max_verifications
-    flow
+    app_flow_on_complete
     webhook_uri
     webhook_pem
     app {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/graphql/client/get-single-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/graphql/client/get-single-action.graphql
@@ -6,6 +6,7 @@ query GetSingleAction($action_id: String!) {
     description
     name
     max_verifications
+    flow
     webhook_uri
     webhook_pem
     app {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/AppFlowOnCompleteTypeSelector/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/AppFlowOnCompleteTypeSelector/index.tsx
@@ -1,0 +1,131 @@
+"use client";
+import { CaretIcon } from "@/components/Icons/CaretIcon";
+import {
+  Select,
+  SelectButton,
+  SelectOption,
+  SelectOptions,
+} from "@/components/Select";
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import clsx from "clsx";
+import { FieldError } from "react-hook-form";
+import { twMerge } from "tailwind-merge";
+
+export const AppFlowOnCompleteTypeSelector = (props: {
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+  errors?: FieldError;
+  label: string;
+  helperText?: string;
+  required?: boolean;
+  disabled?: boolean;
+}) => {
+  const {
+    value,
+    onChange,
+    errors,
+    label,
+    helperText,
+    className,
+    required,
+    disabled,
+  } = props;
+
+  const parentClassNames = clsx(
+    "rounded-lg border-[1px] bg-grey-0 text-sm text-grey-700",
+    {
+      "border-grey-200 focus-within:border-blue-500 focus-within:hover:border-blue-500 hover:border-grey-700":
+        !errors && !disabled,
+      "border-system-error-500 text-system-error-500": errors,
+      "border-grey-200 text-grey-400 hover:text-grey-400": disabled,
+    },
+  );
+
+  const selectorClassNames = clsx(
+    "peer h-full bg-transparent py-1.5 focus:outline-none focus:ring-0",
+    {
+      "placeholder:text-grey-400": !errors,
+      "group-hover:placeholder:text-grey-700 group-hover:focus:placeholder:text-blue-400":
+        true,
+    },
+  );
+
+  const labelClassNames = clsx(
+    "ml-4 whitespace-nowrap px-[2px] peer-focus:text-blue-500",
+    {
+      "text-grey-400 peer-focus:text-blue-500 group-hover:text-grey-700":
+        !errors,
+      "text-system-error-500 peer-focus:text-system-error-500": errors,
+    },
+  );
+
+  const appFlowOnCompleteOptions = [
+    { value: "NONE", label: "None" },
+    { value: "VERIFY", label: "Verify" },
+  ];
+
+  return (
+    <Select value={value} onChange={onChange} disabled={disabled}>
+      <div className={"inline-grid font-gta"}>
+        <fieldset
+          className={twMerge(clsx("group grid w-full pb-2", parentClassNames))}
+        >
+          <SelectButton
+            className={clsx(
+              "text-left",
+              selectorClassNames,
+              "grid grid-cols-1fr/auto",
+              className,
+              { "cursor-not-allowed": disabled },
+            )}
+            data-testid="select-flow-type"
+          >
+            <Typography variant={TYPOGRAPHY.R4}>
+              {appFlowOnCompleteOptions.find((option) => option.value === value)?.label ??
+                value}
+            </Typography>
+            {!disabled && (
+              <CaretIcon className="ml-2 text-grey-400 group-hover:text-grey-700" />
+            )}
+          </SelectButton>
+
+          <SelectOptions
+            className={clsx(
+              "mt-3 max-h-36 text-sm focus:outline-none focus:ring-0",
+            )}
+          >
+            {appFlowOnCompleteOptions.map((option) => (
+              <SelectOption key={option.value} value={option.value}>
+                <div className="grid grid-cols-1fr/auto">
+                  <Typography variant={TYPOGRAPHY.R4}>
+                    {option.label}
+                  </Typography>
+                </div>
+              </SelectOption>
+            ))}
+          </SelectOptions>
+          <legend className={labelClassNames}>
+            <Typography variant={TYPOGRAPHY.R4}>{label}</Typography>{" "}
+            {required && <span className="text-system-error-500">*</span>}
+          </legend>
+        </fieldset>
+        <div className={clsx("flex w-full flex-col px-2")}>
+          {helperText && (
+            <Typography variant={TYPOGRAPHY.R5} className="mt-2 text-grey-500">
+              {helperText}
+            </Typography>
+          )}
+          {errors?.message && (
+            <Typography
+              className="mt-2 text-system-error-500"
+              variant={TYPOGRAPHY.R5}
+            >
+              {errors.message}
+            </Typography>
+          )}
+        </div>
+      </div>
+    </Select>
+  );
+};

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/AppFlowOnCompleteTypeSelector/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/AppFlowOnCompleteTypeSelector/index.tsx
@@ -82,8 +82,8 @@ export const AppFlowOnCompleteTypeSelector = (props: {
             data-testid="select-flow-type"
           >
             <Typography variant={TYPOGRAPHY.R4}>
-              {appFlowOnCompleteOptions.find((option) => option.value === value)?.label ??
-                value}
+              {appFlowOnCompleteOptions.find((option) => option.value === value)
+                ?.label ?? value}
             </Typography>
             {!disabled && (
               <CaretIcon className="ml-2 text-grey-400 group-hover:text-grey-700" />

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/FlowTypeSelector/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/FlowTypeSelector/index.tsx
@@ -1,0 +1,131 @@
+"use client";
+import { CaretIcon } from "@/components/Icons/CaretIcon";
+import {
+  Select,
+  SelectButton,
+  SelectOption,
+  SelectOptions,
+} from "@/components/Select";
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import clsx from "clsx";
+import { FieldError } from "react-hook-form";
+import { twMerge } from "tailwind-merge";
+
+export const FlowTypeSelector = (props: {
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+  errors?: FieldError;
+  label: string;
+  helperText?: string;
+  required?: boolean;
+  disabled?: boolean;
+}) => {
+  const {
+    value,
+    onChange,
+    errors,
+    label,
+    helperText,
+    className,
+    required,
+    disabled,
+  } = props;
+
+  const parentClassNames = clsx(
+    "rounded-lg border-[1px] bg-grey-0 text-sm text-grey-700",
+    {
+      "border-grey-200 focus-within:border-blue-500 focus-within:hover:border-blue-500 hover:border-grey-700":
+        !errors && !disabled,
+      "border-system-error-500 text-system-error-500": errors,
+      "border-grey-200 text-grey-400 hover:text-grey-400": disabled,
+    },
+  );
+
+  const selectorClassNames = clsx(
+    "peer h-full bg-transparent py-1.5 focus:outline-none focus:ring-0",
+    {
+      "placeholder:text-grey-400": !errors,
+      "group-hover:placeholder:text-grey-700 group-hover:focus:placeholder:text-blue-400":
+        true,
+    },
+  );
+
+  const labelClassNames = clsx(
+    "ml-4 whitespace-nowrap px-[2px] peer-focus:text-blue-500",
+    {
+      "text-grey-400 peer-focus:text-blue-500 group-hover:text-grey-700":
+        !errors,
+      "text-system-error-500 peer-focus:text-system-error-500": errors,
+    },
+  );
+
+  const flowOptions = [
+    { value: "VERIFY", label: "Verify" },
+    { value: "PARTNER", label: "Partner" },
+  ];
+
+  return (
+    <Select value={value} onChange={onChange} disabled={disabled}>
+      <div className={"inline-grid font-gta"}>
+        <fieldset
+          className={twMerge(clsx("group grid w-full pb-2", parentClassNames))}
+        >
+          <SelectButton
+            className={clsx(
+              "text-left",
+              selectorClassNames,
+              "grid grid-cols-1fr/auto",
+              className,
+              { "cursor-not-allowed": disabled },
+            )}
+            data-testid="select-flow-type"
+          >
+            <Typography variant={TYPOGRAPHY.R4}>
+              {flowOptions.find((option) => option.value === value)?.label ??
+                value}
+            </Typography>
+            {!disabled && (
+              <CaretIcon className="ml-2 text-grey-400 group-hover:text-grey-700" />
+            )}
+          </SelectButton>
+
+          <SelectOptions
+            className={clsx(
+              "mt-3 max-h-36 text-sm focus:outline-none focus:ring-0",
+            )}
+          >
+            {flowOptions.map((option) => (
+              <SelectOption key={option.value} value={option.value}>
+                <div className="grid grid-cols-1fr/auto">
+                  <Typography variant={TYPOGRAPHY.R4}>
+                    {option.label}
+                  </Typography>
+                </div>
+              </SelectOption>
+            ))}
+          </SelectOptions>
+          <legend className={labelClassNames}>
+            <Typography variant={TYPOGRAPHY.R4}>{label}</Typography>{" "}
+            {required && <span className="text-system-error-500">*</span>}
+          </legend>
+        </fieldset>
+        <div className={clsx("flex w-full flex-col px-2")}>
+          {helperText && (
+            <Typography variant={TYPOGRAPHY.R5} className="mt-2 text-grey-500">
+              {helperText}
+            </Typography>
+          )}
+          {errors?.message && (
+            <Typography
+              className="mt-2 text-system-error-500"
+              variant={TYPOGRAPHY.R5}
+            >
+              {errors.message}
+            </Typography>
+          )}
+        </div>
+      </div>
+    </Select>
+  );
+};

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.generated.ts
@@ -11,6 +11,7 @@ export type InsertActionMutationVariables = Types.Exact<{
   app_id: Types.Scalars["String"]["input"];
   external_nullifier: Types.Scalars["String"]["input"];
   max_verifications?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
+  flow: Types.Scalars["action_flow_enum"]["input"];
   webhook_uri?: Types.InputMaybe<Types.Scalars["String"]["input"]>;
   webhook_pem?: Types.InputMaybe<Types.Scalars["String"]["input"]>;
 }>;
@@ -28,6 +29,7 @@ export const InsertActionDocument = gql`
     $app_id: String!
     $external_nullifier: String!
     $max_verifications: Int = 1
+    $flow: action_flow_enum!
     $webhook_uri: String
     $webhook_pem: String
   ) {
@@ -39,6 +41,7 @@ export const InsertActionDocument = gql`
         description: $description
         external_nullifier: $external_nullifier
         max_verifications: $max_verifications
+        flow: $flow
         webhook_uri: $webhook_uri
         webhook_pem: $webhook_pem
       }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.generated.ts
@@ -11,7 +11,7 @@ export type InsertActionMutationVariables = Types.Exact<{
   app_id: Types.Scalars["String"]["input"];
   external_nullifier: Types.Scalars["String"]["input"];
   max_verifications?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
-  flow: Types.Scalars["action_flow_enum"]["input"];
+  app_flow_on_complete: Types.Scalars["app_flow_on_complete_enum"]["input"];
   webhook_uri?: Types.InputMaybe<Types.Scalars["String"]["input"]>;
   webhook_pem?: Types.InputMaybe<Types.Scalars["String"]["input"]>;
 }>;
@@ -29,7 +29,7 @@ export const InsertActionDocument = gql`
     $app_id: String!
     $external_nullifier: String!
     $max_verifications: Int = 1
-    $flow: action_flow_enum!
+    $app_flow_on_complete: app_flow_on_complete_enum!
     $webhook_uri: String
     $webhook_pem: String
   ) {
@@ -41,7 +41,7 @@ export const InsertActionDocument = gql`
         description: $description
         external_nullifier: $external_nullifier
         max_verifications: $max_verifications
-        flow: $flow
+        app_flow_on_complete: $app_flow_on_complete
         webhook_uri: $webhook_uri
         webhook_pem: $webhook_pem
       }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.generated.ts
@@ -11,6 +11,8 @@ export type InsertActionMutationVariables = Types.Exact<{
   app_id: Types.Scalars["String"]["input"];
   external_nullifier: Types.Scalars["String"]["input"];
   max_verifications?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
+  webhook_uri?: Types.InputMaybe<Types.Scalars["String"]["input"]>;
+  webhook_pem?: Types.InputMaybe<Types.Scalars["String"]["input"]>;
 }>;
 
 export type InsertActionMutation = {
@@ -26,6 +28,8 @@ export const InsertActionDocument = gql`
     $app_id: String!
     $external_nullifier: String!
     $max_verifications: Int = 1
+    $webhook_uri: String
+    $webhook_pem: String
   ) {
     insert_action_one(
       object: {
@@ -35,6 +39,8 @@ export const InsertActionDocument = gql`
         description: $description
         external_nullifier: $external_nullifier
         max_verifications: $max_verifications
+        webhook_uri: $webhook_uri
+        webhook_pem: $webhook_pem
       }
     ) {
       id

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.graphql
@@ -1,27 +1,27 @@
 mutation InsertAction(
-    $name: String!
-    $description: String = ""
-    $action: String = ""
-    $app_id: String!
-    $external_nullifier: String!
-    $max_verifications: Int = 1
-    $app_flow_on_complete: app_flow_on_complete_enum!
-    $webhook_uri: String
-    $webhook_pem: String
+  $name: String!
+  $description: String = ""
+  $action: String = ""
+  $app_id: String!
+  $external_nullifier: String!
+  $max_verifications: Int = 1
+  $app_flow_on_complete: app_flow_on_complete_enum!
+  $webhook_uri: String
+  $webhook_pem: String
 ) {
-    insert_action_one(
-        object: {
-            action: $action
-            app_id: $app_id
-            name: $name
-            description: $description
-            external_nullifier: $external_nullifier
-            max_verifications: $max_verifications
-            app_flow_on_complete: $app_flow_on_complete
-            webhook_uri: $webhook_uri
-            webhook_pem: $webhook_pem
-        }
-    ) {
-        id
+  insert_action_one(
+    object: {
+      action: $action
+      app_id: $app_id
+      name: $name
+      description: $description
+      external_nullifier: $external_nullifier
+      max_verifications: $max_verifications
+      app_flow_on_complete: $app_flow_on_complete
+      webhook_uri: $webhook_uri
+      webhook_pem: $webhook_pem
     }
+  ) {
+    id
+  }
 }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.graphql
@@ -5,6 +5,7 @@ mutation InsertAction(
   $app_id: String!
   $external_nullifier: String!
   $max_verifications: Int = 1
+#  $flow: Enu
   $webhook_uri: String
   $webhook_pem: String
 ) {
@@ -16,6 +17,7 @@ mutation InsertAction(
       description: $description
       external_nullifier: $external_nullifier
       max_verifications: $max_verifications
+#      flow: $flow
       webhook_uri: $webhook_uri
       webhook_pem: $webhook_pem
     }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.graphql
@@ -5,8 +5,8 @@ mutation InsertAction(
   $app_id: String!
   $external_nullifier: String!
   $max_verifications: Int = 1
-#  $webhook_uri: String!
-#  $webhook_pem: String!
+  $webhook_uri: String
+  $webhook_pem: String
 ) {
   insert_action_one(
     object: {
@@ -16,8 +16,8 @@ mutation InsertAction(
       description: $description
       external_nullifier: $external_nullifier
       max_verifications: $max_verifications
-#      webhook_uri: $webhook_uri
-#      webhook_pem: $webhook_pem
+      webhook_uri: $webhook_uri
+      webhook_pem: $webhook_pem
     }
   ) {
     id

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.graphql
@@ -1,27 +1,27 @@
 mutation InsertAction(
-  $name: String!
-  $description: String = ""
-  $action: String = ""
-  $app_id: String!
-  $external_nullifier: String!
-  $max_verifications: Int = 1
-  $flow: action_flow_enum!
-  $webhook_uri: String
-  $webhook_pem: String
+    $name: String!
+    $description: String = ""
+    $action: String = ""
+    $app_id: String!
+    $external_nullifier: String!
+    $max_verifications: Int = 1
+    $app_flow_on_complete: app_flow_on_complete_enum!
+    $webhook_uri: String
+    $webhook_pem: String
 ) {
-  insert_action_one(
-    object: {
-      action: $action
-      app_id: $app_id
-      name: $name
-      description: $description
-      external_nullifier: $external_nullifier
-      max_verifications: $max_verifications
-      flow: $flow
-      webhook_uri: $webhook_uri
-      webhook_pem: $webhook_pem
+    insert_action_one(
+        object: {
+            action: $action
+            app_id: $app_id
+            name: $name
+            description: $description
+            external_nullifier: $external_nullifier
+            max_verifications: $max_verifications
+            app_flow_on_complete: $app_flow_on_complete
+            webhook_uri: $webhook_uri
+            webhook_pem: $webhook_pem
+        }
+    ) {
+        id
     }
-  ) {
-    id
-  }
 }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.graphql
@@ -5,7 +5,7 @@ mutation InsertAction(
   $app_id: String!
   $external_nullifier: String!
   $max_verifications: Int = 1
-#  $flow: Enu
+  $flow: action_flow_enum!
   $webhook_uri: String
   $webhook_pem: String
 ) {
@@ -17,7 +17,7 @@ mutation InsertAction(
       description: $description
       external_nullifier: $external_nullifier
       max_verifications: $max_verifications
-#      flow: $flow
+      flow: $flow
       webhook_uri: $webhook_uri
       webhook_pem: $webhook_pem
     }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/graphql/server/insert-action.graphql
@@ -5,6 +5,8 @@ mutation InsertAction(
   $app_id: String!
   $external_nullifier: String!
   $max_verifications: Int = 1
+#  $webhook_uri: String!
+#  $webhook_pem: String!
 ) {
   insert_action_one(
     object: {
@@ -14,6 +16,8 @@ mutation InsertAction(
       description: $description
       external_nullifier: $external_nullifier
       max_verifications: $max_verifications
+#      webhook_uri: $webhook_uri
+#      webhook_pem: $webhook_pem
     }
   ) {
     id

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
@@ -25,6 +25,7 @@ import { toast } from "react-toastify";
 import slugify from "slugify";
 import * as yup from "yup";
 import { GetActionsDocument } from "../graphql/client/actions.generated";
+import { FlowTypeSelector } from "./FlowTypeSelector";
 import { MaxVerificationsSelector } from "./MaxVerificationsSelector";
 import { createActionServerSide } from "./server";
 
@@ -284,24 +285,16 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
             <Controller
               name="flow"
               control={control}
-              render={({ field }) => {
-                return (
-                  <Input
-                    label="Flow"
-                    value={field.value}
-                    onChange={field.onChange}
-                    errors={errors.flow}
-                    required
-                    type="select"
-                    selectOptions={[
-                      { value: "VERIFY", label: "Verify" },
-                      { value: "PARTNER", label: "Partner" },
-                    ]}
-                    data-testid="input-flow"
-                    helperText="The flow type for this action"
-                  />
-                );
-              }}
+              render={({ field }) => (
+                <FlowTypeSelector
+                  value={field.value}
+                  onChange={field.onChange}
+                  errors={errors.flow}
+                  label="Flow"
+                  helperText="The flow type for this action"
+                  required
+                />
+              )}
             />
 
             {watch("flow") === "PARTNER" && (
@@ -312,7 +305,7 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
                   label="Webhook URL"
                   placeholder="https://your-webhook-endpoint.com"
                   helperText="Enter the full URL where webhook payloads will be sent. Must start with 'https://'."
-                  className="h-16"
+                  className="h-12"
                 />
 
                 <Input
@@ -321,7 +314,7 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
                   label="Webhook PEM"
                   placeholder={`-----BEGIN RSA PUBLIC KEY-----\nMII... (your key here) ...AB\n-----END RSA PUBLIC KEY-----`}
                   helperText="Enter the full RSA public key in PEM format, including 'BEGIN' and 'END' lines."
-                  className="h-16"
+                  className="h-12"
                 />
               </>
             )}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
@@ -48,6 +48,13 @@ const createActionSchema = yup.object({
     .number()
     .typeError("Max verifications must be a number")
     .required("This field is required"),
+  webhook_uri: yup.string().optional().url("Must be a valid URL"),
+  webhook_pem: yup.string().when("webhook_uri", {
+    is: (value: string) => !!value,
+    then: (schema) =>
+      schema.required("PEM is required when a webhook URL is provided"),
+    otherwise: (schema) => schema.optional(),
+  }),
 });
 
 export type NewActionFormValues = yup.Asserts<typeof createActionSchema>;
@@ -248,6 +255,24 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
                 }}
               />
             )}
+
+            <Input
+              register={register("webhook_pem")}
+              errors={errors.webhook_uri}
+              label="Webhook URL"
+              placeholder="https://your-webhook-endpoint.com"
+              helperText="Enter the full URL where webhook payloads will be sent. Must start with 'https://'."
+              className="h-16"
+            />
+
+            <Input
+              register={register("webhook_uri")}
+              errors={errors.webhook_uri}
+              label="Webhook PEM"
+              placeholder={`-----BEGIN RSA PUBLIC KEY-----\nMII... (your key here) ...AB\n-----END RSA PUBLIC KEY-----`}
+              helperText="Enter the full RSA public key in PEM format, including 'BEGIN' and 'END' lines."
+              className="h-16"
+            />
 
             <div className="flex w-full justify-end">
               <DecoratedButton

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
@@ -305,7 +305,7 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
                   label="Webhook URL"
                   placeholder="https://your-webhook-endpoint.com"
                   helperText="Enter the full URL where webhook payloads will be sent. Must start with 'https://'."
-                  className="h-12"
+                  className="h-16"
                 />
 
                 <Input
@@ -314,7 +314,7 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
                   label="Webhook PEM"
                   placeholder={`-----BEGIN RSA PUBLIC KEY-----\nMII... (your key here) ...AB\n-----END RSA PUBLIC KEY-----`}
                   helperText="Enter the full RSA public key in PEM format, including 'BEGIN' and 'END' lines."
-                  className="h-12"
+                  className="h-16"
                 />
               </>
             )}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
@@ -113,7 +113,7 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
     mode: "onChange",
     defaultValues: {
       max_verifications: 1,
-      app_flow_on_complete: "VERIFY",
+      app_flow_on_complete: "NONE",
     },
   });
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
@@ -297,7 +297,7 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
               </div>
 
               {showAdvancedConfig && (
-                <div className="space-y-6 pl-4 border-l-2 border-grey-100">
+                <div className="space-y-6 border-l-2 border-grey-100 pl-4">
                   <Controller
                     name="app_flow_on_complete"
                     control={control}
@@ -314,7 +314,7 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
                   />
 
                   {watch("app_flow_on_complete") === "VERIFY" && (
-                    <div className="space-y-6 pl-4 border-l-2 border-grey-100">
+                    <div className="space-y-6 border-l-2 border-grey-100 pl-4">
                       <Input
                         register={register("webhook_uri")}
                         errors={errors.webhook_uri}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
@@ -48,7 +48,7 @@ const createActionSchema = yup
       )
       .required(),
     action: yup.string().required("This field is required"),
-    flow: yup.string().oneOf(['partner', 'verify']).required("This field is required"),
+    flow: yup.string().oneOf(['VERIFY', 'PARTNER']).required("This field is required"),
     max_verifications: yup
       .number()
       .typeError("Max verifications must be a number")
@@ -65,7 +65,7 @@ const createActionSchema = yup
     "Both webhook URL and PEM must be provided or removed",
     function (values) {
       const { webhook_uri, webhook_pem, flow } = values;
-      if (flow !== 'partner') return true;
+      if (flow !== 'PARTNER') return true;
 
       if (!!webhook_uri !== !!webhook_pem) {
         const errorPath = !webhook_uri ? "webhook_uri" : "webhook_pem";
@@ -108,7 +108,7 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
     mode: "onChange",
     defaultValues: {
       max_verifications: 1,
-      flow: 'verify',
+      flow: 'VERIFY',
     },
   });
 
@@ -278,19 +278,30 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
               />
             )}
 
-            <div className="flex flex-col gap-2">
-              <label className="text-sm font-medium">Flow Type</label>
-              <select
-                {...register("flow")}
-                className="rounded-md border border-grey-100 px-3 py-2"
-                data-testid="input-flow"
-              >
-                <option value="verify">Verify</option>
-                <option value="partner">Partner</option>
-              </select>
-            </div>
+            <Controller
+              name="flow"
+              control={control}
+              render={({ field }) => {
+                return (
+                  <Input
+                    label="Flow"
+                    value={field.value}
+                    onChange={field.onChange}
+                    errors={errors.flow}
+                    required
+                    type="select"
+                    selectOptions={[
+                      { value: 'VERIFY', label: 'Verify' },
+                      { value: 'PARTNER', label: 'Partner' }
+                    ]}
+                    data-testid="input-flow"
+                    helperText="The flow type for this action"
+                  />
+                );
+              }}
+            />
 
-            {watch("flow") === "partner" && (
+            {watch("flow") === "PARTNER" && (
               <>
                 <Input
                   register={register("webhook_uri")}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
@@ -48,7 +48,10 @@ const createActionSchema = yup
       )
       .required(),
     action: yup.string().required("This field is required"),
-    flow: yup.string().oneOf(['VERIFY', 'PARTNER']).required("This field is required"),
+    flow: yup
+      .string()
+      .oneOf(["VERIFY", "PARTNER"])
+      .required("This field is required"),
     max_verifications: yup
       .number()
       .typeError("Max verifications must be a number")
@@ -65,7 +68,7 @@ const createActionSchema = yup
     "Both webhook URL and PEM must be provided or removed",
     function (values) {
       const { webhook_uri, webhook_pem, flow } = values;
-      if (flow !== 'PARTNER') return true;
+      if (flow !== "PARTNER") return true;
 
       if (!!webhook_uri !== !!webhook_pem) {
         const errorPath = !webhook_uri ? "webhook_uri" : "webhook_pem";
@@ -108,7 +111,7 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
     mode: "onChange",
     defaultValues: {
       max_verifications: 1,
-      flow: 'VERIFY',
+      flow: "VERIFY",
     },
   });
 
@@ -291,8 +294,8 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
                     required
                     type="select"
                     selectOptions={[
-                      { value: 'VERIFY', label: 'Verify' },
-                      { value: 'PARTNER', label: 'Partner' }
+                      { value: "VERIFY", label: "Verify" },
+                      { value: "PARTNER", label: "Partner" },
                     ]}
                     data-testid="input-flow"
                     helperText="The flow type for this action"

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
@@ -22,9 +22,9 @@ export const createActionSchema = yup.object().shape({
   action: yup.string().required("Action is required"),
   app_id: yup.string().required("App ID is required"),
   max_verifications: yup.number().required("Max verifications is required"),
-  flow: yup
+  app_flow_on_complete: yup
     .string()
-    .oneOf(["VERIFY", "PARTNER"])
+    .oneOf(["NONE", "VERIFY"])
     .required("This field is required"),
   webhook_uri: yup.string().optional().url("Must be a valid URL"),
   webhook_pem: yup.string().when("webhook_uri", {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
@@ -22,6 +22,13 @@ export const createActionSchema = yup.object().shape({
   action: yup.string().required("Action is required"),
   app_id: yup.string().required("App ID is required"),
   max_verifications: yup.number().required("Max verifications is required"),
+  webhook_uri: yup.string().optional().url("Must be a valid URL"),
+  webhook_pem: yup.string().when("webhook_uri", {
+    is: (value: string) => !!value,
+    then: (schema) =>
+      schema.required("PEM is required when a webhook URL is provided"),
+    otherwise: (schema) => schema.optional(),
+  }),
 });
 
 export type CreateActionSchema = yup.Asserts<typeof createActionSchema>;

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
@@ -22,6 +22,10 @@ export const createActionSchema = yup.object().shape({
   action: yup.string().required("Action is required"),
   app_id: yup.string().required("App ID is required"),
   max_verifications: yup.number().required("Max verifications is required"),
+  flow: yup
+    .string()
+    .oneOf(["VERIFY", "PARTNER"])
+    .required("This field is required"),
   webhook_uri: yup.string().optional().url("Must be a valid URL"),
   webhook_pem: yup.string().when("webhook_uri", {
     is: (value: string) => !!value,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/graphql/client/actions.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/graphql/client/actions.generated.ts
@@ -26,6 +26,8 @@ export type GetActionsQuery = {
     name: string;
     max_accounts_per_user: number;
     max_verifications: number;
+    webhook_uri?: string | null;
+    webhook_pem?: string | null;
     updated_at: string;
     nullifiers: {
       __typename?: "nullifier_aggregate";
@@ -57,6 +59,8 @@ export const GetActionsDocument = gql`
       name
       max_accounts_per_user
       max_verifications
+      webhook_uri
+      webhook_pem
       updated_at
       nullifiers: nullifiers_aggregate {
         aggregate {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/graphql/client/actions.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/graphql/client/actions.generated.ts
@@ -26,6 +26,7 @@ export type GetActionsQuery = {
     name: string;
     max_accounts_per_user: number;
     max_verifications: number;
+    flow?: unknown | null;
     webhook_uri?: string | null;
     webhook_pem?: string | null;
     updated_at: string;
@@ -59,6 +60,7 @@ export const GetActionsDocument = gql`
       name
       max_accounts_per_user
       max_verifications
+      flow
       webhook_uri
       webhook_pem
       updated_at

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/graphql/client/actions.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/graphql/client/actions.generated.ts
@@ -26,7 +26,7 @@ export type GetActionsQuery = {
     name: string;
     max_accounts_per_user: number;
     max_verifications: number;
-    flow?: unknown | null;
+    app_flow_on_complete?: unknown | null;
     webhook_uri?: string | null;
     webhook_pem?: string | null;
     updated_at: string;
@@ -60,7 +60,7 @@ export const GetActionsDocument = gql`
       name
       max_accounts_per_user
       max_verifications
-      flow
+      app_flow_on_complete
       webhook_uri
       webhook_pem
       updated_at

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/graphql/client/actions.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/graphql/client/actions.graphql
@@ -14,7 +14,7 @@ query GetActions($app_id: String!, $condition: [action_bool_exp!]) {
     name
     max_accounts_per_user
     max_verifications
-    flow
+    app_flow_on_complete
     webhook_uri
     webhook_pem
     updated_at

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/graphql/client/actions.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/graphql/client/actions.graphql
@@ -14,6 +14,8 @@ query GetActions($app_id: String!, $condition: [action_bool_exp!]) {
     name
     max_accounts_per_user
     max_verifications
+    webhook_uri
+    webhook_pem
     updated_at
     nullifiers: nullifiers_aggregate {
       aggregate {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/graphql/client/actions.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/graphql/client/actions.graphql
@@ -14,6 +14,7 @@ query GetActions($app_id: String!, $condition: [action_bool_exp!]) {
     name
     max_accounts_per_user
     max_verifications
+    flow
     webhook_uri
     webhook_pem
     updated_at


### PR DESCRIPTION
## PR Type

- [x] Regular Task

## Description

* Add support for configuring a webhook, associated with an action.
* `webhook_uri` and `webhook_pem` added to the existing action table.
* Updated the preflight gql query to include both fields.
* The webhook must have a corresponding RSA public key PEM.
* The `webhook_uri` and `webhook_pem` are biconditional dependencies, meaning they either both exist or both don't exist. As such, I've added validations to the create and update actions to ensure that this remains true, with appropriate error messages.
* I've manually tested this in a local dev environment (some screenshots attached).

![Screenshot 2025-02-13 at 4 15 54 PM](https://github.com/user-attachments/assets/d8e7d871-a136-4516-8436-b12525f40c4a)
![Screenshot 2025-02-13 at 4 44 35 PM](https://github.com/user-attachments/assets/0ab8a790-98e5-41ce-8fe5-217dd77a1a2d)
![Screenshot 2025-02-13 at 5 03 44 PM](https://github.com/user-attachments/assets/600aaf7e-0677-4e9e-b680-5284d9bd3368)
![Screenshot 2025-02-13 at 5 06 27 PM](https://github.com/user-attachments/assets/4ac7acb0-bac7-4332-8c04-06714c036c07)
![Screenshot 2025-02-13 at 5 06 35 PM](https://github.com/user-attachments/assets/c661c020-c0ca-4d13-a492-6844f34885a7)