### PR TITLE
fix: serve developer portal correctly on both worldcoin.org and world.org

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -13,6 +13,14 @@ const cdnURLObject = new URL(
 );
 const s3BucketUrl = `https://${process.env.ASSETS_S3_BUCKET_NAME}.s3.${process.env.ASSETS_S3_REGION}.amazonaws.com`;
 const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+// The portal is served from both worldcoin.org and world.org variants of the
+// same hostname. NEXT_PUBLIC_APP_URL is build-baked, so we mirror it onto the
+// sibling domain so CSP allows assets/connections from either origin.
+const altAppUrl = appUrl?.includes(".worldcoin.org")
+  ? appUrl.replace(".worldcoin.org", ".world.org")
+  : appUrl?.includes(".world.org")
+    ? appUrl.replace(".world.org", ".worldcoin.org")
+    : undefined;
 const isDev = process.env.NODE_ENV === "development";
 const generateCsp = () => {
   const nonce = crypto.randomUUID();
@@ -60,6 +68,7 @@ const generateCsp = () => {
         "https://us.i.posthog.com",
         ...(s3BucketUrl ? [s3BucketUrl] : []),
         ...(appUrl ? [appUrl] : []),
+        ...(altAppUrl ? [altAppUrl] : []),
       ],
     },
     {
@@ -72,6 +81,7 @@ const generateCsp = () => {
         ...(s3BucketUrl ? [s3BucketUrl] : []),
         ...(cdnURLObject ? [cdnURLObject.hostname] : []),
         ...(appUrl ? [appUrl] : []),
+        ...(altAppUrl ? [altAppUrl] : []),
       ],
     },
   ];

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -16,11 +16,25 @@ const appUrl = process.env.NEXT_PUBLIC_APP_URL;
 // The portal is served from both worldcoin.org and world.org variants of the
 // same hostname. NEXT_PUBLIC_APP_URL is build-baked, so we mirror it onto the
 // sibling domain so CSP allows assets/connections from either origin.
-const altAppUrl = appUrl?.includes(".worldcoin.org")
-  ? appUrl.replace(".worldcoin.org", ".world.org")
-  : appUrl?.includes(".world.org")
-    ? appUrl.replace(".world.org", ".worldcoin.org")
-    : undefined;
+const computeAltAppUrl = (raw: string | undefined): string | undefined => {
+  if (!raw) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return undefined;
+  }
+  const { hostname } = parsed;
+  if (hostname.endsWith(".worldcoin.org")) {
+    parsed.hostname = `${hostname.slice(0, -".worldcoin.org".length)}.world.org`;
+  } else if (hostname.endsWith(".world.org")) {
+    parsed.hostname = `${hostname.slice(0, -".world.org".length)}.worldcoin.org`;
+  } else {
+    return undefined;
+  }
+  return parsed.origin;
+};
+const altAppUrl = computeAltAppUrl(appUrl);
 const isDev = process.env.NODE_ENV === "development";
 const generateCsp = () => {
   const nonce = crypto.randomUUID();

--- a/web/scenes/Root/providers/providers.tsx
+++ b/web/scenes/Root/providers/providers.tsx
@@ -20,7 +20,7 @@ interface HasuraUserData {
 
 if (typeof window !== "undefined") {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_API_KEY!, {
-    api_host: `${process.env.NEXT_PUBLIC_APP_URL}/ingest`,
+    api_host: `${window.location.origin}/ingest`,
     ui_host: "https://app.posthog.com",
     loaded: (posthog) => {
       if (process.env.NODE_ENV === "development") posthog.debug();


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

The console on `developer.world.org` was flooded with CORS errors because two client-side values were build-baked from `NEXT_PUBLIC_APP_URL` (set to `developer.worldcoin.org` at build time) and didn't follow the request's actual origin:

- **PostHog `api_host`** was hardcoded into the bundle as `https://developer.worldcoin.org/ingest`, so every event/decide call from `developer.world.org` went cross-origin, hit a Cloudflare 308, and got blocked by CORS. Switched to `\`\${window.location.origin}/ingest\`` (the `posthog.init` block is already inside a `typeof window !== "undefined"` guard) so requests stay same-origin and get rewritten to PostHog by `next.config.mjs`.
- **Middleware CSP** put `appUrl` into `connect-src` and `img-src`, allowing only the build-time domain. Mirror it onto its sibling (`.worldcoin.org` ↔ `.world.org`) so both production hostnames (and their staging/dev variants) are accepted regardless of which one the build was pinned to.

No `world-id-deploy` changes needed: ALB has both certs, both hostnames forward to the same target group, S3 CORS lists both origins, and the `allowed-hosts` SSM parameter already contains both for staging/prod/dev.

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.