### PR TITLE
feat: Increase the app limit to 750

### DIFF
--- a/web/api/v2/public/apps/index.ts
+++ b/web/api/v2/public/apps/index.ts
@@ -30,7 +30,7 @@ import {
 const queryParamsSchema = yup
   .object({
     page: yup.number().integer().min(1).default(1).notRequired(),
-    limit: yup.number().integer().min(1).max(1000).notRequired().default(500),
+    limit: yup.number().integer().min(1).max(1000).notRequired().default(750),
     app_mode: yup
       .string()
       .oneOf(["mini-app", "external", "native"])
@@ -106,7 +106,7 @@ export const GET = async (request: NextRequest) => {
 
   country = parsedParams.override_country ?? country;
   const { page, limit } = parsedParams;
-  const limitValue = limit ?? 500;
+  const limitValue = limit ?? 750;
   const offset = page ? (page - 1) * limitValue : 0;
 
   // ANCHOR: Fetch app rankings
@@ -136,7 +136,7 @@ export const GET = async (request: NextRequest) => {
   }
 
   // notify if length is close to limit
-  if (limitValue >= 500 && page === 1 && topApps.length > limitValue * 0.8) {
+  if (limitValue >= 750 && page === 1 && topApps.length > limitValue * 0.8) {
     logger.warn("App store response length is close to limit", {
       limit: limitValue,
       topAppsLength: topApps.length,


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Ticket - [DEV-2223](https://linear.app/worldcoin/issue/DEV-2223/dev-portal-look-into-mini-app-pagination)

Increases the current limit on the number of apps returned by the public endpoint to 750.

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
