### PR TITLE
filter out based on actual id not mapped one

### DIFF
--- a/web/api/v2/public/apps/index.ts
+++ b/web/api/v2/public/apps/index.ts
@@ -6,7 +6,7 @@ import {
   getAppStoreLocalisedCategoriesWithUrls,
   getLocalisedCategory,
 } from "@/lib/categories";
-import { NativeApps } from "@/lib/constants";
+import { NativeApps, NativeAppToAppIdMapping } from "@/lib/constants";
 import { parseLocale } from "@/lib/languages";
 import { AppStatsReturnType } from "@/lib/types";
 import { isValidHostName } from "@/lib/utils";
@@ -146,12 +146,19 @@ export const GET = async (request: NextRequest) => {
     );
   }
 
+  const nativeIdToActualId =
+    NativeAppToAppIdMapping[process.env.NEXT_PUBLIC_APP_ENV];
+
   if (
     !clientVersion ||
     compareVersions(clientVersion, CONTACTS_APP_AVAILABLE_FROM) < 0
   ) {
-    topApps = topApps.filter((app) => app.app_id !== "contacts");
-    highlightsApps = highlightsApps.filter((app) => app.app_id !== "contacts");
+    topApps = topApps.filter(
+      (app) => app.app_id !== nativeIdToActualId.contacts,
+    );
+    highlightsApps = highlightsApps.filter(
+      (app) => app.app_id !== nativeIdToActualId.contacts,
+    );
   }
 
   // ANCHOR: Filter top apps by country

--- a/web/tests/api/v2/public/apps/apps.test.ts
+++ b/web/tests/api/v2/public/apps/apps.test.ts
@@ -1,6 +1,6 @@
 import { GET } from "@/api/v2/public/apps";
 import { AllCategory } from "@/lib/categories";
-import { Categories } from "@/lib/constants";
+import { Categories, NativeAppToAppIdMapping } from "@/lib/constants";
 import { NextRequest } from "next/server";
 import { getSdk as getAppsSdk } from "../../../../../api/v2/public/apps/graphql/get-app-rankings.generated";
 import { getSdk as getWebHighlightsSdk } from "../../../../../api/v2/public/apps/graphql/get-app-web-highlights.generated";
@@ -1231,7 +1231,7 @@ describe("/api/v2/public/apps", () => {
   describe("contacts app client version filtering", () => {
     const mockAppsWithContacts = [
       {
-        app_id: "contacts", // contacts app
+        app_id: NativeAppToAppIdMapping["production"].contacts, // contacts app
         name: "Contacts",
         short_name: "contacts",
         logo_img_url: "logo.png",
@@ -1408,15 +1408,15 @@ describe("/api/v2/public/apps", () => {
       const data = await response.json();
 
       expect(
-        data.app_rankings.top_apps.some(
+        data.app_rankings.top_apps.find(
           (app: any) => app.app_id === "contacts",
         ),
-      ).toBe(false);
+      ).toBe(undefined);
       expect(
-        data.app_rankings.highlights.some(
+        data.app_rankings.highlights.find(
           (app: any) => app.app_id === "contacts",
         ),
-      ).toBe(false);
+      ).toBe(undefined);
     });
   });
 });


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description
we were filtering the contacts miniapp based on "contacts" as app_id, but we should use the actual id, not mapped one
tests reflect that as well now
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
