### PR TITLE
Migrate partially to v2 verify sequencer endpoint

### DIFF
--- a/web/api/helpers/verify.v2.ts
+++ b/web/api/helpers/verify.v2.ts
@@ -1,0 +1,138 @@
+import { IInternalError } from "@/lib/types";
+import { sequencerMapping } from "@/lib/utils";
+import {
+  IInputParams,
+  IVerifyParams,
+  parseProofInputs,
+} from "./verify";
+
+const KNOWN_ERROR_CODES = [
+  // V2 API error mapping
+  // errorId from v2 API -> code returned to client
+  {
+    errorId: "invalid_root",
+    code: "invalid_merkle_root",
+    detail:
+      "The provided Merkle root is invalid. User appears to be unverified.",
+  },
+  {
+    errorId: "root_too_old",
+    code: "root_too_old",
+    detail:
+      "The provided merkle root is too old. Please generate a new proof and try again.",
+  },
+  {
+    errorId: "decompressing_proof_error",
+    code: "invalid_proof",
+    detail:
+      "The provided proof is invalid and it cannot be verified. Please check all inputs and try again.",
+  },
+  {
+    errorId: "prover_error",
+    code: "prover_error",
+    detail:
+      "The prover encountered an error while verifying the proof. Please try again.",
+  },
+];
+
+/**
+ * Verifies a ZKP with the World ID smart contract (V2 API)
+ */
+export const verifyProof = async (
+  proofParams: IInputParams,
+  verifyParams: IVerifyParams,
+): Promise<{
+  success?: true;
+  status?: string;
+  error?: IInternalError;
+}> => {
+  // Parse the inputs
+  const parsed = parseProofInputs(proofParams);
+  if (parsed.error || !parsed.params) {
+    return { error: parsed.error };
+  }
+
+  const { params: parsedParams } = parsed;
+
+  // Query the signup sequencer to verify the proof (V2 API)
+  const body = JSON.stringify({
+    root: parsedParams.merkle_root,
+    nullifierHash: parsedParams.nullifier_hash,
+    externalNullifierHash: parsedParams.external_nullifier,
+    signalHash: parsedParams.signal_hash,
+    proof: parsedParams.proof,
+    // V2 API: maxRootAgeSeconds is now in the request body
+    ...(verifyParams.max_age && { maxRootAgeSeconds: verifyParams.max_age }),
+  });
+
+  const sequencerUrl =
+    sequencerMapping[verifyParams.verification_level]?.[
+      verifyParams.is_staging.toString()
+    ];
+
+  // V2 API endpoint
+  const response = await fetch(`${sequencerUrl}/v2/semaphore-proof/verify`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    try {
+      // V2 API returns JSON error responses
+      const errorResponse = await response.json();
+      const knownError = KNOWN_ERROR_CODES.find(
+        ({ errorId }) => errorId === errorResponse.errorId,
+      );
+      return {
+        error: {
+          message:
+            knownError?.detail ||
+            errorResponse.errorMessage ||
+            `We couldn't verify the provided proof (error code ${errorResponse.errorId}).`,
+          code: knownError?.code || "invalid_proof",
+          statusCode: 400,
+          attribute: null,
+        },
+      };
+    } catch {
+      return {
+        error: {
+          message: "There was an internal issue verifying this proof.",
+          code: "internal_error",
+          statusCode: 500,
+        },
+      };
+    }
+  }
+
+  // V2 API returns { valid: boolean }
+  try {
+    const result = await response.json();
+    if (result.valid === true) {
+      return { success: true };
+    } else {
+      return {
+        error: {
+          message: "The provided proof is invalid.",
+          code: "invalid_proof",
+          statusCode: 400,
+          attribute: null,
+        },
+      };
+    }
+  } catch {
+    return {
+      error: {
+        message: "There was an internal issue processing the verification response.",
+        code: "internal_error",
+        statusCode: 500,
+      },
+    };
+  }
+};
+
+// Re-export utilities from verify.ts for backward compatibility
+export { canVerifyForAction, nullifierHashToBigIntStr } from "./verify";

--- a/web/api/v2/verify/index.ts
+++ b/web/api/v2/verify/index.ts
@@ -10,12 +10,19 @@ import {
   nullifierHashToBigIntStr,
   verifyProof,
 } from "@/api/helpers/verify";
+import { verifyProof as verifyProofV2 } from "@/api/helpers/verify.v2";
+import { logger } from "@/lib/logger";
 import { captureEvent } from "@/services/posthogClient";
 import { AppErrorCodes, VerificationLevel } from "@worldcoin/idkit-core";
 import { NextRequest, NextResponse } from "next/server";
 import * as yup from "yup";
 import { getSdk as atomicUpsertNullifierSdk } from "./graphql/atomic-upsert-nullifier.generated";
 import { getSdk as getFetchAppActionSdk } from "./graphql/fetch-app-action.generated";
+
+// V2 verification whitelist - add app_ids here to use v2 verification
+const V2_ENABLED_APP_IDS = process.env.V2_VERIFICATION_APP_IDS
+  ? process.env.V2_VERIFICATION_APP_IDS.split(",")
+  : [];
 
 const schema = yup.object({
   action: yup
@@ -163,7 +170,15 @@ export async function POST(
 
   try {
     // ANCHOR: Verify the proof with the World ID smart contract
-    const { error, success } = await verifyProof(
+    // Use v2 verification if app_id is in whitelist
+    const useV2 = V2_ENABLED_APP_IDS.includes(app_id);
+    const verifyFunction = useV2 ? verifyProofV2 : verifyProof;
+
+    if (useV2) {
+      logger.info(`Using v2 verification for app_id: ${app_id}`);
+    }
+
+    const { error, success } = await verifyFunction(
       {
         signal_hash: parsedParams.signal_hash,
         proof: parsedParams.proof,


### PR DESCRIPTION
# Summary
This PR migrates to V2 of the sequencer verify endpoint -find the new spec [here](https://github.com/worldcoin/signup-sequencer/blob/main/schemas/openapi-v2.yaml)- feature flagged for specific apps as this is a high risk change.