### PR TITLE
feat: Add timeout and retry logic to send notification request 

### DIFF
--- a/web/api/helpers/fetch-metrics.ts
+++ b/web/api/helpers/fetch-metrics.ts
@@ -25,6 +25,7 @@ const fetchAndProcessMetrics = async (): Promise<ProcessedMetricsCache> => {
     },
     3,
     400,
+    5000,
     false,
   );
 

--- a/web/api/v2/minikit/send-notification/index.ts
+++ b/web/api/v2/minikit/send-notification/index.ts
@@ -7,6 +7,7 @@ import {
   notificationMessageSchema,
   notificationTitleSchema,
 } from "@/lib/schema";
+import { fetchWithRetry } from "@/lib/utils";
 import { createSignedFetcher } from "aws-sigv4-fetch";
 import { GraphQLClient } from "graphql-request";
 import { NextRequest, NextResponse } from "next/server";
@@ -17,6 +18,7 @@ import {
   getSdk as createNotificationLogSdk,
 } from "./graphql/create-notification-log.generated";
 import { getSdk as fetchMetadataSdk } from "./graphql/fetch-metadata.generated";
+
 const USERNAME_SPECIAL_STRING = "${username}";
 
 const sendNotificationBodySchema = yup
@@ -353,7 +355,7 @@ export const POST = async (req: NextRequest) => {
     region: process.env.TRANSACTION_BACKEND_REGION,
   });
 
-  const res = await signedFetch(
+  const res = await fetchWithRetry(
     `${process.env.NEXT_PUBLIC_SEND_NOTIFICATION_ENDPOINT}`,
     {
       method: "POST",
@@ -370,11 +372,27 @@ export const POST = async (req: NextRequest) => {
         teamId: teamId,
       }),
     },
+    3,
+    400,
+    3000,
+    false,
+    signedFetch,
   );
-  const data = await res.json();
+
+  let data: any = {};
 
   if (!res.ok) {
-    console.warn("Error sending notification", {
+    try {
+      if (res.headers.get("content-type")?.includes("application/json")) {
+        data = await res.json();
+      }
+    } catch (e) {
+      logger.warn("Error parsing send notification response body", {
+        error: e,
+      });
+    }
+
+    logger.warn("Error sending notification", {
       data,
       app_id,
       team_id: teamId,

--- a/web/api/v2/minikit/transaction/[transaction_id]/index.ts
+++ b/web/api/v2/minikit/transaction/[transaction_id]/index.ts
@@ -73,10 +73,10 @@ export const GET = async (
         "User-Agent": req.headers.get("user-agent") ?? "DevPortal/1.0",
         "Content-Type": "application/json",
       },
-      signal: AbortSignal.timeout(3000), // 3 seconds timeout
     },
     3, // max retries
     400, // initial retry delay in ms
+    3000, // fetch timeout in ms
     false, // don't throw on error
     signedFetch,
   );

--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -71,6 +71,7 @@ export async function GET(
     { cache: "no-store" },
     3,
     400,
+    5000,
     false,
   );
 


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Ticket - [DEV-2154](https://linear.app/worldcoin/issue/DEV-2154/dev-portal-investigate-504-errors-in-get-apiv2minikitsend-notification)

Adds a timeout of 3 seconds to internal send notification request and introduces a retry mechanism for it.
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
