### PR TITLE
improve open rate chart displays

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/GraphsSection/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/GraphsSection/index.tsx
@@ -224,10 +224,12 @@ const GraphCard: React.FC<GraphCardProps> = ({
 
 const isEligibleForNotificationBadge = (
   avg_notification_open_rate: number | null,
-  is7DaysOfNotificationOpenRateData: boolean,
+  has7DaysOfNotificationOpenRateData: boolean,
 ) => {
   if (!avg_notification_open_rate) return false;
-  return avg_notification_open_rate > 0.1 && !is7DaysOfNotificationOpenRateData;
+  if (!has7DaysOfNotificationOpenRateData) return false;
+
+  return avg_notification_open_rate > 0.1;
 };
 
 // ==================================================================================================
@@ -403,7 +405,7 @@ export const GraphsSection = () => {
     );
   }, [metrics?.open_rate_last_14_days, metricsLoading]);
 
-  const is7DaysOfNotificationOpenRateData = useMemo(
+  const has7DaysOfNotificationOpenRateData = useMemo(
     () =>
       metricsLoading ||
       !metrics?.open_rate_last_14_days ||
@@ -491,7 +493,7 @@ export const GraphsSection = () => {
         tooltip={
           isEligibleForNotificationBadge(
             averageOpenRate,
-            is7DaysOfNotificationOpenRateData,
+            has7DaysOfNotificationOpenRateData,
           ) ? (
             <span>
               Your average open rate ({formattedAverageOpenRate}%) is above the

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/GraphsSection/stat.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/GraphsSection/stat.tsx
@@ -18,7 +18,7 @@ export const Stat = (props: {
     : localizedValue;
 
   statValue = props?.valueSuffix
-    ? `${statValue} ${props.valueSuffix}`
+    ? `${statValue}${props.valueSuffix}`
     : statValue;
 
   return (


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description
- currently, the label at the top of the chart shows the last entry in metrics list
  - this could result in it being 0, even though users may expect an average instead

- show average notification open rate always, instead of last value
- if there's less than 7 days of data, don't show the badge eligibility icon
- if there's more than 7 days of data, show the icon

The above is in line with app-backend logic - it checks `avg_notification_open_rate` on metadata, which is only set if more than 7 days of data is present


<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
