### PR TITLE
fix: optimize /api/v2/public/apps performance and increase app limit

### DIFF
--- a/web/api/helpers/app-store.ts
+++ b/web/api/helpers/app-store.ts
@@ -3,23 +3,57 @@ import { NATIVE_MAPPED_APP_ID, NativeAppToAppIdMapping } from "@/lib/constants";
 import { generateExternalNullifier } from "@/lib/hashing";
 import {
   AppStatsItem,
-  AppStatsReturnType,
   AppStoreFormattedFields,
   AppStoreMetadataDescription,
   AppStoreMetadataFields,
 } from "@/lib/types";
 import { getCDNImageUrl, getLogoImgCDNUrl, tryParseJSON } from "@/lib/utils";
 
+export interface ParameterStoreValues {
+  whitelistedAppsPermit2: string[];
+  whitelistedAppsContracts: string[];
+  implicitCredentialsApps: string[];
+}
+
+export const fetchParameterStoreValues =
+  async (): Promise<ParameterStoreValues> => {
+    const [
+      whitelistedAppsPermit2,
+      whitelistedAppsContracts,
+      implicitCredentialsApps,
+    ] = await Promise.all([
+      global.ParameterStore?.getParameter(
+        "whitelisted-apps/permit2",
+        [] as string[],
+      ) ?? Promise.resolve([]),
+      global.ParameterStore?.getParameter(
+        "whitelisted-apps/contracts",
+        [] as string[],
+      ) ?? Promise.resolve([]),
+      global.ParameterStore?.getParameter(
+        "whitelisted-apps/implicit-credentials",
+        [] as string[],
+      ) ?? Promise.resolve([]),
+    ]);
+
+    return {
+      whitelistedAppsPermit2: whitelistedAppsPermit2 ?? [],
+      whitelistedAppsContracts: whitelistedAppsContracts ?? [],
+      implicitCredentialsApps: implicitCredentialsApps ?? [],
+    };
+  };
+
 export const formatAppMetadata = async (
   appData: AppStoreMetadataFields,
-  appStats: AppStatsReturnType,
+  appStatsMap: Map<string, AppStatsItem>,
   locale: string = "en",
   platform?: string | null,
   country?: string | null,
+  paramStoreValues?: ParameterStoreValues,
 ): Promise<AppStoreFormattedFields> => {
   const { app, ...appMetadata } = appData;
-  const singleAppStats: AppStatsItem | undefined = appStats.find(
-    (stat) => stat.app_id === appMetadata.app_id,
+  const singleAppStats: AppStatsItem | undefined = appStatsMap.get(
+    appMetadata.app_id,
   );
 
   const shouldCompressCountryList =
@@ -51,28 +85,23 @@ export const formatAppMetadata = async (
 
   const name = localisedContent?.name ?? appMetadata.name;
 
-  const whitelistedAppsPermit2 = await global.ParameterStore?.getParameter(
-    "whitelisted-apps/permit2",
-    [] as string[],
-  );
-
-  const whitelistedAppsContracts = await global.ParameterStore?.getParameter(
-    "whitelisted-apps/contracts",
-    [] as string[],
-  );
-
-  const implicitCredentialsApps = await global.ParameterStore?.getParameter(
-    "whitelisted-apps/implicit-credentials",
-    [] as string[],
-  );
+  const {
+    whitelistedAppsPermit2,
+    whitelistedAppsContracts,
+    implicitCredentialsApps,
+  } = paramStoreValues ?? {
+    whitelistedAppsPermit2: [],
+    whitelistedAppsContracts: [],
+    implicitCredentialsApps: [],
+  };
 
   // Check if the app is whitelisted for permit2
-  const permit2Tokens = whitelistedAppsPermit2?.includes(appMetadata.app_id)
+  const permit2Tokens = whitelistedAppsPermit2.includes(appMetadata.app_id)
     ? ["all"]
     : appMetadata.permit2_tokens;
 
-  // Check if the app is whitelisted for permit2
-  const contracts = whitelistedAppsContracts?.includes(appMetadata.app_id)
+  // Check if the app is whitelisted for contracts
+  const contracts = whitelistedAppsContracts.includes(appMetadata.app_id)
     ? ["all"]
     : appMetadata.contracts;
 
@@ -178,8 +207,9 @@ export const formatAppMetadata = async (
     avg_notification_open_rate: getAvgNotificationOpenRate(
       singleAppStats?.open_rate_last_14_days,
     ),
-    can_use_implicit_credentials:
-      implicitCredentialsApps?.includes(appMetadata.app_id) ?? false,
+    can_use_implicit_credentials: implicitCredentialsApps.includes(
+      appMetadata.app_id,
+    ),
   };
 };
 
@@ -215,16 +245,10 @@ const isDefaultPinnedNoGrants = (appId: string) => {
  */
 export const rankApps = (
   apps: AppStoreFormattedFields[],
-  appStats: AppStatsReturnType,
+  appStatsMap: Map<string, AppStatsItem>,
 ) => {
   let maxNewUsers = 0;
   let maxUniqueUsers = 0;
-  // determine maximum values among apps that
-  // are present in the current app store
-  const appIdsSet = new Set<string>(apps.map((app) => app.app_id));
-  const appStoreAppStats = appStats.filter((stat) =>
-    appIdsSet.has(stat.app_id),
-  );
 
   const nativeAppConstants = Object.values(NATIVE_MAPPED_APP_ID);
   const nativeAppIds = Object.values(
@@ -235,55 +259,38 @@ export const rankApps = (
     ...nativeAppIds,
   ]);
 
-  appStoreAppStats.forEach((stat) => {
-    if (combinedNativeAppIds.has(stat.app_id)) {
-      return;
-    }
+  // determine maximum values among apps present in the current app store
+  for (const app of apps) {
+    if (combinedNativeAppIds.has(app.app_id)) continue;
+    const stat = appStatsMap.get(app.app_id);
+    if (!stat) continue;
     maxNewUsers = Math.max(
       maxNewUsers,
       Number(stat.new_users_last_7_days ?? 0),
     );
     maxUniqueUsers = Math.max(maxUniqueUsers, Number(stat.unique_users ?? 0));
-  });
+  }
 
   // ensure we don't divide by zero
   maxNewUsers = maxNewUsers === 0 ? 1 : maxNewUsers;
   maxUniqueUsers = maxUniqueUsers === 0 ? 1 : maxUniqueUsers;
 
+  // pre-compute scores to avoid repeated lookups in sort comparator
+  const scoreMap = new Map<string, number>();
+  for (const app of apps) {
+    const stat = appStatsMap.get(app.app_id);
+    const newUsers = Number(stat?.new_users_last_7_days ?? 0);
+    const uniqueUsers = Number(stat?.unique_users ?? 0);
+    const score =
+      (newUsers / maxNewUsers) * 0.5 + (uniqueUsers / maxUniqueUsers) * 0.5;
+    scoreMap.set(app.app_id, score);
+  }
+
   return apps.sort((a, b) => {
-    // move specific apps to the end
-    if (
-      isDefaultPinnedNoGrants(a.app_id) &&
-      !isDefaultPinnedNoGrants(b.app_id)
-    ) {
-      return 1; // a goes after b
-    }
-    if (
-      !isDefaultPinnedNoGrants(a.app_id) &&
-      isDefaultPinnedNoGrants(b.app_id)
-    ) {
-      return -1; // a goes before b
-    }
+    const aPinned = isDefaultPinnedNoGrants(a.app_id);
+    const bPinned = isDefaultPinnedNoGrants(b.app_id);
+    if (aPinned !== bPinned) return aPinned ? 1 : -1;
 
-    const aStat = appStoreAppStats.find((stat) => stat.app_id === a.app_id);
-    const bStat = appStoreAppStats.find((stat) => stat.app_id === b.app_id);
-
-    // default to 0 if stats not found
-    const aNewUsers = Number(aStat?.new_users_last_7_days ?? 0);
-    const aUniqueUsers = Number(aStat?.unique_users ?? 0);
-    const bNewUsers = Number(bStat?.new_users_last_7_days ?? 0);
-    const bUniqueUsers = Number(bStat?.unique_users ?? 0);
-
-    // normalize values to 0-1 scale
-    const aNormalizedNewUsers = aNewUsers / maxNewUsers;
-    const aNormalizedUniqueUsers = aUniqueUsers / maxUniqueUsers;
-    const bNormalizedNewUsers = bNewUsers / maxNewUsers;
-    const bNormalizedUniqueUsers = bUniqueUsers / maxUniqueUsers;
-
-    // 50% new_users_last_7_days, 50% unique_users
-    const aScore = aNormalizedNewUsers * 0.5 + aNormalizedUniqueUsers * 0.5;
-    const bScore = bNormalizedNewUsers * 0.5 + bNormalizedUniqueUsers * 0.5;
-
-    return bScore - aScore;
+    return (scoreMap.get(b.app_id) ?? 0) - (scoreMap.get(a.app_id) ?? 0);
   });
 };

--- a/web/api/helpers/app-store.ts
+++ b/web/api/helpers/app-store.ts
@@ -43,14 +43,14 @@ export const fetchParameterStoreValues =
     };
   };
 
-export const formatAppMetadata = async (
+export const formatAppMetadata = (
   appData: AppStoreMetadataFields,
   appStatsMap: Map<string, AppStatsItem>,
   locale: string = "en",
   platform?: string | null,
   country?: string | null,
   paramStoreValues?: ParameterStoreValues,
-): Promise<AppStoreFormattedFields> => {
+): AppStoreFormattedFields => {
   const { app, ...appMetadata } = appData;
   const singleAppStats: AppStatsItem | undefined = appStatsMap.get(
     appMetadata.app_id,

--- a/web/api/v2/minikit/app-metadata/[app_id]/index.ts
+++ b/web/api/v2/minikit/app-metadata/[app_id]/index.ts
@@ -1,4 +1,7 @@
-import { formatAppMetadata } from "@/api/helpers/app-store";
+import {
+  fetchParameterStoreValues,
+  formatAppMetadata,
+} from "@/api/helpers/app-store";
 import { errorResponse } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { verifyHashedSecret } from "@/api/helpers/utils";
@@ -127,7 +130,14 @@ export const GET = async (
 
   return NextResponse.json(
     {
-      ...(await formatAppMetadata(appMetadata, new Map(), locale)),
+      ...(await formatAppMetadata(
+        appMetadata,
+        new Map(),
+        locale,
+        undefined,
+        undefined,
+        await fetchParameterStoreValues(),
+      )),
       logo_img_url: null,
       hero_image_url: null,
       meta_tag_image_url: null,

--- a/web/api/v2/minikit/app-metadata/[app_id]/index.ts
+++ b/web/api/v2/minikit/app-metadata/[app_id]/index.ts
@@ -127,7 +127,7 @@ export const GET = async (
 
   return NextResponse.json(
     {
-      ...(await formatAppMetadata(appMetadata, [], locale)),
+      ...(await formatAppMetadata(appMetadata, new Map(), locale)),
       logo_img_url: null,
       hero_image_url: null,
       meta_tag_image_url: null,

--- a/web/api/v2/minikit/app-metadata/[app_id]/index.ts
+++ b/web/api/v2/minikit/app-metadata/[app_id]/index.ts
@@ -130,14 +130,14 @@ export const GET = async (
 
   return NextResponse.json(
     {
-      ...(await formatAppMetadata(
+      ...formatAppMetadata(
         appMetadata,
         new Map(),
         locale,
         undefined,
         undefined,
         await fetchParameterStoreValues(),
-      )),
+      ),
       logo_img_url: null,
       hero_image_url: null,
       meta_tag_image_url: null,

--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -1,4 +1,7 @@
-import { formatAppMetadata } from "@/api/helpers/app-store";
+import {
+  fetchParameterStoreValues,
+  formatAppMetadata,
+} from "@/api/helpers/app-store";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { getAppStoreLocalisedCategoriesWithUrls } from "@/lib/categories";
 import { compareVersions } from "@/lib/compare-versions";
@@ -206,10 +209,14 @@ export async function GET(
   }
 
   const metricsMap = new Map(metricsData.map((stat) => [stat.app_id, stat]));
+  const paramStoreValues = await fetchParameterStoreValues();
   let formattedMetadata = await formatAppMetadata(
     { ...parsedAppMetadata },
     metricsMap,
     locale,
+    undefined,
+    undefined,
+    paramStoreValues,
   );
 
   formattedMetadata = {

--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -205,9 +205,10 @@ export async function GET(
     return NextResponse.json({ error: "App not available" }, { status: 404 });
   }
 
+  const metricsMap = new Map(metricsData.map((stat) => [stat.app_id, stat]));
   let formattedMetadata = await formatAppMetadata(
     { ...parsedAppMetadata },
-    metricsData,
+    metricsMap,
     locale,
   );
 

--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -210,7 +210,7 @@ export async function GET(
 
   const metricsMap = new Map(metricsData.map((stat) => [stat.app_id, stat]));
   const paramStoreValues = await fetchParameterStoreValues();
-  let formattedMetadata = await formatAppMetadata(
+  let formattedMetadata = formatAppMetadata(
     { ...parsedAppMetadata },
     metricsMap,
     locale,

--- a/web/api/v2/public/apps/index.ts
+++ b/web/api/v2/public/apps/index.ts
@@ -17,7 +17,11 @@ import {
 } from "./graphql/get-app-rankings.generated";
 import { getSdk as getWebHighlightsSdk } from "./graphql/get-app-web-highlights.generated";
 
-import { formatAppMetadata, rankApps } from "@/api/helpers/app-store";
+import {
+  fetchParameterStoreValues,
+  formatAppMetadata,
+  rankApps,
+} from "@/api/helpers/app-store";
 import { fetchMetrics } from "@/api/helpers/fetch-metrics";
 import { compareVersions } from "@/lib/compare-versions";
 import { logger } from "@/lib/logger";
@@ -30,7 +34,7 @@ import {
 const queryParamsSchema = yup
   .object({
     page: yup.number().integer().min(1).default(1).notRequired(),
-    limit: yup.number().integer().min(1).max(1000).notRequired().default(750),
+    limit: yup.number().integer().min(1).max(1500).notRequired().default(1000),
     app_mode: yup
       .string()
       .oneOf(["mini-app", "external", "native"])
@@ -136,7 +140,7 @@ export const GET = async (request: NextRequest) => {
   }
 
   // notify if length is close to limit
-  if (limitValue >= 750 && page === 1 && topApps.length > limitValue * 0.8) {
+  if (limitValue >= 1000 && page === 1 && topApps.length > limitValue * 0.8) {
     logger.warn("App store response length is close to limit", {
       limit: limitValue,
       topAppsLength: topApps.length,
@@ -209,21 +213,41 @@ export const GET = async (request: NextRequest) => {
     });
   }
 
-  // ANCHOR: Fetch app stats from metrics service, keep a cache since metrics doesn't update that often
-  const metricsData = await fetchMetrics(country);
+  // ANCHOR: Fetch app stats and parameter store values in parallel
+  const [metricsData, paramStoreValues] = await Promise.all([
+    fetchMetrics(country),
+    fetchParameterStoreValues(),
+  ]);
+
+  // Build a Map for O(1) metric lookups
+  const metricsMap = new Map(metricsData.map((stat) => [stat.app_id, stat]));
 
   const nativeAppMetadata = NativeApps[process.env.NEXT_PUBLIC_APP_ENV];
 
   // ANCHOR: Format all app metadata
   let formattedTopApps = await Promise.all(
     topApps.map((app) =>
-      formatAppMetadata(app, metricsData, locale, platform, country),
+      formatAppMetadata(
+        app,
+        metricsMap,
+        locale,
+        platform,
+        country,
+        paramStoreValues,
+      ),
     ),
   );
 
   let highlightedApps = await Promise.all(
     highlightsApps.map((app) =>
-      formatAppMetadata(app, metricsData, locale, platform, country),
+      formatAppMetadata(
+        app,
+        metricsMap,
+        locale,
+        platform,
+        country,
+        paramStoreValues,
+      ),
     ),
   );
 
@@ -238,9 +262,7 @@ export const GET = async (request: NextRequest) => {
             : app.integration_url,
         app_id: nativeAppItem.app_id,
         app_mode: nativeAppItem.app_mode,
-        unique_users:
-          metricsData.find((stat) => stat.app_id === nativeAppItem.app_id)
-            ?.unique_users ?? 0,
+        unique_users: metricsMap.get(nativeAppItem.app_id)?.unique_users ?? 0,
       };
     }
     return app;
@@ -254,9 +276,7 @@ export const GET = async (request: NextRequest) => {
         integration_url: nativeAppItem.integration_url,
         app_id: nativeAppItem.app_id,
         app_mode: nativeAppItem.app_mode,
-        unique_users:
-          metricsData.find((stat) => stat.app_id === nativeAppItem.app_id)
-            ?.unique_users ?? 0,
+        unique_users: metricsMap.get(nativeAppItem.app_id)?.unique_users ?? 0,
       };
     }
     return app;
@@ -293,27 +313,19 @@ export const GET = async (request: NextRequest) => {
     });
   }
 
-  const rankedApps = rankApps(formattedTopApps, metricsData);
+  const rankedApps = rankApps(formattedTopApps, metricsMap);
 
   /**
    * ANCHOR: Add category_ranking field to each app
    * This is to sort apps inside category,
    * based on the overall ranking in app store
    */
-  const categoryAppsMap = new Map();
-  rankedApps.forEach((app) => {
-    const categoryId = app.category.id;
-    if (!categoryAppsMap.has(categoryId)) {
-      categoryAppsMap.set(
-        categoryId,
-        rankedApps.filter((a) => a.category.id === categoryId),
-      );
-    }
-  });
-
+  const categoryCountMap = new Map<string, number>();
   const rankedAppsWithCategoryRanking = rankedApps.map((app) => {
-    const categoryApps = categoryAppsMap.get(app.category.id);
-    return { ...app, category_ranking: categoryApps.indexOf(app) + 1 };
+    const categoryId = app.category.id;
+    const rank = (categoryCountMap.get(categoryId) ?? 0) + 1;
+    categoryCountMap.set(categoryId, rank);
+    return { ...app, category_ranking: rank };
   });
 
   const responseBody = {

--- a/web/api/v2/public/apps/index.ts
+++ b/web/api/v2/public/apps/index.ts
@@ -225,29 +225,25 @@ export const GET = async (request: NextRequest) => {
   const nativeAppMetadata = NativeApps[process.env.NEXT_PUBLIC_APP_ENV];
 
   // ANCHOR: Format all app metadata
-  let formattedTopApps = await Promise.all(
-    topApps.map((app) =>
-      formatAppMetadata(
-        app,
-        metricsMap,
-        locale,
-        platform,
-        country,
-        paramStoreValues,
-      ),
+  let formattedTopApps = topApps.map((app) =>
+    formatAppMetadata(
+      app,
+      metricsMap,
+      locale,
+      platform,
+      country,
+      paramStoreValues,
     ),
   );
 
-  let highlightedApps = await Promise.all(
-    highlightsApps.map((app) =>
-      formatAppMetadata(
-        app,
-        metricsMap,
-        locale,
-        platform,
-        country,
-        paramStoreValues,
-      ),
+  let highlightedApps = highlightsApps.map((app) =>
+    formatAppMetadata(
+      app,
+      metricsMap,
+      locale,
+      platform,
+      country,
+      paramStoreValues,
     ),
   );
 


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

The `/api/v2/public/apps` endpoint was hitting performance limits, causing the dev portal to go down and mini apps to become unavailable. This PR fixes several algorithmic bottlenecks and raises the default app limit from 750 to 1000 (max from 1000 to 1500):

- **Hoist ParameterStore calls**: `formatAppMetadata` was calling `ParameterStore.getParameter` 3 times per app (~2250 async calls for 750 apps). Now fetched once via `fetchParameterStoreValues()` and passed in, fetched in parallel with metrics.
- **Use Maps for O(1) lookups**: Replaced `Array.find()` with `Map.get()` for metrics data and app stats throughout the endpoint and ranking logic.
- **Pre-compute ranking scores**: `rankApps` sort comparator was doing `.find()` on every comparison (O(n² log n)). Now pre-computes scores into a Map before sorting (O(n log n)).
- **Simplify category ranking**: Replaced O(n²) `.filter()` + `.indexOf()` pattern with a single O(n) counter pass.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.