### PR TITLE
flag to return a deleted app instead of 404

### DIFF
--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -117,8 +117,12 @@ export async function GET(
     }
   }
 
-  const isMetadataVerified =
-    parsedAppMetadata.verification_status === "verified";
+  const shouldShowDeleted = searchParams.get("show_deleted") === "true";
+  const isAppDeleted = parsedAppMetadata.app.deleted_at != null;
+
+  if (isAppDeleted && !shouldShowDeleted) {
+    return NextResponse.json({ error: "App not found" }, { status: 404 });
+  }
 
   // skip checking cf country, when coming from app-backend
   const skipCloudfrontCheck = Boolean(
@@ -130,6 +134,8 @@ export async function GET(
   const override_country = searchParams.get("override_country") || country;
   const shouldUninstallOnDelist = parsedAppMetadata.should_uninstall_on_delist;
   const isDelisted = !parsedAppMetadata.is_reviewer_app_store_approved;
+  const isMetadataVerified =
+    parsedAppMetadata.verification_status === "verified";
 
   // only restrict based on country if app is delisted and should be uninstalled on delist
   // this means that the only two cases where an app is not deeplinkable are:

--- a/web/tests/api/v2/public/apps/app.test.ts
+++ b/web/tests/api/v2/public/apps/app.test.ts
@@ -217,107 +217,6 @@ describe("/api/public/app/[app_id]", () => {
     });
   });
 
