### PR TITLE
add informative toasts to the app store form

### DIFF
--- a/web/lib/schema/index.ts
+++ b/web/lib/schema/index.ts
@@ -83,14 +83,16 @@ export const allowTitleAndEmojisRegex = {
 
 export const httpsLinkSchema = ({
   excludeEmptyString = false,
+  message = "Must be a valid https URL",
 }: {
   excludeEmptyString?: boolean;
+  message?: string;
 } = {}) =>
   yup
     .string()
     .url("Invalid URL")
     .matches(/^https:\/\/[\w-]+(\.\w+)+([\/\w\-\+._/?%&#=]*)?$/, {
-      message: "Must be a valid https URL",
+      message,
       excludeEmptyString,
     });
 
@@ -151,7 +153,7 @@ export const appDescriptionOverviewSchema = yup
       "Overview can only contain letters, numbers and certain special characters.",
     excludeEmptyString: true,
   })
-  .required("This section is required");
+  .required("Description is required");
 
 export const appDescriptionHowItWorksSchema = yup
   .string()

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/FormSchema/field-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/FormSchema/field-schema.ts
@@ -1,11 +1,10 @@
 import { httpsLinkSchema as getHttpsLinkSchema } from "@/lib/schema";
 import * as yup from "yup";
 
-const httpsLinkSchema = getHttpsLinkSchema();
+export const appWebsiteUrlSchema = getHttpsLinkSchema({
+  message: "App Website URL must be a valid https URL",
+}).required("App Website URL is required");
 
-export const appWebsiteUrlSchema = httpsLinkSchema.required(
-  "This field is required",
-);
 export const supportEmailSchema = yup.string().email("Invalid email address");
 
 export const supportLinkSchema = yup
@@ -22,7 +21,11 @@ export const supportLinkSchema = yup
       }
 
       // https url
