### PR TITLE
Handle gracefully invalid nullifier hash

### DIFF
--- a/web/api/v2/verify/index.ts
+++ b/web/api/v2/verify/index.ts
@@ -32,7 +32,14 @@ const schema = yup.object({
       "0x00c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a4", // hashToField("")
     ),
   proof: yup.string().strict().required("This attribute is required."),
-  nullifier_hash: yup.string().strict().required("This attribute is required."),
+  nullifier_hash: yup
+    .string()
+    .strict()
+    .matches(
+      /^(0x)?[\da-fA-F]+$/,
+      "Invalid nullifier_hash. Must be a hex string with optional 0x prefix.",
+    )
+    .required("This attribute is required."),
   merkle_root: yup.string().strict().required("This attribute is required."),
   verification_level: yup
     .string()

--- a/web/tests/integration/api/v2/verify.test.ts
+++ b/web/tests/integration/api/v2/verify.test.ts
@@ -188,10 +188,10 @@ describe("/api/v2/verify [Security Vulnerabilities Integration Tests]", () => {
 
     const body = await secondResponse.json();
     expect(body).toEqual({
-      attribute: null,
-      code: "max_verifications_reached",
-      detail: "This person has already verified for this action.",
-      app_id: appId,
+      attribute: "nullifier_hash",
+      code: "validation_error",
+      detail:
+        "Invalid nullifier_hash. Must be a hex string with optional 0x prefix.",
     });
   });
 
@@ -232,7 +232,7 @@ describe("/api/v2/verify [Security Vulnerabilities Integration Tests]", () => {
     expect(nullifierCheck.rows.length).toBe(1);
 
     // Second attempt with a different prefix
-    const nullifierWithoutPrefix = "dd" + VALID_NULLIFIER_HASH.slice(2);
+    const nullifierWithoutPrefix = "zz" + VALID_NULLIFIER_HASH.slice(2);
 
     console.log("Testing prefix bypass:", {
       withPrefix: VALID_NULLIFIER_HASH,
@@ -251,9 +251,10 @@ describe("/api/v2/verify [Security Vulnerabilities Integration Tests]", () => {
 
     const body = await secondResponse.json();
     expect(body).toMatchObject({
-      attribute: null,
-      code: "invalid_proof",
-      app_id: appId,
+      attribute: "nullifier_hash",
+      code: "validation_error",
+      detail:
+        "Invalid nullifier_hash. Must be a hex string with optional 0x prefix.",
     });
   });
 


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Improve error codes by returning `400` instead of `500` when nullifier hash is invalid hex.

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
