### PR TITLE
Add SKIP_ORIGIN_VALIDATION bypass for prod migration

### DIFF
--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -259,11 +259,13 @@ export const isValidHostName = (request: Request) => {
     return false;
   }
 
-  // Skip check for development and staging (staging may not have custom domains)
-  // TODO(CORPLAT-689): Remove staging bypass after DNS cutover
+  // Skip check for development, staging, and temporarily production
+  // (dedicated accounts may not have custom domains before DNS cutover)
+  // TODO(CORPLAT-689): Remove bypass after production DNS cutover
   if (
     process.env.NODE_ENV === "development" ||
-    process.env.NEXT_PUBLIC_APP_ENV === "staging"
+    process.env.NEXT_PUBLIC_APP_ENV === "staging" ||
+    process.env.SKIP_ORIGIN_VALIDATION === "true"
   ) {
     return true;
   }


### PR DESCRIPTION
## Summary

Adds a `SKIP_ORIGIN_VALIDATION` env-var bypass to `isValidHostName()` so the dedicated devportal-prod account (`558948635617`) can serve `/api/v2/public/app(s)*` during the migration window before `world-id-assets.com` is switched to the new account.

## Why

`isValidHostName()` rejects any request whose `Host` header isn't covered by `NEXT_PUBLIC_IMAGES_CDN_URL` (= `https://world-id-assets.com` in prod). Real user traffic goes through that CDN — `Host` is preserved by CloudFront — and passes cleanly. But during the migration window a subset of direct-to-ALB traffic reaches new prod with a different `Host`, and those requests 400 without this bypass:

- E2E / smoke tests targeting the ALB directly (the failure mode already documented in `world-id-deploy/migration-timeline.md:81` — "public API origin validation (ALB ≠ CloudFront)").
- Residual direct-to-ALB tooling / monitoring during cutover.

The equivalent bypass for **staging** was added in [#1847](https://github.com/worldcoin/developer-portal/pull/1847) (`NEXT_PUBLIC_APP_ENV === "staging"`). This PR extends the same pattern to prod, but guarded by an explicit env var so it only activates where CDK sets it.

## Activation

The env var is **only** set from `world-id-deploy/developer-portal/stacks/web/parameters.ts` for `devportalProd.envs`:

```ts
SKIP_ORIGIN_VALIDATION: "true",
```

(see `worldcoin/world-id-deploy` PR [#505](https://github.com/worldcoin/world-id-deploy/pull/505)).

- `developer-portal@main` without the env var set = behavior is identical to today (safe to merge anytime).
- After PR #505 merges + DevportalProd stage deploys = bypass is active on new prod only.
- **Not set** for staging or for the legacy consumer-prod environment.

## Cleanup

Remove both the code branch here and the env-var in `world-id-deploy` together at Phase 4 step 53, once `world-id-assets.com` DNS is delegated to the dedicated account and direct-to-ALB traffic is no longer a migration concern.

## Test plan

- [ ] `NODE_ENV=development` still bypasses (existing behavior)
- [ ] `NEXT_PUBLIC_APP_ENV=staging` still bypasses (existing behavior)
- [ ] With `SKIP_ORIGIN_VALIDATION=true`, `/api/v2/public/apps` responds 200 for requests whose `Host` doesn't match the CDN
- [ ] With `SKIP_ORIGIN_VALIDATION` unset, prod behavior unchanged (CDN-sourced requests 200, direct-to-ALB requests 400)
