### PR TITLE
fix: refresh service JWT before notification audit log writes

### DIFF
--- a/web/api/v2/minikit/send-notification/index.ts
+++ b/web/api/v2/minikit/send-notification/index.ts
@@ -6,7 +6,6 @@ import { logger } from "@/lib/logger";
 import { fetchWithRetry } from "@/lib/utils";
 import { createSignedFetcher } from "aws-sigv4-fetch";
 import { createHash } from "crypto";
-import { GraphQLClient } from "graphql-request";
 import { NextRequest, NextResponse } from "next/server";
 import * as yup from "yup";
 import { getSdk as fetchApiKeySdk } from "../graphql/fetch-api-key.generated";
@@ -39,7 +38,6 @@ type SendNotificationBodyV2 = yup.InferType<
 const WALLET_ADDRESS_BATCH_SIZE = 100;
 
 export const logNotification = async (
-  serviceClient: GraphQLClient,
   app_id: string,
   wallet_addresses: string[] | undefined,
   mini_app_path: string | undefined,
@@ -58,18 +56,30 @@ export const logNotification = async (
     return;
   }
 
+  // Mint a fresh client here: the service JWT TTL is 1 minute and the caller
+  // can spend longer than that in upstream retries, so any reused client would
+  // hit JWTExpired.
+  const serviceClient = await getAPIServiceGraphqlClient();
+  const sdk = createNotificationLogSdk(serviceClient);
+
   let notificationLog: CreateNotificationLogMutationVariables = {
     app_id,
     mini_app_path,
     message,
   };
 
-  const { insert_notification_log_one } =
-    await createNotificationLogSdk(serviceClient).CreateNotificationLog(
-      notificationLog,
-    );
-
-  const notificationLogId = insert_notification_log_one?.id;
+  let notificationLogId: string | undefined;
+  try {
+    const { insert_notification_log_one } =
+      await sdk.CreateNotificationLog(notificationLog);
+    notificationLogId = insert_notification_log_one?.id;
+  } catch (error) {
+    logger.error("NotificationLog - failed to create notification log", {
+      app_id,
+      error,
+    });
+    return;
+  }
 
   if (!notificationLogId) {
     logger.error(
@@ -78,8 +88,6 @@ export const logNotification = async (
     );
     return;
   }
-
-  const sdk = createNotificationLogSdk(serviceClient);
 
   // Batch inserts to avoid oversized Hasura CTE queries
   for (let i = 0; i < wallet_addresses.length; i += WALLET_ADDRESS_BATCH_SIZE) {
@@ -457,13 +465,12 @@ export const POST = async (req: NextRequest) => {
           ) ?? (parsedParams as SendNotificationBodyV2).localisations?.[0]
         )?.message;
 
-  // Fire-and-forget: log wallet addresses once (not per localisation)
-  logNotification(
-    serviceClient,
-    app_id,
-    wallet_addresses,
-    mini_app_path,
-    logMessage,
+  // Fire-and-forget: log wallet addresses once (not per localisation).
+  // .catch keeps any failure from becoming an unhandled rejection.
+  logNotification(app_id, wallet_addresses, mini_app_path, logMessage).catch(
+    (error) => {
+      logger.error("NotificationLog - unexpected failure", { app_id, error });
+    },
   );
 
   return NextResponse.json({


### PR DESCRIPTION
## PR Type

- [x] Bug Fix

## Description

`logNotification` in `/api/v2/minikit/send-notification` was reusing the `serviceClient` minted at the start of the request handler, but the Hasura service JWT only lives 1 minute and the upstream `fetchWithRetry` can run longer with backoff. By the time the fire-and-forget `CreateNotificationLog` mutation ran, Hasura rejected it with `JWTExpired`, the audit row plus per-wallet rows were dropped, and the missing try/catch around the create call turned the failure into an unhandled rejection (the noisy raw `graphql-request` log we were seeing). `logNotification` now mints its own fresh service client, the create call is wrapped in try/catch with a structured `logger.error`, and the call site has a `.catch` backstop.

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.