### PR TITLE
Make app store copy less confusing

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/SubmitAppModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/SubmitAppModal/index.tsx
@@ -174,11 +174,11 @@ export const SubmitAppModal = (props: SubmitAppModalProps) => {
             />
             <div className="grid gap-y-2">
               <Typography variant={TYPOGRAPHY.R3} className="text-grey-700">
-                Allow listing in Mini Apps
+                Allow listing in mini app store
               </Typography>
               <Typography variant={TYPOGRAPHY.R4} className="text-grey-700">
-                Once you submit your app for review, it may be showcased in
-                World Mini Apps. Not all apps will be displayed.
+                Checking this box means you would like your app to be available
+                in the mini app store.
               </Typography>
             </div>
           </label>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/layout/index.tsx
@@ -46,7 +46,7 @@ export const AppProfileLayout = async (props: AppProfileLayout) => {
               href={`/teams/${params!.teamId}/apps/${params!.appId}/configuration/app-store`}
               segment={"app-store"}
             >
-              <Typography variant={TYPOGRAPHY.R4}>Listing Display</Typography>
+              <Typography variant={TYPOGRAPHY.R4}>Mini App Store</Typography>
             </Tab>
 
             <Tab


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

App store copy is really confusing. We are allowed to use App store if it's not in reference to the Apple App Store

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
