### PR TITLE
fix: optimize notification_log_wallet_address insert performance

### DIFF
--- a/web/api/v2/minikit/send-notification/index.ts
+++ b/web/api/v2/minikit/send-notification/index.ts
@@ -93,10 +93,12 @@ export const logNotification = async (
         })),
       });
     } catch (error) {
-      logger.error(
-        "NotificationLog - failed to insert wallet address batch",
-        { app_id, notificationLogId, batchIndex: i, error },
-      );
+      logger.error("NotificationLog - failed to insert wallet address batch", {
+        app_id,
+        notificationLogId,
+        batchIndex: i,
+        error,
+      });
     }
   }
 };

--- a/web/api/v2/minikit/send-notification/index.ts
+++ b/web/api/v2/minikit/send-notification/index.ts
@@ -36,6 +36,8 @@ type SendNotificationBodyV2 = yup.InferType<
   typeof sendNotificationBodySchemaV2
 >;
 
+const WALLET_ADDRESS_BATCH_SIZE = 100;
+
 export const logNotification = async (
   serviceClient: GraphQLClient,
   app_id: string,
@@ -77,12 +79,26 @@ export const logNotification = async (
     return;
   }
 
-  createNotificationLogSdk(serviceClient).CreateWalletAdressNotificationLogs({
-    objects: wallet_addresses.map((wallet_address) => ({
-      wallet_address,
-      notification_log_id: notificationLogId,
-    })),
-  });
+  const sdk = createNotificationLogSdk(serviceClient);
+
+  // Batch inserts to avoid oversized Hasura CTE queries
+  for (let i = 0; i < wallet_addresses.length; i += WALLET_ADDRESS_BATCH_SIZE) {
+    const batch = wallet_addresses.slice(i, i + WALLET_ADDRESS_BATCH_SIZE);
+
+    try {
+      await sdk.CreateWalletAdressNotificationLogs({
+        objects: batch.map((wallet_address) => ({
+          wallet_address,
+          notification_log_id: notificationLogId,
+        })),
+      });
+    } catch (error) {
+      logger.error(
+        "NotificationLog - failed to insert wallet address batch",
+        { app_id, notificationLogId, batchIndex: i, error },
+      );
+    }
+  }
 };
 
 const getSchemaVersion = (body: object) => {
@@ -430,28 +446,19 @@ export const POST = async (req: NextRequest) => {
     });
   }
   const response: SendNotificationResponse = data.result;
-  if (schemaVersion === "v1") {
-    logNotification(
-      serviceClient,
-      app_id,
-      wallet_addresses,
-      mini_app_path,
-      (parsedParams as SendNotificationBodyV1).message,
-    );
-  } else if (schemaVersion === "v2") {
-    const localisations = (parsedParams as SendNotificationBodyV2)
-      .localisations;
+  const logMessage =
+    schemaVersion === "v1"
+      ? (parsedParams as SendNotificationBodyV1).message
+      : (parsedParams as SendNotificationBodyV2).localisations?.[0]?.message;
 
-    for (const localisation of localisations) {
-      logNotification(
-        serviceClient,
-        app_id,
-        wallet_addresses,
-        mini_app_path,
-        localisation.message,
-      );
-    }
-  }
+  // Fire-and-forget: log wallet addresses once (not per localisation)
+  logNotification(
+    serviceClient,
+    app_id,
+    wallet_addresses,
+    mini_app_path,
+    logMessage,
+  );
 
   return NextResponse.json({
     success: true,

--- a/web/api/v2/minikit/send-notification/index.ts
+++ b/web/api/v2/minikit/send-notification/index.ts
@@ -451,7 +451,11 @@ export const POST = async (req: NextRequest) => {
   const logMessage =
     schemaVersion === "v1"
       ? (parsedParams as SendNotificationBodyV1).message
-      : (parsedParams as SendNotificationBodyV2).localisations?.[0]?.message;
+      : (
+          (parsedParams as SendNotificationBodyV2).localisations?.find(
+            (l) => l.language === "en",
+          ) ?? (parsedParams as SendNotificationBodyV2).localisations?.[0]
+        )?.message;
 
   // Fire-and-forget: log wallet addresses once (not per localisation)
   logNotification(


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Optimizes the `notification_log_wallet_address` bulk insert query that was consuming a large percentage of DB query runtime. Two changes:

1. **Batch inserts into groups of 100** — Hasura wraps bulk inserts in a CTE with `RETURNING *` and constraint checks. Large batches (hundreds of wallet addresses) produce oversized queries with significant planning overhead. Batching keeps each query small and efficient.

2. **Fix v2 schema duplicating wallet address logs per localisation** — Previously, for v2 schema notifications, `logNotification` was called once per localisation entry, each time inserting the *same* full set of wallet addresses. This multiplied insert volume by the number of localisations. Now wallet addresses are logged once regardless of schema version.

Also adds error handling for insert failures that were previously silently swallowed (fire-and-forget without try/catch).

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.