### PR TITLE
Update verification trigger to run only when `uses` column is updated

### DIFF
--- a/hasura/migrations/default/1747841041612_run_verification_trigger_only_when_uses_column_updates/down.sql
+++ b/hasura/migrations/default/1747841041612_run_verification_trigger_only_when_uses_column_updates/down.sql
@@ -1,0 +1,5 @@
+-- Revert to the old trigger that runs on every update
+CREATE OR REPLACE TRIGGER enforce_uses_limit
+BEFORE UPDATE ON nullifier
+FOR EACH ROW
+EXECUTE FUNCTION check_nullifier_uses_limit();

--- a/hasura/migrations/default/1747841041612_run_verification_trigger_only_when_uses_column_updates/up.sql
+++ b/hasura/migrations/default/1747841041612_run_verification_trigger_only_when_uses_column_updates/up.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE TRIGGER enforce_uses_limit
+BEFORE UPDATE OF uses ON nullifier
+FOR EACH ROW
+WHEN (OLD.uses IS DISTINCT FROM NEW.uses)
+EXECUTE FUNCTION check_nullifier_uses_limit();


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

This allows us to update `nullifier_hash_int` column, for rows that have invalid/corrupt uses.

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
