### PR TITLE
alter the sorting algorithm

### DIFF
--- a/web/api/helpers/app-store.ts
+++ b/web/api/helpers/app-store.ts
@@ -141,12 +141,17 @@ export const rankApps = (
   apps: AppStoreFormattedFields[],
   appStats: AppStatsReturnType,
 ) => {
-  // find maximum values for normalization
   let maxNewUsers = 0;
   let maxUniqueUsers = 0;
 
-  // first pass to determine maximum values
-  appStats.forEach((stat) => {
+  // determine maximum values among apps that
+  // are present in the current app store
+  const appIdsSet = new Set<string>(apps.map((app) => app.app_id));
+  const appStoreAppStats = appStats.filter((stat) =>
+    appIdsSet.has(stat.app_id),
+  );
+
+  appStoreAppStats.forEach((stat) => {
     maxNewUsers = Math.max(maxNewUsers, stat.new_users_last_7_days ?? 0);
     maxUniqueUsers = Math.max(maxUniqueUsers, stat.unique_users ?? 0);
   });
@@ -156,8 +161,8 @@ export const rankApps = (
   maxUniqueUsers = maxUniqueUsers === 0 ? 1 : maxUniqueUsers;
 
   return apps.sort((a, b) => {
-    const aStat = appStats.find((stat) => stat.app_id === a.app_id);
-    const bStat = appStats.find((stat) => stat.app_id === b.app_id);
+    const aStat = appStoreAppStats.find((stat) => stat.app_id === a.app_id);
+    const bStat = appStoreAppStats.find((stat) => stat.app_id === b.app_id);
 
     // default to 0 if stats not found
     const aNewUsers = aStat?.new_users_last_7_days ?? 0;

--- a/web/api/helpers/app-store.ts
+++ b/web/api/helpers/app-store.ts
@@ -176,8 +176,8 @@ export const rankApps = (
     const bNormalizedNewUsers = bNewUsers / maxNewUsers;
     const bNormalizedUniqueUsers = bUniqueUsers / maxUniqueUsers;
 
-    // 30% new_users_last_7_days
-    // 70% unique_users
+    // 70% new_users_last_7_days
+    // 30% unique_users
     const aScore = aNormalizedNewUsers * 0.7 + aNormalizedUniqueUsers * 0.3;
     const bScore = bNormalizedNewUsers * 0.7 + bNormalizedUniqueUsers * 0.3;
 

--- a/web/api/helpers/app-store.ts
+++ b/web/api/helpers/app-store.ts
@@ -141,12 +141,41 @@ export const rankApps = (
   apps: AppStoreFormattedFields[],
   appStats: AppStatsReturnType,
 ) => {
+  // find maximum values for normalization
+  let maxNewUsers = 0;
+  let maxUniqueUsers = 0;
+
+  // first pass to determine maximum values
+  appStats.forEach((stat) => {
+    maxNewUsers = Math.max(maxNewUsers, stat.new_users_last_7_days ?? 0);
+    maxUniqueUsers = Math.max(maxUniqueUsers, stat.unique_users ?? 0);
+  });
+
+  // ensure we don't divide by zero
+  maxNewUsers = maxNewUsers === 0 ? 1 : maxNewUsers;
+  maxUniqueUsers = maxUniqueUsers === 0 ? 1 : maxUniqueUsers;
+
   return apps.sort((a, b) => {
     const aStat = appStats.find((stat) => stat.app_id === a.app_id);
     const bStat = appStats.find((stat) => stat.app_id === b.app_id);
 
-    return (
-      (bStat?.new_users_last_7_days ?? 0) - (aStat?.new_users_last_7_days ?? 0)
-    );
+    // default to 0 if stats not found
+    const aNewUsers = aStat?.new_users_last_7_days ?? 0;
+    const aUniqueUsers = aStat?.unique_users ?? 0;
+    const bNewUsers = bStat?.new_users_last_7_days ?? 0;
+    const bUniqueUsers = bStat?.unique_users ?? 0;
+
+    // normalize values to 0-1 scale
+    const aNormalizedNewUsers = aNewUsers / maxNewUsers;
+    const aNormalizedUniqueUsers = aUniqueUsers / maxUniqueUsers;
+    const bNormalizedNewUsers = bNewUsers / maxNewUsers;
+    const bNormalizedUniqueUsers = bUniqueUsers / maxUniqueUsers;
+
+    // 30% new_users_last_7_days
+    // 70% unique_users
+    const aScore = aNormalizedNewUsers * 0.3 + aNormalizedUniqueUsers * 0.7;
+    const bScore = bNormalizedNewUsers * 0.3 + bNormalizedUniqueUsers * 0.7;
+
+    return bScore - aScore;
   });
 };

--- a/web/api/helpers/app-store.ts
+++ b/web/api/helpers/app-store.ts
@@ -178,8 +178,8 @@ export const rankApps = (
 
     // 30% new_users_last_7_days
     // 70% unique_users
-    const aScore = aNormalizedNewUsers * 0.3 + aNormalizedUniqueUsers * 0.7;
-    const bScore = bNormalizedNewUsers * 0.3 + bNormalizedUniqueUsers * 0.7;
+    const aScore = aNormalizedNewUsers * 0.7 + aNormalizedUniqueUsers * 0.3;
+    const bScore = bNormalizedNewUsers * 0.7 + bNormalizedUniqueUsers * 0.3;
 
     return bScore - aScore;
   });


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description
important changes:
before normalizing data, filter the miniapp statistics dataset to include only apps present in the app store (different across countries)
then, filter with 0.3 weight given to total unique users and 0.7 given to new users in past 7 days
For the US app store, this yields the following top 30 miniapps (with default pinned apps removed)
```
Humans vs AI
Cash Convert
UNO
ORO
Cash Daily
ORB
World Republic
Farcade
Claim $MINI Daily
DNA Wallet
Eggs Vault
THE BOX
World Chat Beta
ASTRACOIN
AION
PoolTogether
AXO
Golden Otter Hub
Sage
BitMaster
DNA GenomeX
EarnOS
PUF
Add Money
Crypto Merge
DNA
GalAxo
Golden Otter Maze Game
LOCO
Diamond Rush
```
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
