### PR TITLE
Log invalid JSON bodies in `/verify`

### DIFF
--- a/web/api/v2/verify/index.ts
+++ b/web/api/v2/verify/index.ts
@@ -10,6 +10,7 @@ import {
   nullifierHashToBigIntStr,
   verifyProof,
 } from "@/api/helpers/verify";
+import { logger } from "@/lib/logger";
 import { captureEvent } from "@/services/posthogClient";
 import { AppErrorCodes, VerificationLevel } from "@worldcoin/idkit-core";
 import { NextRequest, NextResponse } from "next/server";
@@ -75,6 +76,9 @@ export async function POST(
   try {
     body = await req.json();
   } catch (error) {
+    const body = await req.text();
+    logger.warn("Invalid JSON in request body", { error, app_id, body });
+
     return errorResponse({
       statusCode: 400,
       code: "invalid_request",


### PR DESCRIPTION
# Summary

This PR adds a warning logs for invalid JSON logs in `/verify`, to monitor close 