### PR TITLE
CORPLAT-370 Use better runner for end-to-end tests

### DIFF
--- a/.github/workflows/ci-app-router.yml
+++ b/.github/workflows/ci-app-router.yml
@@ -148,7 +148,7 @@ jobs:
 
   e2e-tests:
     name: End-to-end Tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-16core
     environment: development
 
     defaults:


### PR DESCRIPTION
End-to-end tests are sometimes failing due to setup timeout. Seems like a lag caused by lack of system resources (CPU/RAM).

Temporarily added a better GitHub-hosted runner to see if this is the case.