### PR TITLE
fix: Bump hasura image version

### DIFF
--- a/hasura/Dockerfile
+++ b/hasura/Dockerfile
@@ -1,6 +1,7 @@
-FROM hasura/graphql-engine:v2.36.4.cli-migrations-v3
+FROM public.ecr.aws/q0d1m9s3/graphql-engine:v2.47.0.cli-migrations-v3
 
 COPY . /hasura
 
 ENV HASURA_GRAPHQL_MIGRATIONS_DIR /hasura/migrations
 ENV HASURA_GRAPHQL_METADATA_DIR  /hasura/metadata
+ENV HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT 3600

--- a/hasura/Dockerfile
+++ b/hasura/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/q0d1m9s3/graphql-engine:v2.36.4.cli-migrations-v3
+FROM hasura/graphql-engine:v2.36.4.cli-migrations-v3
 
 COPY . /hasura
 


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Bumps the Hasura image version to `v2.47.0.cli-migrations-v3` and increases the server timeout to 3600 seconds.
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
