### PR TITLE
feat: Restrict team name update to OWNER

### DIFF
--- a/web/lib/permissions/graphql/server/get-team-update-permissions.generated.ts
+++ b/web/lib/permissions/graphql/server/get-team-update-permissions.generated.ts
@@ -11,27 +11,25 @@ export type GetIsUserPermittedToModifyTeamQueryVariables = Types.Exact<{
 
 export type GetIsUserPermittedToModifyTeamQuery = {
   __typename?: "query_root";
-  team: Array<{ __typename?: "team"; id: string }>;
+  team: Array<{
+    __typename?: "team";
+    id: string;
+    memberships: Array<{
+      __typename?: "membership";
+      user_id: string;
+      role: Types.Role_Enum;
+    }>;
+  }>;
 };
 
 export const GetIsUserPermittedToModifyTeamDocument = gql`
   query GetIsUserPermittedToModifyTeam($teamId: String!, $userId: String!) {
-    team(
-      where: {
-        _and: [
-          { id: { _eq: $teamId } }
-          {
-            memberships: {
-              _and: [
-                { user_id: { _eq: $userId } }
-                { _or: [{ role: { _eq: OWNER } }, { role: { _eq: ADMIN } }] }
-              ]
-            }
-          }
-        ]
-      }
-    ) {
+    team(where: { id: { _eq: $teamId } }) {
       id
+      memberships(where: { user_id: { _eq: $userId }, role: { _eq: OWNER } }) {
+        user_id
+        role
+      }
     }
   }
 `;

--- a/web/lib/permissions/graphql/server/get-team-update-permissions.graphql
+++ b/web/lib/permissions/graphql/server/get-team-update-permissions.graphql
@@ -1,19 +1,9 @@
 query GetIsUserPermittedToModifyTeam($teamId: String!, $userId: String!) {
-  team(
-    where: {
-      _and: [
-        { id: { _eq: $teamId } }
-        {
-          memberships: {
-            _and: [
-              { user_id: { _eq: $userId } }
-              { _or: [{ role: { _eq: OWNER } }, { role: { _eq: ADMIN } }] }
-            ]
-          }
-        }
-      ]
-    }
-  ) {
+  team(where: { id: { _eq: $teamId } }) {
     id
+    memberships(where: { user_id: { _eq: $userId }, role: { _eq: OWNER } }) {
+      user_id
+      role
+    }
   }
 }

--- a/web/lib/permissions/index.ts
+++ b/web/lib/permissions/index.ts
@@ -200,7 +200,7 @@ export const getIsUserAllowedToUpdateTeam = async (teamId: string) => {
     await getAPIServiceGraphqlClient(),
   ).GetIsUserPermittedToModifyTeam({ teamId, userId });
 
-  if (response.team.length === 1 && response.team[0].id === teamId) {
+  if (response.team.length && response.team[0].memberships.length) {
     return true;
   }
   return false;


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Ticket - [DEV-2163](https://linear.app/worldcoin/issue/DEV-2163/h1-access-control-on-developerworldcoinorg)

Restricts the team name update operation to the OWNER role.

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
