### PR TITLE
feat: Create a single global signed fetcher

### DIFF
--- a/web/@types/global.d.ts
+++ b/web/@types/global.d.ts
@@ -8,4 +8,5 @@ declare global {
   var RedisClient: Redis | RedisCluster | undefined;
   var OpenSearchClient: OpenSearchClient | undefined;
   var ParameterStore: ParameterStore | undefined;
+  var TransactionSignedFetcher: typeof fetch | undefined;
 }

--- a/web/api/v2/minikit/send-notification/index.ts
+++ b/web/api/v2/minikit/send-notification/index.ts
@@ -340,10 +340,13 @@ export const POST = async (req: NextRequest) => {
           localisations: (parsedParams as SendNotificationBodyV2).localisations,
         };
 
-  const signedFetch = createSignedFetcher({
-    service: "execute-api",
-    region: process.env.TRANSACTION_BACKEND_REGION,
-  });
+  let signedFetch = global.TransactionSignedFetcher;
+  if (!signedFetch) {
+    signedFetch = createSignedFetcher({
+      service: "execute-api",
+      region: process.env.TRANSACTION_BACKEND_REGION,
+    });
+  }
 
   let res: Response;
 

--- a/web/api/v2/minikit/transaction/[transaction_id]/index.ts
+++ b/web/api/v2/minikit/transaction/[transaction_id]/index.ts
@@ -55,11 +55,13 @@ export const GET = async (
 
   const { app_id: appId, type } = parsedParams;
 
-  const signedFetch = createSignedFetcher({
-    service: "execute-api",
-    region: process.env.TRANSACTION_BACKEND_REGION,
-  });
-
+  let signedFetch = global.TransactionSignedFetcher;
+  if (!signedFetch) {
+    signedFetch = createSignedFetcher({
+      service: "execute-api",
+      region: process.env.TRANSACTION_BACKEND_REGION,
+    });
+  }
   const url =
     type === TransactionTypes.Payment
       ? `${process.env.NEXT_SERVER_INTERNAL_PAYMENTS_ENDPOINT}/miniapp?miniapp-id=${appId}&transaction-id=${transactionId}`

--- a/web/api/v2/minikit/transaction/debug/index.ts
+++ b/web/api/v2/minikit/transaction/debug/index.ts
@@ -105,10 +105,13 @@ export const GET = async (req: NextRequest) => {
     });
   }
 
-  const signedFetch = createSignedFetcher({
-    service: "execute-api",
-    region: process.env.TRANSACTION_BACKEND_REGION,
-  });
+  let signedFetch = global.TransactionSignedFetcher;
+  if (!signedFetch) {
+    signedFetch = createSignedFetcher({
+      service: "execute-api",
+      region: process.env.TRANSACTION_BACKEND_REGION,
+    });
+  }
 
   const res = await signedFetch(
     `${process.env.NEXT_SERVER_INTERNAL_PAYMENTS_ENDPOINT}/miniapp-actions/debug?miniapp-id=${appId}`,

--- a/web/api/v2/minikit/user-grant-cycle/index.ts
+++ b/web/api/v2/minikit/user-grant-cycle/index.ts
@@ -44,10 +44,13 @@ export const GET = async (req: NextRequest) => {
     return apiKeyResult.errorResponse;
   }
 
-  const signedFetch = createSignedFetcher({
-    service: "execute-api",
-    region: process.env.TRANSACTION_BACKEND_REGION,
-  });
+  let signedFetch = global.TransactionSignedFetcher;
+  if (!signedFetch) {
+    signedFetch = createSignedFetcher({
+      service: "execute-api",
+      region: process.env.TRANSACTION_BACKEND_REGION,
+    });
+  }
 
   try {
     const res = await signedFetch(

--- a/web/instrumentation.ts
+++ b/web/instrumentation.ts
@@ -44,6 +44,12 @@ export async function register() {
       opensearch.createIndexIfNotExists();
 
       global.OpenSearchClient = opensearch;
+
+      const { createSignedFetcher } = await import("aws-sigv4-fetch");
+      global.TransactionSignedFetcher = createSignedFetcher({
+        service: "execute-api",
+        region: process.env.TRANSACTION_BACKEND_REGION,
+      });
     }
   } catch (error) {
     return console.error("🔴 Instrumentation registration error: ", error);

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/getAccumulativeTransactionData.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/getAccumulativeTransactionData.ts
@@ -45,10 +45,13 @@ const fetchTransactionData = async (
   const path = getPathFromHeaders() || "";
   const { Teams: teamId } = extractIdsFromPath(path, ["Teams"]);
 
-  const signedFetch = createSignedFetcher({
-    service: "execute-api",
-    region: process.env.TRANSACTION_BACKEND_REGION,
-  });
+  let signedFetch = global.TransactionSignedFetcher;
+  if (!signedFetch) {
+    signedFetch = createSignedFetcher({
+      service: "execute-api",
+      region: process.env.TRANSACTION_BACKEND_REGION,
+    });
+  }
 
   const response = await signedFetch(url, {
     method: "GET",

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Transactions/page/server/index.ts
@@ -23,10 +23,13 @@ export const getTransactionData = async (
       });
     }
 
-    const signedFetch = createSignedFetcher({
-      service: "execute-api",
-      region: process.env.TRANSACTION_BACKEND_REGION,
-    });
+    let signedFetch = global.TransactionSignedFetcher;
+    if (!signedFetch) {
+      signedFetch = createSignedFetcher({
+        service: "execute-api",
+        region: process.env.TRANSACTION_BACKEND_REGION,
+      });
+    }
 
     let url = `${process.env.NEXT_SERVER_INTERNAL_PAYMENTS_ENDPOINT}/miniapp?miniapp-id=${appId}`;
 


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Ticket - [DEV-2241](https://linear.app/worldcoin/issue/DEV-2241/dev-portal-investigate-transaction-endpoint-aws-error)

Recently we started getting `Could not load credentials from any providers` errors when the ECS container experiences high load.
To prevent them from happening, AWS recommends retrieving credentials only once and not every SDK call - https://repost.aws/knowledge-center/ecs-fargate-metadata-errors

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
