### PR TITLE
change header navigation logic

### DIFF
--- a/web/scenes/Portal/layout/Header/index.tsx
+++ b/web/scenes/Portal/layout/Header/index.tsx
@@ -4,8 +4,10 @@ import { Button } from "@/components/Button";
 import { WorldcoinIcon } from "@/components/Icons/WorldcoinIcon";
 import { LoggedUserNav } from "@/components/LoggedUserNav";
 import { SizingWrapper } from "@/components/SizingWrapper";
+import { urls } from "@/lib/urls";
 import { atom, useAtom, useSetAtom } from "jotai";
-import { useEffect } from "react";
+import { useParams } from "next/navigation";
+import { useEffect, useMemo } from "react";
 import { colorAtom } from "..";
 import { Color } from "../../Profile/types";
 import { AppSelector } from "../AppSelector";
@@ -16,10 +18,21 @@ export const createAppDialogOpenedAtom = atom(false);
 export const Header = (props: { color: Color | null }) => {
   const setColor = useSetAtom(colorAtom);
   const [open, setOpen] = useAtom(createAppDialogOpenedAtom);
+  const { teamId, appId } = useParams() as { teamId?: string; appId?: string };
 
   useEffect(() => {
     setColor(props.color);
   }, [props.color, setColor]);
+
+  const logoHref = useMemo(() => {
+    if (teamId && appId) {
+      return urls.app({ team_id: teamId, app_id: appId });
+    }
+    if (teamId) {
+      return urls.apps({ team_id: teamId });
+    }
+    return "/";
+  }, [teamId, appId]);
 
   return (
     <header className="max-md:sticky max-md:top-0 max-md:z-10 max-md:mb-6 max-md:border-b max-md:border-gray-200 max-md:bg-grey-0">
@@ -29,7 +42,7 @@ export const Header = (props: { color: Color | null }) => {
         variant="nav"
       >
         <div className="grid grid-cols-auto/1fr gap-x-4 md:gap-x-8">
-          <Button href="/">
+          <Button href={logoHref}>
             <WorldcoinIcon />
           </Button>
 


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description
Clicking on a header doesn't switch teams. 
- if on a page where both appid and teamid are available, navigate to the app's dashboard
- if on a page where only teamid is available, navigate to the team's app list
- if none of the above is available, navigate to `/` which navigates to first team's first app's dashboard

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
