### PR TITLE
feat: Add timeout and retry logic to transactions request

### DIFF
--- a/web/api/v2/minikit/transaction/[transaction_id]/index.ts
+++ b/web/api/v2/minikit/transaction/[transaction_id]/index.ts
@@ -73,7 +73,7 @@ export const GET = async (
         "User-Agent": req.headers.get("user-agent") ?? "DevPortal/1.0",
         "Content-Type": "application/json",
       },
-      signal: AbortSignal.timeout(5000), // 5 seconds timeout
+      signal: AbortSignal.timeout(3000), // 3 seconds timeout
     },
     3, // max retries
     400, // initial retry delay in ms


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Ticket - [DEV-2098](https://linear.app/worldcoin/issue/DEV-2098/dev-portal-investigate-504-errors-in-get-transaction)

Adds a timeout of 3 seconds to internal transactions request and introduces a retry mechanism for it.
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
