### PR TITLE
fix: tighten CDN origin host check to strict hostname equality

### DIFF
--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -268,10 +268,19 @@ export const isValidHostName = (request: Request) => {
     return true;
   }
   const cdnHost = process.env.NEXT_PUBLIC_IMAGES_CDN_URL;
-  if (!cdnHost || !cdnHost.includes(hostName)) {
+  if (!cdnHost) {
     return false;
   }
-  return true;
+
+  // env var may be a full URL ("https://cdn.example.com") or a bare host ("cdn.example.com")
+  let cdnHostName: string;
+  try {
+    cdnHostName = new URL(cdnHost).host;
+  } catch {
+    cdnHostName = cdnHost;
+  }
+
+  return cdnHostName === hostName;
 };
 
 /**

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -272,15 +272,21 @@ export const isValidHostName = (request: Request) => {
     return false;
   }
 
-  // env var may be a full URL ("https://cdn.example.com") or a bare host ("cdn.example.com")
+  // env var may be a full URL ("https://cdn.example.com") or a bare host ("cdn.example.com");
+  // compare hostnames only (port-insensitive) since the Host header may or may not include a port
+  const stripPort = (h: string) => h.replace(/:\d+$/, "");
   let cdnHostName: string;
-  try {
-    cdnHostName = new URL(cdnHost).host;
-  } catch {
-    cdnHostName = cdnHost;
+  if (cdnHost.includes("://")) {
+    try {
+      cdnHostName = new URL(cdnHost).hostname;
+    } catch {
+      return false;
+    }
+  } else {
+    cdnHostName = stripPort(cdnHost);
   }
 
-  return cdnHostName === hostName;
+  return cdnHostName !== "" && cdnHostName === stripPort(hostName);
 };
 
 /**

--- a/web/tests/api/utils.test.ts
+++ b/web/tests/api/utils.test.ts
@@ -1,5 +1,5 @@
 import { canVerifyForAction } from "@/api/helpers/verify";
-import { validateUri, validateUrl } from "@/lib/utils";
+import { isValidHostName, validateUri, validateUrl } from "@/lib/utils";
 
 describe("canVerifyForAction()", () => {
   test("can verify if it has not verified before", () => {
@@ -141,6 +141,85 @@ describe("validateUrl()", () => {
       expect(
         validateUrl("https://test.com/\nalert(1)", isStaging),
       ).toBeTruthy();
+    });
+  });
+});
+
+describe("isValidHostName()", () => {
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+  const ORIGINAL_APP_ENV = process.env.NEXT_PUBLIC_APP_ENV;
+  const ORIGINAL_CDN = process.env.NEXT_PUBLIC_IMAGES_CDN_URL;
+
+  const makeRequest = (host: string) => {
+    const headers = new Headers();
+    headers.set("host", host);
+    return new Request("https://example.com", { headers });
+  };
+
+  afterEach(() => {
+    Object.defineProperty(process.env, "NODE_ENV", {
+      value: ORIGINAL_NODE_ENV,
+    });
+    process.env.NEXT_PUBLIC_APP_ENV = ORIGINAL_APP_ENV;
+    process.env.NEXT_PUBLIC_IMAGES_CDN_URL = ORIGINAL_CDN;
+  });
+
+  describe("production", () => {
+    beforeEach(() => {
+      Object.defineProperty(process.env, "NODE_ENV", { value: "production" });
+      process.env.NEXT_PUBLIC_APP_ENV = "production";
+      process.env.NEXT_PUBLIC_IMAGES_CDN_URL = "https://cdn.example.com";
+    });
+
+    test("accepts exact host match against full CDN URL", () => {
+      expect(isValidHostName(makeRequest("cdn.example.com"))).toBe(true);
+    });
+
+    test("accepts exact host match against bare host CDN value", () => {
+      process.env.NEXT_PUBLIC_IMAGES_CDN_URL = "cdn.example.com";
+      expect(isValidHostName(makeRequest("cdn.example.com"))).toBe(true);
+    });
+
+    test("rejects single-character host (substring bypass)", () => {
+      // The previous implementation used cdnHost.includes(hostName), so any
+      // substring of the CDN URL (e.g., "h", "cdn") would pass.
+      expect(isValidHostName(makeRequest("h"))).toBe(false);
+      expect(isValidHostName(makeRequest("cdn"))).toBe(false);
+      expect(isValidHostName(makeRequest("example.com"))).toBe(false);
+    });
+
+    test("rejects attacker-controlled host that is a substring of CDN URL", () => {
+      expect(isValidHostName(makeRequest("https"))).toBe(false);
+      expect(isValidHostName(makeRequest(".com"))).toBe(false);
+    });
+
+    test("rejects host containing CDN as a substring", () => {
+      expect(
+        isValidHostName(makeRequest("evil.cdn.example.com.attacker.com")),
+      ).toBe(false);
+    });
+
+    test("rejects when CDN env var is unset", () => {
+      delete process.env.NEXT_PUBLIC_IMAGES_CDN_URL;
+      expect(isValidHostName(makeRequest("cdn.example.com"))).toBe(false);
+    });
+  });
+
+  describe("staging bypass", () => {
+    test("accepts any host when NEXT_PUBLIC_APP_ENV=staging", () => {
+      Object.defineProperty(process.env, "NODE_ENV", { value: "production" });
+      process.env.NEXT_PUBLIC_APP_ENV = "staging";
+      process.env.NEXT_PUBLIC_IMAGES_CDN_URL = "https://cdn.example.com";
+      expect(isValidHostName(makeRequest("anything.com"))).toBe(true);
+    });
+  });
+
+  describe("development bypass", () => {
+    test("accepts any host when NODE_ENV=development", () => {
+      Object.defineProperty(process.env, "NODE_ENV", { value: "development" });
+      process.env.NEXT_PUBLIC_APP_ENV = "production";
+      process.env.NEXT_PUBLIC_IMAGES_CDN_URL = "https://cdn.example.com";
+      expect(isValidHostName(makeRequest("localhost:3000"))).toBe(true);
     });
   });
 });

--- a/web/tests/api/utils.test.ts
+++ b/web/tests/api/utils.test.ts
@@ -199,6 +199,21 @@ describe("isValidHostName()", () => {
       ).toBe(false);
     });
 
+    test("accepts request without port when CDN env has explicit port", () => {
+      process.env.NEXT_PUBLIC_IMAGES_CDN_URL = "https://cdn.example.com:443";
+      expect(isValidHostName(makeRequest("cdn.example.com"))).toBe(true);
+    });
+
+    test("accepts request with port when CDN env has no port", () => {
+      process.env.NEXT_PUBLIC_IMAGES_CDN_URL = "https://cdn.example.com";
+      expect(isValidHostName(makeRequest("cdn.example.com:443"))).toBe(true);
+    });
+
+    test("accepts bare-host CDN env with explicit port", () => {
+      process.env.NEXT_PUBLIC_IMAGES_CDN_URL = "cdn.example.com:443";
+      expect(isValidHostName(makeRequest("cdn.example.com"))).toBe(true);
+    });
+
     test("rejects when CDN env var is unset", () => {
       delete process.env.NEXT_PUBLIC_IMAGES_CDN_URL;
       expect(isValidHostName(makeRequest("cdn.example.com"))).toBe(false);


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

`isValidHostName` in `web/lib/utils.ts` used `cdnHost.includes(hostName)` (substring, wrong direction), so any substring of `NEXT_PUBLIC_IMAGES_CDN_URL` — including a single character like `Host: h` — bypassed the CDN-only origin gate on `/api/v2/public/app/[app_id]`, `/api/v2/public/apps`, and `/api/v2/public/apps/search/[search_term]`.

Replaced with strict hostname equality. The env var is parsed via `new URL()` to extract the host (since the value is a full URL in some envs and a bare hostname in others); on parse failure we fall back to comparing the raw value. The existing `NODE_ENV=development` / `NEXT_PUBLIC_APP_ENV=staging` bypasses are preserved (CORPLAT-689).

Added a test suite covering exact-match for both URL and bare-host CDN values, the substring bypass that previously slipped through, and the staging/dev bypass paths.

Out of scope (flagged but not changed): `/api/v4/proof-context/[id]` has no host gate by design (used pre-auth for the World ID 4.0 proof modal); existing handler tests confirm `/api/v2/public/app/[app_id]` is intentionally allowed to return unverified metadata once the host gate is correct.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.