### PR TITLE
DEV-1748: Add nullifier int column 

### DIFF
--- a/hasura/metadata/databases/default/tables/public_nullifier.yaml
+++ b/hasura/metadata/databases/default/tables/public_nullifier.yaml
@@ -12,8 +12,9 @@ insert_permissions:
       columns:
         - action_id
         - id
-        - uses
         - nullifier_hash
+        - nullifier_hash_int
+        - uses
 select_permissions:
   - role: api_key
     permission:
@@ -33,8 +34,9 @@ select_permissions:
         - action_id
         - created_at
         - id
-        - uses
         - nullifier_hash
+        - nullifier_hash_int
+        - uses
       filter: {}
   - role: user
     permission:

--- a/hasura/migrations/default/1747818197472_alter_table_public_nullifier_add_column_nullifier_hash_int/down.sql
+++ b/hasura/migrations/default/1747818197472_alter_table_public_nullifier_add_column_nullifier_hash_int/down.sql
@@ -1,4 +1,1 @@
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- alter table "public"."nullifier" add column "nullifier_hash_int" text
---  null;
+alter table "public"."nullifier" drop column "nullifier_hash_int";

--- a/hasura/migrations/default/1747818197472_alter_table_public_nullifier_add_column_nullifier_hash_int/down.sql
+++ b/hasura/migrations/default/1747818197472_alter_table_public_nullifier_add_column_nullifier_hash_int/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."nullifier" add column "nullifier_hash_int" text
+--  null;

--- a/hasura/migrations/default/1747818197472_alter_table_public_nullifier_add_column_nullifier_hash_int/up.sql
+++ b/hasura/migrations/default/1747818197472_alter_table_public_nullifier_add_column_nullifier_hash_int/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."nullifier" add column "nullifier_hash_int" text
+ null;

--- a/web/api/helpers/verify.ts
+++ b/web/api/helpers/verify.ts
@@ -394,3 +394,18 @@ export const canVerifyForAction = (
   // Else, can only verify if the max number of verifications has not been met
   return nullifier.uses < max_verifications_per_person;
 };
+
+const normalizeNullifierHash = (nullifierHash: string): string => {
+  const normalized = nullifierHash.toLowerCase().trim().replace(/^0x/, "");
+
+  return `0x${normalized}`;
+};
+
+/**
+ * Converts a nullifier hash to its numeric representation for database storage and comparison
+ * This helps prevent case sensitivity, prefix, and padding bypass attacks
+ */
+export const nullifierHashToBigIntStr = (nullifierHash: string): string => {
+  const normalized = normalizeNullifierHash(nullifierHash);
+  return BigInt(normalized).toString();
+};

--- a/web/api/v1/oidc/authorize/index.ts
+++ b/web/api/v1/oidc/authorize/index.ts
@@ -12,7 +12,7 @@ import {
 } from "@/api/helpers/oidc";
 import { corsHandler } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
-import { verifyProof } from "@/api/helpers/verify";
+import { nullifierHashToBigIntStr, verifyProof } from "@/api/helpers/verify";
 import { Nullifier_Constraint } from "@/graphql/graphql";
 import { logger } from "@/lib/logger";
 import { OIDCFlowType, OIDCResponseType } from "@/lib/types";
