### PR TITLE
Update webhook validation for E2E test config

### DIFF
--- a/web/lib/constants.ts
+++ b/web/lib/constants.ts
@@ -140,7 +140,8 @@ export const PARTNER_TEAM_IDS = {
   staging: [
     "team_1767d2864edd0a422e0974f4a8a406e3",
     "team_3bb5ee7a81ba12e6624b21d03b4a1b2f",
-  ], // IO-Staging-Team, Test Partner
+    "team_ac9fb445581cc231c3fe25187d2ed172",
+  ], // IO-Staging-Team, Test Partner, E2E Test Team
   production: [
     "team_4e67539b4bb0f6dfabeba48793cf747d",
     "team_9b50d04b36a7aa4d2562604f67277376",

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -46,7 +46,12 @@ export const sequencerMapping: Record<
  * @param candidate
  * @returns
  */
-export const validateUrl = (candidate: string, isStaging: boolean): boolean => {
+export const validateUrl = (candidate: string, isNotProduction: boolean): boolean => {
+  // Allow any URL for local and staging development.
+  if (isNotProduction) {
+    return true;
+  }
+
   let parsedUrl;
   try {
     parsedUrl = new URL(candidate);
@@ -60,9 +65,6 @@ export const validateUrl = (candidate: string, isStaging: boolean): boolean => {
   if (!isLocalhost) {
     return isHttps;
   }
-
-  // If the URL is localhost, we only allow it if we're in a staging environment
-  if (!isStaging) return false;
 
   const localhostRegex =
     /^https?:\/\/localhost(:[0-9]+)?(\/[^\s?]*)(\\?[^\s]*)?$/;

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -70,24 +70,6 @@ export const validateUrl = (candidate: string, isStaging: boolean): boolean => {
   return localhostRegex.test(candidate);
 };
 
-export const validateWebhookUrl = (
-  candidate: string,
-  isNotProduction: boolean,
-): boolean => {
-  if (isNotProduction) {
-    return true;
-  }
-
-  let parsedUrl;
-  try {
-    parsedUrl = new URL(candidate);
-  } catch (_) {
-    return false;
-  }
-
-  return parsedUrl.protocol === "https:";
-};
-
 /**
  * Validates the string looks like a valid email address
  * @param candidate

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -46,12 +46,7 @@ export const sequencerMapping: Record<
  * @param candidate
  * @returns
  */
-export const validateUrl = (candidate: string, isNotProduction: boolean): boolean => {
-  // Allow any URL for local and staging development.
-  if (isNotProduction) {
-    return true;
-  }
-
+export const validateUrl = (candidate: string, isStaging: boolean): boolean => {
   let parsedUrl;
   try {
     parsedUrl = new URL(candidate);
@@ -66,10 +61,31 @@ export const validateUrl = (candidate: string, isNotProduction: boolean): boolea
     return isHttps;
   }
 
+  // If the URL is localhost, we only allow it if we're in a staging environment
+  if (!isStaging) return false;
+
   const localhostRegex =
     /^https?:\/\/localhost(:[0-9]+)?(\/[^\s?]*)(\\?[^\s]*)?$/;
 
   return localhostRegex.test(candidate);
+};
+
+export const validateWebhookUrl = (
+  candidate: string,
+  isNotProduction: boolean,
+): boolean => {
+  if (isNotProduction) {
+    return true;
+  }
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(candidate);
+  } catch (_) {
+    return false;
+  }
+
+  return parsedUrl.protocol === "https:";
 };
 
 /**

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
@@ -36,7 +36,6 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
   const isNotProduction = checkIfNotProduction();
   const isPartnerTeam = checkIfPartnerTeam(teamId);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isTestingWebhook, setIsTestingWebhook] = useState(false);
 
   const {
     control,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
@@ -6,7 +6,6 @@ export type ActionContext = {
   is_not_production: boolean;
 };
 
-// Create a schema factory function that accepts the context
 export const createUpdateActionSchema = (context: ActionContext) => {
   return yup
     .object({

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
@@ -1,5 +1,5 @@
 import { validatePublicKey } from "@/lib/crypto.server";
-import { validateWebhookUrl } from "@/lib/utils";
+import { validateUrl } from "@/lib/utils";
 import * as yup from "yup";
 
 export type ActionContext = {
@@ -24,8 +24,8 @@ export const createUpdateActionSchema = (context: ActionContext) => {
         .string()
         .optional()
         .test("is-url", "Must be a valid URL", (value) => {
-          if (!value) return true;
-          return validateWebhookUrl(value, context.is_not_production);
+          if (!value || context.is_not_production) return true;
+          return validateUrl(value, context.is_not_production);
         }),
       webhook_pem: yup
         .string()

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
@@ -44,7 +44,7 @@ export const createUpdateActionSchema = (context: ActionContext) => {
       "webhook-fields",
       "Both webhook URL and PEM must be provided or removed",
       function (values) {
-        const { webhook_uri, webhook_pem, app_flow_on_complete } = values;
+        const { webhook_uri, webhook_pem } = values;
 
         // If both webhook fields are empty, no validation needed
         if (!webhook_uri && !webhook_pem) return true;

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
@@ -1,5 +1,5 @@
 import { validatePublicKey } from "@/lib/crypto.server";
-import { validateUrl } from "@/lib/utils";
+import { validateWebhookUrl } from "@/lib/utils";
 import * as yup from "yup";
 
 export type ActionContext = {
@@ -25,7 +25,7 @@ export const createUpdateActionSchema = (context: ActionContext) => {
         .optional()
         .test("is-url", "Must be a valid URL", (value) => {
           if (!value) return true;
-          return validateUrl(value, context.is_not_production);
+          return validateWebhookUrl(value, context.is_not_production);
         }),
       webhook_pem: yup
         .string()

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
@@ -3,7 +3,7 @@ import {
   allowedCommonCharactersRegex,
   allowedTitleCharactersRegex,
 } from "@/lib/schema";
-import { validateWebhookUrl } from "@/lib/utils";
+import { validateUrl } from "@/lib/utils";
 import * as yup from "yup";
 
 // Check if not in production
@@ -42,8 +42,8 @@ export const createActionSchema = (context: ActionContext) => {
         .string()
         .optional()
         .test("is-url", "Must be a valid URL", (value) => {
-          if (!value) return true;
-          return validateWebhookUrl(value, context.is_not_production);
+          if (!value || context.is_not_production) return true;
+          return validateUrl(value, context.is_not_production);
         }),
       webhook_pem: yup
         .string()

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
@@ -3,7 +3,7 @@ import {
   allowedCommonCharactersRegex,
   allowedTitleCharactersRegex,
 } from "@/lib/schema";
-import { validateUrl } from "@/lib/utils";
+import { validateWebhookUrl } from "@/lib/utils";
 import * as yup from "yup";
 
 // Check if not in production
@@ -43,7 +43,7 @@ export const createActionSchema = (context: ActionContext) => {
         .optional()
         .test("is-url", "Must be a valid URL", (value) => {
           if (!value) return true;
-          return validateUrl(value, context.is_not_production);
+          return validateWebhookUrl(value, context.is_not_production);
         }),
       webhook_pem: yup
         .string()


### PR DESCRIPTION
## PR Type

- [x] Regular Task

## Description

Our tests need to be able to make local calls (e.g. to an endpoint like `/internal/test`) which the previous config did not allow for. This fixes that, and also allow-lists our E2E test team.

Tested locally.

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [x] I have updated the documentation as needed.
