### PR TITLE
fix: Add deleted app check on /apps redirect

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/page/graphql/server/apps.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/page/graphql/server/apps.generated.ts
@@ -15,7 +15,10 @@ export type InitialAppQuery = {
 
 export const InitialAppDocument = gql`
   query InitialApp($teamId: String!) {
-    app(where: { team: { id: { _eq: $teamId } } }, limit: 1) {
+    app(
+      where: { team: { id: { _eq: $teamId } }, deleted_at: { _is_null: true } }
+      limit: 1
+    ) {
       id
     }
   }

--- a/web/scenes/Portal/Teams/TeamId/Apps/page/graphql/server/apps.gql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/page/graphql/server/apps.gql
@@ -1,5 +1,8 @@
 query InitialApp($teamId: String!) {
-  app(where: { team: { id: { _eq: $teamId } } }, limit: 1) {
+  app(
+    where: { team: { id: { _eq: $teamId } }, deleted_at: { _is_null: true } }
+    limit: 1
+  ) {
     id
   }
 }


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Ticket - [DEV-2167](https://linear.app/worldcoin/issue/DEV-2167/dev-portal-users-get-404-when-they-delete-their-only-app)

Adds a check, that the app is deleted, not to redirect to it anymore.
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
