### PR TITLE
Refactor v2 of Fetch Metrics

### DIFF
--- a/web/api/hasura/invalidate-cache/index.ts
+++ b/web/api/hasura/invalidate-cache/index.ts
@@ -1,4 +1,5 @@
 import { errorHasuraQuery } from "@/api/helpers/errors";
+import { clearMetricsCache } from "@/api/helpers/fetch-metrics";
 import { protectInternalEndpoint } from "@/api/helpers/utils";
 import { logger } from "@/lib/logger";
 import {
@@ -81,6 +82,8 @@ export const POST = async (req: NextRequest) => {
 
     const command = new CreateInvalidationCommand(input);
     await client.send(command);
+
+    await clearMetricsCache();
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/web/api/hasura/invalidate-cache/index.ts
+++ b/web/api/hasura/invalidate-cache/index.ts
@@ -80,10 +80,10 @@ export const POST = async (req: NextRequest) => {
       },
     };
 
+    await clearMetricsCache();
+
     const command = new CreateInvalidationCommand(input);
     await client.send(command);
-
-    await clearMetricsCache();
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/web/api/helpers/fetch-metrics.ts
+++ b/web/api/helpers/fetch-metrics.ts
@@ -8,116 +8,115 @@ interface ProcessedMetricsCache {
 }
 
 let memoryCache: ProcessedMetricsCache | null = null;
-let pendingFetch: Promise<ProcessedMetricsCache | null> | null = null;
+let pendingFetch: Promise<ProcessedMetricsCache> | null = null;
 
-const MEMORY_CACHE_TTL = 2 * 60 * 60 * 1000; // 2 hours
+const MEMORY_CACHE_TTL = 10 * 60 * 1000; // 10 minutes
 
 /**
  * Fetch and process raw metrics data, caching results for all countries
  */
-const fetchAndProcessMetrics =
-  async (): Promise<ProcessedMetricsCache | null> => {
-    const response = await fetchWithRetry(
-      `${process.env.NEXT_PUBLIC_METRICS_SERVICE_ENDPOINT}/stats/data.json`,
-      {
-        headers: {
-          "Cache-Control": "max-age=300", // 5 minutes, same as CloudFront
-        },
+const fetchAndProcessMetrics = async (): Promise<ProcessedMetricsCache> => {
+  const response = await fetchWithRetry(
+    `${process.env.NEXT_PUBLIC_METRICS_SERVICE_ENDPOINT}/stats/data.json`,
+    {
+      headers: {
+        "Cache-Control": "max-age=300", // 5 minutes, same as CloudFront
       },
-      3,
-      400,
-      false,
-    );
+    },
+    3,
+    400,
+    false,
+  );
 
-    if (response.status !== 200) {
-      console.error("Failed to fetch metrics", {
-        status: response.status,
-        statusText: response.statusText,
-      });
-      throw new Error("Failed to fetch metrics");
+  if (response.status !== 200) {
+    console.error("Failed to fetch metrics", {
+      status: response.status,
+      statusText: response.statusText,
+    });
+    throw new Error("Failed to fetch metrics");
+  }
+
+  const rawData: MetricsServiceAppData[] = await response.json();
+
+  const byCountry = new Map<string, AppStatsReturnType>();
+  const countries = new Set<string>();
+
+  const global = rawData.map((app) => {
+    let uniqueUsersSum = 0;
+    let newUsersSum = 0;
+    let totalUsersSum = 0;
+
+    if (app.unique_users_last_7_days) {
+      for (const user of app.unique_users_last_7_days) {
+        if (user.country) countries.add(user.country.toUpperCase());
+        uniqueUsersSum += user.value || 0;
+      }
     }
 
-    const rawData: MetricsServiceAppData[] = await response.json();
+    if (app.new_users_last_7_days) {
+      for (const user of app.new_users_last_7_days) {
+        if (user.country) countries.add(user.country.toUpperCase());
+        newUsersSum += user.value || 0;
+      }
+    }
 
-    const byCountry = new Map<string, AppStatsReturnType>();
-    const countries = new Set<string>();
+    if (app.total_users_last_7_days) {
+      for (const user of app.total_users_last_7_days) {
+        if (user.country) countries.add(user.country.toUpperCase());
+        totalUsersSum += user.value || 0;
+      }
+    }
 
-    const global = rawData.map((app) => {
-      let uniqueUsersSum = 0;
-      let newUsersSum = 0;
-      let totalUsersSum = 0;
+    return {
+      ...app,
+      unique_users_last_7_days: uniqueUsersSum || undefined,
+      new_users_last_7_days: newUsersSum || undefined,
+      total_users_last_7_days: totalUsersSum || undefined,
+    };
+  });
+
+  // Process country-specific data
+  for (const country of countries) {
+    const countryData = rawData.map((app) => {
+      let uniqueUsers: number | undefined;
+      let newUsers: number | undefined;
+      let totalUsers: number | undefined;
 
       if (app.unique_users_last_7_days) {
-        for (const user of app.unique_users_last_7_days) {
-          if (user.country) countries.add(user.country.toUpperCase());
-          uniqueUsersSum += user.value || 0;
-        }
+        uniqueUsers = app.unique_users_last_7_days.find(
+          (user) => user.country?.toUpperCase() === country,
+        )?.value;
       }
 
       if (app.new_users_last_7_days) {
-        for (const user of app.new_users_last_7_days) {
-          if (user.country) countries.add(user.country.toUpperCase());
-          newUsersSum += user.value || 0;
-        }
+        newUsers = app.new_users_last_7_days.find(
+          (user) => user.country?.toUpperCase() === country,
+        )?.value;
       }
 
       if (app.total_users_last_7_days) {
-        for (const user of app.total_users_last_7_days) {
-          if (user.country) countries.add(user.country.toUpperCase());
-          totalUsersSum += user.value || 0;
-        }
+        totalUsers = app.total_users_last_7_days.find(
+          (user) => user.country?.toUpperCase() === country,
+        )?.value;
       }
 
       return {
         ...app,
-        unique_users_last_7_days: uniqueUsersSum || undefined,
-        new_users_last_7_days: newUsersSum || undefined,
-        total_users_last_7_days: totalUsersSum || undefined,
+        unique_users_last_7_days: uniqueUsers,
+        new_users_last_7_days: newUsers,
+        total_users_last_7_days: totalUsers,
       };
     });
 
-    // Process country-specific data
-    for (const country of countries) {
-      const countryData = rawData.map((app) => {
-        let uniqueUsers: number | undefined;
-        let newUsers: number | undefined;
-        let totalUsers: number | undefined;
+    byCountry.set(country, countryData);
+  }
 
-        if (app.unique_users_last_7_days) {
-          uniqueUsers = app.unique_users_last_7_days.find(
-            (user) => user.country?.toUpperCase() === country,
-          )?.value;
-        }
-
-        if (app.new_users_last_7_days) {
-          newUsers = app.new_users_last_7_days.find(
-            (user) => user.country?.toUpperCase() === country,
-          )?.value;
-        }
-
-        if (app.total_users_last_7_days) {
-          totalUsers = app.total_users_last_7_days.find(
-            (user) => user.country?.toUpperCase() === country,
-          )?.value;
-        }
-
-        return {
-          ...app,
-          unique_users_last_7_days: uniqueUsers,
-          new_users_last_7_days: newUsers,
-          total_users_last_7_days: totalUsers,
-        };
-      });
-
-      byCountry.set(country, countryData);
-    }
-
-    return {
-      byCountry,
-      global,
-      timestamp: Date.now(),
-    };
+  return {
+    byCountry,
+    global,
+    timestamp: Date.now(),
   };
+};
 
 /**
  * Fetch metrics from the metrics service with in-memory caching and request deduplication.
@@ -150,10 +149,7 @@ export const fetchMetrics = async (
   // If there's already a pending fetch, await it (request deduplication)
   if (pendingFetch) {
     const result = await pendingFetch;
-    if (!result) {
-      console.error("Failed to fetch metrics data");
-      return [];
-    }
+
     return country
       ? result.byCountry.get(country.toUpperCase()) || []
       : result.global;

--- a/web/api/helpers/fetch-metrics.ts
+++ b/web/api/helpers/fetch-metrics.ts
@@ -1,141 +1,200 @@
 import { AppStatsReturnType, MetricsServiceAppData } from "@/lib/types";
 import { fetchWithRetry } from "@/lib/utils";
 
-const pendingRequests = new Map<string, Promise<AppStatsReturnType>>();
+interface ProcessedMetricsCache {
+  byCountry: Map<string, AppStatsReturnType>;
+  global: AppStatsReturnType;
+  timestamp: number;
+}
+
+let processedCache: ProcessedMetricsCache | null = null;
+let pendingFetch: Promise<void> | null = null;
 
 /**
- * Fetch metrics from the metrics service with request deduplication
+ * Fetch and process raw metrics data, caching results for all countries
+ */
+const fetchAndProcessMetrics = async (): Promise<void> => {
+  const response = await fetchWithRetry(
+    `${process.env.NEXT_PUBLIC_METRICS_SERVICE_ENDPOINT}/stats/data.json`,
+    {
+      headers: {
+        "Cache-Control": "max-age=600", // 10 minutes, since metrics only updates every few hours
+      },
+    },
+    3,
+    400,
+    false,
+  );
+
+  if (response.status !== 200) {
+    console.error("Failed to fetch metrics", {
+      status: response.status,
+      statusText: response.statusText,
+    });
+    throw new Error("Failed to fetch metrics");
+  }
+
+  const rawData: MetricsServiceAppData[] = await response.json();
+
+  // Process data for all countries in one pass
+  const byCountry = new Map<string, AppStatsReturnType>();
+  const countries = new Set<string>();
+
+  // Collect all countries
+  rawData.forEach((app) => {
+    app.unique_users_last_7_days?.forEach((user) => {
+      if (user.country) countries.add(user.country.toUpperCase());
+    });
+    app.new_users_last_7_days?.forEach((user) => {
+      if (user.country) countries.add(user.country.toUpperCase());
+    });
+    app.total_users_last_7_days?.forEach((user) => {
+      if (user.country) countries.add(user.country.toUpperCase());
+    });
+  });
+
+  // Process data for each country
+  countries.forEach((country) => {
+    const countryData = rawData.map((app) => {
+      let uniqueUsers: number | undefined;
+      let newUsers: number | undefined;
+      let totalUsers: number | undefined;
+
+      if (app.unique_users_last_7_days) {
+        const userData = app.unique_users_last_7_days.find(
+          (user) => user.country?.toUpperCase() === country,
+        );
+        uniqueUsers = userData?.value;
+      }
+
+      if (app.new_users_last_7_days) {
+        const userData = app.new_users_last_7_days.find(
+          (user) => user.country?.toUpperCase() === country,
+        );
+        newUsers = userData?.value;
+      }
+
+      if (app.total_users_last_7_days) {
+        const userData = app.total_users_last_7_days.find(
+          (user) => user.country?.toUpperCase() === country,
+        );
+        totalUsers = userData?.value;
+      }
+
+      return {
+        ...app,
+        unique_users_last_7_days: uniqueUsers,
+        new_users_last_7_days: newUsers,
+        total_users_last_7_days: totalUsers,
+      };
+    });
+
+    byCountry.set(country, countryData);
+  });
+
+  // Process global data (sum all countries)
+  const global = rawData.map((app) => {
+    let uniqueUsersSum = 0;
+    let newUsersSum = 0;
+    let totalUsersSum = 0;
+
+    if (app.unique_users_last_7_days) {
+      for (const user of app.unique_users_last_7_days) {
+        uniqueUsersSum += Number(user.value) || 0;
+      }
+    }
+
+    if (app.new_users_last_7_days) {
+      for (const user of app.new_users_last_7_days) {
+        newUsersSum += Number(user.value) || 0;
+      }
+    }
+
+    if (app.total_users_last_7_days) {
+      for (const user of app.total_users_last_7_days) {
+        totalUsersSum += Number(user.value) || 0;
+      }
+    }
+
+    return {
+      ...app,
+      unique_users_last_7_days: uniqueUsersSum || undefined,
+      new_users_last_7_days: newUsersSum || undefined,
+      total_users_last_7_days: totalUsersSum || undefined,
+    };
+  });
+
+  // Cache the processed data
+  processedCache = {
+    byCountry,
+    global,
+    timestamp: Date.now(),
+  };
+};
+
+/**
+ * Fetch metrics from the metrics service with 10-minute caching for all countries.
+ * While fetching, we return the stalecached data.
  *
- * This function ensures that multiple concurrent requests for the same data
- * (same country) will share a single network request and JSON parsing operation.
+ * This function processes metrics data once and caches it for all countries.
+ * Subsequent requests for any country or global data use the cached processed data.
  *
- * @param expirationTime - The time to cache the data for in seconds (passed to HTTP headers)
+ * @param expirationTime - Not used anymore, kept for API compatibility
  * @param country - The country to fetch data for
  * @returns The metrics data with the country data if specified, otherwise sum all values
  */
 export const fetchMetrics = async (
-  expirationTime: number = 3600, // Default to 1 hour (3600 seconds)
   country?: string | null,
 ): Promise<AppStatsReturnType> => {
-  const requestKey = `metrics_${country || "all"}`;
+  const now = Date.now();
+  const TEN_MINUTES_IN_MS = 10 * 60 * 1000; // 10 minutes in milliseconds
 
-  const pendingRequest = pendingRequests.get(requestKey);
-  if (pendingRequest) {
-    return pendingRequest;
+  // Check if we have fresh cached data
+  if (processedCache) {
+    const age = now - processedCache.timestamp;
+    if (age < TEN_MINUTES_IN_MS) {
+      return country
+        ? processedCache.byCountry.get(country.toUpperCase()) || []
+        : processedCache.global;
+    }
   }
 
-  const requestPromise = (async () => {
+  // Cache is stale or doesn't exist, or there's already a fetch in progress
+  if (pendingFetch) {
+    // There's already a fetch in progress, return the stale data
+    if (processedCache) {
+      return country
+        ? processedCache.byCountry.get(country.toUpperCase()) || []
+        : processedCache.global;
+    } else {
+      await pendingFetch;
+      return country
+        ? processedCache!.byCountry.get(country.toUpperCase()) || []
+        : processedCache!.global;
+    }
+  }
+
+  // No pending fetch, start a new one
+  pendingFetch = (async () => {
     try {
-      const fetchOptions: RequestInit = {};
-
-      if (expirationTime <= 0) {
-        fetchOptions.cache = "no-store";
-        fetchOptions.headers = {
-          "Cache-Control": "no-cache, no-store, must-revalidate",
-          Expires: "0",
-        };
-      } else {
-        fetchOptions.headers = {
-          "Cache-Control": `max-age=${Math.floor(expirationTime)}`,
-        };
-      }
-
-      const response = await fetchWithRetry(
-        `${process.env.NEXT_PUBLIC_METRICS_SERVICE_ENDPOINT}/stats/data.json`,
-        fetchOptions,
-        3,
-        400,
-        false,
-      );
-
-      if (response.status !== 200) {
-        console.error("Failed to fetch metrics", {
-          status: response.status,
-          statusText: response.statusText,
-        });
-        return [];
-      }
-
-      const responseData: MetricsServiceAppData[] = await response.json();
-      let metricsData: AppStatsReturnType = [];
-
-      if (country) {
-        // If country is specified return the value for that Country code
-        // for unique_users_last_7_days, new_users_last_7_days, and total_users_last_7_days
-        const upperCountry = country.toUpperCase();
-        metricsData = responseData.map((app) => {
-          let uniqueUsers: number | undefined;
-          let newUsers: number | undefined;
-          let totalUsers: number | undefined;
-
-          if (app.unique_users_last_7_days) {
-            const userData = app.unique_users_last_7_days.find(
-              (user) => user.country?.toUpperCase() === upperCountry,
-            );
-            uniqueUsers = userData?.value;
-          }
-
-          if (app.new_users_last_7_days) {
-            const userData = app.new_users_last_7_days.find(
-              (user) => user.country?.toUpperCase() === upperCountry,
-            );
-            newUsers = userData?.value;
-          }
-
-          if (app.total_users_last_7_days) {
-            const userData = app.total_users_last_7_days.find(
-              (user) => user.country?.toUpperCase() === upperCountry,
-            );
-            totalUsers = userData?.value;
-          }
-
-          return {
-            ...app,
-            unique_users_last_7_days: uniqueUsers,
-            new_users_last_7_days: newUsers,
-            total_users_last_7_days: totalUsers,
-          };
-        });
-      } else {
-        metricsData = responseData.map((app) => {
-          let uniqueUsersSum = 0;
-          let newUsersSum = 0;
-          let totalUsersSum = 0;
-
-          if (app.unique_users_last_7_days) {
-            for (const user of app.unique_users_last_7_days) {
-              uniqueUsersSum += Number(user.value) || 0;
-            }
-          }
-
-          if (app.new_users_last_7_days) {
-            for (const user of app.new_users_last_7_days) {
-              newUsersSum += Number(user.value) || 0;
-            }
-          }
-
-          if (app.total_users_last_7_days) {
-            for (const user of app.total_users_last_7_days) {
-              totalUsersSum += Number(user.value) || 0;
-            }
-          }
-
-          return {
-            ...app,
-            unique_users_last_7_days: uniqueUsersSum || undefined,
-            new_users_last_7_days: newUsersSum || undefined,
-            total_users_last_7_days: totalUsersSum || undefined,
-          };
-        });
-      }
-
-      return metricsData;
+      await fetchAndProcessMetrics();
     } finally {
-      pendingRequests.delete(requestKey);
+      pendingFetch = null;
     }
   })();
 
-  pendingRequests.set(requestKey, requestPromise);
-
-  return requestPromise;
+  // This situation is called if we don't have a pending fetch, but have stale data and we should start a new fetch
+  if (processedCache) {
+    pendingFetch.catch((error) => {
+      console.error("Error fetching metrics", { error });
+    });
+    return country
+      ? processedCache.byCountry.get(country.toUpperCase()) || []
+      : processedCache.global;
+  } else {
+    await pendingFetch;
+    return country
+      ? processedCache!.byCountry.get(country.toUpperCase()) || []
+      : processedCache!.global;
+  }
 };

--- a/web/api/helpers/fetch-metrics.ts
+++ b/web/api/helpers/fetch-metrics.ts
@@ -54,21 +54,21 @@ const fetchAndProcessMetrics = async (): Promise<void> => {
     if (app.unique_users_last_7_days) {
       for (const user of app.unique_users_last_7_days) {
         if (user.country) countries.add(user.country.toUpperCase());
-        uniqueUsersSum += Number(user.value) || 0;
+        uniqueUsersSum += user.value || 0;
       }
     }
 
     if (app.new_users_last_7_days) {
       for (const user of app.new_users_last_7_days) {
         if (user.country) countries.add(user.country.toUpperCase());
-        newUsersSum += Number(user.value) || 0;
+        newUsersSum += user.value || 0;
       }
     }
 
     if (app.total_users_last_7_days) {
       for (const user of app.total_users_last_7_days) {
         if (user.country) countries.add(user.country.toUpperCase());
-        totalUsersSum += Number(user.value) || 0;
+        totalUsersSum += user.value || 0;
       }
     }
 
@@ -79,42 +79,6 @@ const fetchAndProcessMetrics = async (): Promise<void> => {
       total_users_last_7_days: totalUsersSum || undefined,
     };
   });
-
-  // Process country-specific data in a single pass per country
-  for (const country of countries) {
-    const countryData = rawData.map((app) => {
-      let uniqueUsers: number | undefined;
-      let newUsers: number | undefined;
-      let totalUsers: number | undefined;
-
-      if (app.unique_users_last_7_days) {
-        uniqueUsers = app.unique_users_last_7_days.find(
-          (user) => user.country?.toUpperCase() === country,
-        )?.value;
-      }
-
-      if (app.new_users_last_7_days) {
-        newUsers = app.new_users_last_7_days.find(
-          (user) => user.country?.toUpperCase() === country,
-        )?.value;
-      }
-
-      if (app.total_users_last_7_days) {
-        totalUsers = app.total_users_last_7_days.find(
-          (user) => user.country?.toUpperCase() === country,
-        )?.value;
-      }
-
-      return {
-        ...app,
-        unique_users_last_7_days: uniqueUsers,
-        new_users_last_7_days: newUsers,
-        total_users_last_7_days: totalUsers,
-      };
-    });
-
-    byCountry.set(country, countryData);
-  }
 
   // Cache the processed data
   await redis.setex(

--- a/web/api/helpers/fetch-metrics.ts
+++ b/web/api/helpers/fetch-metrics.ts
@@ -141,6 +141,8 @@ export const fetchMetrics = async (
       return country
         ? memoryCache.byCountry.get(country.toUpperCase()) || []
         : memoryCache.global;
+    } else {
+      console.log("Memory cache is stale, fetching fresh data");
     }
   }
 
@@ -188,5 +190,4 @@ export const fetchMetrics = async (
  */
 export const clearMetricsCache = () => {
   memoryCache = null;
-  console.log("Metrics cache cleared");
 };

--- a/web/api/v2/public/apps/index.ts
+++ b/web/api/v2/public/apps/index.ts
@@ -209,8 +209,8 @@ export const GET = async (request: NextRequest) => {
     });
   }
 
-  // ANCHOR: Fetch app stats from metrics service, no cache as this endpoint is already cached by CloudFront
-  const metricsData = await fetchMetrics(0, country);
+  // ANCHOR: Fetch app stats from metrics service, keep a cache since metrics doesn't update that often
+  const metricsData = await fetchMetrics(country);
 
   const nativeAppMetadata = NativeApps[process.env.NEXT_PUBLIC_APP_ENV];
 


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description
Fetch metrics currently returns a huge list of data. 

This implementation changes the logic to such
1. We do a single call to the metrics service that calculates the data for each country and global. The data is then cached in memory for 10 minutes.
2. Any requests that come in while this call is in progress will await the call. 
3. If there is already data in the memory cache we will return that immediately. 

Upon invalidating cache we also clear the memory cache as this is what we'd expect when invalidating on the retool side to get fresh rankings

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
