### PR TITLE
fix: Remove user permissions to delete app metadata

### DIFF
--- a/hasura/metadata/databases/default/tables/public_app_metadata.yaml
+++ b/hasura/metadata/databases/default/tables/public_app_metadata.yaml
@@ -476,20 +476,3 @@ delete_permissions:
       filter:
         verification_status:
           _eq: verified
-  - role: user
-    permission:
-      filter:
-        _and:
-          - verification_status:
-              _neq: verified
-          - app:
-              team:
-                memberships:
-                  _and:
-                    - user_id:
-                        _eq: X-Hasura-User-Id
-                    - _or:
-                        - role:
-                            _eq: OWNER
-                        - role:
-                            _eq: ADMIN


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description
Ticket - [DEV-1723](https://linear.app/worldcoin/issue/DEV-1723/h1-admin-role-can-permanently-lock-out-team-owner-and-newly-invited)
Deletes the ADMIN and OWNER user permissions to delete app metadata, as there is no use-case for them on the frontend.
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
