### PR TITLE
remove platform check from single get endpoint

### DIFF
--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -151,14 +151,6 @@ export async function GET(
     );
   }
 
-  const platform = headers.get("client-name");
-  const isAndroidOnly = parsedAppMetadata.is_android_only;
-
-  // do not restrict for drafts, so developers can work on the app
-  if (isAndroidOnly && isMetadataVerified && platform === "ios") {
-    return NextResponse.json({ error: "App not available" }, { status: 451 });
-  }
-
   const nativeIdToActualId =
     NativeAppToAppIdMapping[process.env.NEXT_PUBLIC_APP_ENV];
 


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description
app shouldn't be cleared from home screen when set to android only. existing users should still be able to access.
This change leaves app store filtering, so the app won't be listed, but will be deeplinkable and accessible to users
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
