### PR TITLE
feat: Give QA role permissions to create apps

### DIFF
--- a/hasura/metadata/databases/default/tables/public_app.yaml
+++ b/hasura/metadata/databases/default/tables/public_app.yaml
@@ -25,7 +25,11 @@ array_relationships:
 insert_permissions:
   - role: qa
     permission:
-      check: {}
+      check:
+        team:
+          memberships:
+            user_id:
+              _eq: X-Hasura-User-Id
       columns:
         - description_internal
         - dev_rewards_approved

--- a/hasura/metadata/databases/default/tables/public_app_metadata.yaml
+++ b/hasura/metadata/databases/default/tables/public_app_metadata.yaml
@@ -25,8 +25,13 @@ insert_permissions:
     permission:
       check:
         app:
-          deleted_at:
-            _is_null: true
+          _and:
+            - team:
+                memberships:
+                  user_id:
+                    _eq: X-Hasura-User-Id
+            - deleted_at:
+                _is_null: true
       columns:
         - app_id
         - app_mode

--- a/hasura/metadata/databases/default/tables/public_membership.yaml
+++ b/hasura/metadata/databases/default/tables/public_membership.yaml
@@ -9,6 +9,17 @@ object_relationships:
     using:
       foreign_key_constraint_on: user_id
 insert_permissions:
+  - role: qa
+    permission:
+      check:
+        user_id:
+          _eq: X-Hasura-User-Id
+      columns:
+        - id
+        - role
+        - team_id
+        - user_id
+    comment: ""
   - role: service
     permission:
       check: {}

--- a/hasura/metadata/databases/default/tables/public_team.yaml
+++ b/hasura/metadata/databases/default/tables/public_team.yaml
@@ -31,6 +31,13 @@ computed_fields:
         schema: public
     comment: A computed field that returns a quantity of team owners
 insert_permissions:
+  - role: qa
+    permission:
+      check: {}
+      columns:
+        - id
+        - name
+    comment: ""
   - role: service
     permission:
       check: {}


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Ticket - [DEV-2256](https://linear.app/worldcoin/issue/DEV-2256/dev-portal-give-qa-role-permissions-to-create-app-metadata)

* Grants the QA role permissions to create apps, app metadata, teams and memberships
* Removes permissions from user and API key roles to do these actions (we do it via the service role now)

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
