### PR TITLE
feat: Refactor server side action responses

### DIFF
--- a/web/api/helpers/errors.ts
+++ b/web/api/helpers/errors.ts
@@ -1,4 +1,5 @@
 import { logger } from "@/lib/logger";
+import { FormActionResult } from "@/lib/types";
 import { NextRequest, NextResponse } from "next/server";
 import "server-only";
 
@@ -184,30 +185,6 @@ export function errorHasuraQuery({
   );
 }
 
-export class ServerSideValidationError extends Error {
-  public additionalInfo: any;
-  public sourceError?: Error;
-  public app_id?: string;
-  public team_id?: string;
-
-  constructor(
-    message: string,
-    additionalInfo: any,
-    sourceError?: Error,
-    app_id?: string,
-    team_id?: string,
-  ) {
-    super(message);
-    this.name = "ServerSideValidationError";
-    this.additionalInfo = additionalInfo;
-    this.sourceError = sourceError;
-    this.app_id = app_id;
-    this.team_id = team_id;
-
-    Object.setPrototypeOf(this, ServerSideValidationError.prototype);
-  }
-}
-
 export function errorFormAction({
   error,
   message,
@@ -222,7 +199,7 @@ export function errorFormAction({
   app_id?: string;
   team_id?: string;
   logLevel?: "error" | "warn";
-}): never {
+}): FormActionResult {
   logger[logLevel || "error"](message, {
     error,
     additionalInfo,
@@ -230,11 +207,5 @@ export function errorFormAction({
     team_id,
   });
 
-  throw new ServerSideValidationError(
-    message,
-    additionalInfo,
-    error,
-    app_id,
-    team_id,
-  );
+  return { success: false, message, error };
 }

--- a/web/api/helpers/errors.ts
+++ b/web/api/helpers/errors.ts
@@ -214,14 +214,16 @@ export function errorFormAction({
   additionalInfo,
   app_id,
   team_id,
+  logLevel,
 }: {
   error?: Error;
   message: string;
   additionalInfo?: object;
   app_id?: string;
   team_id?: string;
+  logLevel?: "error" | "warn";
 }): never {
-  logger.error(message, {
+  logger[logLevel || "error"](message, {
     error,
     additionalInfo,
     app_id,

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -316,3 +316,9 @@ export enum TokenPrecision {
   WLD = 18,
   USDCE = 6,
 }
+
+export interface FormActionResult {
+  success: boolean;
+  message: string;
+  [key: string]: unknown;
+}

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -333,10 +333,10 @@ export const checkIfPartnerTeam = (teamId: string) => {
 };
 
 /**
- * Checks if the app is not in a production environment
+ * Checks if the app is in a production environment
  */
-export const checkIfNotProduction = (): boolean => {
-  return process.env.NEXT_PUBLIC_APP_ENV !== "production";
+export const checkIfProduction = (): boolean => {
+  return process.env.NEXT_PUBLIC_APP_ENV === "production";
 };
 
 const DEFAULT_MAX_RETRIES = 3;

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
@@ -6,7 +6,7 @@ import { Toggle } from "@/components/Toggle";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { reformatPem } from "@/lib/crypto.client";
 import { useRefetchQueries } from "@/lib/use-refetch-queries";
-import { checkIfNotProduction, checkIfPartnerTeam } from "@/lib/utils";
+import { checkIfPartnerTeam, checkIfProduction } from "@/lib/utils";
 import { yupResolver } from "@hookform/resolvers/yup";
 import clsx from "clsx";
 import { useCallback, useState } from "react";
@@ -32,7 +32,7 @@ type UpdateActionProps = {
 
 export const UpdateActionForm = (props: UpdateActionProps) => {
   const { action, teamId } = props;
-  const isNotProduction = checkIfNotProduction();
+  const isProduction = checkIfProduction();
   const isPartnerTeam = checkIfPartnerTeam(teamId);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -44,9 +44,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
     watch,
     reset,
   } = useForm<UpdateActionSchema>({
-    resolver: yupResolver(
-      createUpdateActionSchema({ is_not_production: isNotProduction }),
-    ),
+    resolver: yupResolver(createUpdateActionSchema({ isProduction })),
     mode: "onChange",
     defaultValues: {
       name: action.name,
@@ -87,7 +85,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
         values,
         teamId,
         action.id,
-        isNotProduction,
+        isProduction,
       );
 
       if (!result.success) {
@@ -105,7 +103,7 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
     [
       teamId,
       action.id,
-      isNotProduction,
+      isProduction,
       refetchAction,
       refetchSingleAction,
       reset,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
@@ -76,40 +76,31 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
 
   const submit = useCallback(
     async (values: UpdateActionSchema) => {
-      try {
-        setIsSubmitting(true);
+      setIsSubmitting(true);
 
-        // Reformat PEM client-side before submission
-        if (values.webhook_pem) {
-          values.webhook_pem = reformatPem(values.webhook_pem);
-        }
+      // Reformat PEM client-side before submission
+      if (values.webhook_pem) {
+        values.webhook_pem = reformatPem(values.webhook_pem);
+      }
 
-        const result = await updateActionServerSide(
-          values,
-          teamId,
-          action.id,
-          isNotProduction,
-        );
+      const result = await updateActionServerSide(
+        values,
+        teamId,
+        action.id,
+        isNotProduction,
+      );
 
-        if (result instanceof Error) {
-          throw result;
-        }
+      if (!result.success) {
+        console.error("Update action failed: ", result.message);
+        toast.error(result.message);
+      } else {
         toast.success(`Action "${values.name}" updated.`);
-
         await refetchAction();
         await refetchSingleAction();
-
         reset(values);
-      } catch (error) {
-        console.error("Update Action: ", error);
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : "Error occurred while updating action.",
-        );
-      } finally {
-        setIsSubmitting(false);
       }
+
+      setIsSubmitting(false);
     },
     [
       teamId,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/index.tsx
@@ -89,7 +89,6 @@ export const UpdateActionForm = (props: UpdateActionProps) => {
       );
 
       if (!result.success) {
-        console.error("Update action failed: ", result.message);
         toast.error(result.message);
       } else {
         toast.success(`Action "${values.name}" updated.`);

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
@@ -3,7 +3,7 @@ import { validateUrl } from "@/lib/utils";
 import * as yup from "yup";
 
 export type ActionContext = {
-  is_not_production: boolean;
+  isProduction: boolean;
 };
 
 export const createUpdateActionSchema = (context: ActionContext) => {
@@ -21,8 +21,8 @@ export const createUpdateActionSchema = (context: ActionContext) => {
         .string()
         .optional()
         .test("is-url", "Must be a valid URL", (value) => {
-          if (!value || context.is_not_production) return true;
-          return validateUrl(value, context.is_not_production);
+          if (!value || !context.isProduction) return true;
+          return validateUrl(value, !context.isProduction);
         }),
       webhook_pem: yup
         .string()

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/index.ts
@@ -48,6 +48,7 @@ export async function updateActionServerSide(
         message: "The user does not have permission to update this action",
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -67,6 +68,7 @@ export async function updateActionServerSide(
         additionalInfo: { initialValues },
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -101,6 +103,7 @@ export async function updateActionServerSide(
       additionalInfo: { initialValues },
       team_id: teamId,
       app_id: appId,
+      logLevel: "error",
     });
   }
 }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/index.ts
@@ -36,7 +36,7 @@ export async function updateActionServerSide(
   initialValues: UpdateActionSchema,
   teamId: string,
   actionId: string,
-  isNotProduction: boolean,
+  isProduction: boolean,
 ): Promise<FormActionResult> {
   let appId: string | undefined;
   try {
@@ -44,7 +44,11 @@ export async function updateActionServerSide(
     const { Apps: appIdFromPath } = extractIdsFromPath(path, ["Apps"]);
     appId = appIdFromPath;
 
-    if (!(await getIsUserAllowedToUpdateAction(teamId, actionId))) {
+    const isUserAllowedToUpdateAction = await getIsUserAllowedToUpdateAction(
+      teamId,
+      actionId,
+    );
+    if (!isUserAllowedToUpdateAction) {
       return errorFormAction({
         message: "The user does not have permission to update this action",
         team_id: teamId,
@@ -54,7 +58,7 @@ export async function updateActionServerSide(
     }
 
     const updateActionSchema = createUpdateActionSchema({
-      is_not_production: isNotProduction,
+      isProduction,
     });
 
     const { isValid, parsedParams: parsedInitialValues } =

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
@@ -105,7 +105,6 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
       );
 
       if (!result.success) {
-        console.error("Create action failed: ", result.message);
         posthog.capture("action_creation_failed", {
           name: values.name,
           app_id: appId,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/index.tsx
@@ -12,7 +12,7 @@ import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { reformatPem } from "@/lib/crypto.client";
 import { EngineType } from "@/lib/types";
 import { useRefetchQueries } from "@/lib/use-refetch-queries";
-import { checkIfNotProduction, checkIfPartnerTeam } from "@/lib/utils";
+import { checkIfPartnerTeam, checkIfProduction } from "@/lib/utils";
 import { yupResolver } from "@hookform/resolvers/yup";
 import clsx from "clsx";
 import { useParams, usePathname, useRouter } from "next/navigation";
@@ -41,7 +41,7 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
   const router = useRouter();
   const appId = params?.appId as `app_${string}`;
   const teamId = params?.teamId as string;
-  const isNotProduction = checkIfNotProduction();
+  const isProduction = checkIfProduction();
   const isPartnerTeam = checkIfPartnerTeam(teamId);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -56,9 +56,7 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
     reset,
     setFocus,
   } = useForm<CreateActionSchema>({
-    resolver: yupResolver(
-      createActionSchema({ is_not_production: isNotProduction }),
-    ),
+    resolver: yupResolver(createActionSchema({ isProduction })),
     mode: "onChange",
     defaultValues: {
       max_verifications: 1,
@@ -103,7 +101,7 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
         values,
         teamId,
         appId,
-        isNotProduction,
+        isProduction,
       );
 
       if (!result.success) {
@@ -145,7 +143,7 @@ export const CreateActionModal = (props: CreateActionModalProps) => {
       appId,
       firstAction,
       teamId,
-      isNotProduction,
+      isProduction,
       refetchActions,
       reset,
       router,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
@@ -8,7 +8,7 @@ import * as yup from "yup";
 
 // Check if not in production
 export type ActionContext = {
-  is_not_production: boolean;
+  isProduction: boolean;
 };
 
 // Create a schema factory function that accepts the context
@@ -42,8 +42,8 @@ export const createActionSchema = (context: ActionContext) => {
         .string()
         .optional()
         .test("is-url", "Must be a valid URL", (value) => {
-          if (!value || context.is_not_production) return true;
-          return validateUrl(value, context.is_not_production);
+          if (!value || !context.isProduction) return true;
+          return validateUrl(value, !context.isProduction);
         }),
       webhook_pem: yup
         .string()

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/index.ts
@@ -37,7 +37,7 @@ export async function createActionServerSide(
   initialValues: CreateActionSchema,
   teamId: string,
   appId: string,
-  isNotProduction: boolean,
+  isProduction: boolean,
 ): Promise<FormActionResult> {
   try {
     if (!(await getIsUserAllowedToInsertAction(teamId, appId))) {
@@ -50,7 +50,7 @@ export async function createActionServerSide(
       });
     }
 
-    const schema = createActionSchema({ is_not_production: isNotProduction });
+    const schema = createActionSchema({ isProduction });
 
     const { isValid, parsedParams: parsedInitialValues } =
       await validateRequestSchema({

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/index.ts
@@ -44,6 +44,7 @@ export async function createActionServerSide(
           "The user does not have permission to create actions for this app",
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -61,6 +62,7 @@ export async function createActionServerSide(
         additionalInfo: { initialValues },
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -98,6 +100,7 @@ export async function createActionServerSide(
       additionalInfo: { initialValues },
       team_id: teamId,
       app_id: appId,
+      logLevel: "error",
     });
   }
 }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/index.ts
@@ -37,56 +37,67 @@ export async function createActionServerSide(
   appId: string,
   isNotProduction: boolean,
 ) {
-  if (!(await getIsUserAllowedToInsertAction(teamId, appId))) {
-    errorFormAction({
-      message: "createActionServerSide - invalid permissions",
-      team_id: teamId,
+  try {
+    if (!(await getIsUserAllowedToInsertAction(teamId, appId))) {
+      errorFormAction({
+        message:
+          "The user does not have permission to create actions for this app",
+        team_id: teamId,
+        app_id: appId,
+      });
+    }
+
+    const schema = createActionSchema({ is_not_production: isNotProduction });
+
+    const { isValid, parsedParams: parsedInitialValues } =
+      await validateRequestSchema({
+        schema,
+        value: initialValues,
+      });
+
+    if (!isValid || !parsedInitialValues) {
+      errorFormAction({
+        message: "The provided action data is invalid",
+        additionalInfo: { initialValues },
+        team_id: teamId,
+        app_id: appId,
+      });
+    }
+
+    // Do not allow webhook_uri, webhook_pem, and app_flow_on_complete to be set if the app is not a partner app
+    if (!checkIfPartnerTeam(teamId)) {
+      parsedInitialValues.webhook_uri = undefined;
+      parsedInitialValues.webhook_pem = undefined;
+      parsedInitialValues.app_flow_on_complete = "NONE";
+    }
+
+    if (parsedInitialValues.webhook_pem) {
+      parsedInitialValues.webhook_pem = await normalizePublicKey(
+        parsedInitialValues.webhook_pem,
+      );
+    }
+
+    const client = await getAPIServiceGraphqlClient();
+
+    const result = await getCreateActionSdk(client).InsertAction({
+      ...parsedInitialValues,
       app_id: appId,
-    });
-  }
-
-  const schema = createActionSchema({ is_not_production: isNotProduction });
-
-  const { isValid, parsedParams: parsedInitialValues } =
-    await validateRequestSchema({
-      schema,
-      value: initialValues,
+      external_nullifier: generateExternalNullifier(
+        appId,
+        parsedInitialValues.action,
+      ).digest,
     });
 
-  if (!isValid || !parsedInitialValues) {
+    return {
+      action_id: result.insert_action_one?.id,
+    };
+  } catch (error) {
     errorFormAction({
-      message: "createActionServerSide - invalid request",
+      message: "An error occurred while creating the action",
+      error: error as Error,
       additionalInfo: { initialValues },
       team_id: teamId,
       app_id: appId,
     });
   }
-
-  // Do not allow webhook_uri, webhook_pem, and app_flow_on_complete to be set if the app is not a partner app
-  if (!checkIfPartnerTeam(teamId)) {
-    parsedInitialValues.webhook_uri = undefined;
-    parsedInitialValues.webhook_pem = undefined;
-    parsedInitialValues.app_flow_on_complete = "NONE";
-  }
-
-  if (parsedInitialValues.webhook_pem) {
-    parsedInitialValues.webhook_pem = await normalizePublicKey(
-      parsedInitialValues.webhook_pem,
-    );
-  }
-
-  const client = await getAPIServiceGraphqlClient();
-
-  const result = await getCreateActionSdk(client).InsertAction({
-    ...parsedInitialValues,
-    app_id: appId,
-    external_nullifier: generateExternalNullifier(
-      appId,
-      parsedInitialValues.action,
-    ).digest,
-  });
-
-  return {
-    action_id: result.insert_action_one?.id,
-  };
 }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
@@ -176,7 +176,6 @@ export const SetupForm = (props: LinksFormProps) => {
       );
 
       if (!result.success) {
-        console.error("Update app metadata failed: ", result.message);
         toast.error(result.message);
       } else {
         refetchAppMetadata();

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
@@ -24,15 +24,15 @@ import clsx from "clsx";
 import { ChangeEvent, useCallback, useEffect, useMemo } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import { toast } from "react-toastify";
-import * as yup from "yup";
 import {
   FetchAppMetadataDocument,
   FetchAppMetadataQuery,
 } from "../../../graphql/client/fetch-app-metadata.generated";
-import { schema } from "../form-schema";
+import {
+  updateSetupInitialSchema,
+  UpdateSetupInitialSchema,
+} from "../form-schema";
 import { validateAndUpdateSetupServerSide } from "../server/submit";
-
-type LinksFormValues = yup.Asserts<typeof schema>;
 
 type LinksFormProps = {
   appId: string;
@@ -103,8 +103,8 @@ export const SetupForm = (props: LinksFormProps) => {
     formState: { errors, isDirty, isValid, dirtyFields },
     setError,
     control,
-  } = useForm<LinksFormValues>({
-    resolver: yupResolver(schema),
+  } = useForm<UpdateSetupInitialSchema>({
+    resolver: yupResolver(updateSetupInitialSchema),
     mode: "onChange",
 
     defaultValues: {
@@ -152,7 +152,7 @@ export const SetupForm = (props: LinksFormProps) => {
   ]);
 
   const submit = useCallback(
-    async (values: LinksFormValues) => {
+    async (values: UpdateSetupInitialSchema) => {
       // Check if app_mode is true and whitelisted_addresses is not provided or empty
       if (
         values.app_mode &&
@@ -171,18 +171,7 @@ export const SetupForm = (props: LinksFormProps) => {
       }
 
       const result = await validateAndUpdateSetupServerSide(
-        {
-          is_whitelist_disabled: values.is_whitelist_disabled,
-          whitelisted_addresses: values.whitelisted_addresses,
-          app_mode: values.app_mode as keyof typeof AppMode,
-          associated_domains: values.associated_domains,
-          contracts: values.contracts,
-          permit2_tokens: values.permit2_tokens,
-          can_import_all_contacts: values.can_import_all_contacts,
-          max_notifications_per_day: values.max_notifications_per_day,
-          is_allowed_unlimited_notifications:
-            values.is_allowed_unlimited_notifications,
-        },
+        values,
         appMetadata?.id ?? "",
       );
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
@@ -153,44 +153,45 @@ export const SetupForm = (props: LinksFormProps) => {
 
   const submit = useCallback(
     async (values: LinksFormValues) => {
-      try {
-        // Check if app_mode is true and whitelisted_addresses is not provided or empty
-        if (
-          values.app_mode &&
-          !values.is_whitelist_disabled &&
-          (!values.whitelisted_addresses ||
-            values.whitelisted_addresses.length === 0)
-        ) {
-          setError("whitelisted_addresses", {
-            type: "manual",
-            message:
-              "Mini Apps must have at least one whitelisted payment address.",
-          });
-          throw new Error(
+      // Check if app_mode is true and whitelisted_addresses is not provided or empty
+      if (
+        values.app_mode &&
+        !values.is_whitelist_disabled &&
+        (!values.whitelisted_addresses ||
+          values.whitelisted_addresses.length === 0)
+      ) {
+        setError("whitelisted_addresses", {
+          type: "manual",
+          message:
             "Mini Apps must have at least one whitelisted payment address.",
-          );
-        }
-
-        await validateAndUpdateSetupServerSide(
-          {
-            is_whitelist_disabled: values.is_whitelist_disabled,
-            whitelisted_addresses: values.whitelisted_addresses,
-            app_mode: values.app_mode as keyof typeof AppMode,
-            associated_domains: values.associated_domains,
-            contracts: values.contracts,
-            permit2_tokens: values.permit2_tokens,
-            can_import_all_contacts: values.can_import_all_contacts,
-            max_notifications_per_day: values.max_notifications_per_day,
-            is_allowed_unlimited_notifications:
-              values.is_allowed_unlimited_notifications,
-          },
-          appMetadata?.id ?? "",
+        });
+        throw new Error(
+          "Mini Apps must have at least one whitelisted payment address.",
         );
-        refetchAppMetadata();
+      }
 
+      const result = await validateAndUpdateSetupServerSide(
+        {
+          is_whitelist_disabled: values.is_whitelist_disabled,
+          whitelisted_addresses: values.whitelisted_addresses,
+          app_mode: values.app_mode as keyof typeof AppMode,
+          associated_domains: values.associated_domains,
+          contracts: values.contracts,
+          permit2_tokens: values.permit2_tokens,
+          can_import_all_contacts: values.can_import_all_contacts,
+          max_notifications_per_day: values.max_notifications_per_day,
+          is_allowed_unlimited_notifications:
+            values.is_allowed_unlimited_notifications,
+        },
+        appMetadata?.id ?? "",
+      );
+
+      if (!result.success) {
+        console.error("Update app metadata failed: ", result.message);
+        toast.error(result.message);
+      } else {
+        refetchAppMetadata();
         toast.success("App information updated successfully");
-      } catch (e) {
-        toast.error("Failed to update app information");
       }
     },
     [appMetadata?.id, refetchAppMetadata, setError],

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/server/submit.ts
@@ -29,6 +29,7 @@ export async function validateAndUpdateSetupServerSide(
           "The user does not have permission to update this app metadata",
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -44,6 +45,7 @@ export async function validateAndUpdateSetupServerSide(
         team_id: teamId,
         app_id: appId,
         additionalInfo: { initialValues },
+        logLevel: "warn",
       });
     }
 
@@ -94,6 +96,7 @@ export async function validateAndUpdateSetupServerSide(
       team_id: teamId,
       app_id: appId,
       additionalInfo: { initialValues, app_metadata_id },
+      logLevel: "error",
     });
   }
 }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/server/submit.ts
@@ -4,16 +4,18 @@ import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { getIsUserAllowedToUpdateAppMetadata } from "@/lib/permissions";
 import { extractIdsFromPath, getPathFromHeaders } from "@/lib/server-utils";
+import { FormActionResult } from "@/lib/types";
 import { formatMultipleStringInput } from "@/lib/utils";
 import {
   updateSetupInitialSchema,
   UpdateSetupInitialSchema,
 } from "../form-schema";
 import { getSdk as getUpdateSetupSdk } from "../SetupForm/graphql/server/update-setup.generated";
+
 export async function validateAndUpdateSetupServerSide(
   initialValues: UpdateSetupInitialSchema,
   app_metadata_id: string,
-) {
+): Promise<FormActionResult> {
   const path = getPathFromHeaders() || "";
   const { Apps: appId, Teams: teamId } = extractIdsFromPath(path, [
     "Apps",
@@ -24,7 +26,7 @@ export async function validateAndUpdateSetupServerSide(
     const isUserAllowedToUpdateAppMetadata =
       await getIsUserAllowedToUpdateAppMetadata(app_metadata_id);
     if (!isUserAllowedToUpdateAppMetadata) {
-      errorFormAction({
+      return errorFormAction({
         message:
           "The user does not have permission to update this app metadata",
         team_id: teamId,
@@ -40,7 +42,7 @@ export async function validateAndUpdateSetupServerSide(
       });
 
     if (!isValid || !parsedInitialValues) {
-      errorFormAction({
+      return errorFormAction({
         message: "The provided app metadata is invalid",
         team_id: teamId,
         app_id: appId,
@@ -89,8 +91,13 @@ export async function validateAndUpdateSetupServerSide(
       is_allowed_unlimited_notifications,
       max_notifications_per_day,
     });
+
+    return {
+      success: true,
+      message: "App metadata updated successfully",
+    };
   } catch (error) {
-    errorFormAction({
+    return errorFormAction({
       error: error as Error,
       message: "An error occurred while updating the app metadata",
       team_id: teamId,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/server/submit.ts
@@ -25,7 +25,8 @@ export async function validateAndUpdateSetupServerSide(
       await getIsUserAllowedToUpdateAppMetadata(app_metadata_id);
     if (!isUserAllowedToUpdateAppMetadata) {
       errorFormAction({
-        message: "validateAndUpdateSetupServerSide - invalid permissions",
+        message:
+          "The user does not have permission to update this app metadata",
         team_id: teamId,
         app_id: appId,
       });
@@ -39,7 +40,7 @@ export async function validateAndUpdateSetupServerSide(
 
     if (!isValid || !parsedInitialValues) {
       errorFormAction({
-        message: "validateAndUpdateSetupServerSide - invalid input",
+        message: "The provided app metadata is invalid",
         team_id: teamId,
         app_id: appId,
         additionalInfo: { initialValues },
@@ -89,7 +90,7 @@ export async function validateAndUpdateSetupServerSide(
   } catch (error) {
     errorFormAction({
       error: error as Error,
-      message: "validateAndUpdateSetupServerSide - error updating setup",
+      message: "An error occurred while updating the app metadata",
       team_id: teamId,
       app_id: appId,
       additionalInfo: { initialValues, app_metadata_id },

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
@@ -232,7 +232,6 @@ export const AppStoreForm = (props: {
             lang,
           );
           if (!result.success) {
-            console.error("Delete localisation failed: ", result.message);
             toast.error(result.message);
           }
           // Remove from deleting set when done or on error
@@ -419,7 +418,6 @@ export const AppStoreForm = (props: {
       const result =
         await validateAndUpdateAppLocaleInfoServerSide(commonProperties);
       if (!result.success) {
-        console.error("Update app locale info failed: ", result.message);
         toast.error(result.message);
       } else {
         await refetchAppMetadata();
@@ -433,7 +431,6 @@ export const AppStoreForm = (props: {
       });
 
       if (!result.success) {
-        console.error("Update localisation failed: ", result.message);
         toast.error(result.message);
       } else {
         await refetchLocalisation({
@@ -468,7 +465,6 @@ export const AppStoreForm = (props: {
         is_for_humans_only: data.is_for_humans_only,
       });
       if (!result.success) {
-        console.error("Update app support info failed: ", result.message);
         toast.error(result.message);
       } else {
         await refetchAppMetadata();

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
@@ -110,7 +110,6 @@ export const AppStoreForm = (props: {
         appId,
       );
       if (!result.success) {
-        console.error("Add localisation failed: ", result.message);
         toast.error(result.message);
       } else {
         await refetchLocalisation({

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/AppStoreLocalised/index.tsx
@@ -104,12 +104,20 @@ export const AppStoreForm = (props: {
 
   const createLocalisation = useCallback(
     async (lang: string) => {
-      try {
-        await addEmptyLocalisationServerSide(appMetadata.id, lang, appId);
+      const result = await addEmptyLocalisationServerSide(
+        appMetadata.id,
+        lang,
+        appId,
+      );
+      if (!result.success) {
+        console.error("Add localisation failed: ", result.message);
+        toast.error(result.message);
+      } else {
         await refetchLocalisation({
           id: appMetadata.id,
           locale: lang,
         });
+
         client.cache.evict({
           fieldName: "get_all_unverified_images",
           args: {
@@ -119,22 +127,13 @@ export const AppStoreForm = (props: {
           },
         });
         client.cache.gc();
-        // Remove from creating set when done
-        setCreatingLocalisations((prev) => {
-          const newSet = new Set(prev);
-          newSet.delete(lang);
-          return newSet;
-        });
-      } catch (error) {
-        console.error("Failed to add localisation:", error);
-        toast.error("Failed to add localisation");
-        // Remove from creating set on error
-        setCreatingLocalisations((prev) => {
-          const newSet = new Set(prev);
-          newSet.delete(lang);
-          return newSet;
-        });
       }
+      // Remove from creating set when done
+      setCreatingLocalisations((prev) => {
+        const newSet = new Set(prev);
+        newSet.delete(lang);
+        return newSet;
+      });
     },
     [appMetadata.id, appId, refetchLocalisation],
   );
@@ -229,24 +228,20 @@ export const AppStoreForm = (props: {
         });
 
         const removePromises = languagesToRemove.map(async (lang) => {
-          try {
-            await deleteLocalisationServerSide(appMetadata.id, lang);
-            // Remove from deleting set when done
-            setDeletingLocalisations((prev) => {
-              const newSet = new Set(prev);
-              newSet.delete(lang);
-              return newSet;
-            });
-          } catch (error) {
-            console.error("Failed to delete localisation:", error);
-            toast.error("Failed to delete localisation");
-            // Remove from deleting set on error
-            setDeletingLocalisations((prev) => {
-              const newSet = new Set(prev);
-              newSet.delete(lang);
-              return newSet;
-            });
+          const result = await deleteLocalisationServerSide(
+            appMetadata.id,
+            lang,
+          );
+          if (!result.success) {
+            console.error("Delete localisation failed: ", result.message);
+            toast.error(result.message);
           }
+          // Remove from deleting set when done or on error
+          setDeletingLocalisations((prev) => {
+            const newSet = new Set(prev);
+            newSet.delete(lang);
+            return newSet;
+          });
         });
 
         // Execute all promises in parallel
@@ -420,27 +415,33 @@ export const AppStoreForm = (props: {
       world_app_description,
     } as const;
 
-    try {
-      // if locale is en, set the data on app_metadata directly
-      if (locale === "en") {
+    // if locale is en, set the data on app_metadata directly
+    if (locale === "en") {
+      const result =
         await validateAndUpdateAppLocaleInfoServerSide(commonProperties);
+      if (!result.success) {
+        console.error("Update app locale info failed: ", result.message);
+        toast.error(result.message);
+      } else {
         await refetchAppMetadata();
-        return;
       }
-
+    } else {
       const localisation = localisedData?.localisations?.[0];
 
-      await validateAndUpdateLocalisationServerSide({
+      const result = await validateAndUpdateLocalisationServerSide({
         localisation_id: localisation?.id ?? "",
         ...commonProperties,
       });
-      await refetchLocalisation({
-        id: appMetadata.id,
-        locale: locale,
-      });
-    } catch (e) {
-      console.error("App information failed to update: ", e);
-      toast.error("Failed to save localisation");
+
+      if (!result.success) {
+        console.error("Update localisation failed: ", result.message);
+        toast.error(result.message);
+      } else {
+        await refetchLocalisation({
+          id: appMetadata.id,
+          locale: locale,
+        });
+      }
     }
   }, [
     appId,
@@ -454,28 +455,29 @@ export const AppStoreForm = (props: {
   // Anchor: Submit Form
   const submit = useCallback(
     async (data: AppStoreLocalisedForm) => {
-      try {
-        setIsSubmitting(true);
-        await saveLocalisation();
-        await validateAndUpdateAppSupportInfoServerSide({
-          app_metadata_id: appMetadata?.id,
-          is_support_email: isSupportEmail,
-          support_link: data.support_link,
-          support_email: data.support_email,
-          app_website_url: data.app_website_url,
-          supported_countries: data.supported_countries,
-          category: data.category,
-          is_android_only: data.is_android_only,
-          is_for_humans_only: data.is_for_humans_only,
-        });
+      setIsSubmitting(true);
+      await saveLocalisation();
+      const result = await validateAndUpdateAppSupportInfoServerSide({
+        app_metadata_id: appMetadata?.id,
+        is_support_email: isSupportEmail,
+        support_link: data.support_link,
+        support_email: data.support_email,
+        app_website_url: data.app_website_url,
+        supported_countries: data.supported_countries,
+        category: data.category,
+        is_android_only: data.is_android_only,
+        is_for_humans_only: data.is_for_humans_only,
+      });
+      if (!result.success) {
+        console.error("Update app support info failed: ", result.message);
+        toast.error(result.message);
+      } else {
         await refetchAppMetadata();
         toast.success("App information updated successfully");
-      } catch (e) {
-        toast.error("Failed to update app information");
-      } finally {
-        setIsSubmitting(false);
-        toast.update("formState", { autoClose: 0 });
       }
+
+      setIsSubmitting(false);
+      toast.update("formState", { autoClose: 0 });
     },
     [appMetadata?.id, isSupportEmail, refetchAppMetadata, saveLocalisation],
   );

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/server/submit.ts
@@ -67,6 +67,7 @@ export async function validateAndUpdateLocalisationServerSide(
           "The user does not have permission to update this localisation",
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -82,6 +83,7 @@ export async function validateAndUpdateLocalisationServerSide(
         additionalInfo: { initalValues },
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -113,6 +115,7 @@ export async function validateAndUpdateLocalisationServerSide(
       },
       team_id: teamId,
       app_id: appId,
+      logLevel: "error",
     });
   }
 }
@@ -149,6 +152,7 @@ export async function validateAndUpdateAppLocaleInfoServerSide(
           "The user does not have permission to update this app metadata",
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -164,6 +168,7 @@ export async function validateAndUpdateAppLocaleInfoServerSide(
         additionalInfo: { initalValues },
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -194,6 +199,7 @@ export async function validateAndUpdateAppLocaleInfoServerSide(
       },
       team_id: teamId,
       app_id: appId,
+      logLevel: "error",
     });
   }
 }
@@ -230,6 +236,7 @@ export async function validateAndUpdateAppSupportInfoServerSide(
           "The user does not have permission to update this app metadata",
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -245,6 +252,7 @@ export async function validateAndUpdateAppSupportInfoServerSide(
         additionalInfo: { initalValues },
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -271,6 +279,7 @@ export async function validateAndUpdateAppSupportInfoServerSide(
       additionalInfo: { input, initalValues },
       team_id: teamId,
       app_id: appId,
+      logLevel: "error",
     });
   }
 }
@@ -292,6 +301,7 @@ export async function deleteLocalisationServerSide(
         additionalInfo: { appMetadataId, locale },
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -303,6 +313,7 @@ export async function deleteLocalisationServerSide(
           "The user does not have permission to delete this localisation",
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -318,6 +329,7 @@ export async function deleteLocalisationServerSide(
       additionalInfo: { appMetadataId, locale },
       team_id: teamId,
       app_id: appId,
+      logLevel: "error",
     });
   }
 }
@@ -339,6 +351,7 @@ export async function addEmptyLocalisationServerSide(
           "The user does not have permission to create localisations for this app",
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -370,6 +383,7 @@ export async function addEmptyLocalisationServerSide(
       additionalInfo: { appMetadataId, locale },
       team_id: teamId,
       app_id: appId,
+      logLevel: "error",
     });
   }
 }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/server/submit.ts
@@ -10,6 +10,7 @@ import {
   getIsUserAllowedToUpdateLocalisation,
 } from "@/lib/permissions";
 import { extractIdsFromPath, getPathFromHeaders } from "@/lib/server-utils";
+import { FormActionResult } from "@/lib/types";
 import { getSdk as getDeleteLocalisationSdk } from "../AppStoreLocalised/graphql/server/delete-localisation.generated";
 import { getSdk as getFetchLocalisationSdk } from "../AppStoreLocalised/graphql/server/fetch-localisation.generated";
 import { getSdk as getInsertLocalisationSdk } from "../AppStoreLocalised/graphql/server/insert-localisation.generated";
@@ -33,9 +34,10 @@ import {
   UpdateLocalisationInitialSchema,
   updateLocalisationInitialSchema,
 } from "../form-schema";
+
 export async function validateAndUpdateLocalisationServerSide(
   params: UpdateLocalisationInitialSchema,
-) {
+): Promise<FormActionResult> {
   const path = getPathFromHeaders() || "";
   const { Apps: appId, Teams: teamId } = extractIdsFromPath(path, [
     "Apps",
@@ -62,7 +64,7 @@ export async function validateAndUpdateLocalisationServerSide(
     const isUserAllowedToUpdateLocalisation =
       await getIsUserAllowedToUpdateLocalisation(params.localisation_id);
     if (!isUserAllowedToUpdateLocalisation) {
-      errorFormAction({
+      return errorFormAction({
         message:
           "The user does not have permission to update this localisation",
         team_id: teamId,
@@ -78,7 +80,7 @@ export async function validateAndUpdateLocalisationServerSide(
       });
 
     if (!isValid || !parsedInitialValues) {
-      errorFormAction({
+      return errorFormAction({
         message: "The provided localisation data is invalid",
         additionalInfo: { initalValues },
         team_id: teamId,
@@ -105,8 +107,13 @@ export async function validateAndUpdateLocalisationServerSide(
 
     const client = await getAPIServiceGraphqlClient();
     await getUpdateLocalisationSdk(client).UpdateLocalisation(encodedInput);
+
+    return {
+      success: true,
+      message: "Localisation updated successfully",
+    };
   } catch (error) {
-    errorFormAction({
+    return errorFormAction({
       error: error as Error,
       message: "An error occurred while updating the localisation",
       additionalInfo: {
@@ -122,7 +129,7 @@ export async function validateAndUpdateLocalisationServerSide(
 
 export async function validateAndUpdateAppLocaleInfoServerSide(
   params: UpdateAppLocaleInfoInitialSchema,
-) {
+): Promise<FormActionResult> {
   const path = getPathFromHeaders() || "";
   const { Apps: appId, Teams: teamId } = extractIdsFromPath(path, [
     "Apps",
@@ -147,7 +154,7 @@ export async function validateAndUpdateAppLocaleInfoServerSide(
     const isUserAllowedToUpdateAppMetadata =
       await getIsUserAllowedToUpdateAppMetadata(params.app_metadata_id);
     if (!isUserAllowedToUpdateAppMetadata) {
-      errorFormAction({
+      return errorFormAction({
         message:
           "The user does not have permission to update this app metadata",
         team_id: teamId,
@@ -163,7 +170,7 @@ export async function validateAndUpdateAppLocaleInfoServerSide(
       });
 
     if (!isValid || !parsedInitialValues) {
-      errorFormAction({
+      return errorFormAction({
         message: "The provided app locale info is invalid",
         additionalInfo: { initalValues },
         team_id: teamId,
@@ -189,8 +196,13 @@ export async function validateAndUpdateAppLocaleInfoServerSide(
 
     const client = await getAPIServiceGraphqlClient();
     await getUpdateAppInfoSdk(client).UpdateAppInfo(encodedInput);
+
+    return {
+      success: true,
+      message: "App locale info updated successfully",
+    };
   } catch (error) {
-    errorFormAction({
+    return errorFormAction({
       error: error as Error,
       message: "An error occurred while updating the app locale info",
       additionalInfo: {
@@ -206,7 +218,7 @@ export async function validateAndUpdateAppLocaleInfoServerSide(
 
 export async function validateAndUpdateAppSupportInfoServerSide(
   params: UpdateAppSupportInfoInitialSchema,
-) {
+): Promise<FormActionResult> {
   const path = getPathFromHeaders() || "";
   const { Apps: appId, Teams: teamId } = extractIdsFromPath(path, [
     "Apps",
@@ -231,7 +243,7 @@ export async function validateAndUpdateAppSupportInfoServerSide(
     const isUserAllowedToUpdateAppMetadata =
       await getIsUserAllowedToUpdateAppMetadata(params.app_metadata_id);
     if (!isUserAllowedToUpdateAppMetadata) {
-      errorFormAction({
+      return errorFormAction({
         message:
           "The user does not have permission to update this app metadata",
         team_id: teamId,
@@ -247,7 +259,7 @@ export async function validateAndUpdateAppSupportInfoServerSide(
       });
 
     if (!isValid || !parsedInitialValues) {
-      errorFormAction({
+      return errorFormAction({
         message: "The provided app support info is invalid",
         additionalInfo: { initalValues },
         team_id: teamId,
@@ -272,8 +284,13 @@ export async function validateAndUpdateAppSupportInfoServerSide(
 
     const client = await getAPIServiceGraphqlClient();
     await getUpdateAppInfoSdk(client).UpdateAppInfo(input);
+
+    return {
+      success: true,
+      message: "App support info updated successfully",
+    };
   } catch (error) {
-    errorFormAction({
+    return errorFormAction({
       error: error as Error,
       message: "An error occurred while updating the app support info",
       additionalInfo: { input, initalValues },
@@ -287,7 +304,7 @@ export async function validateAndUpdateAppSupportInfoServerSide(
 export async function deleteLocalisationServerSide(
   appMetadataId: string,
   locale: string,
-) {
+): Promise<FormActionResult> {
   const path = getPathFromHeaders() || "";
   const { Apps: appId, Teams: teamId } = extractIdsFromPath(path, [
     "Apps",
@@ -296,7 +313,7 @@ export async function deleteLocalisationServerSide(
 
   try {
     if (locale === "en") {
-      errorFormAction({
+      return errorFormAction({
         message: "English localization cannot be removed",
         additionalInfo: { appMetadataId, locale },
         team_id: teamId,
@@ -308,7 +325,7 @@ export async function deleteLocalisationServerSide(
     const isUserAllowedToDeleteLocalisation =
       await getIsUserAllowedToDeleteLocalisation(appMetadataId, locale);
     if (!isUserAllowedToDeleteLocalisation) {
-      errorFormAction({
+      return errorFormAction({
         message:
           "The user does not have permission to delete this localisation",
         team_id: teamId,
@@ -322,8 +339,13 @@ export async function deleteLocalisationServerSide(
       app_metadata_id: appMetadataId,
       locale,
     });
+
+    return {
+      success: true,
+      message: "Localisation deleted successfully",
+    };
   } catch (error) {
-    errorFormAction({
+    return errorFormAction({
       error: error as Error,
       message: "An error occurred while deleting the localisation",
       additionalInfo: { appMetadataId, locale },
@@ -338,7 +360,7 @@ export async function addEmptyLocalisationServerSide(
   appMetadataId: string,
   locale: string,
   appId: string,
-) {
+): Promise<FormActionResult> {
   const path = getPathFromHeaders() || "";
   const { Teams: teamId } = extractIdsFromPath(path, ["Teams"]);
 
@@ -346,7 +368,7 @@ export async function addEmptyLocalisationServerSide(
     const isUserAllowedToInsertLocalisation =
       await getIsUserAllowedToInsertLocalisation(appId);
     if (!isUserAllowedToInsertLocalisation) {
-      errorFormAction({
+      return errorFormAction({
         message:
           "The user does not have permission to create localisations for this app",
         team_id: teamId,
@@ -366,7 +388,10 @@ export async function addEmptyLocalisationServerSide(
 
     if (localisations.length > 0) {
       // Localization already exists, return early
-      return;
+      return {
+        success: true,
+        message: "Localisation already exists",
+      };
     }
 
     // Create new localization
@@ -376,8 +401,13 @@ export async function addEmptyLocalisationServerSide(
         locale,
       },
     });
+
+    return {
+      success: true,
+      message: "Localisation created successfully",
+    };
   } catch (error) {
-    errorFormAction({
+    return errorFormAction({
       error: error as Error,
       message: "An error occurred while creating the localisation",
       additionalInfo: { appMetadataId, locale },

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/server/submit.ts
@@ -64,7 +64,7 @@ export async function validateAndUpdateLocalisationServerSide(
     if (!isUserAllowedToUpdateLocalisation) {
       errorFormAction({
         message:
-          "validateAndUpdateLocalisationServerSide - invalid permissions",
+          "The user does not have permission to update this localisation",
         team_id: teamId,
         app_id: appId,
       });
@@ -78,7 +78,7 @@ export async function validateAndUpdateLocalisationServerSide(
 
     if (!isValid || !parsedInitialValues) {
       errorFormAction({
-        message: "validateAndUpdateLocalisationServerSide - invalid input",
+        message: "The provided localisation data is invalid",
         additionalInfo: { initalValues },
         team_id: teamId,
         app_id: appId,
@@ -106,7 +106,7 @@ export async function validateAndUpdateLocalisationServerSide(
   } catch (error) {
     errorFormAction({
       error: error as Error,
-      message: "validateAndUpdateLocalisation - error updating localisation",
+      message: "An error occurred while updating the localisation",
       additionalInfo: {
         encodedInput,
         initalValues,
@@ -146,7 +146,7 @@ export async function validateAndUpdateAppLocaleInfoServerSide(
     if (!isUserAllowedToUpdateAppMetadata) {
       errorFormAction({
         message:
-          "validateAndUpdateAppLocaleInfoServerSide - invalid permissions",
+          "The user does not have permission to update this app metadata",
         team_id: teamId,
         app_id: appId,
       });
@@ -160,7 +160,7 @@ export async function validateAndUpdateAppLocaleInfoServerSide(
 
     if (!isValid || !parsedInitialValues) {
       errorFormAction({
-        message: "validateAndUpdateAppLocaleInfoServerSide - invalid input",
+        message: "The provided app locale info is invalid",
         additionalInfo: { initalValues },
         team_id: teamId,
         app_id: appId,
@@ -187,8 +187,7 @@ export async function validateAndUpdateAppLocaleInfoServerSide(
   } catch (error) {
     errorFormAction({
       error: error as Error,
-      message:
-        "validateAndUpdateAppLocaleInfo - error updating app locale info",
+      message: "An error occurred while updating the app locale info",
       additionalInfo: {
         encodedInput,
         initalValues,
@@ -228,7 +227,7 @@ export async function validateAndUpdateAppSupportInfoServerSide(
     if (!isUserAllowedToUpdateAppMetadata) {
       errorFormAction({
         message:
-          "validateAndUpdateAppSupportInfoServerSide - invalid permissions",
+          "The user does not have permission to update this app metadata",
         team_id: teamId,
         app_id: appId,
       });
@@ -242,7 +241,7 @@ export async function validateAndUpdateAppSupportInfoServerSide(
 
     if (!isValid || !parsedInitialValues) {
       errorFormAction({
-        message: "validateAndUpdateAppSupportInfoServerSide - invalid input",
+        message: "The provided app support info is invalid",
         additionalInfo: { initalValues },
         team_id: teamId,
         app_id: appId,
@@ -268,8 +267,7 @@ export async function validateAndUpdateAppSupportInfoServerSide(
   } catch (error) {
     errorFormAction({
       error: error as Error,
-      message:
-        "validateAndUpdateAppSupportInfo - error updating app support info",
+      message: "An error occurred while updating the app support info",
       additionalInfo: { input, initalValues },
       team_id: teamId,
       app_id: appId,
@@ -290,8 +288,7 @@ export async function deleteLocalisationServerSide(
   try {
     if (locale === "en") {
       errorFormAction({
-        message:
-          "deleteLocalisationServerSide - english localization cannot be removed",
+        message: "English localization cannot be removed",
         additionalInfo: { appMetadataId, locale },
         team_id: teamId,
         app_id: appId,
@@ -302,7 +299,8 @@ export async function deleteLocalisationServerSide(
       await getIsUserAllowedToDeleteLocalisation(appMetadataId, locale);
     if (!isUserAllowedToDeleteLocalisation) {
       errorFormAction({
-        message: "deleteLocalisationServerSide - invalid permissions",
+        message:
+          "The user does not have permission to delete this localisation",
         team_id: teamId,
         app_id: appId,
       });
@@ -316,7 +314,7 @@ export async function deleteLocalisationServerSide(
   } catch (error) {
     errorFormAction({
       error: error as Error,
-      message: "deleteLocalisation - error deleting localisation",
+      message: "An error occurred while deleting the localisation",
       additionalInfo: { appMetadataId, locale },
       team_id: teamId,
       app_id: appId,
@@ -337,7 +335,8 @@ export async function addEmptyLocalisationServerSide(
       await getIsUserAllowedToInsertLocalisation(appId);
     if (!isUserAllowedToInsertLocalisation) {
       errorFormAction({
-        message: "addEmptyLocalisationServerSide - invalid permissions",
+        message:
+          "The user does not have permission to create localisations for this app",
         team_id: teamId,
         app_id: appId,
       });
@@ -367,7 +366,7 @@ export async function addEmptyLocalisationServerSide(
   } catch (error) {
     errorFormAction({
       error: error as Error,
-      message: "addEmptyLocalisation - error adding empty localisation",
+      message: "An error occurred while creating the localisation",
       additionalInfo: { appMetadataId, locale },
       team_id: teamId,
       app_id: appId,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/hooks/useAppStoreForm.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/hooks/useAppStoreForm.ts
@@ -85,26 +85,18 @@ export const useAppStoreForm = (appId: string, appMetadata: AppMetadata) => {
 
   const submit = useCallback(
     async (data: AppStoreFormValues) => {
-      try {
-        console.log("submit", data);
-        const result = await updateAppStoreMetadata({
-          ...data,
-          app_metadata_id: appMetadata.id,
-        });
+      const result = await updateAppStoreMetadata({
+        ...data,
+        app_metadata_id: appMetadata.id,
+      });
 
-        if (!result.success) {
-          toast.error(result.message);
-          return;
-        }
-
-        toast.success(result.message);
+      if (!result.success) {
+        toast.error(result.message);
+      } else {
         await Promise.all([refetchAppMetadata(), refetchLocalisations()]);
         toast.success("App information updated successfully");
-      } catch (e) {
-        toast.error("Failed to update app information");
-      } finally {
-        toast.update("formState", { autoClose: 0 });
       }
+      toast.update("formState", { autoClose: 0 });
     },
     [appMetadata.id, refetchAppMetadata, refetchLocalisations],
   );

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/server/update-app-store.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/server/update-app-store.ts
@@ -50,6 +50,7 @@ export async function updateAppStoreMetadata(
           "The user does not have permission to update this app metadata",
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -66,6 +67,7 @@ export async function updateAppStoreMetadata(
         additionalInfo: { formData },
         team_id: teamId,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -148,6 +150,7 @@ export async function updateAppStoreMetadata(
       additionalInfo: { formData },
       team_id: teamId,
       app_id: appId,
+      logLevel: "error",
     });
   }
 }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/server/update-app-store.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/server/update-app-store.ts
@@ -4,6 +4,7 @@ import { errorFormAction } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { getIsUserAllowedToUpdateAppMetadata } from "@/lib/permissions";
 import { extractIdsFromPath, getPathFromHeaders } from "@/lib/server-utils";
+import { FormActionResult } from "@/lib/types";
 import * as yup from "yup";
 import { mainAppStoreFormSchema } from "../FormSchema/form-schema";
 import { AppStoreFormValues } from "../FormSchema/types";
@@ -13,11 +14,6 @@ import {
   encodeDescription,
   extractImagePathWithExtensionFromActualUrl,
 } from "../utils";
-
-type FormActionResult = {
-  success: boolean;
-  message: string;
-};
 
 const schema = mainAppStoreFormSchema
   .concat(
@@ -31,6 +27,7 @@ type Schema = yup.Asserts<typeof schema>;
 const formatEmailLink = (email: string): string => {
   return `mailto:${email}`;
 };
+
 export async function updateAppStoreMetadata(
   formData: Schema,
 ): Promise<FormActionResult> {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/server/update-app-store.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/server/update-app-store.ts
@@ -45,10 +45,12 @@ export async function updateAppStoreMetadata(
       await getIsUserAllowedToUpdateAppMetadata(formData.app_metadata_id);
 
     if (!isUserAllowedToUpdateAppMetadata) {
-      return {
-        success: false,
-        message: "insufficient permissions to update app metadata",
-      };
+      return errorFormAction({
+        message:
+          "The user does not have permission to update this app metadata",
+        team_id: teamId,
+        app_id: appId,
+      });
     }
 
     let parsedParams: AppStoreFormValues;
@@ -60,7 +62,7 @@ export async function updateAppStoreMetadata(
     } catch (validationError) {
       return errorFormAction({
         error: validationError as Error,
-        message: "validation failed",
+        message: "The provided app metadata is invalid",
         additionalInfo: { formData },
         team_id: teamId,
         app_id: appId,
@@ -140,11 +142,9 @@ export async function updateAppStoreMetadata(
       message: "app store information updated successfully",
     };
   } catch (error) {
-    console.error("GraphQL error updating app store metadata:", error);
-
     return errorFormAction({
       error: error as Error,
-      message: "updateAppStoreMetadata - unexpected error",
+      message: "An error occurred while updating the app metadata",
       additionalInfo: { formData },
       team_id: teamId,
       app_id: appId,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/SubmitAppModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/SubmitAppModal/index.tsx
@@ -90,36 +90,42 @@ export const SubmitAppModal = (props: SubmitAppModalProps) => {
           toast.error("Localisation not set for all languages");
           return;
         }
-
-        if (values.is_developer_allow_listing && !canSubmitAppStore) {
-          toast.error(
-            "Featured and showcase images are required for listing in Mini Apps",
-          );
-          return;
-        }
-
-        await validateAndSubmitAppForReviewFormServerSide({
-          input: {
-            app_metadata_id: appMetadataId,
-            team_id: teamId,
-            is_developer_allow_listing: values.is_developer_allow_listing,
-            changelog: values.changelog,
-          },
-        });
-        await refetchAppMetadata();
-
-        posthog.capture("app_submitted_for_review", {
-          app_id: appId,
-          team_id: teamId,
-          is_developer_allow_listing: values.is_developer_allow_listing,
-        });
-
-        toast.success("App submitted for review");
-        setOpen(false);
       } catch (error: any) {
         console.error("Submit App Modal Failed: ", error);
         toast.error("Failed to submit app for review");
       }
+
+      if (values.is_developer_allow_listing && !canSubmitAppStore) {
+        toast.error(
+          "Featured and showcase images are required for listing in Mini Apps",
+        );
+        return;
+      }
+
+      const result = await validateAndSubmitAppForReviewFormServerSide({
+        input: {
+          app_metadata_id: appMetadataId,
+          team_id: teamId,
+          is_developer_allow_listing: values.is_developer_allow_listing,
+          changelog: values.changelog,
+        },
+      });
+      if (!result.success) {
+        console.error("Failed to submit app for review: ", result.message);
+        toast.error(result.message);
+        return;
+      }
+
+      await refetchAppMetadata();
+
+      posthog.capture("app_submitted_for_review", {
+        app_id: appId,
+        team_id: teamId,
+        is_developer_allow_listing: values.is_developer_allow_listing,
+      });
+
+      toast.success("App submitted for review");
+      setOpen(false);
     },
     [
       appId,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/SubmitAppModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/SubmitAppModal/index.tsx
@@ -111,7 +111,6 @@ export const SubmitAppModal = (props: SubmitAppModalProps) => {
         },
       });
       if (!result.success) {
-        console.error("Failed to submit app for review: ", result.message);
         toast.error(result.message);
         return;
       }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/server/submit.ts
@@ -5,6 +5,7 @@ import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { getIsUserAllowedToUpdateAppMetadata } from "@/lib/permissions";
 import { extractIdsFromPath, getPathFromHeaders } from "@/lib/server-utils";
+import { FormActionResult } from "@/lib/types";
 import { submitAppSchema as schema, SubmitAppSchema } from "../form-schema";
 import { getSdk as getSubmitAppSdk } from "../SubmitAppModal/graphql/server/submit-app.generated";
 
@@ -12,7 +13,7 @@ export async function validateAndSubmitAppForReviewFormServerSide({
   input,
 }: {
   input: SubmitAppSchema;
-}) {
+}): Promise<FormActionResult> {
   const path = getPathFromHeaders() || "";
   const { Apps: appId } = extractIdsFromPath(path, ["Apps"]);
 
@@ -20,7 +21,7 @@ export async function validateAndSubmitAppForReviewFormServerSide({
     const isUserAllowedToUpdateAppMetadata =
       await getIsUserAllowedToUpdateAppMetadata(input.app_metadata_id);
     if (!isUserAllowedToUpdateAppMetadata) {
-      errorFormAction({
+      return errorFormAction({
         message:
           "The user does not have permission to submit this app for review",
         team_id: input.team_id,
@@ -35,7 +36,7 @@ export async function validateAndSubmitAppForReviewFormServerSide({
     });
 
     if (!isValid || !parsedInput) {
-      errorFormAction({
+      return errorFormAction({
         message: "The provided review data is invalid",
         additionalInfo: { input },
         team_id: input.team_id,
@@ -53,8 +54,13 @@ export async function validateAndSubmitAppForReviewFormServerSide({
       verification_status: "awaiting_review",
       changelog: parsedInput.changelog,
     });
+
+    return {
+      success: true,
+      message: "App submitted for review successfully",
+    };
   } catch (error) {
-    errorFormAction({
+    return errorFormAction({
       message:
         "validateAndSubmitAppForReviewFormServerSide - error submitting app for review",
       error: error as Error,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/server/submit.ts
@@ -25,6 +25,7 @@ export async function validateAndSubmitAppForReviewFormServerSide({
           "The user does not have permission to submit this app for review",
         team_id: input.team_id,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -39,6 +40,7 @@ export async function validateAndSubmitAppForReviewFormServerSide({
         additionalInfo: { input },
         team_id: input.team_id,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -59,6 +61,7 @@ export async function validateAndSubmitAppForReviewFormServerSide({
       additionalInfo: { input },
       team_id: input.team_id,
       app_id: appId,
+      logLevel: "error",
     });
   }
 }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/server/submit.ts
@@ -22,7 +22,7 @@ export async function validateAndSubmitAppForReviewFormServerSide({
     if (!isUserAllowedToUpdateAppMetadata) {
       errorFormAction({
         message:
-          "validateAndSubmitAppForReviewFormServerSide - invalid permissions",
+          "The user does not have permission to submit this app for review",
         team_id: input.team_id,
         app_id: appId,
       });
@@ -35,7 +35,7 @@ export async function validateAndSubmitAppForReviewFormServerSide({
 
     if (!isValid || !parsedInput) {
       errorFormAction({
-        message: "validateAndSubmitAppForReviewFormServerSide - invalid input",
+        message: "The provided review data is invalid",
         additionalInfo: { input },
         team_id: input.team_id,
         app_id: appId,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/SubmitAppModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/SubmitAppModal/index.tsx
@@ -112,7 +112,6 @@ export const SubmitAppModal = (props: SubmitAppModalProps) => {
         },
       });
       if (!result.success) {
-        console.error("Failed to submit app for review: ", result.message);
         toast.error(result.message);
         return;
       }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/SubmitAppModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/SubmitAppModal/index.tsx
@@ -90,36 +90,42 @@ export const SubmitAppModal = (props: SubmitAppModalProps) => {
           toast.error("Localisation not set for all languages");
           return;
         }
+      } catch (error) {
+        console.error("Failed to validate localisation: ", error);
+        toast.error("Failed to validate localisation");
+        return;
+      }
 
-        if (values.is_developer_allow_listing && !canSubmitAppStore) {
-          toast.error(
-            "Featured and showcase images are required for listing in Mini Apps",
-          );
-          return;
-        }
+      if (values.is_developer_allow_listing && !canSubmitAppStore) {
+        toast.error(
+          "Featured and showcase images are required for listing in Mini Apps",
+        );
+        return;
+      }
 
-        await submitAppForReviewFormServerSide({
-          input: {
-            app_metadata_id: appMetadataId,
-            team_id: teamId,
-            is_developer_allow_listing: values.is_developer_allow_listing,
-            changelog: values.changelog,
-          },
-        });
-        await refetchAppMetadata();
-
-        posthog.capture("app_submitted_for_review", {
-          app_id: appId,
+      const result = await submitAppForReviewFormServerSide({
+        input: {
+          app_metadata_id: appMetadataId,
           team_id: teamId,
           is_developer_allow_listing: values.is_developer_allow_listing,
-        });
-
-        toast.success("App submitted for review");
-        setOpen(false);
-      } catch (error: any) {
-        console.error("Submit App Modal Failed: ", error);
-        toast.error("Failed to submit app for review");
+          changelog: values.changelog,
+        },
+      });
+      if (!result.success) {
+        console.error("Failed to submit app for review: ", result.message);
+        toast.error(result.message);
+        return;
       }
+      await refetchAppMetadata();
+
+      posthog.capture("app_submitted_for_review", {
+        app_id: appId,
+        team_id: teamId,
+        is_developer_allow_listing: values.is_developer_allow_listing,
+      });
+
+      toast.success("App submitted for review");
+      setOpen(false);
     },
     [
       appId,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/index.tsx
@@ -143,10 +143,6 @@ export const AppTopBarRefactored = (props: AppTopBarProps) => {
 
               if (!result.success) {
                 toast.error(result.message);
-                console.error(
-                  "Failed to save app information: ",
-                  result.message,
-                );
               } else {
                 toast.success("App information saved");
                 resolve();

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/index.tsx
@@ -136,23 +136,20 @@ export const AppTopBarRefactored = (props: AppTopBarProps) => {
         await new Promise<void>((resolve, reject) => {
           form.handleSubmit(
             async (data) => {
-              try {
-                // This should call the updateAppStoreMetadata action
-                const result = await updateAppStoreMetadata({
-                  ...data,
-                  app_metadata_id: appMetadata.id,
-                });
+              const result = await updateAppStoreMetadata({
+                ...data,
+                app_metadata_id: appMetadata.id,
+              });
 
-                if (!result.success) {
-                  toast.error("Failed to save app information");
-                  return;
-                }
-
+              if (!result.success) {
+                toast.error(result.message);
+                console.error(
+                  "Failed to save app information: ",
+                  result.message,
+                );
+              } else {
                 toast.success("App information saved");
                 resolve();
-              } catch (e) {
-                toast.error("Failed to save app information");
-                reject(e);
               }
             },
             (errors) => {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/server/submit.ts
@@ -5,6 +5,7 @@ import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { getIsUserAllowedToUpdateAppMetadata } from "@/lib/permissions";
 import { extractIdsFromPath, getPathFromHeaders } from "@/lib/server-utils";
+import { FormActionResult } from "@/lib/types";
 import * as yup from "yup";
 import { getSdk as getSubmitAppSdk } from "../SubmitAppModal/graphql/server/submit-app.generated";
 
@@ -25,7 +26,7 @@ export async function submitAppForReviewFormServerSide({
   input,
 }: {
   input: SubmitAppForReviewSchema;
-}) {
+}): Promise<FormActionResult> {
   const path = getPathFromHeaders() || "";
   const { Apps: appId } = extractIdsFromPath(path, ["Apps"]);
 
@@ -33,7 +34,7 @@ export async function submitAppForReviewFormServerSide({
     const isUserAllowedToUpdateAppMetadata =
       await getIsUserAllowedToUpdateAppMetadata(input.app_metadata_id);
     if (!isUserAllowedToUpdateAppMetadata) {
-      errorFormAction({
+      return errorFormAction({
         message:
           "The user does not have permission to submit this app for review",
         team_id: input.team_id,
@@ -48,7 +49,7 @@ export async function submitAppForReviewFormServerSide({
     });
 
     if (!isValid || !parsedInput) {
-      errorFormAction({
+      return errorFormAction({
         message: "The provided review data is invalid",
         additionalInfo: { input },
         team_id: input.team_id,
@@ -66,8 +67,13 @@ export async function submitAppForReviewFormServerSide({
       verification_status: "awaiting_review",
       changelog: parsedInput.changelog,
     });
+
+    return {
+      success: true,
+      message: "App submitted for review successfully",
+    };
   } catch (error) {
-    errorFormAction({
+    return errorFormAction({
       message: "An error occurred while submitting the app for review",
       error: error as Error,
       additionalInfo: { input },

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/server/submit.ts
@@ -35,7 +35,7 @@ export async function submitAppForReviewFormServerSide({
     if (!isUserAllowedToUpdateAppMetadata) {
       errorFormAction({
         message:
-          "validateAndSubmitAppForReviewFormServerSide - invalid permissions",
+          "The user does not have permission to submit this app for review",
         team_id: input.team_id,
         app_id: appId,
       });
@@ -48,7 +48,7 @@ export async function submitAppForReviewFormServerSide({
 
     if (!isValid || !parsedInput) {
       errorFormAction({
-        message: "validateAndSubmitAppForReviewFormServerSide - invalid input",
+        message: "The provided review data is invalid",
         additionalInfo: { input },
         team_id: input.team_id,
         app_id: appId,
@@ -66,8 +66,7 @@ export async function submitAppForReviewFormServerSide({
     });
   } catch (error) {
     errorFormAction({
-      message:
-        "validateAndSubmitAppForReviewFormServerSide - error submitting app for review",
+      message: "An error occurred while submitting the app for review",
       error: error as Error,
       additionalInfo: { input },
       team_id: input.team_id,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/server/submit.ts
@@ -38,6 +38,7 @@ export async function submitAppForReviewFormServerSide({
           "The user does not have permission to submit this app for review",
         team_id: input.team_id,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -52,6 +53,7 @@ export async function submitAppForReviewFormServerSide({
         additionalInfo: { input },
         team_id: input.team_id,
         app_id: appId,
+        logLevel: "warn",
       });
     }
 
@@ -71,6 +73,7 @@ export async function submitAppForReviewFormServerSide({
       additionalInfo: { input },
       team_id: input.team_id,
       app_id: appId,
+      logLevel: "error",
     });
   }
 }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
@@ -90,10 +90,6 @@ export const BasicInformation = (props: {
     async (data: BasicInformationFormValues) => {
       const result = await validateAndSubmitServerSide(appMetaData?.id, data);
       if (!result.success) {
-        console.error(
-          "Failed to update app basic information: ",
-          result.message,
-        );
         toast.error(result.message);
       } else {
         await refetchAppMetadata();

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
@@ -88,14 +88,16 @@ export const BasicInformation = (props: {
 
   const submit = useCallback(
     async (data: BasicInformationFormValues) => {
-      try {
-        await validateAndSubmitServerSide(appMetaData?.id, data);
+      const result = await validateAndSubmitServerSide(appMetaData?.id, data);
+      if (!result.success) {
+        console.error(
+          "Failed to update app basic information: ",
+          result.message,
+        );
+        toast.error(result.message);
+      } else {
         await refetchAppMetadata();
-
         toast.success("App information updated successfully");
-      } catch (e) {
-        console.error("Basic Info Failed to Update: ", e);
-        toast.error("Failed to update app information");
       }
     },
     [appMetaData?.id, refetchAppMetadata],

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/server/submit.ts
@@ -23,7 +23,8 @@ export async function validateAndSubmitServerSide(
       await getIsUserAllowedToUpdateAppMetadata(app_metadata_id);
     if (!isUserAllowedToUpdateAppMetadata) {
       errorFormAction({
-        message: "validateAndSubmitServerSide - invalid permissions",
+        message:
+          "The user does not have permission to update this app metadata",
         app_id: input?.app_id ?? undefined,
         team_id: teamId,
       });
@@ -36,7 +37,7 @@ export async function validateAndSubmitServerSide(
 
     if (!isValid || !parsedInput) {
       errorFormAction({
-        message: "validateAndSubmitServerSide - invalid input",
+        message: "The provided app metadata basic information is invalid",
         additionalInfo: { app_metadata_id, input },
         team_id: teamId,
         app_id: input?.app_id ?? undefined,
@@ -53,7 +54,8 @@ export async function validateAndSubmitServerSide(
     });
   } catch (error) {
     return errorFormAction({
-      message: "Error updating app configuration basic form",
+      message:
+        "An error occurred while updating the app metadata basic information",
       error: error as Error,
       additionalInfo: { app_metadata_id, input },
       team_id: teamId,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/server/submit.ts
@@ -27,6 +27,7 @@ export async function validateAndSubmitServerSide(
           "The user does not have permission to update this app metadata",
         app_id: input?.app_id ?? undefined,
         team_id: teamId,
+        logLevel: "warn",
       });
     }
 
@@ -41,6 +42,7 @@ export async function validateAndSubmitServerSide(
         additionalInfo: { app_metadata_id, input },
         team_id: teamId,
         app_id: input?.app_id ?? undefined,
+        logLevel: "warn",
       });
     }
 
@@ -60,6 +62,7 @@ export async function validateAndSubmitServerSide(
       additionalInfo: { app_metadata_id, input },
       team_id: teamId,
       app_id: input?.app_id ?? undefined,
+      logLevel: "error",
     });
   }
 }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/index.tsx
@@ -18,7 +18,6 @@ export const TransactionsPage = async (props: TransactionsPageProps) => {
   const result = await getTransactionData(appId);
   let transactionData: PaymentMetadata[] = [];
   if (!result.success) {
-    console.error("Failed to fetch transaction data: ", result.message);
     toast.error(result.message);
   } else {
     transactionData = result.data as PaymentMetadata[];

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/index.tsx
@@ -1,7 +1,9 @@
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { PaymentMetadata } from "@/lib/types";
 import { Suspense } from "react";
 import Skeleton from "react-loading-skeleton";
+import { toast } from "react-toastify";
 import { TransactionsTable } from "./TransactionsTable";
 import { getTransactionData } from "./server";
 
@@ -13,7 +15,14 @@ export const TransactionsPage = async (props: TransactionsPageProps) => {
   const { params } = props;
   const appId = params?.appId as `app_${string}`;
 
-  const transactionData = await getTransactionData(appId);
+  const result = await getTransactionData(appId);
+  let transactionData: PaymentMetadata[] = [];
+  if (!result.success) {
+    console.error("Failed to fetch transaction data: ", result.message);
+    toast.error(result.message);
+  } else {
+    transactionData = result.data as PaymentMetadata[];
+  }
 
   return (
     <div className="my-6 min-h-[100dvh]">

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/getAccumulativeTransactionData.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/getAccumulativeTransactionData.ts
@@ -84,8 +84,7 @@ export const getAccumulativePaymentsData = async (
   try {
     if (!process.env.NEXT_SERVER_INTERNAL_PAYMENTS_ENDPOINT) {
       errorFormAction({
-        message:
-          "getAccumulativePaymentsData - internal payments endpoint must be set",
+        message: "The internal payments endpoint is not set",
         app_id: appId,
         team_id: teamId,
       });
@@ -172,7 +171,7 @@ export const getAccumulativePaymentsData = async (
     };
   } catch (error) {
     errorFormAction({
-      message: "getAccumulativePaymentsData - error fetching transaction data",
+      message: "Failed to fetch transaction data",
       error: error as Error,
       app_id: appId,
       team_id: teamId,
@@ -192,8 +191,7 @@ export const getAccumulativeTransactionsData = async (
   try {
     if (!process.env.NEXT_SERVER_INTERNAL_PAYMENTS_ENDPOINT) {
       errorFormAction({
-        message:
-          "getAccumulativeTransactionsData - internal transactions endpoint must be set",
+        message: "The internal transactions endpoint is not set",
         app_id: appId,
         team_id: teamId,
       });
@@ -232,8 +230,7 @@ export const getAccumulativeTransactionsData = async (
     };
   } catch (error) {
     errorFormAction({
-      message:
-        "getAccumulativeTransactionsData - error fetching transaction data",
+      message: "Failed to fetch transaction data",
       error: error as Error,
       app_id: appId,
       team_id: teamId,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/getAccumulativeTransactionData.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/getAccumulativeTransactionData.ts
@@ -3,6 +3,7 @@
 import { errorFormAction } from "@/api/helpers/errors";
 import { extractIdsFromPath, getPathFromHeaders } from "@/lib/server-utils";
 import {
+  FormActionResult,
   PaymentMetadata,
   TokenPrecision,
   TransactionMetadata,
@@ -10,13 +11,15 @@ import {
 } from "@/lib/types";
 import { createSignedFetcher } from "aws-sigv4-fetch";
 
-export type GetAccumulativePaymentsDataReturnType = Awaited<
-  ReturnType<typeof getAccumulativePaymentsData>
->;
+export type GetAccumulativePaymentsDataReturnType = {
+  accumulativePayments: PaymentMetadata[];
+  accumulatedTokenAmountUSD: number;
+};
 
-export type GetAccumulativeTransactionsDataReturnType = Awaited<
-  ReturnType<typeof getAccumulativeTransactionsData>
->;
+export type GetAccumulativeTransactionsDataReturnType = {
+  accumulativeTransactions: TransactionMetadata[];
+  accumulatedTransactionCount: number;
+};
 
 const calculateUSDAmount = (
   tokenAmount: number,
@@ -75,16 +78,13 @@ const fetchTransactionData = async (
 */
 export const getAccumulativePaymentsData = async (
   appId: string,
-): Promise<{
-  accumulativePayments: PaymentMetadata[];
-  accumulatedTokenAmountUSD: number;
-}> => {
+): Promise<FormActionResult> => {
   const path = getPathFromHeaders() || "";
   const { Teams: teamId } = extractIdsFromPath(path, ["Teams"]);
 
   try {
     if (!process.env.NEXT_SERVER_INTERNAL_PAYMENTS_ENDPOINT) {
-      errorFormAction({
+      return errorFormAction({
         message: "The internal payments endpoint is not set",
         app_id: appId,
         team_id: teamId,
@@ -168,11 +168,17 @@ export const getAccumulativePaymentsData = async (
       );
 
     return {
-      accumulativePayments,
-      accumulatedTokenAmountUSD: roundToTwoDecimals(accumulatedTokenAmountUSD),
+      success: true,
+      message: "Transaction data fetched successfully",
+      data: {
+        accumulativePayments,
+        accumulatedTokenAmountUSD: roundToTwoDecimals(
+          accumulatedTokenAmountUSD,
+        ),
+      },
     };
   } catch (error) {
-    errorFormAction({
+    return errorFormAction({
       message: "Failed to fetch transaction data",
       error: error as Error,
       app_id: appId,
@@ -184,16 +190,13 @@ export const getAccumulativePaymentsData = async (
 
 export const getAccumulativeTransactionsData = async (
   appId: string,
-): Promise<{
-  accumulativeTransactions: TransactionMetadata[];
-  accumulatedTransactionCount: number;
-}> => {
+): Promise<FormActionResult> => {
   const path = getPathFromHeaders() || "";
   const { Teams: teamId } = extractIdsFromPath(path, ["Teams"]);
 
   try {
     if (!process.env.NEXT_SERVER_INTERNAL_PAYMENTS_ENDPOINT) {
-      errorFormAction({
+      return errorFormAction({
         message: "The internal transactions endpoint is not set",
         app_id: appId,
         team_id: teamId,
@@ -229,11 +232,15 @@ export const getAccumulativeTransactionsData = async (
     );
 
     return {
-      accumulativeTransactions: sortedTransactions,
-      accumulatedTransactionCount,
+      success: true,
+      message: "Transaction data fetched successfully",
+      data: {
+        accumulativeTransactions: sortedTransactions,
+        accumulatedTransactionCount,
+      },
     };
   } catch (error) {
-    errorFormAction({
+    return errorFormAction({
       message: "Failed to fetch transaction data",
       error: error as Error,
       app_id: appId,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/getAccumulativeTransactionData.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/getAccumulativeTransactionData.ts
@@ -62,6 +62,7 @@ const fetchTransactionData = async (
       additionalInfo: { url, response, data },
       team_id: teamId,
       app_id: appId,
+      logLevel: "error",
     });
   }
 
@@ -87,6 +88,7 @@ export const getAccumulativePaymentsData = async (
         message: "The internal payments endpoint is not set",
         app_id: appId,
         team_id: teamId,
+        logLevel: "error",
       });
     }
 
@@ -175,6 +177,7 @@ export const getAccumulativePaymentsData = async (
       error: error as Error,
       app_id: appId,
       team_id: teamId,
+      logLevel: "error",
     });
   }
 };
@@ -194,6 +197,7 @@ export const getAccumulativeTransactionsData = async (
         message: "The internal transactions endpoint is not set",
         app_id: appId,
         team_id: teamId,
+        logLevel: "error",
       });
     }
 
@@ -234,6 +238,7 @@ export const getAccumulativeTransactionsData = async (
       error: error as Error,
       app_id: appId,
       team_id: teamId,
+      logLevel: "error",
     });
   }
 };

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/index.ts
@@ -18,6 +18,7 @@ export const getTransactionData = async (
         additionalInfo: { transactionId },
         app_id: appId,
         team_id: teamId,
+        logLevel: "error",
       });
     }
 
@@ -47,6 +48,7 @@ export const getTransactionData = async (
         additionalInfo: { transactionId, response, data },
         app_id: appId,
         team_id: teamId,
+        logLevel: "error",
       });
     }
     return (data?.result?.transactions || []).sort(
@@ -60,6 +62,7 @@ export const getTransactionData = async (
       additionalInfo: { transactionId },
       app_id: appId,
       team_id: teamId,
+      logLevel: "error",
     });
   }
 };

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/index.ts
@@ -14,7 +14,7 @@ export const getTransactionData = async (
   try {
     if (!process.env.NEXT_SERVER_INTERNAL_PAYMENTS_ENDPOINT) {
       errorFormAction({
-        message: "getTransactionData - internal payments endpoint must be set",
+        message: "The internal payments endpoint is not set",
         additionalInfo: { transactionId },
         app_id: appId,
         team_id: teamId,
@@ -43,7 +43,7 @@ export const getTransactionData = async (
     const data = await response.json();
     if (!response.ok) {
       errorFormAction({
-        message: "getTransactionData - failed to fetch transaction data",
+        message: "Failed to fetch transaction data",
         additionalInfo: { transactionId, response, data },
         app_id: appId,
         team_id: teamId,
@@ -55,7 +55,7 @@ export const getTransactionData = async (
     );
   } catch (error) {
     errorFormAction({
-      message: "getTransactionData - failed to fetch transaction data",
+      message: "Failed to fetch transaction data",
       error: error as Error,
       additionalInfo: { transactionId },
       app_id: appId,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/GraphsSection/use-get-accumulative-transactions.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/GraphsSection/use-get-accumulative-transactions.ts
@@ -15,17 +15,17 @@ export const useGetAccumulativeTransactions = (appId: string) => {
 
   useEffect(() => {
     const fetchTransactions = async () => {
-      try {
-        const paymentsData = await getAccumulativePaymentsData(appId);
-        setPayments(paymentsData);
-        // TODO once we have metrics endpoint
-        // const transactionsData = await getAccumulativeTransactionsData(appId);
-        // setTransactions(transactionsData);
-      } catch (err) {
-        setError(err);
-      } finally {
-        setLoading(false);
+      const result = await getAccumulativePaymentsData(appId);
+      if (!result.success) {
+        setError(result.message);
+        console.error("Failed to fetch payments data: ", result.message);
+      } else {
+        setPayments(result.data as GetAccumulativePaymentsDataReturnType);
       }
+      // TODO once we have metrics endpoint
+      // const transactionsData = await getAccumulativeTransactionsData(appId);
+      // setTransactions(transactionsData);
+      setLoading(false);
     };
 
     fetchTransactions();

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/StatCardGlobalRanking/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/StatCardGlobalRanking/index.tsx
@@ -1,13 +1,17 @@
 "use server";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import Skeleton from "react-loading-skeleton";
-import { getAppMetricsData } from "../../server";
+import { AppMetricsData, getAppMetricsData } from "../../server";
 
 const title = "Global ranking";
 
 export const StatCardGlobalRanking = async (props: { appId: string }) => {
-  const value = await getAppMetricsData(props.appId);
-  const splitValue = value.appRanking.split(" / ") as [string, string];
+  let splitValue: [string, string] | undefined;
+  const result = await getAppMetricsData(props.appId);
+  if (result.success) {
+    const value = result.data as AppMetricsData;
+    splitValue = value.appRanking.split(" / ") as [string, string];
+  }
 
   return (
     <div className="flex flex-col gap-y-2">
@@ -15,7 +19,7 @@ export const StatCardGlobalRanking = async (props: { appId: string }) => {
         {title}
       </Typography>
       <div className="flex items-center gap-x-2">
-        {value ? (
+        {splitValue ? (
           <Typography variant={TYPOGRAPHY.H3} className="text-grey-700">
             <span>{splitValue[0]}</span>
             <span className="text-grey-300"> / {splitValue[1]}</span>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/StatCards/use-get-metrics.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/StatCards/use-get-metrics.ts
@@ -8,14 +8,14 @@ export const useGetMetrics = (appId: string) => {
 
   useEffect(() => {
     const fetchMetrics = async () => {
-      try {
-        const data = await getAppMetricsData(appId);
-        setMetrics(data);
-      } catch (err) {
-        setError(err);
-      } finally {
-        setLoading(false);
+      const result = await getAppMetricsData(appId);
+      if (!result.success) {
+        console.error("Failed to fetch app metrics data: ", result.message);
+        setError(result.error);
+      } else {
+        setMetrics(result.data as AppMetricsData);
       }
+      setLoading(false);
     };
 
     fetchMetrics();

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/server/index.ts
@@ -53,7 +53,7 @@ export const getAppMetricsData = async (
 
   if (!metricsData.ok) {
     errorFormAction({
-      message: "getAppMetricsData - failed to fetch metrics data",
+      message: "Failed to fetch metrics data",
       additionalInfo: { status: metricsData.status },
       team_id: teamId,
       app_id: appId,

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/server/index.ts
@@ -57,6 +57,7 @@ export const getAppMetricsData = async (
       additionalInfo: { status: metricsData.status },
       team_id: teamId,
       app_id: appId,
+      logLevel: "error",
     });
   }
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/server/index.ts
@@ -2,7 +2,7 @@
 
 import { errorFormAction } from "@/api/helpers/errors";
 import { extractIdsFromPath, getPathFromHeaders } from "@/lib/server-utils";
-import { DataByCountry } from "@/lib/types";
+import { DataByCountry, FormActionResult } from "@/lib/types";
 
 export type AppMetricsData = {
   total_impressions: number | null;
@@ -37,7 +37,7 @@ type NotificationData = {
 
 export const getAppMetricsData = async (
   appId: string,
-): Promise<AppMetricsData> => {
+): Promise<FormActionResult> => {
   const path = getPathFromHeaders() || "";
   const { Teams: teamId } = extractIdsFromPath(path, ["Teams"]);
 
@@ -52,7 +52,7 @@ export const getAppMetricsData = async (
   );
 
   if (!metricsData.ok) {
-    errorFormAction({
+    return errorFormAction({
       message: "Failed to fetch metrics data",
       additionalInfo: { status: metricsData.status },
       team_id: teamId,
@@ -68,16 +68,20 @@ export const getAppMetricsData = async (
 
   if (!appMetrics) {
     return {
-      total_impressions: 0,
-      total_impressions_last_7_days: 0,
-      total_users: 0,
-      total_users_last_7_days: 0,
-      unique_users: 0,
-      unique_users_last_7_days: 0,
-      new_users_last_7_days: 0,
-      appRanking: "-- / --",
-      open_rate_last_14_days: [],
-      notification_opt_in_rate: 0,
+      success: true,
+      message: "App metrics data is empty",
+      data: {
+        total_impressions: 0,
+        total_impressions_last_7_days: 0,
+        total_users: 0,
+        total_users_last_7_days: 0,
+        unique_users: 0,
+        unique_users_last_7_days: 0,
+        new_users_last_7_days: 0,
+        appRanking: "-- / --",
+        open_rate_last_14_days: [],
+        notification_opt_in_rate: 0,
+      },
     };
   }
 
@@ -87,27 +91,31 @@ export const getAppMetricsData = async (
 
   // For now we just sum all the countries and don't do anything by country
   return {
-    total_impressions: appMetrics.total_impressions,
-    total_impressions_last_7_days: appMetrics.total_impressions_last_7_days,
-    total_users: appMetrics.total_users,
-    total_users_last_7_days:
-      appMetrics.total_users_last_7_days?.reduce(
-        (acc, curr) => acc + curr.value,
-        0,
-      ) || null,
-    unique_users: appMetrics.unique_users,
-    unique_users_last_7_days:
-      appMetrics.unique_users_last_7_days?.reduce(
-        (acc, curr) => acc + curr.value,
-        0,
-      ) || null,
-    new_users_last_7_days:
-      appMetrics.new_users_last_7_days?.reduce(
-        (acc, curr) => acc + curr.value,
-        0,
-      ) || null,
-    appRanking,
-    open_rate_last_14_days: appMetrics.open_rate_last_14_days,
-    notification_opt_in_rate: appMetrics.notification_opt_in_rate,
+    success: true,
+    message: "App metrics data fetched successfully",
+    data: {
+      total_impressions: appMetrics.total_impressions,
+      total_impressions_last_7_days: appMetrics.total_impressions_last_7_days,
+      total_users: appMetrics.total_users,
+      total_users_last_7_days:
+        appMetrics.total_users_last_7_days?.reduce(
+          (acc, curr) => acc + curr.value,
+          0,
+        ) || null,
+      unique_users: appMetrics.unique_users,
+      unique_users_last_7_days:
+        appMetrics.unique_users_last_7_days?.reduce(
+          (acc, curr) => acc + curr.value,
+          0,
+        ) || null,
+      new_users_last_7_days:
+        appMetrics.new_users_last_7_days?.reduce(
+          (acc, curr) => acc + curr.value,
+          0,
+        ) || null,
+      appRanking,
+      open_rate_last_14_days: appMetrics.open_rate_last_14_days,
+      notification_opt_in_rate: appMetrics.notification_opt_in_rate,
+    },
   };
 };

--- a/web/scenes/Portal/Teams/TeamId/Team/Settings/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/Settings/page/index.tsx
@@ -49,13 +49,13 @@ export const TeamSettingsPage = () => {
 
   const submit = useCallback(
     async (values: FormValues) => {
-      try {
-        await validateAndUpdateTeamServerSide(values.name, teamId);
+      const result = await validateAndUpdateTeamServerSide(values.name, teamId);
+      if (!result.success) {
+        console.error("Failed to update team: ", result.message);
+        toast.error(result.message);
+      } else {
         toast.success("Your team was successfully updated");
         await Promise.all([refetchTeam(), refetchMe()]);
-      } catch (error) {
-        console.error("Failed to update team: ", error);
-        toast.error("Error updating team");
       }
     },
     [teamId, refetchTeam, refetchMe],

--- a/web/scenes/Portal/Teams/TeamId/Team/Settings/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/Settings/page/index.tsx
@@ -51,7 +51,6 @@ export const TeamSettingsPage = () => {
     async (values: FormValues) => {
       const result = await validateAndUpdateTeamServerSide(values.name, teamId);
       if (!result.success) {
-        console.error("Failed to update team: ", result.message);
         toast.error(result.message);
       } else {
         toast.success("Your team was successfully updated");

--- a/web/scenes/Portal/Teams/TeamId/Team/Settings/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/Settings/server/submit.ts
@@ -4,17 +4,18 @@ import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { getIsUserAllowedToUpdateTeam } from "@/lib/permissions";
 import { teamNameSchema } from "@/lib/schema";
+import { FormActionResult } from "@/lib/types";
 import { getSdk as getUpdateTeamSdk } from "../graphql/server/update-team.generated";
 
 export async function validateAndUpdateTeamServerSide(
   teamName: string,
   teamId: string,
-) {
+): Promise<FormActionResult> {
   try {
     const isUserAllowedToUpdateTeam =
       await getIsUserAllowedToUpdateTeam(teamId);
     if (!isUserAllowedToUpdateTeam) {
-      errorFormAction({
+      return errorFormAction({
         message: "The user does not have permission to update this team",
         team_id: teamId,
         logLevel: "warn",
@@ -28,7 +29,7 @@ export async function validateAndUpdateTeamServerSide(
       });
 
     if (!isValid || !parsedTeamName) {
-      errorFormAction({
+      return errorFormAction({
         message: "The provided team data is invalid",
         additionalInfo: { teamName },
         team_id: teamId,
@@ -43,8 +44,13 @@ export async function validateAndUpdateTeamServerSide(
         name: parsedTeamName,
       },
     });
+
+    return {
+      success: true,
+      message: "Team updated successfully",
+    };
   } catch (error) {
-    errorFormAction({
+    return errorFormAction({
       error: error as Error,
       message: "An error occurred while updating the team",
       additionalInfo: { teamName },

--- a/web/scenes/Portal/Teams/TeamId/Team/Settings/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/Settings/server/submit.ts
@@ -15,7 +15,7 @@ export async function validateAndUpdateTeamServerSide(
       await getIsUserAllowedToUpdateTeam(teamId);
     if (!isUserAllowedToUpdateTeam) {
       errorFormAction({
-        message: "validateAndUpdateTeamServerSide - invalid permissions",
+        message: "The user does not have permission to update this team",
         team_id: teamId,
       });
     }
@@ -28,7 +28,7 @@ export async function validateAndUpdateTeamServerSide(
 
     if (!isValid || !parsedTeamName) {
       errorFormAction({
-        message: "validateAndUpdateTeamServerSide - invalid input",
+        message: "The provided team data is invalid",
         additionalInfo: { teamName },
         team_id: teamId,
       });
@@ -44,7 +44,7 @@ export async function validateAndUpdateTeamServerSide(
   } catch (error) {
     errorFormAction({
       error: error as Error,
-      message: "validateAndUpdateTeamServerSide - error updating team",
+      message: "An error occurred while updating the team",
       additionalInfo: { teamName },
       team_id: teamId,
     });

--- a/web/scenes/Portal/Teams/TeamId/Team/Settings/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/Settings/server/submit.ts
@@ -17,6 +17,7 @@ export async function validateAndUpdateTeamServerSide(
       errorFormAction({
         message: "The user does not have permission to update this team",
         team_id: teamId,
+        logLevel: "warn",
       });
     }
 
@@ -31,6 +32,7 @@ export async function validateAndUpdateTeamServerSide(
         message: "The provided team data is invalid",
         additionalInfo: { teamName },
         team_id: teamId,
+        logLevel: "warn",
       });
     }
 
@@ -47,6 +49,7 @@ export async function validateAndUpdateTeamServerSide(
       message: "An error occurred while updating the team",
       additionalInfo: { teamName },
       team_id: teamId,
+      logLevel: "error",
     });
   }
 }

--- a/web/scenes/Portal/layout/CreateAppDialog/index.tsx
+++ b/web/scenes/Portal/layout/CreateAppDialog/index.tsx
@@ -65,7 +65,6 @@ export const CreateAppDialog = (props: DialogProps) => {
       }
       const result = await validateAndInsertAppServerSide(values, teamId);
       if (!result.success) {
-        console.error("Create app failed: ", result.message);
         toast.error(result.message);
         posthog.capture("app_creation_failed", {
           team_id: teamId,

--- a/web/scenes/Portal/layout/CreateAppDialog/index.tsx
+++ b/web/scenes/Portal/layout/CreateAppDialog/index.tsx
@@ -63,15 +63,15 @@ export const CreateAppDialog = (props: DialogProps) => {
       if (!teamId) {
         return toast.error("Failed to create app");
       }
-      try {
-        await validateAndInsertAppServerSide(values, teamId);
-      } catch (error) {
-        toast.error("Error while creating app");
-
+      const result = await validateAndInsertAppServerSide(values, teamId);
+      if (!result.success) {
+        console.error("Create app failed: ", result.message);
+        toast.error(result.message);
         posthog.capture("app_creation_failed", {
           team_id: teamId,
           environment: values.build,
           engine: values.verification,
+          error: result?.error,
         });
       }
       const [refetched] = await refetchApps();

--- a/web/scenes/Portal/layout/CreateAppDialog/server/submit.ts
+++ b/web/scenes/Portal/layout/CreateAppDialog/server/submit.ts
@@ -16,6 +16,7 @@ export async function validateAndInsertAppServerSide(
       errorFormAction({
         message: "The user does not have permission to create apps",
         team_id,
+        logLevel: "warn",
       });
     }
 
@@ -30,6 +31,7 @@ export async function validateAndInsertAppServerSide(
         message: "The provided app data is invalid",
         additionalInfo: { initialValues },
         team_id,
+        logLevel: "warn",
       });
     }
 
@@ -50,6 +52,7 @@ export async function validateAndInsertAppServerSide(
       error: error as Error,
       additionalInfo: { initialValues },
       team_id,
+      logLevel: "error",
     });
   }
 }

--- a/web/scenes/Portal/layout/CreateAppDialog/server/submit.ts
+++ b/web/scenes/Portal/layout/CreateAppDialog/server/submit.ts
@@ -14,7 +14,7 @@ export async function validateAndInsertAppServerSide(
     const isUserAllowedToInsertApp = await getIsUserAllowedToInsertApp(team_id);
     if (!isUserAllowedToInsertApp) {
       errorFormAction({
-        message: "validateAndInsertAppServerSide - invalid permissions",
+        message: "The user does not have permission to create apps",
         team_id,
       });
     }
@@ -27,7 +27,7 @@ export async function validateAndInsertAppServerSide(
 
     if (!isValid || !parsedInitialValues) {
       errorFormAction({
-        message: "validateAndInsertAppServerSide - invalid input",
+        message: "The provided app data is invalid",
         additionalInfo: { initialValues },
         team_id,
       });
@@ -46,7 +46,7 @@ export async function validateAndInsertAppServerSide(
     });
   } catch (error) {
     errorFormAction({
-      message: "validateAndInsertAppServerSide - error inserting app",
+      message: "An error occurred while creating the app",
       error: error as Error,
       additionalInfo: { initialValues },
       team_id,


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description
Ticket - [DEV-2079](https://linear.app/worldcoin/issue/DEV-2079/dev-portal-refactor-server-side-actions-to-return-errors-gracefuly)

Refactors the server-side Next.js actions to return errors gracefully, instead of throwing them.
This way, we will no longer see 500 from Next.js when an error response is returned.
Brings all responses to a uniform format, with `success` and `message` fields to help analyze the response.

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
