### PR TITLE
Improve Traditional Chinese localisation

### DIFF
--- a/web/lib/languages.ts
+++ b/web/lib/languages.ts
@@ -269,13 +269,21 @@ export const parseLocale = (locale: string) => {
   // Split on either - or _
   const major_locale = locale.split(/[-_]/)[0];
   const secondary_locale = locale.split(/[-_]/)?.[1];
+  const tertiary_locale = locale.split(/[-_]/)?.[2];
 
   const language = supportedLanguages.find(
     (lang) => lang.value === major_locale,
   );
 
   // Handle Chinese -- Default to Simplified Chinese
-  if (major_locale === "zh" && secondary_locale?.toUpperCase() === "TW") {
+  // Handle zh-Hant-TW and zh-TW as Traditional Chinese (TW)
+  const isZhHantTw =
+    major_locale === "zh" &&
+    secondary_locale?.toUpperCase() === "HANT" &&
+    tertiary_locale?.toUpperCase() === "TW";
+  const isZhTw =
+    major_locale === "zh" && secondary_locale?.toUpperCase() === "TW";
+  if (isZhHantTw || isZhTw) {
     return "zh_TW";
   } else if (major_locale === "zh") {
     return "zh_CN";

--- a/web/tests/unit/parse-locale.test.ts
+++ b/web/tests/unit/parse-locale.test.ts
@@ -5,9 +5,10 @@ describe("parseLocale", () => {
     expect(parseLocale("en-US")).toBe("en");
   });
 
-  it("should parse zh-TW and zh_TW", () => {
+  it("should parse zh-TW and zh_TW and zh-Hant-TW", () => {
     expect(parseLocale("zh-TW")).toBe("zh_TW");
     expect(parseLocale("zh_TW")).toBe("zh_TW");
+    expect(parseLocale("zh-Hant-TW")).toBe("zh_TW");
   });
 
   it("should parse es-419 and es_419", () => {


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Handle `zh-Hant-TW` locale as `zh_TW`, because this how iOS sends it.

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
