### PR TITLE
new mappings, version filtering logic in /apps

### DIFF
--- a/web/api/v2/public/apps/index.ts
+++ b/web/api/v2/public/apps/index.ts
@@ -26,7 +26,7 @@ import {
 } from "./graphql/get-highlighted-apps.generated";
 
 // TODO remove when min app is higher
-const CONTACTS_APP_AVAILABLE_FROM = "2.8.7801";
+const CONTACTS_APP_AVAILABLE_FROM = "2.8.7900";
 
 const queryParamsSchema = yup.object({
   page: yup.number().integer().min(1).default(1).notRequired(),

--- a/web/api/v2/public/apps/index.ts
+++ b/web/api/v2/public/apps/index.ts
@@ -25,7 +25,8 @@ import {
   getSdk as getHighlightsSdk,
 } from "./graphql/get-highlighted-apps.generated";
 
-const CONTACTS_APP_AVAILABLE_FROM = "2.8.78001";
+// TODO remove when min app is higher
+const CONTACTS_APP_AVAILABLE_FROM = "2.8.7801";
 
 const queryParamsSchema = yup.object({
   page: yup.number().integer().min(1).default(1).notRequired(),
@@ -146,8 +147,8 @@ export const GET = async (request: NextRequest) => {
   }
 
   if (
-    clientVersion &&
-    compareVersions(clientVersion, CONTACTS_APP_AVAILABLE_FROM) >= 0
+    !clientVersion ||
+    compareVersions(clientVersion, CONTACTS_APP_AVAILABLE_FROM) < 0
   ) {
     topApps = topApps.filter((app) => app.app_id !== "contacts");
     highlightsApps = highlightsApps.filter((app) => app.app_id !== "contacts");

--- a/web/lib/compare-versions.ts
+++ b/web/lib/compare-versions.ts
@@ -1,0 +1,46 @@
+/**
+ * Compares two version strings in the format 'x.y.z'.
+ *
+ * @param {string} version1 - The first version string to compare.
+ * @param {string} version2 - The second version string to compare.
+ * @returns {number} - Returns 0 if the versions are equal, 1 if version1 is greater, and -1 if version2 is greater.
+ *
+ * @example
+ * // Returns 0
+ * compareVersions('1.0.0', '1.0.0');
+ *
+ * @example
+ * // Returns 1
+ * compareVersions('2.1.0', '2.0.1');
+ *
+ * @example
+ * // Returns -1
+ * compareVersions('1.0.0', '1.0.1');
+ *
+ * @remarks
+ * The function considers only the first three parts of the version strings. If a part is missing, it is treated as 0.
+ */
+export function compareVersions(version1: string, version2: string): number {
+  if (version1 === version2) return 0;
+
+  const v1 = version1
+    .split('.')
+    .slice(0, 3)
+    .map((n) => parseInt(n, 10));
+  const v2 = version2
+    .split('.')
+    .slice(0, 3)
+    .map((n) => parseInt(n, 10));
+
+  const length = Math.max(v1.length, v2.length);
+
+  for (let i = 0; i < length; i++) {
+    const n1 = v1[i] ?? 0;
+    const n2 = v2[i] ?? 0;
+
+    if (n1 > n2) return 1;
+    if (n1 < n2) return -1;
+  }
+
+  return 0;
+}

--- a/web/lib/compare-versions.ts
+++ b/web/lib/compare-versions.ts
@@ -24,11 +24,11 @@ export function compareVersions(version1: string, version2: string): number {
   if (version1 === version2) return 0;
 
   const v1 = version1
-    .split('.')
+    .split(".")
     .slice(0, 3)
     .map((n) => parseInt(n, 10));
   const v2 = version2
-    .split('.')
+    .split(".")
     .slice(0, 3)
     .map((n) => parseInt(n, 10));
 

--- a/web/lib/compare-versions.unit.spec.ts
+++ b/web/lib/compare-versions.unit.spec.ts
@@ -1,18 +1,18 @@
-import { compareVersions } from './compare-versions';
+import { compareVersions } from "./compare-versions";
 
-describe('compareVersions', () => {
-  it('different cases', () => {
-    expect(compareVersions('', '')).toBe(0);
-    expect(compareVersions('0', '0')).toBe(0);
-    expect(compareVersions('0', '0.0')).toBe(0);
-    expect(compareVersions('1', '0.5')).toBe(1);
-    expect(compareVersions('1.2', '0.5')).toBe(1);
-    expect(compareVersions('0.1', '0.0.2')).toBe(1);
-    expect(compareVersions('0.1', '0.1.2')).toBe(-1);
-    expect(compareVersions('0.0.1', '0')).toBe(1);
-    expect(compareVersions('1.2.5', '1')).toBe(1);
-    expect(compareVersions('0.0.1', '0.1')).toBe(-1);
-    expect(compareVersions('0.0.1', '0.0.1')).toBe(0);
-    expect(compareVersions('0.0.1', '0.0.2')).toBe(-1);
+describe("compareVersions", () => {
+  it("different cases", () => {
+    expect(compareVersions("", "")).toBe(0);
+    expect(compareVersions("0", "0")).toBe(0);
+    expect(compareVersions("0", "0.0")).toBe(0);
+    expect(compareVersions("1", "0.5")).toBe(1);
+    expect(compareVersions("1.2", "0.5")).toBe(1);
+    expect(compareVersions("0.1", "0.0.2")).toBe(1);
+    expect(compareVersions("0.1", "0.1.2")).toBe(-1);
+    expect(compareVersions("0.0.1", "0")).toBe(1);
+    expect(compareVersions("1.2.5", "1")).toBe(1);
+    expect(compareVersions("0.0.1", "0.1")).toBe(-1);
+    expect(compareVersions("0.0.1", "0.0.1")).toBe(0);
+    expect(compareVersions("0.0.1", "0.0.2")).toBe(-1);
   });
 });

--- a/web/lib/compare-versions.unit.spec.ts
+++ b/web/lib/compare-versions.unit.spec.ts
@@ -1,0 +1,18 @@
+import { compareVersions } from './compare-versions';
+
+describe('compareVersions', () => {
+  it('different cases', () => {
+    expect(compareVersions('', '')).toBe(0);
+    expect(compareVersions('0', '0')).toBe(0);
+    expect(compareVersions('0', '0.0')).toBe(0);
+    expect(compareVersions('1', '0.5')).toBe(1);
+    expect(compareVersions('1.2', '0.5')).toBe(1);
+    expect(compareVersions('0.1', '0.0.2')).toBe(1);
+    expect(compareVersions('0.1', '0.1.2')).toBe(-1);
+    expect(compareVersions('0.0.1', '0')).toBe(1);
+    expect(compareVersions('1.2.5', '1')).toBe(1);
+    expect(compareVersions('0.0.1', '0.1')).toBe(-1);
+    expect(compareVersions('0.0.1', '0.0.1')).toBe(0);
+    expect(compareVersions('0.0.1', '0.0.2')).toBe(-1);
+  });
+});

--- a/web/lib/constants.ts
+++ b/web/lib/constants.ts
@@ -60,11 +60,13 @@ export const NativeAppToAppIdMapping: Record<string, Record<string, string>> = {
     invites: "app_901d6025acb2a1492a2f2becb5c83d1d",
     network: "app_a8309f030d83505a1632e1ed9dfb57cc",
     grants_native: "app_staging_39ccc5b13235e4227a7c38b23203e59f",
+    contacts: "app_701d0e4883e350804a0811f7b2529425",
   },
   production: {
     grants: "app_d2905e660b94ad24d6fc97816182ab35",
     invites: "app_432af83feb4051e72fd7ee682f365c39",
     network: "app_a23c6398432498825962a9b96294dde1",
+    contacts: "app_32fa11ef4b55fc5865dcd6e45ef281f5",
   },
 };
 
@@ -97,6 +99,11 @@ export const NativeApps: Record<string, NativeAppsMap> = {
       integration_url: "worldapp://worldcoin",
       app_mode: "native",
     },
+    [NativeAppToAppIdMapping.staging.contacts]: {
+      app_id: "contacts",
+      integration_url: "worldapp://contacts",
+      app_mode: "native",
+    },
   },
   production: {
     [NativeAppToAppIdMapping.production.grants]: {
@@ -112,6 +119,11 @@ export const NativeApps: Record<string, NativeAppsMap> = {
     [NativeAppToAppIdMapping.production.network]: {
       app_id: "network",
       integration_url: "worldapp://network",
+      app_mode: "native",
+    },
+    [NativeAppToAppIdMapping.production.contacts]: {
+      app_id: "contacts",
+      integration_url: "worldapp://contacts",
       app_mode: "native",
     },
   },

--- a/web/tests/api/v2/public/apps/apps.test.ts
+++ b/web/tests/api/v2/public/apps/apps.test.ts
@@ -1346,7 +1346,7 @@ describe("/api/v2/public/apps", () => {
         {
           headers: {
             host: "cdn.test.com",
-            "client-version": "2.8.7801", // exactly the minimum version
+            "client-version": "2.8.7900", // exactly the minimum version
           },
         },
       );
@@ -1372,7 +1372,7 @@ describe("/api/v2/public/apps", () => {
         {
           headers: {
             host: "cdn.test.com",
-            "client-version": "2.9.0", // above the minimum version
+            "client-version": "2.8.8000", // above the minimum version
           },
         },
       );

--- a/web/tests/api/v2/public/apps/apps.test.ts
+++ b/web/tests/api/v2/public/apps/apps.test.ts
@@ -1227,4 +1227,196 @@ describe("/api/v2/public/apps", () => {
       );
     });
   });
+
+  describe("contacts app client version filtering", () => {
+    const mockAppsWithContacts = [
+      {
+        app_id: "contacts", // contacts app
+        name: "Contacts",
+        short_name: "contacts",
+        logo_img_url: "logo.png",
+        hero_image_url: "hero.png",
+        showcase_img_urls: ["showcase1.png"],
+        category: "Social",
+        world_app_button_text: "random",
+        world_app_description: "random",
+        whitelisted_addresses: ["0x1234"],
+        app_mode: "mini-app",
+        verification_status: "verified",
+        is_allowed_unlimited_notifications: false,
+        max_notifications_per_day: 10,
+        description: JSON.stringify({
+          description_overview: "test",
+          description_how_it_works: "",
+          description_connect: "",
+        }),
+        app: {
+          team: { name: "Test Team" },
+          rating_sum: 10,
+          rating_count: 2,
+        },
+      },
+      {
+        app_id: "another-app", // different app
+        name: "Another App",
+        short_name: "another",
+        logo_img_url: "logo.png",
+        hero_image_url: "hero.png",
+        showcase_img_urls: ["showcase1.png"],
+        category: "Social",
+        world_app_button_text: "random",
+        world_app_description: "random",
+        whitelisted_addresses: ["0x1234"],
+        app_mode: "mini-app",
+        verification_status: "verified",
+        is_allowed_unlimited_notifications: false,
+        max_notifications_per_day: 10,
+        description: JSON.stringify({
+          description_overview: "test",
+          description_how_it_works: "",
+          description_connect: "",
+        }),
+        app: {
+          team: { name: "Test Team" },
+          rating_sum: 10,
+          rating_count: 2,
+        },
+      },
+    ];
+
+    beforeEach(() => {
+      // setup for these tests
+      global.fetch = jest.fn().mockResolvedValue({
+        json: jest.fn().mockResolvedValue([]),
+      }) as jest.Mock;
+
+      process.env.NEXT_PUBLIC_APP_ENV = "production";
+      process.env.NEXT_PUBLIC_METRICS_SERVICE_ENDPOINT =
+        "https://metrics.example.com";
+      process.env.NEXT_PUBLIC_IMAGES_CDN_URL = "cdn.test.com";
+
+      jest.mocked(getWebHighlightsSdk).mockImplementation(() => ({
+        GetHighlights: jest.fn().mockResolvedValue({
+          app_rankings: [{ rankings: [] }],
+        }),
+      }));
+
+      jest.mocked(getHighlightsSdk).mockImplementation(() => ({
+        GetHighlights: jest.fn().mockResolvedValue({
+          highlights: mockAppsWithContacts, // same test data for highlights
+        }),
+      }));
+
+      jest.mocked(getAppsSdk).mockImplementation(() => ({
+        GetApps: jest.fn().mockResolvedValue({
+          top_apps: mockAppsWithContacts,
+        }),
+      }));
+    });
+
+    test("should not include contacts app when client version is below minimum version", async () => {
+      const request = new NextRequest(
+        "https://cdn.test.com/api/v2/public/apps",
+        {
+          headers: {
+            host: "cdn.test.com",
+            "client-version": "2.8.7800", // below the minimum version
+          },
+        },
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(
+        data.app_rankings.top_apps.some(
+          (app: any) => app.app_id === "contacts",
+        ),
+      ).toBe(false);
+      expect(
+        data.app_rankings.highlights.some(
+          (app: any) => app.app_id === "contacts",
+        ),
+      ).toBe(false);
+    });
+
+    test("should include contacts app when client version is at minimum version", async () => {
+      const request = new NextRequest(
+        "https://cdn.test.com/api/v2/public/apps",
+        {
+          headers: {
+            host: "cdn.test.com",
+            "client-version": "2.8.7801", // exactly the minimum version
+          },
+        },
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(
+        data.app_rankings.top_apps.some(
+          (app: any) => app.app_id === "contacts",
+        ),
+      ).toBe(true);
+      expect(
+        data.app_rankings.highlights.some(
+          (app: any) => app.app_id === "contacts",
+        ),
+      ).toBe(true);
+    });
+
+    test("should include contacts app when client version is above minimum version", async () => {
+      const request = new NextRequest(
+        "https://cdn.test.com/api/v2/public/apps",
+        {
+          headers: {
+            host: "cdn.test.com",
+            "client-version": "2.9.0", // above the minimum version
+          },
+        },
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      // contacts app should be filtered out from both top_apps and highlights
+      expect(
+        data.app_rankings.top_apps.some(
+          (app: any) => app.app_id === "contacts",
+        ),
+      ).toBe(true);
+      expect(
+        data.app_rankings.highlights.some(
+          (app: any) => app.app_id === "contacts",
+        ),
+      ).toBe(true);
+    });
+
+    test("should not include contacts app when client version header is missing", async () => {
+      const request = new NextRequest(
+        "https://cdn.test.com/api/v2/public/apps",
+        {
+          headers: {
+            host: "cdn.test.com",
+            // no client-version header
+          },
+        },
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(
+        data.app_rankings.top_apps.some(
+          (app: any) => app.app_id === "contacts",
+        ),
+      ).toBe(false);
+      expect(
+        data.app_rankings.highlights.some(
+          (app: any) => app.app_id === "contacts",
+        ),
+      ).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description
we'll have contacts as a new native miniapp. this pr adds app_id mappings, and version filtering as we want to show the app only above a certain version
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
