### PR TITLE
make button container click-through

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/components/SaveButton.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/components/SaveButton.tsx
@@ -13,10 +13,10 @@ export const SaveButton = ({
   onSubmit,
 }: SaveButtonProps) => {
   return (
-    <div className="fixed inset-x-0 bottom-0 z-50 h-32 bg-transparent shadow-lg">
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 h-32 bg-transparent shadow-lg">
       {/* copied from sizing wrapper */}
       <div className="grid grid-cols-[minmax(24px,1fr)_minmax(0,calc(1440px-9vw*2))_minmax(24px,1fr)] pr-3 pt-2 md:pt-8">
-        <div className="col-start-2 flex justify-self-end">
+        <div className="pointer-events-auto col-start-2 flex justify-self-end">
           <DecoratedButton
             type="submit"
             variant="primary"


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description
Makes it so that the save button container is click-through (user can click elements underneath), while keeping the button itself clickable.

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
