### PR TITLE
fix: Replace must with filter in OpenSearch

### DIFF
--- a/web/lib/opensearch.ts
+++ b/web/lib/opensearch.ts
@@ -128,20 +128,20 @@ export class OpenSearchClient {
     verificationStatus?: string,
     isReviewerWorldAppApproved?: boolean,
   ): Promise<string[]> {
-    const must = [];
+    const filter = [];
 
     // Add filters to the query if they are provided
     if (verificationStatus) {
-      must.push({
-        match: {
+      filter.push({
+        term: {
           verification_status: verificationStatus,
         },
       });
     }
 
     if (isReviewerWorldAppApproved) {
-      must.push({
-        match: {
+      filter.push({
+        term: {
           is_reviewer_world_app_approved: isReviewerWorldAppApproved,
         },
       });
@@ -171,7 +171,8 @@ export class OpenSearchClient {
               },
             },
           ],
-          must,
+          filter,
+          minimum_should_match: 1,
         },
       },
       sort: ["_score"],


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Fixes the OpenSearch query performance issue by replacing the `must` clause with a `filter` clause (which is cached).

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
