### PR TITLE
fix: Introduce timeout parameter to avoid using same options object

### DIFF
--- a/web/api/helpers/fetch-metrics.ts
+++ b/web/api/helpers/fetch-metrics.ts
@@ -25,6 +25,7 @@ const fetchAndProcessMetrics = async (): Promise<ProcessedMetricsCache> => {
     },
     3,
     400,
+    5000,
     false,
   );
 

--- a/web/api/v2/minikit/transaction/[transaction_id]/index.ts
+++ b/web/api/v2/minikit/transaction/[transaction_id]/index.ts
@@ -73,10 +73,10 @@ export const GET = async (
         "User-Agent": req.headers.get("user-agent") ?? "DevPortal/1.0",
         "Content-Type": "application/json",
       },
-      signal: AbortSignal.timeout(3000), // 3 seconds timeout
     },
     3, // max retries
     400, // initial retry delay in ms
+    3000, // fetch timeout in ms
     false, // don't throw on error
     signedFetch,
   );

--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -71,6 +71,7 @@ export async function GET(
     { cache: "no-store" },
     3,
     400,
+    5000,
     false,
   );
 


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

If timeout is specified in the fetch options, it's used only once. All subsequent requests time out instantaneously. 
This PR creates a timeout object for each request.
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
