### PR TITLE
fix: Delete app stats trigger

### DIFF
--- a/hasura/metadata/databases/default/tables/public_nullifier.yaml
+++ b/hasura/metadata/databases/default/tables/public_nullifier.yaml
@@ -77,18 +77,3 @@ update_permissions:
             deleted_at:
               _is_null: true
       check: null
-event_triggers:
-  - name: increment_app_stats
-    definition:
-      enable_manual: false
-      update:
-        columns:
-          - uses
-    retry_conf:
-      interval_sec: 10
-      num_retries: 5
-      timeout_sec: 20
-    webhook: '{{NEXT_API_URL}}/_increment-app-stats'
-    headers:
-      - name: Authorization
-        value_from_env: INTERNAL_ENDPOINTS_SECRET


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description
Delete app stats trigger since it creates high load on the DB.

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
