### PR TITLE
fix: Add clean up migration

### DIFF
--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -12,7 +12,7 @@ services:
       retries: 5
 
   hasura_test:
-    image: hasura/graphql-engine:v2.36.4.cli-migrations-v3
+    image: hasura/graphql-engine:v2.47.0.cli-migrations-v3
     ports:
       - "8081:8080"
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
 
   hasura:
     # remember to update developer-portal-deployment with the same image
-    image: hasura/graphql-engine:v2.36.4.cli-migrations-v3
+    image: hasura/graphql-engine:v2.47.0.cli-migrations-v3
     ports:
       - "8080:8080"
     depends_on:

--- a/hasura/migrations/default/1745259204240_reset_invalid_fields/up.sql
+++ b/hasura/migrations/default/1745259204240_reset_invalid_fields/up.sql
@@ -1,0 +1,29 @@
+UPDATE public.app_metadata
+SET
+  logo_img_url = CASE
+    WHEN logo_img_url IS NOT NULL AND logo_img_url != ''
+      AND logo_img_url !~* '^([a-zA-Z0-9_-]+)\.(png|jpg)$'
+    THEN ''
+    ELSE logo_img_url
+  END,
+
+  app_website_url = CASE
+    WHEN app_website_url IS NOT NULL AND app_website_url != '' 
+      AND NOT (app_website_url ~* '^https://([[:alnum:]_-]+\.)+[[:alnum:]_-]+(/[[:alnum:]_\-./?%&=]*)?$')
+    THEN ''
+    ELSE app_website_url
+  END,
+
+  source_code_url = CASE
+    WHEN source_code_url IS NOT NULL AND source_code_url != ''
+      AND NOT (source_code_url ~* '^https://([[:alnum:]_-]+\.)+[[:alnum:]_-]+(/[[:alnum:]_\-./?%&=]*)?$')
+    THEN ''
+    ELSE source_code_url
+  END,
+
+  integration_url = CASE
+    WHEN integration_url IS NOT NULL AND integration_url != ''
+      AND NOT (integration_url ~* '^https://([[:alnum:]_-]+\.)+[[:alnum:]_-]+(/[[:alnum:]_\-./?%&=]*)?$')
+    THEN ''
+    ELSE integration_url
+  END;

--- a/hasura/migrations/default/1745259377078_is_android_only_default_false/down.sql
+++ b/hasura/migrations/default/1745259377078_is_android_only_default_false/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."app_metadata" alter column "is_android_only" drop not null;
+alter table "public"."app_metadata" alter column "is_android_only" drop default;

--- a/hasura/migrations/default/1745259377078_is_android_only_default_false/up.sql
+++ b/hasura/migrations/default/1745259377078_is_android_only_default_false/up.sql
@@ -1,0 +1,5 @@
+update "public"."app_metadata" set "is_android_only" = false;
+ 
+alter table "public"."app_metadata" alter column "is_android_only" set default false;
+ 
+alter table "public"."app_metadata" alter column "is_android_only" set not null;


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description
Ticket - [DEV-1621](https://linear.app/worldcoin/issue/DEV-1621/[mobile]-fix-migrations-android-only-flag-needs-to-default-to-false)
Adds a migration to clean up the invalid URLs in the app_metadata table.

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
