### PR TITLE
DEV-1748: Fix nullifier hash prefix vulnerability

### DIFF
--- a/web/api/helpers/verify.ts
+++ b/web/api/helpers/verify.ts
@@ -192,11 +192,13 @@ function decodeAbiEncodedProof(encodedProof: string): string[] {
  * @param value The value to decode
  * @returns The decoded hex string
  */
-function decodeToHexString(value: string): string {
+export function decodeToHexString(value: string): string {
+  const normalized = value.toLowerCase().trim().replace(/^0x/, "");
+
   return toBeHex(
     AbiCoder.defaultAbiCoder().decode(
       ["uint256"],
-      `0x${value.slice(2).padStart(64, "0")}`,
+      `0x${normalized.padStart(64, "0")}`,
     )[0],
   );
 }

--- a/web/tests/api/helpers/verify.test.ts
+++ b/web/tests/api/helpers/verify.test.ts
@@ -1,4 +1,8 @@
-import { decodeProof, parseProofInputs } from "@/api/helpers/verify";
+import {
+  decodeProof,
+  decodeToHexString,
+  parseProofInputs,
+} from "@/api/helpers/verify";
 import { toBeHex } from "ethers";
 
 jest.mock(
@@ -315,6 +319,77 @@ describe("verify helpers", () => {
       expect(result.error).toBeDefined();
       expect(result.error?.attribute).toBe("signal");
       expect(result.params).toBeUndefined();
+    });
+  });
+
+  describe("decodeToHexString", () => {
+    it("should normalize different input formats to the same hex output", () => {
+      // Create variations of the same value with different formats
+      const baseValue = "123abc";
+      const inputVariations = [
+        baseValue, // Plain value
+        `0x${baseValue}`, // With 0x prefix
+        ` ${baseValue} `, // With whitespace
+        ` 0x${baseValue} `, // With prefix and whitespace
+        `0X${baseValue}`, // With capitalized prefix
+        `${baseValue.toUpperCase()}`, // All uppercase
+        `0x${baseValue.toUpperCase()}`, // With prefix and uppercase
+      ];
+
+      // Get the expected output
+      const expectedOutput = decodeToHexString(baseValue);
+
+      // All variations should produce the same output
+      inputVariations.forEach((input) => {
+        const output = decodeToHexString(input);
+        expect(output).toBe(expectedOutput);
+      });
+    });
+
+    it("should NOT treat different prefixes as the same value due to ABI decoding", () => {
+      // This test demonstrates that while the function strips 0x prefixes,
+      // the ABI decoding treats the values as different numbers
+      const value1 = "1234abcd";
+      const value2 = "5678abcd";
+
+      // These should decode to different values
+      const output1 = decodeToHexString(value1);
+      const output2 = decodeToHexString(value2);
+      expect(output1).not.toBe(output2);
+
+      // When using 0x prefixes, they should still be different because
+      // the ABI decoder interprets them as different numbers
+      const prefixed1 = "0x1234abcd";
+      const prefixed2 = "0x5678abcd";
+
+      const prefixedOutput1 = decodeToHexString(prefixed1);
+      const prefixedOutput2 = decodeToHexString(prefixed2);
+
+      // Verify they're different (demonstrating that stripping 0x doesn't make them equal)
+      expect(prefixedOutput1).not.toBe(prefixedOutput2);
+
+      // Verify that prefixed and non-prefixed versions of the same value are equivalent
+      expect(output1).toBe(prefixedOutput1);
+      expect(output2).toBe(prefixedOutput2);
+    });
+
+    it("should demonstrate equivalent inputs due to normalization", () => {
+      // Create valid inputs that should be treated as different for security purposes
+      const value1 = "0xabcdef"; // With 0x prefix
+      const value2 = "abcdef"; // Without prefix
+      const value3 = " abcdef "; // With whitespace
+      const value4 = "ABCDEF"; // All uppercase
+
+      // All of these should produce the same output
+      const output1 = decodeToHexString(value1);
+      const output2 = decodeToHexString(value2);
+      const output3 = decodeToHexString(value3);
+      const output4 = decodeToHexString(value4);
+
+      // Check that all outputs are the same despite different inputs
+      expect(output1).toBe(output2);
+      expect(output2).toBe(output3);
+      expect(output3).toBe(output4);
     });
   });
 });


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Addresses issue #2 from [DEV-1748](https://linear.app/worldcoin/issue/DEV-1748/h1-users-can-validate-zkps-many-times-in-devportal-due-to-case)

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
