### PR TITLE
fix: Return original fetch response instead of 500

### DIFF
--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -386,7 +386,7 @@ export const fetchWithRetry = async (
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
-      const lastResponse = await fetchWithTimeout(
+      lastResponse = await fetchWithTimeout(
         url,
         options,
         fetchTimeoutInMS,


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Fixes the `fetchWithRetry` function to respond with the original response if available.

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
