### PR TITLE
fix: raise app limit

### DIFF
--- a/web/api/v2/public/apps/index.ts
+++ b/web/api/v2/public/apps/index.ts
@@ -28,7 +28,7 @@ import {
 
 const queryParamsSchema = yup.object({
   page: yup.number().integer().min(1).default(1).notRequired(),
-  limit: yup.number().integer().min(1).max(500).notRequired().default(250),
+  limit: yup.number().integer().min(1).max(1000).notRequired().default(500),
   app_mode: yup
     .string()
     .oneOf(["mini-app", "external", "native"])


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

limit is applied BEFORE any country filtering. Once we hit 250 miniapps, some were not returned anymore. Right now total is 265, raised the limit to 500 which is an immediate fix and gives us time to adjust 

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
