### PR TITLE
fix: Revert "Get Hasura docker image from AWS public ECR (#1294)"

### DIFF
--- a/hasura/Dockerfile
+++ b/hasura/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/q0d1m9s3/graphql-engine:v2.36.4.cli-migrations-v3
+FROM hasura/graphql-engine:v2.36.4.cli-migrations-v3
 
 COPY . /hasura
 


### PR DESCRIPTION
This reverts commit 5102985cf4e4899eb2813c6fee213a1161caa521.

## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Reverts the Hasura docker image to the one from the public registry.
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