@@ -338,6 +338,7 @@ export async function POST(req: NextRequest) {
             object: {
               nullifier_hash,
               action_id: app.action_id,
+              nullifier_hash_int: nullifierHashToBigIntStr(nullifier_hash),
             },
             on_conflict: {
               constraint: Nullifier_Constraint.NullifierPkey,

--- a/web/api/v2/verify/graphql/atomic-upsert-nullifier.generated.ts
+++ b/web/api/v2/verify/graphql/atomic-upsert-nullifier.generated.ts
@@ -7,6 +7,7 @@ type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
 export type AtomicUpsertNullifierMutationVariables = Types.Exact<{
   action_id: Types.Scalars["String"]["input"];
   nullifier_hash: Types.Scalars["String"]["input"];
+  nullifier_hash_int: Types.Scalars["String"]["input"];
 }>;
 
 export type AtomicUpsertNullifierMutation = {
@@ -14,6 +15,7 @@ export type AtomicUpsertNullifierMutation = {
   insert_nullifier_one?: {
     __typename?: "nullifier";
     nullifier_hash: string;
+    nullifier_hash_int?: string | null;
   } | null;
   update_nullifier?: {
     __typename?: "nullifier_mutation_response";
@@ -23,6 +25,7 @@ export type AtomicUpsertNullifierMutation = {
       uses: number;
       created_at: string;
       nullifier_hash: string;
+      nullifier_hash_int?: string | null;
     }>;
   } | null;
 };
@@ -31,16 +34,19 @@ export const AtomicUpsertNullifierDocument = gql`
   mutation AtomicUpsertNullifier(
     $action_id: String!
     $nullifier_hash: String!
+    $nullifier_hash_int: String!
   ) {
     insert_nullifier_one(
       object: {
         action_id: $action_id
         nullifier_hash: $nullifier_hash
+        nullifier_hash_int: $nullifier_hash_int
         uses: 0
       }
       on_conflict: { constraint: unique_nullifier_hash, update_columns: [] }
     ) {
       nullifier_hash
+      nullifier_hash_int
     }
     update_nullifier(
       where: { nullifier_hash: { _eq: $nullifier_hash } }
@@ -51,6 +57,7 @@ export const AtomicUpsertNullifierDocument = gql`
         uses
         created_at
         nullifier_hash
+        nullifier_hash_int
       }
     }
   }

