### PR TITLE
fix: Fix OpenSearch query type to use full-text search

### DIFF
--- a/web/lib/opensearch.ts
+++ b/web/lib/opensearch.ts
@@ -154,19 +154,19 @@ export class OpenSearchClient {
         bool: {
           should: [
             {
+              match_phrase_prefix: {
+                name: {
+                  query: searchTerm,
+                  boost: 2,
+                },
+              },
+            },
+            {
               match: {
                 name: {
                   query: searchTerm,
                   fuzziness: "AUTO",
                   prefix_length: 1,
-                },
-              },
-            },
-            {
-              prefix: {
-                name: {
-                  value: searchTerm,
-                  boost: 2,
                 },
               },
             },


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

The `prefix` query type was wrong as it was using the term-level search and was case-sensitive.
It was fixed by switching to the `match_phrase_prefix` query
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
