### PR TITLE
fix: transaction endpoint is hammering backend

### DIFF
--- a/web/api/v2/minikit/transaction/[transaction_id]/index.ts
+++ b/web/api/v2/minikit/transaction/[transaction_id]/index.ts
@@ -76,7 +76,7 @@ export const GET = async (
         "Content-Type": "application/json",
       },
     },
-    3, // max retries
+    1, // max retries
     400, // initial retry delay in ms
     3000, // fetch timeout in ms
     false, // don't throw on error


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description
The backend DB is having downtime spikes and each time the retries bombard the backend with requests and make it harder for the server to recover. Reduce retry count

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
