### PR TITLE
fix: log underlying error in validate-request-schema 500 path

### DIFF
--- a/web/api/helpers/validate-request-schema.ts
+++ b/web/api/helpers/validate-request-schema.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
 import * as yup from "yup";
 import { errorResponse } from "./errors";
@@ -51,6 +52,12 @@ export const validateRequestSchema = async <T extends yup.Schema>({
       };
       return { isValid: false, handleError };
     }
+
+    logger.error("Unexpected error validating request schema", {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+      app_id,
+    });
 
     const handleError = (req: NextRequest) => {
       return errorResponse({


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Non-yup errors thrown inside \`schema.validate(value)\` in \`web/api/helpers/validate-request-schema.ts\` were silently swallowed — the helper returned a generic 500 (\"Something went wrong. Please try again.\") with no log line, leaving v2 and v4 \`verify\` failures impossible to diagnose. This adds a \`logger.error\` with the underlying error message, stack, and \`app_id\` before the generic 500 is returned, so the next occurrence leaves a real trace in our logs.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.