### PR TITLE
Add notif opt in rate stat

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/server/index.ts
@@ -12,6 +12,7 @@ export type AppMetricsData = {
   n_users_opened_last_14_days: NotificationData[];
   n_users_received_last_14_days: NotificationData[];
   open_rate_last_14_days: NotificationData[];
+  notification_opt_in_rate: number | null;
 };
 
 type NotificationData = {
@@ -56,6 +57,7 @@ export const getAppMetricsData = async (
       n_users_opened_last_14_days: [],
       n_users_received_last_14_days: [],
       open_rate_last_14_days: [],
+      notification_opt_in_rate: 0,
     };
   }
 
@@ -75,5 +77,6 @@ export const getAppMetricsData = async (
     n_users_opened_last_14_days: appMetrics.n_users_opened_last_14_days,
     n_users_received_last_14_days: appMetrics.n_users_received_last_14_days,
     open_rate_last_14_days: appMetrics.open_rate_last_14_days,
+    notification_opt_in_rate: appMetrics.notification_opt_in_rate,
   };
 };


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description
add a single value stat to notification chart
<img width="532" alt="Screenshot 2025-05-22 at 18 38 17" src="https://github.com/user-attachments/assets/ab7cc1bb-53bc-456f-8c53-ca18a56dc407" />
update chart colors, so that old ones match the legend, and notification chart doesn't collide with old ones. Opt-in rate is a single value not a time series so added it as an additional stat, seemed to fit in alright. 
Once we get more related 1 value stats i'll move it out to a new section/component
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
