### PR TITLE
pass en localization data to final validator

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/index.tsx
@@ -157,9 +157,18 @@ export const AppTopBarRefactored = (props: AppTopBarProps) => {
         });
       }
 
+      const formValues = form.getValues();
+      const enLocalization = formValues.localisations.find(
+        (l) => l.language === "en",
+      );
+
       await mainAppStoreFormReviewSubmitSchema.validate(
         {
-          ...form.getValues(),
+          ...formValues,
+          name: enLocalization?.name,
+          short_name: enLocalization?.short_name,
+          world_app_description: enLocalization?.world_app_description,
+          description_overview: enLocalization?.description_overview,
           logo_img_url: appMetadata.logo_img_url,
         },
         {


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description
fixes a bug where when a user creates a brand new app, fills out all fields and tries to submit for review, they get an error.
This is because the validator expects en data (name, short name etc.) in the top level, not nested in localizations array only

saving & refreshing the page fixes this bug

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
