### PR TITLE
fix: downgrade App not found log to warn in get-unverified-images

### DIFF
--- a/web/api/hasura/get-unverified-images/index.ts
+++ b/web/api/hasura/get-unverified-images/index.ts
@@ -99,6 +99,7 @@ export const POST = async (req: NextRequest) => {
         code: "not_found",
         team_id,
         app_id,
+        logLevel: "warn",
       });
     }
 

--- a/web/api/helpers/errors.ts
+++ b/web/api/helpers/errors.ts
@@ -168,14 +168,16 @@ export function errorHasuraQuery({
   detail = "Something went wrong.",
   app_id,
   team_id,
+  logLevel = "error",
 }: {
   req: NextRequest;
   code?: string;
   detail?: string;
   app_id?: string;
   team_id?: string;
+  logLevel?: "error" | "warn" | "info";
 }) {
-  logger.error(detail, {
+  logger[logLevel](detail, {
     req,
     error: { code },
     app_id,


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

The `get_all_unverified_images` Hasura action was logging "App not found" via `errorHasuraQuery`, which always logs at `error` level. That branch fires for expected client/state conditions (deleted app, race, user no longer on team, missing localisation row) and was generating noisy alerts we can't act on. Added an optional `logLevel` parameter to `errorHasuraQuery` (defaults to `"error"`, no behavior change for other callers) and pass `"warn"` from the not-found branch.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.