-      if (httpsLinkSchema.isValidSync(value)) {
+      if (
+        getHttpsLinkSchema({
+          message: "Support Link must be a valid https URL",
+        }).isValidSync(value)
+      ) {
         return true;
       }
 
@@ -34,11 +37,11 @@ export const supportedCountriesSchema = yup
   .array(
     yup
       .string()
-      .required("This field is required")
+      .required("This field is required required")
       .length(2, "Invalid country code"),
   )
-  .min(1, "This field is required")
-  .required("This field is required")
+  .min(1, "Supported Countries is required")
+  .required("Supported Countries is required")
   .default([]);
 export const categorySchema = yup.string().optional();
 export const isAndroidOnlySchema = yup

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/FormSchema/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/FormSchema/form-schema.ts
@@ -31,25 +31,18 @@ export const mainAppStoreFormSchema = yup
   .object({
     category: categorySchema,
     app_website_url: appWebsiteUrlSchema,
-    support_link: supportLinkSchema.test({
-      message: "Either support link or support email must be provided",
-      test: function (this, _, ctx) {
-        const { support_link, support_email } = ctx.parent || {};
-
-        // exactly one must be provided
-        return !!(support_link || support_email);
-      },
-    }),
-    support_email: supportEmailSchema.test({
-      message: "Either support link or support email must be provided",
-      test: function (this, _, ctx) {
-        const { support_link, support_email } = ctx.parent || {};
-
-        // exactly one must be provided
-        return !!(support_link || support_email);
-      },
-    }),
     support_type: yup.string().oneOf(["email", "link"]),
+    support_link: yup.string().when("support_type", {
+      is: "link",
+      then: (_schema) => supportLinkSchema.required("Support link is required"),
+      otherwise: (_schema) => yup.string().length(0),
+    }),
+    support_email: yup.string().when("support_type", {
+      is: "email",
+      then: (_schema) =>
+        supportEmailSchema.required("Support email is required"),
+      otherwise: (_schema) => yup.string().length(0),
+    }),
     is_android_only: isAndroidOnlySchema,
     is_for_humans_only: isForHumansOnlySchema,
     supported_countries: supportedCountriesSchema,
@@ -77,7 +70,7 @@ export const localisationFormReviewSubmitSchema = yup
       "App tag line is required",
     ),
     description_overview: appDescriptionOverviewSchema.required(
-      "Description is required",
+      "Overview is required",
     ),
     meta_tag_image_url: yup.string().notRequired(),
     showcase_img_urls: yup

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/LogoImageUpload/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/LogoImageUpload/index.tsx
@@ -159,6 +159,7 @@ export const LogoImageUpload = (props: LogoImageUploadProps) => {
     <div
       className={clsx(
         "relative flex w-20 flex-col items-center justify-center",
+        isError && "mb-4",
       )}
     >
       <Dialog open={showDialog} onClose={() => setShowDialog(false)}>
@@ -270,7 +271,6 @@ export const LogoImageUpload = (props: LogoImageUploadProps) => {
         className={clsx(
           "absolute -bottom-2 -right-2 rounded-full border-2 border-grey-200 bg-white p-2 text-grey-500 hover:bg-grey-50",
           { hidden: !isEditable || viewMode === "verified" },
-          { "bottom-7": isError },
         )}
       >
         <EditIcon className="size-3" />
@@ -278,7 +278,7 @@ export const LogoImageUpload = (props: LogoImageUploadProps) => {
       {isError && (
         <Typography
           variant={TYPOGRAPHY.R5}
-          className="left-0 top-20 mt-1 flex w-max shrink text-red-500"
+          className="absolute left-0 top-[84px] mt-4 flex w-max shrink text-red-500"
         >
           Logo is required.
         </Typography>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/app-store-refactored.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/app-store-refactored.tsx
@@ -33,6 +33,7 @@ export const AppStoreFormRefactored = ({
     handleSupportTypeChange,
     submit,
     isEditable,
+    onInvalid,
   } = useAppStoreForm(appId, appMetadata);
 
   const isEnoughPermissions = useMemo(() => {
@@ -44,12 +45,14 @@ export const AppStoreFormRefactored = ({
 
   return (
     <div className="mb-24 grid max-w-[580px] grid-cols-1fr/auto">
-      <form className="grid gap-y-6" onSubmit={handleSubmit(submit)}>
+      <form className="grid gap-y-6" onSubmit={handleSubmit(submit, onInvalid)}>
         <LogoSection
           appId={appId}
           teamId={teamId}
           appMetadata={appMetadata}
           isEditable={isEditable}
+          isEnoughPermissions={isEnoughPermissions}
+          errors={errors}
         />
 
         <CategorySection
@@ -117,7 +120,7 @@ export const AppStoreFormRefactored = ({
         <SaveButton
           isSubmitting={isSubmitting}
           isDisabled={!isEditable || !isEnoughPermissions || isSubmitting}
-          onSubmit={handleSubmit(submit)}
+          onSubmit={handleSubmit(submit, onInvalid)}
         />
       </form>
     </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/components/FormSections/CountriesSection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/components/FormSections/CountriesSection.tsx
@@ -55,6 +55,7 @@ export const CountriesSection = ({
             errors={errors.supported_countries}
             required
             selectAll={() => field.onChange(countries.map((c) => c.value))}
+            canClearAll={field.value?.length > 0}
             clearAll={() => field.onChange([])}
             showSelectedList
             searchPlaceholder="Start by typing country..."

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/components/FormSections/LocalisationsSection/components/LocalisationFields.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/components/FormSections/LocalisationsSection/components/LocalisationFields.tsx
@@ -102,7 +102,7 @@ export const LocalisationFields = ({
         name={`localisations.${selectedIndex}.description_overview`}
         render={({ field: overviewField }) => (
           <TextArea
-            label="Overview"
+            label="Description"
             required
             rows={7}
             maxLength={1500}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/components/FormSections/LogoSection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/components/FormSections/LogoSection.tsx
@@ -1,13 +1,15 @@
 import { useSearchParams } from "next/navigation";
+import { FieldErrors } from "react-hook-form";
+import { AppStoreFormValues } from "../../FormSchema/types";
 import { LogoImageUpload } from "../../LogoImageUpload";
-import { AppMetadata } from "../../types/AppStoreFormTypes";
+import { AppMetadata, FormSectionProps } from "../../types/AppStoreFormTypes";
 import { FormSection } from "../FormFields/FormSection";
 
-type LogoSectionProps = {
+type LogoSectionProps = FormSectionProps & {
   appId: string;
   teamId: string;
   appMetadata: AppMetadata;
-  isEditable: boolean;
+  errors?: FieldErrors<AppStoreFormValues & { logo_img_url?: string }>;
 };
 
 export const LogoSection = ({
@@ -15,9 +17,13 @@ export const LogoSection = ({
   teamId,
   appMetadata,
   isEditable,
+  errors,
 }: LogoSectionProps) => {
   const searchParams = useSearchParams();
   const shouldDefaultOpenLogoEditor = searchParams.get("editLogo") === "true";
+
+  const hasLogoError = Boolean(errors?.logo_img_url);
+
   return (
     <FormSection
       title="Logo image"
@@ -28,7 +34,7 @@ export const LogoSection = ({
         appMetadataId={appMetadata.id}
         teamId={teamId}
         isEditable={isEditable}
-        isError={false}
+        isError={hasLogoError}
         logoFile={appMetadata.logo_img_url}
         defaultOpen={shouldDefaultOpenLogoEditor}
       />

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/hooks/useAppStoreForm.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/hooks/useAppStoreForm.ts
@@ -1,12 +1,18 @@
 import { useRefetchQueries } from "@/lib/use-refetch-queries";
 import { useCallback, useEffect } from "react";
-import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import {
+  FieldErrors,
+  useFieldArray,
+  useFormContext,
+  useWatch,
+} from "react-hook-form";
 import { toast } from "react-toastify";
 import { FetchAppMetadataDocument } from "../../graphql/client/fetch-app-metadata.generated";
 import { AppStoreFormValues } from "../FormSchema/types";
 import { FetchLocalisationsDocument } from "../graphql/client/fetch-localisations.generated";
 import { updateAppStoreMetadata } from "../server/update-app-store";
 import { AppMetadata, SupportType } from "../types/AppStoreFormTypes";
+import { getFirstFormError } from "../utils/form-error-utils";
 import { useSupportType } from "./useSupportType";
 
 export const useAppStoreForm = (appId: string, appMetadata: AppMetadata) => {
@@ -100,6 +106,16 @@ export const useAppStoreForm = (appId: string, appMetadata: AppMetadata) => {
     [appMetadata.id, refetchAppMetadata, refetchLocalisations],
   );
 
+  const onInvalid = useCallback(
+    (errors: FieldErrors<AppStoreFormValues>) => {
+      const errorMessage = getFirstFormError(errors, localisations);
+      if (errorMessage) {
+        toast.error(errorMessage);
+      }
+    },
+    [localisations],
+  );
+
   return {
     control,
     handleSubmit,
@@ -111,6 +127,7 @@ export const useAppStoreForm = (appId: string, appMetadata: AppMetadata) => {
     supportType,
     handleSupportTypeChange,
     submit,
+    onInvalid,
     isEditable,
   };
 };

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/server/update-app-store.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/server/update-app-store.ts
@@ -7,7 +7,6 @@ import { extractIdsFromPath, getPathFromHeaders } from "@/lib/server-utils";
 import { FormActionResult } from "@/lib/types";
 import * as yup from "yup";
 import { mainAppStoreFormSchema } from "../FormSchema/form-schema";
-import { AppStoreFormValues } from "../FormSchema/types";
 import { getSdk as getDeleteUnusedSdk } from "../graphql/server/delete-unused-localisations.generated";
 import { getSdk as getUpdateAppStoreSdk } from "../graphql/server/update-app-store-complete.generated";
 import {
@@ -51,7 +50,7 @@ export async function updateAppStoreMetadata(
       });
     }
 
-    let parsedParams: AppStoreFormValues;
+    let parsedParams: Schema;
 
     try {
       parsedParams = await schema.validate(formData, {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/utils/form-error-utils.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/utils/form-error-utils.ts
@@ -2,6 +2,9 @@ import { FormLanguage, languageMap } from "@/lib/languages";
 import { FieldError, FieldErrors } from "react-hook-form";
 import { AppStoreFormValues } from "../FormSchema/types";
 
+export const MULTIPLE_ERRORS_TOAST_MESSAGE =
+  "There are multiple errors in the form";
+
 /**
  * extracts the localisation index from a react-hook-form ref name
  * @example "localisations.2.name" -> 2
@@ -47,15 +50,19 @@ function extractLocalisationError(
     return null;
   }
 
+  // filters out undefined elements
+  if (localisationErrors.filter(Boolean).length > 1) {
+    return MULTIPLE_ERRORS_TOAST_MESSAGE;
+  }
+
   for (const localisationError of localisationErrors) {
     if (!localisationError || typeof localisationError !== "object") {
       continue;
     }
-
     const errorFields = Object.keys(localisationError);
 
     if (errorFields.length > 1) {
-      return "There are multiple errors in the form";
+      return MULTIPLE_ERRORS_TOAST_MESSAGE;
     }
 
     for (const field of errorFields) {
@@ -92,7 +99,7 @@ export const getFirstFormError = (
   ][];
 
   if (errorsIterable.length > 1) {
-    return "There are multiple errors in the form";
+    return MULTIPLE_ERRORS_TOAST_MESSAGE;
   }
 
   for (const [field, error] of errorsIterable) {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/utils/form-error-utils.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStoreRefactored/utils/form-error-utils.ts
@@ -1,0 +1,119 @@
+import { FormLanguage, languageMap } from "@/lib/languages";
+import { FieldError, FieldErrors } from "react-hook-form";
+import { AppStoreFormValues } from "../FormSchema/types";
+
+/**
+ * extracts the localisation index from a react-hook-form ref name
+ * @example "localisations.2.name" -> 2
+ */
+function extractLocalisationIndex(refName?: string): number | null {
+  if (!refName) return null;
+
+  const parts = refName.split(".");
+  const indexStr = parts.at(-2);
+  const index = Number(indexStr);
+
+  return Number.isFinite(index) ? index : null;
+}
+
+/**
+ * formats an error message with the language label prefix
+ */
+function formatLocalisationErrorMessage(
+  fieldError: FieldError,
+  localisations: AppStoreFormValues["localisations"],
+): string | null {
+  const localisationIndex = extractLocalisationIndex(fieldError?.ref?.name);
+
+  if (localisationIndex !== null && localisations[localisationIndex]) {
+    const language = localisations[localisationIndex].language as FormLanguage;
+    const languageLabel = languageMap[language].label;
+    return fieldError.message
+      ? `${languageLabel}: ${fieldError.message}`
+      : null;
+  }
+
+  return fieldError?.message || null;
+}
+
+/**
+ * extracts the first error from localisation field errors
+ */
+function extractLocalisationError(
+  localisationErrors: FieldErrors<AppStoreFormValues>["localisations"],
+  localisations: AppStoreFormValues["localisations"],
+): string | null {
+  if (!Array.isArray(localisationErrors)) {
+    return null;
+  }
+
+  for (const localisationError of localisationErrors) {
+    if (!localisationError || typeof localisationError !== "object") {
+      continue;
+    }
+
+    const errorFields = Object.keys(localisationError);
+
+    if (errorFields.length > 1) {
+      return "There are multiple errors in the form";
+    }
+
+    for (const field of errorFields) {
+      const fieldError = localisationError[
+        field as keyof typeof localisationError
+      ] as FieldError;
+
+      if (fieldError) {
+        const errorMessage = formatLocalisationErrorMessage(
+          fieldError,
+          localisations,
+        );
+        if (errorMessage) {
+          return errorMessage;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * extracts the first error message from app store form for toast notification
+ */
+export const getFirstFormError = (
+  errors: FieldErrors<AppStoreFormValues>,
+  localisations: AppStoreFormValues["localisations"],
+): string | null => {
+  // check top level field errors
+  const errorsIterable = Object.entries(errors) as [
+    keyof AppStoreFormValues,
+    FieldError,
+  ][];
+
+  if (errorsIterable.length > 1) {
+    return "There are multiple errors in the form";
+  }
+
+  for (const [field, error] of errorsIterable) {
+    if (field === "localisations") {
+      continue;
+    }
+    if (error?.message) {
+      return error.message;
+    }
+  }
+
+  // check nested localisation errors
+  if (errors.localisations) {
+    const localisationError = extractLocalisationError(
+      errors.localisations,
+      localisations,
+    );
+    if (localisationError) {
+      return localisationError;
+    }
+  }
+
+  return null;
+};

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBarRefactored/index.tsx
@@ -28,7 +28,10 @@ import * as yup from "yup";
 import { mainAppStoreFormReviewSubmitSchema } from "../AppStoreRefactored/FormSchema/form-schema";
 import { AppStoreFormValues } from "../AppStoreRefactored/FormSchema/types";
 import { updateAppStoreMetadata } from "../AppStoreRefactored/server/update-app-store";
-import { getFirstFormError } from "../AppStoreRefactored/utils/form-error-utils";
+import {
+  getFirstFormError,
+  MULTIPLE_ERRORS_TOAST_MESSAGE,
+} from "../AppStoreRefactored/utils/form-error-utils";
 import {
   FetchAppMetadataDocument,
   FetchAppMetadataQuery,
@@ -191,7 +194,6 @@ export const AppTopBarRefactored = (props: AppTopBarProps) => {
       // if all validation passed, show submission modal
       setShowSubmitAppModal(true);
     } catch (error) {
-      console.log("submit for review error", { error });
       let errorMessage = "Error occurred while submitting app for review";
 
       if (error instanceof yup.ValidationError) {
@@ -212,6 +214,11 @@ export const AppTopBarRefactored = (props: AppTopBarProps) => {
             });
           }
         });
+
+        // check for multiple errors after setting them on form
+        if (error.inner.length > 1) {
+          errorMessage = MULTIPLE_ERRORS_TOAST_MESSAGE;
+        }
 
         toast.error(errorMessage);
         return;


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description
Adds toasts when there are errors in form and user tries to submit. Right now we're only highlighting all errors, now we also let them know via a toast.
- if there's a single error, the toast lets the user know which one and where. For errors in localizations, specifies the localization name + field error. Example: `English: Short name is required`
- if there are more than 1 error, toast says `There are multiple errors in the form` - this is easily changeable to show the first found error. Issue here is that the "first" error is different when submitting the form using `Save` and `Submit for Review`. This is due to how yup and react-hook-form group errors. If we're fine with these two errors being possibly different (but still valid) then I will remove the `There are multiple errors in the form` string.
- improved various error strings in validators (from `This field is required` to a field-specific error)
- improved logo image error display margins

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