--- a/web/api/v2/verify/graphql/atomic-upsert-nullifier.graphql
+++ b/web/api/v2/verify/graphql/atomic-upsert-nullifier.graphql
@@ -1,9 +1,19 @@
-mutation AtomicUpsertNullifier($action_id: String!, $nullifier_hash: String!) {
+mutation AtomicUpsertNullifier(
+  $action_id: String!
+  $nullifier_hash: String!
+  $nullifier_hash_int: String!
+) {
   insert_nullifier_one(
-    object: { action_id: $action_id, nullifier_hash: $nullifier_hash, uses: 0 }
+    object: {
+      action_id: $action_id
+      nullifier_hash: $nullifier_hash
+      nullifier_hash_int: $nullifier_hash_int
+      uses: 0
+    }
     on_conflict: { constraint: unique_nullifier_hash, update_columns: [] }
   ) {
     nullifier_hash
+    nullifier_hash_int
   }
 
   update_nullifier(
@@ -15,6 +25,7 @@ mutation AtomicUpsertNullifier($action_id: String!, $nullifier_hash: String!) {
       uses
       created_at
       nullifier_hash
+      nullifier_hash_int
     }
   }
 }

--- a/web/api/v2/verify/index.ts
+++ b/web/api/v2/verify/index.ts
@@ -5,7 +5,11 @@ import {
 } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
-import { canVerifyForAction, verifyProof } from "@/api/helpers/verify";
+import {
+  canVerifyForAction,
+  nullifierHashToBigIntStr,
+  verifyProof,
+} from "@/api/helpers/verify";
 import { captureEvent } from "@/services/posthogClient";
 import { AppErrorCodes, VerificationLevel } from "@worldcoin/idkit-core";
 import { NextRequest, NextResponse } from "next/server";
@@ -202,6 +206,7 @@ export async function POST(
     ).AtomicUpsertNullifier({
       action_id: action.id,
       nullifier_hash: parsedParams.nullifier_hash,
+      nullifier_hash_int: nullifierHashToBigIntStr(parsedParams.nullifier_hash),
     });
 
     if (!upsertResponse?.update_nullifier?.returning?.length) {

--- a/web/graphql/graphql.schema.json
+++ b/web/graphql/graphql.schema.json
@@ -49897,6 +49897,18 @@
             "deprecationReason": null
           },
           {
+            "name": "nullifier_hash_int",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "args": [],
@@ -50610,6 +50622,18 @@
             "deprecationReason": null
           },
           {
+            "name": "nullifier_hash_int",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "type": {
@@ -50751,6 +50775,18 @@
             "deprecationReason": null
           },
           {
+            "name": "nullifier_hash_int",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "type": {
@@ -50822,6 +50858,18 @@
           },
           {
             "name": "nullifier_hash",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash_int",
             "description": null,
             "args": [],
             "type": {
@@ -50917,6 +50965,18 @@
             "deprecationReason": null
           },
           {
+            "name": "nullifier_hash_int",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "type": {
@@ -50988,6 +51048,18 @@
           },
           {
             "name": "nullifier_hash",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash_int",
             "description": null,
             "args": [],
             "type": {
@@ -51072,6 +51144,18 @@
           },
           {
             "name": "nullifier_hash",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash_int",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -51292,6 +51376,18 @@
             "deprecationReason": null
           },
           {
+            "name": "nullifier_hash_int",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "type": {
@@ -51380,6 +51476,12 @@
             "deprecationReason": null
           },
           {
+            "name": "nullifier_hash_int",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": "column name",
             "isDeprecated": false,
@@ -51438,6 +51540,18 @@
           },
           {
             "name": "nullifier_hash",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash_int",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -51709,6 +51823,18 @@
             "deprecationReason": null
           },
           {
+            "name": "nullifier_hash_int",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "type": {
@@ -51811,6 +51937,12 @@
           },
           {
             "name": "nullifier_hash",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nullifier_hash_int",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null

--- a/web/graphql/graphql.ts
+++ b/web/graphql/graphql.ts
@@ -7300,6 +7300,7 @@ export type Nullifier = {
   created_at: Scalars["timestamptz"]["output"];
   id: Scalars["String"]["output"];
   nullifier_hash: Scalars["String"]["output"];
+  nullifier_hash_int?: Maybe<Scalars["String"]["output"]>;
   updated_at: Scalars["timestamptz"]["output"];
   uses: Scalars["Int"]["output"];
 };
@@ -7387,6 +7388,7 @@ export type Nullifier_Bool_Exp = {
   created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
   id?: InputMaybe<String_Comparison_Exp>;
   nullifier_hash?: InputMaybe<String_Comparison_Exp>;
+  nullifier_hash_int?: InputMaybe<String_Comparison_Exp>;
   updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
   uses?: InputMaybe<Int_Comparison_Exp>;
 };
@@ -7411,6 +7413,7 @@ export type Nullifier_Insert_Input = {
   created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   id?: InputMaybe<Scalars["String"]["input"]>;
   nullifier_hash?: InputMaybe<Scalars["String"]["input"]>;
+  nullifier_hash_int?: InputMaybe<Scalars["String"]["input"]>;
   updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   uses?: InputMaybe<Scalars["Int"]["input"]>;
 };
@@ -7422,6 +7425,7 @@ export type Nullifier_Max_Fields = {
   created_at?: Maybe<Scalars["timestamptz"]["output"]>;
   id?: Maybe<Scalars["String"]["output"]>;
   nullifier_hash?: Maybe<Scalars["String"]["output"]>;
+  nullifier_hash_int?: Maybe<Scalars["String"]["output"]>;
   updated_at?: Maybe<Scalars["timestamptz"]["output"]>;
   uses?: Maybe<Scalars["Int"]["output"]>;
 };
@@ -7432,6 +7436,7 @@ export type Nullifier_Max_Order_By = {
   created_at?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   nullifier_hash?: InputMaybe<Order_By>;
+  nullifier_hash_int?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
   uses?: InputMaybe<Order_By>;
 };
@@ -7443,6 +7448,7 @@ export type Nullifier_Min_Fields = {
   created_at?: Maybe<Scalars["timestamptz"]["output"]>;
   id?: Maybe<Scalars["String"]["output"]>;
   nullifier_hash?: Maybe<Scalars["String"]["output"]>;
+  nullifier_hash_int?: Maybe<Scalars["String"]["output"]>;
   updated_at?: Maybe<Scalars["timestamptz"]["output"]>;
   uses?: Maybe<Scalars["Int"]["output"]>;
 };
@@ -7453,6 +7459,7 @@ export type Nullifier_Min_Order_By = {
   created_at?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   nullifier_hash?: InputMaybe<Order_By>;
+  nullifier_hash_int?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
   uses?: InputMaybe<Order_By>;
 };
@@ -7480,6 +7487,7 @@ export type Nullifier_Order_By = {
   created_at?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   nullifier_hash?: InputMaybe<Order_By>;
+  nullifier_hash_int?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
   uses?: InputMaybe<Order_By>;
 };
@@ -7500,6 +7508,8 @@ export enum Nullifier_Select_Column {
   /** column name */
   NullifierHash = "nullifier_hash",
   /** column name */
+  NullifierHashInt = "nullifier_hash_int",
+  /** column name */
   UpdatedAt = "updated_at",
   /** column name */
   Uses = "uses",
@@ -7511,6 +7521,7 @@ export type Nullifier_Set_Input = {
   created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   id?: InputMaybe<Scalars["String"]["input"]>;
   nullifier_hash?: InputMaybe<Scalars["String"]["input"]>;
+  nullifier_hash_int?: InputMaybe<Scalars["String"]["input"]>;
   updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   uses?: InputMaybe<Scalars["Int"]["input"]>;
 };
@@ -7562,6 +7573,7 @@ export type Nullifier_Stream_Cursor_Value_Input = {
   created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   id?: InputMaybe<Scalars["String"]["input"]>;
   nullifier_hash?: InputMaybe<Scalars["String"]["input"]>;
+  nullifier_hash_int?: InputMaybe<Scalars["String"]["input"]>;
   updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   uses?: InputMaybe<Scalars["Int"]["input"]>;
 };
@@ -7587,6 +7599,8 @@ export enum Nullifier_Update_Column {
   Id = "id",
   /** column name */
   NullifierHash = "nullifier_hash",
+  /** column name */
+  NullifierHashInt = "nullifier_hash_int",
   /** column name */
   UpdatedAt = "updated_at",
   /** column name */

--- a/web/tests/api/helpers/verify.test.ts
+++ b/web/tests/api/helpers/verify.test.ts
@@ -1,4 +1,8 @@
-import { decodeProof, parseProofInputs } from "@/api/helpers/verify";
+import {
+  decodeProof,
+  nullifierHashToBigIntStr,
+  parseProofInputs,
+} from "@/api/helpers/verify";
 import { toBeHex } from "ethers";
 
 jest.mock(
@@ -315,6 +319,41 @@ describe("verify helpers", () => {
       expect(result.error).toBeDefined();
       expect(result.error?.attribute).toBe("signal");
       expect(result.params).toBeUndefined();
+    });
+  });
+
+  describe("nullifierHashToBigIntStr", () => {
+    it("should convert a standard hash to BigInt string", () => {
+      const hash = "0x123abc";
+      const result = nullifierHashToBigIntStr(hash);
+      expect(result).toBe("1194684");
+    });
+
+    it("should normalize hash by removing 0x prefix and converting to lowercase", () => {
+      const hash = "0xABC123";
+      const result = nullifierHashToBigIntStr(hash);
+      expect(result).toBe("11256099");
+    });
+
+    it("should handle hash without 0x prefix", () => {
+      const hash = "abc123";
+      const result = nullifierHashToBigIntStr(hash);
+      expect(result).toBe("11256099");
+    });
+
+    it("should handle hash with whitespace", () => {
+      const hash = " 0xabc123 ";
+      const result = nullifierHashToBigIntStr(hash);
+      expect(result).toBe("11256099");
+    });
+
+    it("should handle real-world size nullifier hash", () => {
+      const hash =
+        "0x0447c1b95a5a808a36d3966216404ff4d522f1e66ecddf9c22439393f00cf616";
+      const result = nullifierHashToBigIntStr(hash);
+      // A 256-bit number is too large to check the exact value, so we verify it's a string of digits
+      expect(result).toMatch(/^\d+$/);
+      expect(result.length).toBeGreaterThan(70); // A 256-bit number in decimal is ~78 digits
     });
   });
 });


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

This PR adds `nullifier_hash_int` column to store the integer representation of the hex `nullfier_hash`, this will improve security solving case sensitive, padding issues we have.


<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