-  test("Returns correct value for deleted app", async () => {
-    jest.mocked(getAppMetadataSdk).mockImplementation(() => ({
-      GetAppMetadata: jest.fn().mockResolvedValue({
-        app_metadata: [
-          {
-            name: "Example App",
-            app_id: "1",
-            short_name: "test",
-            logo_img_url: "logo.png",
-            showcase_img_urls: ["showcase1.png", "showcase2.png"],
-            meta_tag_image_url: "meta_tag_image.png",
-            hero_image_url: "",
-            world_app_description:
-              "This is an example app designed to showcase the capabilities of our platform.",
-            world_app_button_text: "Use Integration",
-            category: "Productivity",
-            description:
-              '{"description_overview":"fewf","description_how_it_works":"few","description_connect":"fewf"}',
-            integration_url: "https://example.com/integration",
-            app_website_url: "https://example.com",
-            source_code_url: "https://github.com/example/app",
-            whitelisted_addresses: ["0x1234", "0x5678"],
-            app_mode: "mini-app",
-            support_link: "andy@gmail.com",
-            supported_countries: ["us"],
-            associated_domains: ["https://worldcoin.org"],
-            contracts: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
-            permit2_tokens: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
-            supported_languages: ["en", "es"],
-            verification_status: "verified",
-            is_allowed_unlimited_notifications: false,
-            max_notifications_per_day: 10,
-            app: {
-              team: {
-                name: "Example Team",
-              },
-              rating_sum: 10,
-              rating_count: 3,
-              deleted_at: "2016-01-25T10:10:10.555555",
-            },
-          },
-        ],
-      }),
-    }));
-
-    const request = new NextRequest("https://cdn.test.com/api/public/app/1", {
-      headers: {
-        host: "cdn.test.com",
-      },
-    });
-    const response = await GET(request, { params: { app_id: "1" } });
-    expect(await response.json()).toEqual({
-      app_data: {
-        name: "Example App",
-        app_id: "1",
-        app_rating: 3.33,
-        short_name: "test",
-        logo_img_url: "https://cdn.test.com/1/logo.png",
-        meta_tag_image_url: "https://cdn.test.com/1/meta_tag_image.png",
-        showcase_img_urls: [
-          "https://cdn.test.com/1/showcase1.png",
-          "https://cdn.test.com/1/showcase2.png",
-        ],
-        hero_image_url: "",
-        category: {
-          id: "productivity",
-          name: "Productivity",
-        },
-        integration_url: "https://example.com/integration",
-        app_website_url: "https://example.com",
-        source_code_url: "https://github.com/example/app",
-        team_name: "Example Team",
-        whitelisted_addresses: ["0x1234", "0x5678"],
-        app_mode: "mini-app",
-        associated_domains: ["https://worldcoin.org"],
-        contracts: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
-        permit2_tokens: ["0x0c892815f0B058E69987920A23FBb33c834289cf"],
-        ratings_external_nullifier:
-          "0x00051f128f73eec6f444e98dca57697f9cce04fb3f2e0e63dea5351ccde35b8e",
-        support_link: "andy@gmail.com",
-        supported_countries: ["us"],
-        supported_languages: ["en", "es"],
-        unique_users: 0,
-        impressions: 0,
-        verification_status: "verified",
-        is_allowed_unlimited_notifications: false,
-        max_notifications_per_day: 10,
-        description: {
-          how_it_works: "",
-          how_to_connect: "",
-          overview: "fewf",
-        },
-        world_app_button_text: "Get Mini App",
-        world_app_description:
-          "This is an example app designed to showcase the capabilities of our platform.",
-        avg_notification_open_rate: null,
-        deleted_at: "2016-01-25T10:10:10.555555",
-      },
-    });
-  });
-
   test("Implements native app correctly", async () => {
     const request = new NextRequest(
       "https://cdn.test.com/api/v2/public/app/TEST_APP",
@@ -1466,6 +1365,77 @@ describe("/api/public/app/[app_id]", () => {
       const data = await response.json();
       expect(data).toHaveProperty("app_data");
       expect(data.app_data.name).toBe("Contacts App");
+    });
+  });
+
+  describe("show_deleted parameter behavior", () => {
+    beforeEach(() => {
+      jest.mocked(getAppMetadataSdk).mockImplementation(() => ({
+        GetAppMetadata: jest.fn().mockResolvedValue({
+          app_metadata: [
+            {
+              name: "Deleted App",
+              app_id: "deleted-app-1",
+              short_name: "deleted",
+              logo_img_url: "logo.png",
+              showcase_img_urls: ["showcase1.png"],
+              hero_image_url: "",
+              category: "Social",
+              description: '{"description_overview":"Deleted app"}',
+              integration_url: "https://example.com/integration",
+              verification_status: "verified",
+              is_allowed_unlimited_notifications: false,
+              max_notifications_per_day: 10,
+              app: {
+                team: {
+                  name: "Test Team",
+                },
+                rating_sum: 10,
+                rating_count: 2,
+                deleted_at: "2024-01-01T10:00:00.000Z", // app is deleted
+              },
+            },
+          ],
+        }),
+      }));
+    });
+
+    test("should return 404 when app is deleted and show_deleted is not set", async () => {
+      const request = new NextRequest(
+        "https://cdn.test.com/api/v2/public/app/deleted-app-1",
+        {
+          headers: {
+            host: "cdn.test.com",
+          },
+        },
+      );
+
+      const response = await GET(request, {
+        params: { app_id: "deleted-app-1" },
+      });
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({ error: "App not found" });
+    });
+
+    test("should return app data when app is deleted but show_deleted=true", async () => {
+      const request = new NextRequest(
+        "https://cdn.test.com/api/v2/public/app/deleted-app-1?show_deleted=true",
+        {
+          headers: {
+            host: "cdn.test.com",
+          },
+        },
+      );
+
+      const response = await GET(request, {
+        params: { app_id: "deleted-app-1" },
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.app_data.name).toBe("Deleted App");
+      expect(data.app_data.deleted_at).toBe("2024-01-01T10:00:00.000Z");
     });
   });
 });


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description
Deleted apps should not be returned to home-screen

- introduces new `show_deleted` flag
- changes endpoint behavior to return a 404 when metadata is deleted, unless this new flag is present and true
- adds tests for this behavior

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
