### PR TITLE
Add World ID MCP endpoint

### DIFF
--- a/hasura/metadata/databases/default/tables/public_app.yaml
+++ b/hasura/metadata/databases/default/tables/public_app.yaml
@@ -99,6 +99,7 @@ select_permissions:
         - is_archived
         - is_banned
         - is_staging
+        - name
         - rating_count
         - rating_sum
         - status

--- a/hasura/metadata/databases/default/tables/public_app_metadata.yaml
+++ b/hasura/metadata/databases/default/tables/public_app_metadata.yaml
@@ -221,6 +221,7 @@ select_permissions:
         - category
         - content_card_image_url
         - contracts
+        - created_at
         - description
         - hero_image_url
         - id

--- a/web/api/hasura/graphql/checkAppInTeam.generated.ts
+++ b/web/api/hasura/graphql/checkAppInTeam.generated.ts
@@ -1,0 +1,79 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type CheckAppInTeamQueryVariables = Types.Exact<{
+  team_id: Types.Scalars["String"]["input"];
+  app_id: Types.Scalars["String"]["input"];
+}>;
+
+export type CheckAppInTeamQuery = {
+  __typename?: "query_root";
+  app: Array<{
+    __typename?: "app";
+    id: string;
+    app_metadata: Array<{ __typename?: "app_metadata"; id: string }>;
+  }>;
+};
+
+export const CheckAppInTeamDocument = gql`
+  query CheckAppInTeam($team_id: String!, $app_id: String!) {
+    app(
+      where: {
+        id: { _eq: $app_id }
+        team_id: { _eq: $team_id }
+        deleted_at: { _is_null: true }
+      }
+      limit: 1
+    ) {
+      id
+      app_metadata(
+        where: { verification_status: { _eq: "unverified" } }
+        limit: 1
+      ) {
+        id
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    CheckAppInTeam(
+      variables: CheckAppInTeamQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CheckAppInTeamQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CheckAppInTeamQuery>(
+            CheckAppInTeamDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "CheckAppInTeam",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/hasura/graphql/checkAppInTeam.graphql
+++ b/web/api/hasura/graphql/checkAppInTeam.graphql
@@ -1,0 +1,18 @@
+query CheckAppInTeam($team_id: String!, $app_id: String!) {
+  app(
+    where: {
+      id: { _eq: $app_id }
+      team_id: { _eq: $team_id }
+      deleted_at: { _is_null: true }
+    }
+    limit: 1
+  ) {
+    id
+    app_metadata(
+      where: { verification_status: { _eq: "unverified" } }
+      limit: 1
+    ) {
+      id
+    }
+  }
+}

--- a/web/api/hasura/upload-image/index.ts
+++ b/web/api/hasura/upload-image/index.ts
@@ -1,3 +1,4 @@
+import { getSdk as checkAppInTeamDocumentSDK } from "@/api/hasura/graphql/checkAppInTeam.generated";
 import { getSdk as checkUserInAppDocumentSDK } from "@/api/hasura/graphql/checkUserInApp.generated";
 import { errorHasuraQuery } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
@@ -37,14 +38,10 @@ export const POST = async (req: NextRequest) => {
       });
     }
 
-    const userId = body.session_variables["x-hasura-user-id"];
-    if (!userId) {
-      return errorHasuraQuery({
-        req,
-        detail: "user_id must be set.",
-        code: "required",
-      });
-    }
+    const sessionVariables = body.session_variables ?? {};
+    const role = sessionVariables["x-hasura-role"];
+    const userId = sessionVariables["x-hasura-user-id"];
+    const sessionTeamId = sessionVariables["x-hasura-team-id"];
 
     team_id = body.input.team_id;
 
@@ -72,6 +69,8 @@ export const POST = async (req: NextRequest) => {
 
     const { image_type, content_type_ending, locale } = parsedParams;
     app_id = parsedParams.app_id;
+    const uploadAppId = app_id;
+    const uploadTeamId = team_id;
 
     if (!["png", "jpeg"].includes(content_type_ending)) {
       return errorHasuraQuery({
@@ -84,24 +83,79 @@ export const POST = async (req: NextRequest) => {
     }
     const client = await getAPIServiceGraphqlClient();
 
-    const { team: userTeam } = await checkUserInAppDocumentSDK(
-      client,
-    ).CheckUserInApp({
-      team_id,
-      app_id,
-      user_id: userId,
-    });
-
-    // Admins and Owners allowed to upload images
-    if (userTeam.length === 0) {
-      return errorHasuraQuery({
-        req,
-        detail: "App not found.",
-        code: "not_found",
-        app_id,
-        team_id,
+    const getUploadableApp = async () => {
+      const { app } = await checkAppInTeamDocumentSDK(
+        client,
+      ).CheckAppInTeam({
+        team_id: uploadTeamId,
+        app_id: uploadAppId,
       });
+
+      return app.find((currentApp) => currentApp.app_metadata.length > 0);
+    };
+
+    // This action is exposed to both dashboard users and Dev Portal API keys.
+    if (role === "api_key") {
+      if (sessionTeamId !== team_id) {
+        return errorHasuraQuery({
+          req,
+          detail: "App not found.",
+          code: "not_found",
+          app_id,
+          team_id,
+        });
+      }
+
+      if (!(await getUploadableApp())) {
+        return errorHasuraQuery({
+          req,
+          detail: "App not found.",
+          code: "not_found",
+          app_id,
+          team_id,
+        });
+      }
+    } else {
+      if (!userId) {
+        return errorHasuraQuery({
+          req,
+          detail: "user_id must be set.",
+          code: "required",
+          app_id,
+          team_id,
+        });
+      }
+
+      const { team: userTeam } = await checkUserInAppDocumentSDK(
+        client,
+      ).CheckUserInApp({
+        team_id,
+        app_id,
+        user_id: userId,
+      });
+
+      // Admins and Owners allowed to upload images
+      if (userTeam.length === 0) {
+        return errorHasuraQuery({
+          req,
+          detail: "App not found.",
+          code: "not_found",
+          app_id,
+          team_id,
+        });
+      }
+
+      if (!(await getUploadableApp())) {
+        return errorHasuraQuery({
+          req,
+          detail: "App not found.",
+          code: "not_found",
+          app_id,
+          team_id,
+        });
+      }
     }
+
     if (!process.env.ASSETS_S3_REGION) {
       throw new Error("AWS Region must be set.");
     }

--- a/web/api/hasura/upload-image/index.ts
+++ b/web/api/hasura/upload-image/index.ts
@@ -84,9 +84,7 @@ export const POST = async (req: NextRequest) => {
     const client = await getAPIServiceGraphqlClient();
 
     const getUploadableApp = async () => {
-      const { app } = await checkAppInTeamDocumentSDK(
-        client,
-      ).CheckAppInTeam({
+      const { app } = await checkAppInTeamDocumentSDK(client).CheckAppInTeam({
         team_id: uploadTeamId,
         app_id: uploadAppId,
       });

--- a/web/api/helpers/portal-events.ts
+++ b/web/api/helpers/portal-events.ts
@@ -1,0 +1,22 @@
+import { logger } from "@/lib/logger";
+
+type PortalActor = "human" | "mcp";
+
+type PortalEventParams = {
+  event: "app_creation" | "action_creation" | "app_submission";
+  actor: PortalActor;
+  team_id?: string;
+  app_id?: string;
+  action?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export const logPortalEvent = (params: PortalEventParams) => {
+  logger.info(`portal_${params.event}`, {
+    actor: params.actor,
+    team_id: params.team_id,
+    app_id: params.app_id,
+    action: params.action,
+    ...params.metadata,
+  });
+};

--- a/web/api/mcp/graphql/app-context.generated.ts
+++ b/web/api/mcp/graphql/app-context.generated.ts
@@ -1,0 +1,160 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type McpAppContextQueryVariables = Types.Exact<{
+  team_id: Types.Scalars["String"]["input"];
+  app_id: Types.Scalars["String"]["input"];
+}>;
+
+export type McpAppContextQuery = {
+  __typename?: "query_root";
+  app: Array<{
+    __typename?: "app";
+    id: string;
+    name: string;
+    engine: string;
+    is_staging: boolean;
+    status: string;
+    app_metadata: Array<{
+      __typename?: "app_metadata";
+      id: string;
+      name: string;
+      short_name: string;
+      app_mode: string;
+      category: string;
+      content_card_image_url: string;
+      description: string;
+      hero_image_url: string;
+      integration_url: string;
+      is_android_only: boolean;
+      app_website_url: string;
+      is_for_humans_only: boolean;
+      logo_img_url: string;
+      meta_tag_image_url: string;
+      support_link: string;
+      showcase_img_urls?: Array<string> | null;
+      world_app_description: string;
+      world_app_button_text: string;
+      verification_status: string;
+      is_developer_allow_listing: boolean;
+      supported_countries?: Array<string> | null;
+      supported_languages?: Array<string> | null;
+    }>;
+    rp_registration: Array<{
+      __typename?: "rp_registration";
+      rp_id: string;
+      mode: unknown;
+      status: unknown;
+      signer_address?: string | null;
+      staging_status?: unknown | null;
+      actions_v4: Array<{
+        __typename?: "action_v4";
+        id: string;
+        action: string;
+        description: string;
+        environment: unknown;
+      }>;
+    }>;
+  }>;
+};
+
+export const McpAppContextDocument = gql`
+  query McpAppContext($team_id: String!, $app_id: String!) {
+    app(
+      where: {
+        id: { _eq: $app_id }
+        team_id: { _eq: $team_id }
+        deleted_at: { _is_null: true }
+      }
+      limit: 1
+    ) {
+      id
+      name
+      engine
+      is_staging
+      status
+      app_metadata(
+        where: { verification_status: { _neq: "verified" } }
+        order_by: { created_at: desc }
+        limit: 1
+      ) {
+        id
+        name
+        short_name
+        app_mode
+        category
+        content_card_image_url
+        description
+        hero_image_url
+        integration_url
+        is_android_only
+        app_website_url
+        is_for_humans_only
+        logo_img_url
+        meta_tag_image_url
+        support_link
+        showcase_img_urls
+        world_app_description
+        world_app_button_text
+        verification_status
+        is_developer_allow_listing
+        supported_countries
+        supported_languages
+      }
+      rp_registration {
+        rp_id
+        mode
+        status
+        signer_address
+        staging_status
+        actions_v4(order_by: { created_at: desc }) {
+          id
+          action
+          description
+          environment
+        }
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    McpAppContext(
+      variables: McpAppContextQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<McpAppContextQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<McpAppContextQuery>(McpAppContextDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        "McpAppContext",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/mcp/graphql/app-context.graphql
+++ b/web/api/mcp/graphql/app-context.graphql
@@ -1,0 +1,57 @@
+query McpAppContext($team_id: String!, $app_id: String!) {
+  app(
+    where: {
+      id: { _eq: $app_id }
+      team_id: { _eq: $team_id }
+      deleted_at: { _is_null: true }
+    }
+    limit: 1
+  ) {
+    id
+    name
+    engine
+    is_staging
+    status
+    app_metadata(
+      where: { verification_status: { _neq: "verified" } }
+      order_by: { created_at: desc }
+      limit: 1
+    ) {
+      id
+      name
+      short_name
+      app_mode
+      category
+      content_card_image_url
+      description
+      hero_image_url
+      integration_url
+      is_android_only
+      app_website_url
+      is_for_humans_only
+      logo_img_url
+      meta_tag_image_url
+      support_link
+      showcase_img_urls
+      world_app_description
+      world_app_button_text
+      verification_status
+      is_developer_allow_listing
+      supported_countries
+      supported_languages
+    }
+    rp_registration {
+      rp_id
+      mode
+      status
+      signer_address
+      staging_status
+      actions_v4(order_by: { created_at: desc }) {
+        id
+        action
+        description
+        environment
+      }
+    }
+  }
+}

--- a/web/api/mcp/graphql/authenticate-team.generated.ts
+++ b/web/api/mcp/graphql/authenticate-team.generated.ts
@@ -5,18 +5,27 @@ import { GraphQLClient, RequestOptions } from "graphql-request";
 import gql from "graphql-tag";
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
 export type McpAuthenticateTeamQueryVariables = Types.Exact<{
-  [key: string]: never;
+  id: Types.Scalars["String"]["input"];
 }>;
 
 export type McpAuthenticateTeamQuery = {
   __typename?: "query_root";
-  team: Array<{ __typename?: "team"; id: string }>;
+  api_key_by_pk?: {
+    __typename?: "api_key";
+    id: string;
+    api_key: string;
+    is_active: boolean;
+    team_id: string;
+  } | null;
 };
 
 export const McpAuthenticateTeamDocument = gql`
-  query McpAuthenticateTeam {
-    team(limit: 1) {
+  query McpAuthenticateTeam($id: String!) {
+    api_key_by_pk(id: $id) {
       id
+      api_key
+      is_active
+      team_id
     }
   }
 `;
@@ -41,7 +50,7 @@ export function getSdk(
 ) {
   return {
     McpAuthenticateTeam(
-      variables?: McpAuthenticateTeamQueryVariables,
+      variables: McpAuthenticateTeamQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
     ): Promise<McpAuthenticateTeamQuery> {
       return withWrapper(

--- a/web/api/mcp/graphql/authenticate-team.generated.ts
+++ b/web/api/mcp/graphql/authenticate-team.generated.ts
@@ -1,0 +1,61 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type McpAuthenticateTeamQueryVariables = Types.Exact<{
+  [key: string]: never;
+}>;
+
+export type McpAuthenticateTeamQuery = {
+  __typename?: "query_root";
+  team: Array<{ __typename?: "team"; id: string }>;
+};
+
+export const McpAuthenticateTeamDocument = gql`
+  query McpAuthenticateTeam {
+    team(limit: 1) {
+      id
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    McpAuthenticateTeam(
+      variables?: McpAuthenticateTeamQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<McpAuthenticateTeamQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<McpAuthenticateTeamQuery>(
+            McpAuthenticateTeamDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "McpAuthenticateTeam",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/mcp/graphql/authenticate-team.graphql
+++ b/web/api/mcp/graphql/authenticate-team.graphql
@@ -1,0 +1,5 @@
+query McpAuthenticateTeam {
+  team(limit: 1) {
+    id
+  }
+}

--- a/web/api/mcp/graphql/authenticate-team.graphql
+++ b/web/api/mcp/graphql/authenticate-team.graphql
@@ -1,5 +1,8 @@
-query McpAuthenticateTeam {
-  team(limit: 1) {
+query McpAuthenticateTeam($id: String!) {
+  api_key_by_pk(id: $id) {
     id
+    api_key
+    is_active
+    team_id
   }
 }

--- a/web/api/mcp/graphql/create-app.generated.ts
+++ b/web/api/mcp/graphql/create-app.generated.ts
@@ -1,0 +1,112 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type McpCreateAppMutationVariables = Types.Exact<{
+  team_id: Types.Scalars["String"]["input"];
+  name: Types.Scalars["String"]["input"];
+  engine: Types.Scalars["String"]["input"];
+  is_staging: Types.Scalars["Boolean"]["input"];
+  category: Types.Scalars["String"]["input"];
+  integration_url: Types.Scalars["String"]["input"];
+  app_mode: Types.Scalars["String"]["input"];
+}>;
+
+export type McpCreateAppMutation = {
+  __typename?: "mutation_root";
+  insert_app_one?: {
+    __typename?: "app";
+    id: string;
+    name: string;
+    is_staging: boolean;
+    engine: string;
+    app_metadata: Array<{
+      __typename?: "app_metadata";
+      id: string;
+      app_mode: string;
+      category: string;
+      integration_url: string;
+    }>;
+  } | null;
+};
+
+export const McpCreateAppDocument = gql`
+  mutation McpCreateApp(
+    $team_id: String!
+    $name: String!
+    $engine: String!
+    $is_staging: Boolean!
+    $category: String!
+    $integration_url: String!
+    $app_mode: String!
+  ) {
+    insert_app_one(
+      object: {
+        engine: $engine
+        name: $name
+        is_staging: $is_staging
+        team_id: $team_id
+        app_metadata: {
+          data: {
+            name: $name
+            integration_url: $integration_url
+            app_mode: $app_mode
+            category: $category
+          }
+        }
+      }
+    ) {
+      id
+      name
+      is_staging
+      engine
+      app_metadata(order_by: { created_at: desc }, limit: 1) {
+        id
+        app_mode
+        category
+        integration_url
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    McpCreateApp(
+      variables: McpCreateAppMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<McpCreateAppMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<McpCreateAppMutation>(
+            McpCreateAppDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "McpCreateApp",
+        "mutation",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/mcp/graphql/create-app.graphql
+++ b/web/api/mcp/graphql/create-app.graphql
@@ -1,0 +1,37 @@
+mutation McpCreateApp(
+  $team_id: String!
+  $name: String!
+  $engine: String!
+  $is_staging: Boolean!
+  $category: String!
+  $integration_url: String!
+  $app_mode: String!
+) {
+  insert_app_one(
+    object: {
+      engine: $engine
+      name: $name
+      is_staging: $is_staging
+      team_id: $team_id
+      app_metadata: {
+        data: {
+          name: $name
+          integration_url: $integration_url
+          app_mode: $app_mode
+          category: $category
+        }
+      }
+    }
+  ) {
+    id
+    name
+    is_staging
+    engine
+    app_metadata(order_by: { created_at: desc }, limit: 1) {
+      id
+      app_mode
+      category
+      integration_url
+    }
+  }
+}

--- a/web/api/mcp/graphql/submit-app-for-review.generated.ts
+++ b/web/api/mcp/graphql/submit-app-for-review.generated.ts
@@ -1,0 +1,83 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type McpSubmitAppForReviewMutationVariables = Types.Exact<{
+  app_metadata_id: Types.Scalars["String"]["input"];
+  is_developer_allow_listing: Types.Scalars["Boolean"]["input"];
+  changelog: Types.Scalars["String"]["input"];
+}>;
+
+export type McpSubmitAppForReviewMutation = {
+  __typename?: "mutation_root";
+  update_app_metadata_by_pk?: {
+    __typename?: "app_metadata";
+    id: string;
+    app_id: string;
+    verification_status: string;
+    is_developer_allow_listing: boolean;
+  } | null;
+};
+
+export const McpSubmitAppForReviewDocument = gql`
+  mutation McpSubmitAppForReview(
+    $app_metadata_id: String!
+    $is_developer_allow_listing: Boolean!
+    $changelog: String!
+  ) {
+    update_app_metadata_by_pk(
+      pk_columns: { id: $app_metadata_id }
+      _set: {
+        verification_status: "awaiting_review"
+        is_developer_allow_listing: $is_developer_allow_listing
+        changelog: $changelog
+      }
+    ) {
+      id
+      app_id
+      verification_status
+      is_developer_allow_listing
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    McpSubmitAppForReview(
+      variables: McpSubmitAppForReviewMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<McpSubmitAppForReviewMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<McpSubmitAppForReviewMutation>(
+            McpSubmitAppForReviewDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "McpSubmitAppForReview",
+        "mutation",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/mcp/graphql/submit-app-for-review.graphql
+++ b/web/api/mcp/graphql/submit-app-for-review.graphql
@@ -1,0 +1,19 @@
+mutation McpSubmitAppForReview(
+  $app_metadata_id: String!
+  $is_developer_allow_listing: Boolean!
+  $changelog: String!
+) {
+  update_app_metadata_by_pk(
+    pk_columns: { id: $app_metadata_id }
+    _set: {
+      verification_status: "awaiting_review"
+      is_developer_allow_listing: $is_developer_allow_listing
+      changelog: $changelog
+    }
+  ) {
+    id
+    app_id
+    verification_status
+    is_developer_allow_listing
+  }
+}

--- a/web/api/mcp/graphql/team-context.generated.ts
+++ b/web/api/mcp/graphql/team-context.generated.ts
@@ -1,0 +1,122 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type McpTeamContextQueryVariables = Types.Exact<{
+  team_id: Types.Scalars["String"]["input"];
+}>;
+
+export type McpTeamContextQuery = {
+  __typename?: "query_root";
+  team_by_pk?: {
+    __typename?: "team";
+    id: string;
+    name?: string | null;
+    apps: Array<{
+      __typename?: "app";
+      id: string;
+      name: string;
+      engine: string;
+      is_staging: boolean;
+      status: string;
+      created_at: string;
+      app_metadata: Array<{
+        __typename?: "app_metadata";
+        id: string;
+        name: string;
+        app_mode: string;
+        category: string;
+        integration_url: string;
+        verification_status: string;
+      }>;
+      rp_registration: Array<{
+        __typename?: "rp_registration";
+        rp_id: string;
+        mode: unknown;
+        status: unknown;
+        signer_address?: string | null;
+        staging_status?: unknown | null;
+      }>;
+    }>;
+  } | null;
+};
+
+export const McpTeamContextDocument = gql`
+  query McpTeamContext($team_id: String!) {
+    team_by_pk(id: $team_id) {
+      id
+      name
+      apps(
+        where: { deleted_at: { _is_null: true } }
+        order_by: { created_at: desc }
+      ) {
+        id
+        name
+        engine
+        is_staging
+        status
+        created_at
+        app_metadata(
+          where: { verification_status: { _neq: "verified" } }
+          order_by: { created_at: desc }
+          limit: 1
+        ) {
+          id
+          name
+          app_mode
+          category
+          integration_url
+          verification_status
+        }
+        rp_registration {
+          rp_id
+          mode
+          status
+          signer_address
+          staging_status
+        }
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    McpTeamContext(
+      variables: McpTeamContextQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<McpTeamContextQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<McpTeamContextQuery>(
+            McpTeamContextDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "McpTeamContext",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/mcp/graphql/team-context.graphql
+++ b/web/api/mcp/graphql/team-context.graphql
@@ -1,0 +1,36 @@
+query McpTeamContext($team_id: String!) {
+  team_by_pk(id: $team_id) {
+    id
+    name
+    apps(
+      where: { deleted_at: { _is_null: true } }
+      order_by: { created_at: desc }
+    ) {
+      id
+      name
+      engine
+      is_staging
+      status
+      created_at
+      app_metadata(
+        where: { verification_status: { _neq: "verified" } }
+        order_by: { created_at: desc }
+        limit: 1
+      ) {
+        id
+        name
+        app_mode
+        category
+        integration_url
+        verification_status
+      }
+      rp_registration {
+        rp_id
+        mode
+        status
+        signer_address
+        staging_status
+      }
+    }
+  }
+}

--- a/web/api/mcp/graphql/update-app-metadata.generated.ts
+++ b/web/api/mcp/graphql/update-app-metadata.generated.ts
@@ -1,0 +1,115 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type McpUpdateAppMetadataMutationVariables = Types.Exact<{
+  app_metadata_id: Types.Scalars["String"]["input"];
+  set: Types.App_Metadata_Set_Input;
+}>;
+
+export type McpUpdateAppMetadataMutation = {
+  __typename?: "mutation_root";
+  update_app_metadata_by_pk?: {
+    __typename?: "app_metadata";
+    id: string;
+    app_id: string;
+    name: string;
+    short_name: string;
+    app_mode: string;
+    category: string;
+    integration_url: string;
+    app_website_url: string;
+    support_link: string;
+    content_card_image_url: string;
+    description: string;
+    hero_image_url: string;
+    is_android_only: boolean;
+    is_for_humans_only: boolean;
+    logo_img_url: string;
+    meta_tag_image_url: string;
+    showcase_img_urls?: Array<string> | null;
+    world_app_description: string;
+    world_app_button_text: string;
+    verification_status: string;
+    supported_countries?: Array<string> | null;
+    supported_languages?: Array<string> | null;
+    is_developer_allow_listing: boolean;
+  } | null;
+};
+
+export const McpUpdateAppMetadataDocument = gql`
+  mutation McpUpdateAppMetadata(
+    $app_metadata_id: String!
+    $set: app_metadata_set_input!
+  ) {
+    update_app_metadata_by_pk(
+      pk_columns: { id: $app_metadata_id }
+      _set: $set
+    ) {
+      id
+      app_id
+      name
+      short_name
+      app_mode
+      category
+      integration_url
+      app_website_url
+      support_link
+      content_card_image_url
+      description
+      hero_image_url
+      is_android_only
+      is_for_humans_only
+      logo_img_url
+      meta_tag_image_url
+      showcase_img_urls
+      world_app_description
+      world_app_button_text
+      verification_status
+      supported_countries
+      supported_languages
+      is_developer_allow_listing
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    McpUpdateAppMetadata(
+      variables: McpUpdateAppMetadataMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<McpUpdateAppMetadataMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<McpUpdateAppMetadataMutation>(
+            McpUpdateAppMetadataDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "McpUpdateAppMetadata",
+        "mutation",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/mcp/graphql/update-app-metadata.graphql
+++ b/web/api/mcp/graphql/update-app-metadata.graphql
@@ -1,0 +1,30 @@
+mutation McpUpdateAppMetadata(
+  $app_metadata_id: String!
+  $set: app_metadata_set_input!
+) {
+  update_app_metadata_by_pk(pk_columns: { id: $app_metadata_id }, _set: $set) {
+    id
+    app_id
+    name
+    short_name
+    app_mode
+    category
+    integration_url
+    app_website_url
+    support_link
+    content_card_image_url
+    description
+    hero_image_url
+    is_android_only
+    is_for_humans_only
+    logo_img_url
+    meta_tag_image_url
+    showcase_img_urls
+    world_app_description
+    world_app_button_text
+    verification_status
+    supported_countries
+    supported_languages
+    is_developer_allow_listing
+  }
+}

--- a/web/api/mcp/graphql/upsert-action-v4.generated.ts
+++ b/web/api/mcp/graphql/upsert-action-v4.generated.ts
@@ -1,0 +1,91 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type McpUpsertActionV4MutationVariables = Types.Exact<{
+  rp_id: Types.Scalars["String"]["input"];
+  action: Types.Scalars["String"]["input"];
+  description: Types.Scalars["String"]["input"];
+  environment: Types.Scalars["action_environment"]["input"];
+}>;
+
+export type McpUpsertActionV4Mutation = {
+  __typename?: "mutation_root";
+  insert_action_v4_one?: {
+    __typename?: "action_v4";
+    id: string;
+    rp_id: string;
+    action: string;
+    description: string;
+    environment: unknown;
+  } | null;
+};
+
+export const McpUpsertActionV4Document = gql`
+  mutation McpUpsertActionV4(
+    $rp_id: String!
+    $action: String!
+    $description: String!
+    $environment: action_environment!
+  ) {
+    insert_action_v4_one(
+      object: {
+        rp_id: $rp_id
+        action: $action
+        description: $description
+        environment: $environment
+      }
+      on_conflict: {
+        constraint: action_v4_rp_id_action_environment_key
+        update_columns: [description]
+      }
+    ) {
+      id
+      rp_id
+      action
+      description
+      environment
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    McpUpsertActionV4(
+      variables: McpUpsertActionV4MutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<McpUpsertActionV4Mutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<McpUpsertActionV4Mutation>(
+            McpUpsertActionV4Document,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "McpUpsertActionV4",
+        "mutation",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/mcp/graphql/upsert-action-v4.graphql
+++ b/web/api/mcp/graphql/upsert-action-v4.graphql
@@ -1,0 +1,25 @@
+mutation McpUpsertActionV4(
+  $rp_id: String!
+  $action: String!
+  $description: String!
+  $environment: action_environment!
+) {
+  insert_action_v4_one(
+    object: {
+      rp_id: $rp_id
+      action: $action
+      description: $description
+      environment: $environment
+    }
+    on_conflict: {
+      constraint: action_v4_rp_id_action_environment_key
+      update_columns: [description]
+    }
+  ) {
+    id
+    rp_id
+    action
+    description
+    environment
+  }
+}

--- a/web/api/mcp/graphql/upsert-rp-registration.generated.ts
+++ b/web/api/mcp/graphql/upsert-rp-registration.generated.ts
@@ -40,7 +40,7 @@ export const McpUpsertRpRegistrationDocument = gql`
       }
       on_conflict: {
         constraint: rp_registration_app_id_key
-        update_columns: [mode, signer_address, status]
+        update_columns: [signer_address]
       }
     ) {
       rp_id

--- a/web/api/mcp/graphql/upsert-rp-registration.generated.ts
+++ b/web/api/mcp/graphql/upsert-rp-registration.generated.ts
@@ -1,0 +1,92 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type McpUpsertRpRegistrationMutationVariables = Types.Exact<{
+  rp_id: Types.Scalars["String"]["input"];
+  app_id: Types.Scalars["String"]["input"];
+  mode: Types.Scalars["rp_registration_mode"]["input"];
+  signer_address?: Types.InputMaybe<Types.Scalars["String"]["input"]>;
+}>;
+
+export type McpUpsertRpRegistrationMutation = {
+  __typename?: "mutation_root";
+  insert_rp_registration_one?: {
+    __typename?: "rp_registration";
+    rp_id: string;
+    app_id: string;
+    mode: unknown;
+    signer_address?: string | null;
+    status: unknown;
+  } | null;
+};
+
+export const McpUpsertRpRegistrationDocument = gql`
+  mutation McpUpsertRpRegistration(
+    $rp_id: String!
+    $app_id: String!
+    $mode: rp_registration_mode!
+    $signer_address: String
+  ) {
+    insert_rp_registration_one(
+      object: {
+        rp_id: $rp_id
+        app_id: $app_id
+        mode: $mode
+        signer_address: $signer_address
+        status: pending
+      }
+      on_conflict: {
+        constraint: rp_registration_app_id_key
+        update_columns: [mode, signer_address, status]
+      }
+    ) {
+      rp_id
+      app_id
+      mode
+      signer_address
+      status
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    McpUpsertRpRegistration(
+      variables: McpUpsertRpRegistrationMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<McpUpsertRpRegistrationMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<McpUpsertRpRegistrationMutation>(
+            McpUpsertRpRegistrationDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "McpUpsertRpRegistration",
+        "mutation",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/mcp/graphql/upsert-rp-registration.graphql
+++ b/web/api/mcp/graphql/upsert-rp-registration.graphql
@@ -14,7 +14,7 @@ mutation McpUpsertRpRegistration(
     }
     on_conflict: {
       constraint: rp_registration_app_id_key
-      update_columns: [mode, signer_address, status]
+      update_columns: [signer_address]
     }
   ) {
     rp_id

--- a/web/api/mcp/graphql/upsert-rp-registration.graphql
+++ b/web/api/mcp/graphql/upsert-rp-registration.graphql
@@ -1,0 +1,26 @@
+mutation McpUpsertRpRegistration(
+  $rp_id: String!
+  $app_id: String!
+  $mode: rp_registration_mode!
+  $signer_address: String
+) {
+  insert_rp_registration_one(
+    object: {
+      rp_id: $rp_id
+      app_id: $app_id
+      mode: $mode
+      signer_address: $signer_address
+      status: pending
+    }
+    on_conflict: {
+      constraint: rp_registration_app_id_key
+      update_columns: [mode, signer_address, status]
+    }
+  ) {
+    rp_id
+    app_id
+    mode
+    signer_address
+    status
+  }
+}

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -12,6 +12,14 @@ import { getSdk as getMcpUpsertRpRegistrationSdk } from "@/api/mcp/graphql/upser
 import { generateRpIdString } from "@/api/helpers/rp-utils";
 import { CategoryNameIterable } from "@/lib/categories";
 import { logger } from "@/lib/logger";
+import { mainAppStoreFormReviewSubmitSchema } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/FormSchema/form-schema";
+import { LocalisationData } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/types/AppStoreFormTypes";
+import { getSupportType } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/utils";
+import {
+  getLocalisationFormValues,
+  transformMailtoToRawEmail,
+} from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/utils/dataTransforms";
+import { getSdk as getReviewAppMetadataSdk } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/graphql/server/fetch-review-app-metadata.generated";
 import { Wallet } from "ethers";
 import { GraphQLClient } from "graphql-request";
 import { NextRequest, NextResponse } from "next/server";
@@ -339,6 +347,13 @@ const rotateWorldIdSigningKey = async (input: unknown, ctx: ToolContext) => {
     throw new McpError("World ID is not configured for this app.", -32004);
   }
 
+  if (registration.mode !== "self_managed") {
+    throw new McpError(
+      "Managed (platform) signing keys must be rotated from the developer portal UI so the on-chain signer is updated. The MCP can only rotate self-managed keys.",
+      -32004,
+    );
+  }
+
   const signingKey = makeWallet(args.signer_private_key);
   const data = await getMcpUpsertRpRegistrationSdk(
     ctx.client,
@@ -560,6 +575,56 @@ const tools = {
     }
     if (metadata.verification_status !== "unverified") {
       throw new McpError("Only unverified apps can be submitted.", -32004);
+    }
+
+    const reviewData = await getReviewAppMetadataSdk(
+      ctx.client,
+    ).FetchAppMetadataById({ app_metadata_id: metadata.id });
+    const reviewMetadata = reviewData.app_metadata[0];
+    if (!reviewMetadata) {
+      throw new McpError(
+        "App metadata not found or not in unverified state.",
+        -32004,
+      );
+    }
+
+    const localisations = getLocalisationFormValues(
+      reviewMetadata,
+      reviewData.localisations as LocalisationData,
+    );
+    const supportLinkOrEmail = reviewMetadata.support_link;
+    const supportType = getSupportType(supportLinkOrEmail);
+    const supportLink = supportType === "link" ? supportLinkOrEmail : "";
+    const rawSupportEmail =
+      supportType === "email"
+        ? transformMailtoToRawEmail(supportLinkOrEmail)
+        : "";
+
+    try {
+      await mainAppStoreFormReviewSubmitSchema.validate(
+        {
+          ...reviewMetadata,
+          support_type: supportType,
+          support_link: supportLink,
+          support_email: rawSupportEmail,
+          localisations,
+        },
+        {
+          abortEarly: false,
+          strict: true,
+          stripUnknown: true,
+          context: { isMiniApp: reviewMetadata.app_mode === "mini-app" },
+        },
+      );
+    } catch (error) {
+      if (error instanceof yup.ValidationError) {
+        throw new McpError(
+          "App metadata is incomplete and cannot be submitted for review.",
+          -32602,
+          error.errors,
+        );
+      }
+      throw error;
     }
 
     const data = await getMcpSubmitAppForReviewSdk(

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -1,0 +1,954 @@
+import { errorResponse } from "@/api/helpers/errors";
+import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { logPortalEvent } from "@/api/helpers/portal-events";
+import { verifyHashedSecret } from "@/api/helpers/utils";
+import { CategoryNameIterable } from "@/lib/categories";
+import { generateRpIdString } from "@/api/helpers/rp-utils";
+import { logger } from "@/lib/logger";
+import { Wallet } from "ethers";
+import { GraphQLClient, gql } from "graphql-request";
+import { NextRequest, NextResponse } from "next/server";
+import * as yup from "yup";
+
+type JsonRpcRequest = {
+  jsonrpc?: "2.0";
+  id?: string | number | null;
+  method?: string;
+  params?: any;
+};
+
+type McpAuthContext = {
+  apiKeyId: string;
+  teamId: string;
+};
+
+type ToolContext = McpAuthContext & {
+  client: GraphQLClient;
+};
+
+class McpError extends Error {
+  constructor(
+    message: string,
+    public code = -32000,
+    public data?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+const AUTHENTICATE_API_KEY = gql`
+  query AuthenticateApiKey($id: String!) {
+    api_key_by_pk(id: $id) {
+      id
+      api_key
+      is_active
+      team_id
+    }
+  }
+`;
+
+const GET_TEAM_CONTEXT = gql`
+  query McpTeamContext($team_id: String!) {
+    team_by_pk(id: $team_id) {
+      id
+      name
+      apps(
+        where: { deleted_at: { _is_null: true } }
+        order_by: { created_at: desc }
+      ) {
+        id
+        name
+        engine
+        is_staging
+        status
+        created_at
+        app_metadata(
+          where: { verification_status: { _neq: "verified" } }
+          order_by: { created_at: desc }
+          limit: 1
+        ) {
+          id
+          name
+          app_mode
+          category
+          integration_url
+          verification_status
+        }
+        rp_registration {
+          rp_id
+          mode
+          status
+          signer_address
+          staging_status
+        }
+      }
+    }
+  }
+`;
+
+const GET_APP_CONTEXT = gql`
+  query McpAppContext($team_id: String!, $app_id: String!) {
+    app(
+      where: {
+        id: { _eq: $app_id }
+        team_id: { _eq: $team_id }
+        deleted_at: { _is_null: true }
+      }
+      limit: 1
+    ) {
+      id
+      name
+      engine
+      is_staging
+      status
+      app_metadata(
+        where: { verification_status: { _neq: "verified" } }
+        order_by: { created_at: desc }
+        limit: 1
+      ) {
+        id
+        name
+        short_name
+        app_mode
+        category
+        integration_url
+        app_website_url
+        support_link
+        world_app_description
+        world_app_button_text
+        verification_status
+        is_developer_allow_listing
+        supported_countries
+        supported_languages
+      }
+      rp_registration {
+        rp_id
+        mode
+        status
+        signer_address
+        staging_status
+        actions_v4(order_by: { created_at: desc }) {
+          id
+          action
+          description
+          environment
+        }
+      }
+    }
+  }
+`;
+
+const CREATE_APP = gql`
+  mutation McpCreateApp(
+    $team_id: String!
+    $name: String!
+    $engine: String!
+    $is_staging: Boolean!
+    $category: String!
+    $integration_url: String!
+    $app_mode: String!
+  ) {
+    insert_app_one(
+      object: {
+        engine: $engine
+        name: $name
+        is_staging: $is_staging
+        team_id: $team_id
+        app_metadata: {
+          data: {
+            name: $name
+            integration_url: $integration_url
+            app_mode: $app_mode
+            category: $category
+          }
+        }
+      }
+    ) {
+      id
+      name
+      is_staging
+      engine
+      app_metadata(order_by: { created_at: desc }, limit: 1) {
+        id
+        app_mode
+        category
+        integration_url
+      }
+    }
+  }
+`;
+
+const UPSERT_RP_REGISTRATION = gql`
+  mutation McpUpsertRpRegistration(
+    $rp_id: String!
+    $app_id: String!
+    $mode: rp_registration_mode!
+    $signer_address: String
+  ) {
+    insert_rp_registration_one(
+      object: {
+        rp_id: $rp_id
+        app_id: $app_id
+        mode: $mode
+        signer_address: $signer_address
+        status: pending
+      }
+      on_conflict: {
+        constraint: rp_registration_app_id_key
+        update_columns: [mode, signer_address, status]
+      }
+    ) {
+      rp_id
+      app_id
+      mode
+      signer_address
+      status
+    }
+  }
+`;
+
+const UPSERT_ACTION_V4 = gql`
+  mutation McpUpsertActionV4(
+    $rp_id: String!
+    $action: String!
+    $description: String!
+    $environment: String!
+  ) {
+    insert_action_v4_one(
+      object: {
+        rp_id: $rp_id
+        action: $action
+        description: $description
+        environment: $environment
+      }
+      on_conflict: {
+        constraint: action_v4_rp_id_action_environment_key
+        update_columns: [description]
+      }
+    ) {
+      id
+      rp_id
+      action
+      description
+      environment
+    }
+  }
+`;
+
+const UPDATE_APP_METADATA = gql`
+  mutation McpUpdateAppMetadata(
+    $app_metadata_id: String!
+    $set: app_metadata_set_input!
+  ) {
+    update_app_metadata_by_pk(
+      pk_columns: { id: $app_metadata_id }
+      _set: $set
+    ) {
+      id
+      app_id
+      name
+      short_name
+      app_mode
+      category
+      integration_url
+      app_website_url
+      support_link
+      world_app_description
+      world_app_button_text
+      verification_status
+      supported_countries
+      supported_languages
+      is_developer_allow_listing
+    }
+  }
+`;
+
+const SUBMIT_APP_FOR_REVIEW = gql`
+  mutation McpSubmitAppForReview(
+    $app_metadata_id: String!
+    $is_developer_allow_listing: Boolean!
+    $changelog: String!
+  ) {
+    update_app_metadata_by_pk(
+      pk_columns: { id: $app_metadata_id }
+      _set: {
+        verification_status: "awaiting_review"
+        is_developer_allow_listing: $is_developer_allow_listing
+        changelog: $changelog
+      }
+    ) {
+      id
+      app_id
+      verification_status
+      is_developer_allow_listing
+    }
+  }
+`;
+
+const toolDefinitions = [
+  {
+    name: "get_team_context",
+    description: "Fetch the Dev Portal team and app context for this API key.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_app_config",
+    description: "Fetch app, World ID, Mini App, and app store configuration.",
+    inputSchema: {
+      type: "object",
+      properties: { app_id: { type: "string" } },
+      required: ["app_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "create_app",
+    description: "Create an external World ID app or Mini App.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        app_mode: { type: "string", enum: ["external", "mini-app"] },
+        integration_url: { type: "string" },
+        category: { type: "string" },
+        build: { type: "string", enum: ["production", "staging"] },
+        verification: { type: "string", enum: ["cloud", "on-chain"] },
+      },
+      required: ["name"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "configure_world_id",
+    description:
+      "Create or update World ID 4.0 RP config and optionally generate a signing key.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        app_id: { type: "string" },
+        mode: { type: "string", enum: ["managed", "self_managed"] },
+        signer_private_key: { type: "string" },
+        generate_signing_key: { type: "boolean" },
+      },
+      required: ["app_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_world_id_signing_key",
+    description:
+      "Fetch signer address. Private keys are only returned on MCP generation/rotation.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        app_id: { type: "string" },
+        rotate_if_unavailable: { type: "boolean" },
+      },
+      required: ["app_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "rotate_world_id_signing_key",
+    description: "Generate or set a new World ID signing key for an app.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        app_id: { type: "string" },
+        signer_private_key: { type: "string" },
+      },
+      required: ["app_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "create_world_id_action",
+    description: "Create or update a World ID 4.0 action for an app.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        app_id: { type: "string" },
+        action: { type: "string" },
+        description: { type: "string" },
+        environment: { type: "string", enum: ["production", "staging"] },
+      },
+      required: ["app_id", "action"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "configure_mini_app",
+    description: "Update Mini App portal settings and app store metadata.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        app_id: { type: "string" },
+        name: { type: "string" },
+        short_name: { type: "string" },
+        integration_url: { type: "string" },
+        category: { type: "string" },
+        app_website_url: { type: "string" },
+        support_link: { type: "string" },
+        world_app_description: { type: "string" },
+        world_app_button_text: { type: "string" },
+        supported_countries: { type: "array", items: { type: "string" } },
+        supported_languages: { type: "array", items: { type: "string" } },
+        is_developer_allow_listing: { type: "boolean" },
+      },
+      required: ["app_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "submit_app_for_review",
+    description:
+      "Submit an app for review after explicit confirmation from the user.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        app_id: { type: "string" },
+        confirm_submission: { type: "boolean" },
+        changelog: { type: "string" },
+        is_developer_allow_listing: { type: "boolean" },
+      },
+      required: ["app_id", "confirm_submission"],
+      additionalProperties: false,
+    },
+  },
+];
+
+const appIdSchema = yup.object({ app_id: yup.string().required() }).noUnknown();
+
+const createAppSchema = yup
+  .object({
+    name: yup.string().trim().required(),
+    app_mode: yup.string().oneOf(["external", "mini-app"]).default("external"),
+    integration_url: yup
+      .string()
+      .url()
+      .matches(/^https:\/\//)
+      .default("https://docs.world.org/"),
+    category: yup.string().optional(),
+    build: yup.string().oneOf(["production", "staging"]).default("production"),
+    verification: yup.string().oneOf(["cloud", "on-chain"]).default("cloud"),
+  })
+  .noUnknown();
+
+const configureWorldIdSchema = yup
+  .object({
+    app_id: yup.string().required(),
+    mode: yup.string().oneOf(["managed", "self_managed"]).default("managed"),
+    signer_private_key: yup.string().optional(),
+    generate_signing_key: yup.boolean().default(true),
+  })
+  .noUnknown();
+
+const createActionSchema = yup
+  .object({
+    app_id: yup.string().required(),
+    action: yup.string().trim().required(),
+    description: yup.string().default(""),
+    environment: yup
+      .string()
+      .oneOf(["production", "staging"])
+      .default("production"),
+  })
+  .noUnknown();
+
+const configureMiniAppSchema = yup
+  .object({
+    app_id: yup.string().required(),
+    name: yup.string().optional(),
+    short_name: yup.string().optional(),
+    integration_url: yup
+      .string()
+      .url()
+      .matches(/^https:\/\//)
+      .optional(),
+    category: yup.string().oneOf(CategoryNameIterable).optional(),
+    app_website_url: yup.string().url().optional(),
+    support_link: yup.string().optional(),
+    world_app_description: yup.string().optional(),
+    world_app_button_text: yup.string().optional(),
+    supported_countries: yup.array().of(yup.string().length(2)).optional(),
+    supported_languages: yup.array().of(yup.string()).optional(),
+    is_developer_allow_listing: yup.boolean().optional(),
+  })
+  .noUnknown();
+
+const submitAppSchema = yup
+  .object({
+    app_id: yup.string().required(),
+    confirm_submission: yup.boolean().oneOf([true]).required(),
+    changelog: yup.string().default("Submitted via MCP"),
+    is_developer_allow_listing: yup.boolean().default(false),
+  })
+  .noUnknown();
+
+const parseApiKey = (req: NextRequest) => {
+  const raw = req.headers.get("authorization")?.split(/\s+/).at(-1);
+  if (!raw) {
+    throw new McpError("API key is required.", -32001);
+  }
+
+  const decoded = Buffer.from(raw.replace(/^api_/, ""), "base64").toString(
+    "utf8",
+  );
+  const [id, secret] = decoded.split(":");
+
+  if (!id || !secret) {
+    throw new McpError("Invalid API key format.", -32001);
+  }
+
+  return { id, secret };
+};
+
+const authenticate = async (req: NextRequest): Promise<McpAuthContext> => {
+  const { id, secret } = parseApiKey(req);
+  const client = await getAPIServiceGraphqlClient();
+  const result = await client.request<{
+    api_key_by_pk?: {
+      id: string;
+      api_key: string;
+      is_active: boolean;
+      team_id: string;
+    } | null;
+  }>(AUTHENTICATE_API_KEY, { id });
+
+  const apiKey = result.api_key_by_pk;
+  if (!apiKey) {
+    throw new McpError("API key not found.", -32001);
+  }
+  if (!apiKey.is_active) {
+    throw new McpError("API key is inactive.", -32001);
+  }
+  if (!verifyHashedSecret(apiKey.id, secret, apiKey.api_key)) {
+    throw new McpError("API key is not valid.", -32001);
+  }
+
+  return { apiKeyId: apiKey.id, teamId: apiKey.team_id };
+};
+
+const parseInput = async <T>(schema: yup.Schema<T>, value: unknown) => {
+  try {
+    return await schema.validate(value ?? {}, {
+      abortEarly: false,
+      stripUnknown: true,
+      strict: true,
+    });
+  } catch (error) {
+    if (error instanceof yup.ValidationError) {
+      throw new McpError("Invalid tool input.", -32602, error.errors);
+    }
+    throw error;
+  }
+};
+
+const content = (value: unknown) => ({
+  content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+});
+
+const requireApp = async (
+  client: GraphQLClient,
+  teamId: string,
+  appId: string,
+) => {
+  const data = await client.request<{ app: any[] }>(GET_APP_CONTEXT, {
+    team_id: teamId,
+    app_id: appId,
+  });
+  const app = data.app[0];
+  if (!app) {
+    throw new McpError("App not found for this API key.", -32004);
+  }
+  return app;
+};
+
+const makeWallet = (privateKey?: string) => {
+  const wallet = privateKey ? new Wallet(privateKey) : Wallet.createRandom();
+  return {
+    private_key: wallet.privateKey,
+    signer_address: wallet.address,
+  };
+};
+
+const tools: Record<
+  string,
+  (input: unknown, ctx: ToolContext) => Promise<any>
+> = {
+  get_team_context: async (_input, ctx) => {
+    const data = await ctx.client.request(GET_TEAM_CONTEXT, {
+      team_id: ctx.teamId,
+    });
+    return content(data);
+  },
+
+  get_app_config: async (input, ctx) => {
+    const { app_id } = await parseInput(appIdSchema, input);
+    const app = await requireApp(ctx.client, ctx.teamId, app_id);
+    return content({
+      app,
+      verify_endpoint: app.rp_registration[0]
+        ? `/api/v4/verify/${app.rp_registration[0].rp_id}`
+        : null,
+      proof_context_endpoint: app.rp_registration[0]
+        ? `/api/v4/proof-context/${app.rp_registration[0].rp_id}`
+        : null,
+    });
+  },
+
+  create_app: async (input, ctx) => {
+    const args = await parseInput(createAppSchema, input);
+    const category =
+      args.category ?? (args.app_mode === "mini-app" ? "Other" : "External");
+
+    if (!CategoryNameIterable.includes(category as any)) {
+      throw new McpError("Invalid app category.", -32602);
+    }
+
+    const data = await ctx.client.request<{ insert_app_one: any }>(CREATE_APP, {
+      team_id: ctx.teamId,
+      name: args.name,
+      is_staging: args.build === "staging",
+      engine: args.verification,
+      category,
+      integration_url: args.integration_url,
+      app_mode: args.app_mode,
+    });
+
+    const app = data.insert_app_one;
+    logPortalEvent({
+      event: "app_creation",
+      actor: "mcp",
+      team_id: ctx.teamId,
+      app_id: app?.id,
+      metadata: {
+        environment: args.build,
+        engine: args.verification,
+        app_mode: args.app_mode,
+      },
+    });
+
+    return content({ app });
+  },
+
+  configure_world_id: async (input, ctx) => {
+    const args = await parseInput(configureWorldIdSchema, input);
+    const app = await requireApp(ctx.client, ctx.teamId, args.app_id);
+    const existingRegistration = app.rp_registration[0];
+    if (existingRegistration) {
+      return content({
+        rp_registration: existingRegistration,
+        signing_key: null,
+        verify_endpoint: `/api/v4/verify/${existingRegistration.rp_id}`,
+        proof_context_endpoint: `/api/v4/proof-context/${existingRegistration.rp_id}`,
+        message:
+          "World ID is already configured. Use rotate_world_id_signing_key to generate a new private signing key.",
+      });
+    }
+
+    const signingKey =
+      args.mode === "managed" && args.generate_signing_key
+        ? makeWallet(args.signer_private_key)
+        : args.signer_private_key
+          ? makeWallet(args.signer_private_key)
+          : null;
+
+    const data = await ctx.client.request<{ insert_rp_registration_one: any }>(
+      UPSERT_RP_REGISTRATION,
+      {
+        rp_id: generateRpIdString(args.app_id),
+        app_id: args.app_id,
+        mode: args.mode,
+        signer_address: signingKey?.signer_address ?? null,
+      },
+    );
+
+    return content({
+      rp_registration: data.insert_rp_registration_one,
+      signing_key: signingKey,
+      verify_endpoint: `/api/v4/verify/${data.insert_rp_registration_one.rp_id}`,
+      proof_context_endpoint: `/api/v4/proof-context/${data.insert_rp_registration_one.rp_id}`,
+      warning:
+        "Private keys are returned only at generation/rotation time. Store the private_key securely in the app environment.",
+    });
+  },
+
+  get_world_id_signing_key: async (input, ctx) => {
+    const args = await parseInput(
+      appIdSchema.shape({
+        rotate_if_unavailable: yup.boolean().default(false),
+      }),
+      input,
+    );
+    const app = await requireApp(ctx.client, ctx.teamId, args.app_id);
+    const registration = app.rp_registration[0];
+    if (!registration) {
+      throw new McpError("World ID is not configured for this app.", -32004);
+    }
+
+    if (args.rotate_if_unavailable) {
+      return tools.rotate_world_id_signing_key(input, ctx);
+    }
+
+    return content({
+      rp_id: registration.rp_id,
+      signer_address: registration.signer_address,
+      private_key: null,
+      message:
+        "Existing private signing keys are not recoverable. Use rotate_world_id_signing_key to generate a new key.",
+    });
+  },
+
+  rotate_world_id_signing_key: async (input, ctx) => {
+    const args = await parseInput(
+      appIdSchema.shape({ signer_private_key: yup.string().optional() }),
+      input,
+    );
+    const app = await requireApp(ctx.client, ctx.teamId, args.app_id);
+    const registration = app.rp_registration[0];
+    if (!registration) {
+      throw new McpError("World ID is not configured for this app.", -32004);
+    }
+
+    const signingKey = makeWallet(args.signer_private_key);
+    const data = await ctx.client.request<{ insert_rp_registration_one: any }>(
+      UPSERT_RP_REGISTRATION,
+      {
+        rp_id: registration.rp_id,
+        app_id: args.app_id,
+        mode: registration.mode,
+        signer_address: signingKey.signer_address,
+      },
+    );
+
+    return content({
+      rp_registration: data.insert_rp_registration_one,
+      signing_key: signingKey,
+      warning:
+        "Store private_key securely. It is not recoverable after this response.",
+    });
+  },
+
+  create_world_id_action: async (input, ctx) => {
+    const args = await parseInput(createActionSchema, input);
+    const app = await requireApp(ctx.client, ctx.teamId, args.app_id);
+    const registration = app.rp_registration[0];
+    if (!registration?.rp_id) {
+      throw new McpError("World ID is not configured for this app.", -32004);
+    }
+
+    const data = await ctx.client.request<{ insert_action_v4_one: any }>(
+      UPSERT_ACTION_V4,
+      {
+        rp_id: registration.rp_id,
+        action: args.action,
+        description: args.description,
+        environment: args.environment,
+      },
+    );
+
+    logPortalEvent({
+      event: "action_creation",
+      actor: "mcp",
+      team_id: ctx.teamId,
+      app_id: args.app_id,
+      action: args.action,
+      metadata: { environment: args.environment, action_version: "v4" },
+    });
+
+    return content({
+      action: data.insert_action_v4_one,
+      registration_status: registration.status,
+    });
+  },
+
+  configure_mini_app: async (input, ctx) => {
+    const args = await parseInput(configureMiniAppSchema, input);
+    const app = await requireApp(ctx.client, ctx.teamId, args.app_id);
+    const metadata = app.app_metadata[0];
+    if (!metadata) {
+      throw new McpError("Editable app metadata not found.", -32004);
+    }
+    if (metadata.verification_status === "verified") {
+      throw new McpError("Verified app metadata cannot be edited.", -32004);
+    }
+
+    const { app_id: _appId, ...rest } = args;
+    const set = Object.fromEntries(
+      Object.entries({
+        ...rest,
+        app_mode: "mini-app",
+      }).filter(([, value]) => value !== undefined),
+    );
+
+    const data = await ctx.client.request<{ update_app_metadata_by_pk: any }>(
+      UPDATE_APP_METADATA,
+      {
+        app_metadata_id: metadata.id,
+        set,
+      },
+    );
+
+    return content({ app_metadata: data.update_app_metadata_by_pk });
+  },
+
+  submit_app_for_review: async (input, ctx) => {
+    const args = await parseInput(submitAppSchema, input);
+    const app = await requireApp(ctx.client, ctx.teamId, args.app_id);
+    if (app.is_staging) {
+      throw new McpError(
+        "Staging apps cannot be submitted for review.",
+        -32004,
+      );
+    }
+
+    const metadata = app.app_metadata[0];
+    if (!metadata) {
+      throw new McpError("Editable app metadata not found.", -32004);
+    }
+    if (metadata.verification_status !== "unverified") {
+      throw new McpError("Only unverified apps can be submitted.", -32004);
+    }
+
+    const data = await ctx.client.request<{
+      update_app_metadata_by_pk: any;
+    }>(SUBMIT_APP_FOR_REVIEW, {
+      app_metadata_id: metadata.id,
+      is_developer_allow_listing: args.is_developer_allow_listing,
+      changelog: args.changelog,
+    });
+
+    logPortalEvent({
+      event: "app_submission",
+      actor: "mcp",
+      team_id: ctx.teamId,
+      app_id: args.app_id,
+      metadata: {
+        is_developer_allow_listing: args.is_developer_allow_listing,
+      },
+    });
+
+    return content({ app_metadata: data.update_app_metadata_by_pk });
+  },
+};
+
+const handleJsonRpc = async (req: NextRequest, message: JsonRpcRequest) => {
+  if (message.method === "initialize") {
+    return {
+      protocolVersion: "2025-06-18",
+      capabilities: { tools: {} },
+      serverInfo: { name: "world-developer-portal", version: "0.1.0" },
+    };
+  }
+
+  if (message.method === "tools/list") {
+    await authenticate(req);
+    return { tools: toolDefinitions };
+  }
+
+  if (message.method === "tools/call") {
+    const auth = await authenticate(req);
+    const client = await getAPIServiceGraphqlClient();
+    const name = message.params?.name;
+    const handler = tools[name];
+    if (!handler) {
+      throw new McpError(`Unknown tool: ${name}`, -32601);
+    }
+    return handler(message.params?.arguments, { ...auth, client });
+  }
+
+  if (message.method === "ping") {
+    return {};
+  }
+
+  throw new McpError(`Unsupported MCP method: ${message.method}`, -32601);
+};
+
+const jsonRpcResponse = (
+  id: JsonRpcRequest["id"],
+  result: unknown,
+  init?: ResponseInit,
+) =>
+  NextResponse.json(
+    {
+      jsonrpc: "2.0",
+      id,
+      result,
+    },
+    init,
+  );
+
+const jsonRpcError = (
+  id: JsonRpcRequest["id"],
+  error: McpError,
+  status = 200,
+) =>
+  NextResponse.json(
+    {
+      jsonrpc: "2.0",
+      id,
+      error: {
+        code: error.code,
+        message: error.message,
+        data: error.data,
+      },
+    },
+    { status },
+  );
+
+export const POST = async (req: NextRequest) => {
+  let message: JsonRpcRequest;
+  try {
+    message = await req.json();
+  } catch {
+    return errorResponse({
+      statusCode: 400,
+      code: "invalid_request",
+      detail: "Invalid JSON-RPC request body.",
+      attribute: null,
+      req,
+    });
+  }
+
+  if (message.id === undefined || message.id === null) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  try {
+    const result = await handleJsonRpc(req, message);
+    return jsonRpcResponse(message.id, await result);
+  } catch (error) {
+    if (error instanceof McpError) {
+      return jsonRpcError(message.id, error);
+    }
+
+    logger.error("Unhandled MCP error", {
+      error: error as Error,
+      method: message.method,
+    });
+    return jsonRpcError(
+      message.id,
+      new McpError("Internal MCP server error.", -32603),
+    );
+  }
+};
+
+export const GET = async () =>
+  NextResponse.json({
+    name: "world-developer-portal",
+    transport: "streamable-http",
+    endpoint: "/api/mcp",
+  });
+
+export const OPTIONS = async () =>
+  new NextResponse(null, {
+    status: 204,
+    headers: {
+      Allow: "GET, POST, OPTIONS",
+    },
+  });

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -570,7 +570,6 @@ const parseInput = async <T>(schema: yup.Schema<T>, value: unknown) => {
     return await schema.validate(value ?? {}, {
       abortEarly: false,
       stripUnknown: true,
-      strict: true,
     });
   } catch (error) {
     if (error instanceof yup.ValidationError) {
@@ -608,10 +607,37 @@ const makeWallet = (privateKey?: string) => {
   };
 };
 
-const tools: Record<
-  string,
-  (input: unknown, ctx: ToolContext) => Promise<any>
-> = {
+const rotateWorldIdSigningKey = async (input: unknown, ctx: ToolContext) => {
+  const args = await parseInput(
+    appIdSchema.shape({ signer_private_key: yup.string().optional() }),
+    input,
+  );
+  const app = await requireApp(ctx.client, ctx.teamId, args.app_id);
+  const registration = app.rp_registration[0];
+  if (!registration) {
+    throw new McpError("World ID is not configured for this app.", -32004);
+  }
+
+  const signingKey = makeWallet(args.signer_private_key);
+  const data = await ctx.client.request<{ insert_rp_registration_one: any }>(
+    UPSERT_RP_REGISTRATION,
+    {
+      rp_id: registration.rp_id,
+      app_id: args.app_id,
+      mode: registration.mode,
+      signer_address: signingKey.signer_address,
+    },
+  );
+
+  return content({
+    rp_registration: data.insert_rp_registration_one,
+    signing_key: signingKey,
+    warning:
+      "Store private_key securely. It is not recoverable after this response.",
+  });
+};
+
+const tools = {
   get_team_context: async (_input, ctx) => {
     const data = await ctx.client.request(GET_TEAM_CONTEXT, {
       team_id: ctx.teamId,
@@ -724,7 +750,7 @@ const tools: Record<
     }
 
     if (args.rotate_if_unavailable) {
-      return tools.rotate_world_id_signing_key(input, ctx);
+      return rotateWorldIdSigningKey({ app_id: args.app_id }, ctx);
     }
 
     return content({
@@ -736,35 +762,7 @@ const tools: Record<
     });
   },
 
-  rotate_world_id_signing_key: async (input, ctx) => {
-    const args = await parseInput(
-      appIdSchema.shape({ signer_private_key: yup.string().optional() }),
-      input,
-    );
-    const app = await requireApp(ctx.client, ctx.teamId, args.app_id);
-    const registration = app.rp_registration[0];
-    if (!registration) {
-      throw new McpError("World ID is not configured for this app.", -32004);
-    }
-
-    const signingKey = makeWallet(args.signer_private_key);
-    const data = await ctx.client.request<{ insert_rp_registration_one: any }>(
-      UPSERT_RP_REGISTRATION,
-      {
-        rp_id: registration.rp_id,
-        app_id: args.app_id,
-        mode: registration.mode,
-        signer_address: signingKey.signer_address,
-      },
-    );
-
-    return content({
-      rp_registration: data.insert_rp_registration_one,
-      signing_key: signingKey,
-      warning:
-        "Store private_key securely. It is not recoverable after this response.",
-    });
-  },
+  rotate_world_id_signing_key: rotateWorldIdSigningKey,
 
   create_world_id_action: async (input, ctx) => {
     const args = await parseInput(createActionSchema, input);
@@ -867,38 +865,89 @@ const tools: Record<
 
     return content({ app_metadata: data.update_app_metadata_by_pk });
   },
+} satisfies Record<string, (input: unknown, ctx: ToolContext) => Promise<any>>;
+
+type McpMethod = "initialize" | "ping" | "tools/list" | "tools/call";
+type ToolName = keyof typeof tools;
+
+const parseMcpMethod = (value: unknown): McpMethod => {
+  switch (value) {
+    case "initialize":
+    case "ping":
+    case "tools/list":
+    case "tools/call":
+      return value;
+    default:
+      throw new McpError(`Unsupported MCP method: ${String(value)}`, -32601);
+  }
+};
+
+const parseToolName = (value: unknown): ToolName => {
+  switch (value) {
+    case "get_team_context":
+    case "get_app_config":
+    case "create_app":
+    case "configure_world_id":
+    case "get_world_id_signing_key":
+    case "rotate_world_id_signing_key":
+    case "create_world_id_action":
+    case "configure_mini_app":
+    case "submit_app_for_review":
+      return value;
+    default:
+      throw new McpError(`Unknown tool: ${String(value)}`, -32601);
+  }
+};
+
+const executeTool = async (
+  name: ToolName,
+  input: unknown,
+  ctx: ToolContext,
+) => {
+  switch (name) {
+    case "get_team_context":
+      return tools.get_team_context(input, ctx);
+    case "get_app_config":
+      return tools.get_app_config(input, ctx);
+    case "create_app":
+      return tools.create_app(input, ctx);
+    case "configure_world_id":
+      return tools.configure_world_id(input, ctx);
+    case "get_world_id_signing_key":
+      return tools.get_world_id_signing_key(input, ctx);
+    case "rotate_world_id_signing_key":
+      return tools.rotate_world_id_signing_key(input, ctx);
+    case "create_world_id_action":
+      return tools.create_world_id_action(input, ctx);
+    case "configure_mini_app":
+      return tools.configure_mini_app(input, ctx);
+    case "submit_app_for_review":
+      return tools.submit_app_for_review(input, ctx);
+  }
 };
 
 const handleJsonRpc = async (req: NextRequest, message: JsonRpcRequest) => {
-  if (message.method === "initialize") {
-    return {
-      protocolVersion: "2025-06-18",
-      capabilities: { tools: {} },
-      serverInfo: { name: "world-developer-portal", version: "0.1.0" },
-    };
-  }
+  const method = parseMcpMethod(message.method);
+  const auth = await authenticate(req);
 
-  if (message.method === "tools/list") {
-    await authenticate(req);
-    return { tools: toolDefinitions };
-  }
-
-  if (message.method === "tools/call") {
-    const auth = await authenticate(req);
-    const client = await getAPIServiceGraphqlClient();
-    const name = message.params?.name;
-    const handler = tools[name];
-    if (!handler) {
-      throw new McpError(`Unknown tool: ${name}`, -32601);
+  switch (method) {
+    case "initialize":
+      return {
+        protocolVersion: "2025-06-18",
+        capabilities: { tools: {} },
+        serverInfo: { name: "world-developer-portal", version: "0.1.0" },
+      };
+    case "ping":
+      return {};
+    case "tools/list": {
+      return { tools: toolDefinitions };
     }
-    return handler(message.params?.arguments, { ...auth, client });
+    case "tools/call": {
+      const client = await getAPIServiceGraphqlClient();
+      const name = parseToolName(message.params?.name);
+      return executeTool(name, message.params?.arguments, { ...auth, client });
+    }
   }
-
-  if (message.method === "ping") {
-    return {};
-  }
-
-  throw new McpError(`Unsupported MCP method: ${message.method}`, -32601);
 };
 
 const jsonRpcResponse = (

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -1,5 +1,12 @@
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { logPortalEvent } from "@/api/helpers/portal-events";
+import {
+  generateRpIdString,
+  mapOnChainToDbStatus,
+  normalizeAddress,
+  parseRpId,
+} from "@/api/helpers/rp-utils";
+import { getRpFromContract } from "@/api/helpers/temporal-rpc";
 import { verifyHashedSecret } from "@/api/helpers/utils";
 import { getSdk as getMcpAppContextSdk } from "@/api/mcp/graphql/app-context.generated";
 import { getSdk as getMcpAuthenticateTeamSdk } from "@/api/mcp/graphql/authenticate-team.generated";
@@ -9,7 +16,8 @@ import { getSdk as getMcpTeamContextSdk } from "@/api/mcp/graphql/team-context.g
 import { getSdk as getMcpUpdateAppMetadataSdk } from "@/api/mcp/graphql/update-app-metadata.generated";
 import { getSdk as getMcpUpsertActionV4Sdk } from "@/api/mcp/graphql/upsert-action-v4.generated";
 import { getSdk as getMcpUpsertRpRegistrationSdk } from "@/api/mcp/graphql/upsert-rp-registration.generated";
-import { generateRpIdString } from "@/api/helpers/rp-utils";
+import { getSdk as getUpdateRpStatusSdk } from "@/api/v4/rp-status/[rp_id]/graphql/update-rp-status.generated";
+import { getSdk as getUpdateStagingStatusSdk } from "@/api/v4/rp-status/[rp_id]/graphql/update-staging-status.generated";
 import { CategoryNameIterable } from "@/lib/categories";
 import { logger } from "@/lib/logger";
 import { mainAppStoreFormReviewSubmitSchema } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/FormSchema/form-schema";
@@ -111,6 +119,19 @@ const toolDefinitions = [
       properties: {
         app_id: { type: "string" },
         rotate_if_unavailable: { type: "boolean" },
+      },
+      required: ["app_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_world_id_registration_status",
+    description:
+      "Fetch and sync World ID RP registration status from the registry contracts for an app.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        app_id: { type: "string" },
       },
       required: ["app_id"],
       additionalProperties: false,
@@ -333,6 +354,8 @@ const content = (value: unknown) => ({
   content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
 });
 
+const rpStatusEndpoint = (rpId: string) => `/api/v4/rp-status/${rpId}`;
+
 const requireApp = async (
   client: GraphQLClient,
   teamId: string,
@@ -347,6 +370,130 @@ const requireApp = async (
     throw new McpError("App not found for this API key.", -32004);
   }
   return app;
+};
+
+const syncWorldIdRegistrationStatus = async (
+  input: unknown,
+  ctx: ToolContext,
+) => {
+  const { app_id } = await parseInput(appIdSchema, input);
+  const app = await requireApp(ctx.client, ctx.teamId, app_id);
+  const registration = app.rp_registration[0];
+  if (!registration) {
+    throw new McpError("World ID is not configured for this app.", -32004);
+  }
+
+  const productionContractAddress = process.env.RP_REGISTRY_CONTRACT_ADDRESS;
+  if (!productionContractAddress) {
+    throw new McpError("RP Registry is not configured.", -32603);
+  }
+
+  const rpId = registration.rp_id;
+  const numericRpId = parseRpId(rpId);
+  const currentProductionStatus = registration.status as string;
+  const currentStagingStatus =
+    (registration.staging_status as string | null | undefined) ?? null;
+
+  let productionStatus = currentProductionStatus;
+  let productionInitialized = false;
+
+  try {
+    const productionRp = await getRpFromContract(
+      numericRpId,
+      productionContractAddress,
+    );
+    productionInitialized = productionRp.initialized;
+
+    if (productionRp.initialized) {
+      productionStatus = mapOnChainToDbStatus(
+        productionRp.initialized,
+        productionRp.active,
+      );
+    }
+  } catch (error) {
+    logger.error("Failed to fetch MCP RP status from production contract", {
+      error,
+      app_id,
+      rp_id: rpId,
+    });
+    throw new McpError("Failed to fetch production RP status.", -32603);
+  }
+
+  if (productionInitialized && productionStatus !== currentProductionStatus) {
+    await getUpdateRpStatusSdk(ctx.client).UpdateRpStatus({
+      rp_id: rpId,
+      status: productionStatus,
+    });
+  }
+
+  const stagingContractAddress =
+    process.env.RP_REGISTRY_STAGING_CONTRACT_ADDRESS || null;
+  let stagingStatus: string | null = currentStagingStatus;
+  let stagingInitialized: boolean | null = null;
+  let stagingSynced = false;
+
+  if (stagingContractAddress) {
+    try {
+      const stagingRp = await getRpFromContract(
+        numericRpId,
+        stagingContractAddress,
+      );
+      stagingInitialized = stagingRp.initialized;
+
+      if (stagingRp.initialized) {
+        const expectedSigner = registration.signer_address;
+        const canTrustOnChainStaging =
+          !expectedSigner ||
+          normalizeAddress(stagingRp.signer).toLowerCase() ===
+            normalizeAddress(expectedSigner).toLowerCase();
+
+        const mappedStagingStatus = mapOnChainToDbStatus(
+          stagingRp.initialized,
+          stagingRp.active,
+        );
+        stagingStatus = canTrustOnChainStaging
+          ? mappedStagingStatus
+          : currentStagingStatus ?? mappedStagingStatus;
+
+        if (canTrustOnChainStaging && stagingStatus !== currentStagingStatus) {
+          await getUpdateStagingStatusSdk(ctx.client).UpdateStagingStatus({
+            rp_id: rpId,
+            staging_status: stagingStatus,
+          });
+          stagingSynced = true;
+        }
+      } else {
+        stagingStatus = "pending";
+      }
+    } catch (error) {
+      logger.error("Failed to fetch MCP RP status from staging contract", {
+        error,
+        app_id,
+        rp_id: rpId,
+      });
+      stagingStatus = "failed";
+    }
+  }
+
+  return content({
+    rp_id: rpId,
+    app_id,
+    mode: registration.mode,
+    production_status: productionStatus,
+    staging_status: stagingStatus,
+    synced: {
+      production:
+        productionInitialized && productionStatus !== currentProductionStatus,
+      staging: stagingSynced,
+    },
+    on_chain: {
+      production_initialized: productionInitialized,
+      staging_initialized: stagingInitialized,
+    },
+    status_endpoint: rpStatusEndpoint(rpId),
+    verify_endpoint: `/api/v4/verify/${rpId}`,
+    proof_context_endpoint: `/api/v4/proof-context/${rpId}`,
+  });
 };
 
 const makeWallet = (privateKey?: string) => {
@@ -420,6 +567,9 @@ const tools = {
       proof_context_endpoint: app.rp_registration[0]
         ? `/api/v4/proof-context/${app.rp_registration[0].rp_id}`
         : null,
+      status_endpoint: app.rp_registration[0]
+        ? rpStatusEndpoint(app.rp_registration[0].rp_id)
+        : null,
     });
   },
 
@@ -468,6 +618,7 @@ const tools = {
         signing_key: null,
         verify_endpoint: `/api/v4/verify/${existingRegistration.rp_id}`,
         proof_context_endpoint: `/api/v4/proof-context/${existingRegistration.rp_id}`,
+        status_endpoint: rpStatusEndpoint(existingRegistration.rp_id),
         message:
           "World ID is already configured. Use rotate_world_id_signing_key to generate a new private signing key.",
       });
@@ -496,6 +647,7 @@ const tools = {
       signing_key: signingKey,
       verify_endpoint: `/api/v4/verify/${rpRegistration.rp_id}`,
       proof_context_endpoint: `/api/v4/proof-context/${rpRegistration.rp_id}`,
+      status_endpoint: rpStatusEndpoint(rpRegistration.rp_id),
       warning:
         "Private keys are returned only at generation/rotation time. Store the private_key securely in the app environment. To use platform-managed (on-chain) registration instead, configure the app from the developer portal UI.",
     });
@@ -522,10 +674,13 @@ const tools = {
       rp_id: registration.rp_id,
       signer_address: registration.signer_address,
       private_key: null,
+      status_endpoint: rpStatusEndpoint(registration.rp_id),
       message:
         "Existing private signing keys are not recoverable. Use rotate_world_id_signing_key to generate a new key.",
     });
   },
+
+  get_world_id_registration_status: syncWorldIdRegistrationStatus,
 
   rotate_world_id_signing_key: rotateWorldIdSigningKey,
 
@@ -705,6 +860,7 @@ const parseToolName = (value: unknown): ToolName => {
     case "create_app":
     case "configure_world_id":
     case "get_world_id_signing_key":
+    case "get_world_id_registration_status":
     case "rotate_world_id_signing_key":
     case "create_world_id_action":
     case "configure_mini_app":
@@ -731,6 +887,8 @@ const executeTool = async (
       return tools.configure_world_id(input, ctx);
     case "get_world_id_signing_key":
       return tools.get_world_id_signing_key(input, ctx);
+    case "get_world_id_registration_status":
+      return tools.get_world_id_registration_status(input, ctx);
     case "rotate_world_id_signing_key":
       return tools.rotate_world_id_signing_key(input, ctx);
     case "create_world_id_action":

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -809,7 +809,7 @@ export const POST = async (req: NextRequest) => {
     );
   }
 
-  if (message.id === undefined || message.id === null) {
+  if (message.id === undefined) {
     return new NextResponse(null, { status: 202 });
   }
 

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -82,12 +82,11 @@ const toolDefinitions = [
   {
     name: "configure_world_id",
     description:
-      "Create or update World ID 4.0 RP config and optionally generate a signing key.",
+      "Create World ID 4.0 RP config in self-managed mode and optionally generate a signing key. Managed mode (where the platform performs on-chain registration on the developer's behalf) requires user-session permissions and must be configured from the developer portal UI.",
     inputSchema: {
       type: "object",
       properties: {
         app_id: { type: "string" },
-        mode: { type: "string", enum: ["managed", "self_managed"] },
         signer_private_key: { type: "string" },
         generate_signing_key: { type: "boolean" },
       },
@@ -206,7 +205,6 @@ const createAppSchema = yup
 const configureWorldIdSchema = yup
   .object({
     app_id: yup.string().required(),
-    mode: yup.string().oneOf(["managed", "self_managed"]).default("managed"),
     signer_private_key: yup.string().optional(),
     generate_signing_key: yup.boolean().default(true),
   })
@@ -432,18 +430,16 @@ const tools = {
     }
 
     const signingKey =
-      args.mode === "managed" && args.generate_signing_key
+      args.generate_signing_key || args.signer_private_key
         ? makeWallet(args.signer_private_key)
-        : args.signer_private_key
-          ? makeWallet(args.signer_private_key)
-          : null;
+        : null;
 
     const data = await getMcpUpsertRpRegistrationSdk(
       ctx.client,
     ).McpUpsertRpRegistration({
       rp_id: generateRpIdString(args.app_id),
       app_id: args.app_id,
-      mode: args.mode,
+      mode: "self_managed",
       signer_address: signingKey?.signer_address ?? null,
     });
     const rpRegistration = data.insert_rp_registration_one;
@@ -457,7 +453,7 @@ const tools = {
       verify_endpoint: `/api/v4/verify/${rpRegistration.rp_id}`,
       proof_context_endpoint: `/api/v4/proof-context/${rpRegistration.rp_id}`,
       warning:
-        "Private keys are returned only at generation/rotation time. Store the private_key securely in the app environment.",
+        "Private keys are returned only at generation/rotation time. Store the private_key securely in the app environment. To use platform-managed (on-chain) registration instead, configure the app from the developer portal UI.",
     });
   },
 

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -111,9 +111,17 @@ const GET_APP_CONTEXT = gql`
         short_name
         app_mode
         category
+        content_card_image_url
+        description
+        hero_image_url
         integration_url
+        is_android_only
         app_website_url
+        is_for_humans_only
+        logo_img_url
+        meta_tag_image_url
         support_link
+        showcase_img_urls
         world_app_description
         world_app_button_text
         verification_status
@@ -212,7 +220,7 @@ const UPSERT_ACTION_V4 = gql`
     $rp_id: String!
     $action: String!
     $description: String!
-    $environment: String!
+    $environment: action_environment!
   ) {
     insert_action_v4_one(
       object: {
@@ -253,6 +261,14 @@ const UPDATE_APP_METADATA = gql`
       integration_url
       app_website_url
       support_link
+      content_card_image_url
+      description
+      hero_image_url
+      is_android_only
+      is_for_humans_only
+      logo_img_url
+      meta_tag_image_url
+      showcase_img_urls
       world_app_description
       world_app_button_text
       verification_status
@@ -393,11 +409,19 @@ const toolDefinitions = [
         category: { type: "string" },
         app_website_url: { type: "string" },
         support_link: { type: "string" },
+        description: { type: "string" },
+        logo_img_url: { type: "string" },
+        hero_image_url: { type: "string" },
+        meta_tag_image_url: { type: "string" },
+        showcase_img_urls: { type: "array", items: { type: "string" } },
+        content_card_image_url: { type: "string" },
         world_app_description: { type: "string" },
         world_app_button_text: { type: "string" },
         supported_countries: { type: "array", items: { type: "string" } },
         supported_languages: { type: "array", items: { type: "string" } },
+        is_android_only: { type: "boolean" },
         is_developer_allow_listing: { type: "boolean" },
+        is_for_humans_only: { type: "boolean" },
       },
       required: ["app_id"],
       additionalProperties: false,
@@ -472,11 +496,19 @@ const configureMiniAppSchema = yup
     category: yup.string().oneOf(CategoryNameIterable).optional(),
     app_website_url: yup.string().url().optional(),
     support_link: yup.string().optional(),
+    description: yup.string().optional(),
+    logo_img_url: yup.string().optional(),
+    hero_image_url: yup.string().optional(),
+    meta_tag_image_url: yup.string().optional(),
+    showcase_img_urls: yup.array().of(yup.string()).optional(),
+    content_card_image_url: yup.string().optional(),
     world_app_description: yup.string().optional(),
     world_app_button_text: yup.string().optional(),
     supported_countries: yup.array().of(yup.string().length(2)).optional(),
     supported_languages: yup.array().of(yup.string()).optional(),
+    is_android_only: yup.boolean().optional(),
     is_developer_allow_listing: yup.boolean().optional(),
+    is_for_humans_only: yup.boolean().optional(),
   })
   .noUnknown();
 
@@ -774,8 +806,8 @@ const tools: Record<
     if (!metadata) {
       throw new McpError("Editable app metadata not found.", -32004);
     }
-    if (metadata.verification_status === "verified") {
-      throw new McpError("Verified app metadata cannot be edited.", -32004);
+    if (metadata.verification_status !== "unverified") {
+      throw new McpError("Only unverified app metadata can be edited.", -32004);
     }
 
     const { app_id: _appId, ...rest } = args;

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -1,6 +1,6 @@
-import { errorResponse } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { logPortalEvent } from "@/api/helpers/portal-events";
+import { verifyHashedSecret } from "@/api/helpers/utils";
 import { getSdk as getMcpAppContextSdk } from "@/api/mcp/graphql/app-context.generated";
 import { getSdk as getMcpAuthenticateTeamSdk } from "@/api/mcp/graphql/authenticate-team.generated";
 import { getSdk as getMcpCreateAppSdk } from "@/api/mcp/graphql/create-app.generated";
@@ -264,34 +264,55 @@ const submitAppSchema = yup
     app_id: yup.string().required(),
     confirm_submission: yup.boolean().oneOf([true]).required(),
     changelog: yup.string().default("Submitted via MCP"),
-    is_developer_allow_listing: yup.boolean().default(false),
+    is_developer_allow_listing: yup.boolean().optional(),
   })
   .noUnknown();
 
+const parseApiKey = (authorization: string | null) => {
+  if (!authorization) return null;
+  const [scheme, token] = authorization.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token?.startsWith("api_")) {
+    return null;
+  }
+  let decoded: string;
+  try {
+    decoded = Buffer.from(token.slice("api_".length), "base64").toString(
+      "utf8",
+    );
+  } catch {
+    return null;
+  }
+  const [id, secret] = decoded.split(":");
+  if (!id || !secret) return null;
+  return { id, secret };
+};
+
 const authenticate = async (req: NextRequest): Promise<McpAuthContext> => {
-  const authorization = req.headers.get("authorization");
-  if (!authorization) {
+  const credentials = parseApiKey(req.headers.get("authorization"));
+  if (!credentials) {
     throw new McpError("API key is required.", -32001);
   }
 
-  const client = new GraphQLClient(`${req.nextUrl.origin}/api/v1/graphql`, {
-    fetch,
-    headers: { Authorization: authorization },
-  });
-
-  let result;
+  const serviceClient = await getAPIServiceGraphqlClient();
+  let apiKey;
   try {
-    result = await getMcpAuthenticateTeamSdk(client).McpAuthenticateTeam();
+    const result = await getMcpAuthenticateTeamSdk(
+      serviceClient,
+    ).McpAuthenticateTeam({ id: credentials.id });
+    apiKey = result.api_key_by_pk;
   } catch {
     throw new McpError("API key is not valid.", -32001);
   }
 
-  const teamId = result.team[0]?.id;
-  if (!teamId) {
+  if (
+    !apiKey ||
+    !apiKey.is_active ||
+    !verifyHashedSecret(apiKey.id, credentials.secret, apiKey.api_key)
+  ) {
     throw new McpError("API key is not valid.", -32001);
   }
 
-  return { teamId };
+  return { teamId: apiKey.team_id };
 };
 
 const parseInput = async <T>(schema: yup.Schema<T>, value: unknown) => {
@@ -627,11 +648,16 @@ const tools = {
       throw error;
     }
 
+    const isDeveloperAllowListing =
+      args.is_developer_allow_listing ??
+      metadata.is_developer_allow_listing ??
+      false;
+
     const data = await getMcpSubmitAppForReviewSdk(
       ctx.client,
     ).McpSubmitAppForReview({
       app_metadata_id: metadata.id,
-      is_developer_allow_listing: args.is_developer_allow_listing,
+      is_developer_allow_listing: isDeveloperAllowListing,
       changelog: args.changelog,
     });
 
@@ -641,7 +667,7 @@ const tools = {
       team_id: ctx.teamId,
       app_id: args.app_id,
       metadata: {
-        is_developer_allow_listing: args.is_developer_allow_listing,
+        is_developer_allow_listing: isDeveloperAllowListing,
       },
     });
 
@@ -769,13 +795,10 @@ export const POST = async (req: NextRequest) => {
   try {
     message = await req.json();
   } catch {
-    return errorResponse({
-      statusCode: 400,
-      code: "invalid_request",
-      detail: "Invalid JSON-RPC request body.",
-      attribute: null,
-      req,
-    });
+    return jsonRpcError(
+      null,
+      new McpError("Invalid JSON-RPC request body.", -32700),
+    );
   }
 
   if (message.id === undefined || message.id === null) {

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -350,7 +350,15 @@ const requireApp = async (
 };
 
 const makeWallet = (privateKey?: string) => {
-  const wallet = privateKey ? new Wallet(privateKey) : Wallet.createRandom();
+  let wallet;
+  try {
+    wallet = privateKey ? new Wallet(privateKey) : Wallet.createRandom();
+  } catch {
+    throw new McpError(
+      "Invalid signer_private_key: must be a 32-byte hex-encoded private key.",
+      -32602,
+    );
+  }
   return {
     private_key: wallet.privateKey,
     signer_address: wallet.address,
@@ -506,7 +514,7 @@ const tools = {
       throw new McpError("World ID is not configured for this app.", -32004);
     }
 
-    if (args.rotate_if_unavailable) {
+    if (args.rotate_if_unavailable && !registration.signer_address) {
       return rotateWorldIdSigningKey({ app_id: args.app_id }, ctx);
     }
 

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -1,12 +1,19 @@
 import { errorResponse } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { logPortalEvent } from "@/api/helpers/portal-events";
-import { verifyHashedSecret } from "@/api/helpers/utils";
-import { CategoryNameIterable } from "@/lib/categories";
+import { getSdk as getMcpAppContextSdk } from "@/api/mcp/graphql/app-context.generated";
+import { getSdk as getMcpAuthenticateTeamSdk } from "@/api/mcp/graphql/authenticate-team.generated";
+import { getSdk as getMcpCreateAppSdk } from "@/api/mcp/graphql/create-app.generated";
+import { getSdk as getMcpSubmitAppForReviewSdk } from "@/api/mcp/graphql/submit-app-for-review.generated";
+import { getSdk as getMcpTeamContextSdk } from "@/api/mcp/graphql/team-context.generated";
+import { getSdk as getMcpUpdateAppMetadataSdk } from "@/api/mcp/graphql/update-app-metadata.generated";
+import { getSdk as getMcpUpsertActionV4Sdk } from "@/api/mcp/graphql/upsert-action-v4.generated";
+import { getSdk as getMcpUpsertRpRegistrationSdk } from "@/api/mcp/graphql/upsert-rp-registration.generated";
 import { generateRpIdString } from "@/api/helpers/rp-utils";
+import { CategoryNameIterable } from "@/lib/categories";
 import { logger } from "@/lib/logger";
 import { Wallet } from "ethers";
-import { GraphQLClient, gql } from "graphql-request";
+import { GraphQLClient } from "graphql-request";
 import { NextRequest, NextResponse } from "next/server";
 import * as yup from "yup";
 
@@ -18,7 +25,6 @@ type JsonRpcRequest = {
 };
 
 type McpAuthContext = {
-  apiKeyId: string;
   teamId: string;
 };
 
@@ -35,271 +41,6 @@ class McpError extends Error {
     super(message);
   }
 }
-
-const AUTHENTICATE_API_KEY = gql`
-  query AuthenticateApiKey($id: String!) {
-    api_key_by_pk(id: $id) {
-      id
-      api_key
-      is_active
-      team_id
-    }
-  }
-`;
-
-const GET_TEAM_CONTEXT = gql`
-  query McpTeamContext($team_id: String!) {
-    team_by_pk(id: $team_id) {
-      id
-      name
-      apps(
-        where: { deleted_at: { _is_null: true } }
-        order_by: { created_at: desc }
-      ) {
-        id
-        name
-        engine
-        is_staging
-        status
-        created_at
-        app_metadata(
-          where: { verification_status: { _neq: "verified" } }
-          order_by: { created_at: desc }
-          limit: 1
-        ) {
-          id
-          name
-          app_mode
-          category
-          integration_url
-          verification_status
-        }
-        rp_registration {
-          rp_id
-          mode
-          status
-          signer_address
-          staging_status
-        }
-      }
-    }
-  }
-`;
-
-const GET_APP_CONTEXT = gql`
-  query McpAppContext($team_id: String!, $app_id: String!) {
-    app(
-      where: {
-        id: { _eq: $app_id }
-        team_id: { _eq: $team_id }
-        deleted_at: { _is_null: true }
-      }
-      limit: 1
-    ) {
-      id
-      name
-      engine
-      is_staging
-      status
-      app_metadata(
-        where: { verification_status: { _neq: "verified" } }
-        order_by: { created_at: desc }
-        limit: 1
-      ) {
-        id
-        name
-        short_name
-        app_mode
-        category
-        content_card_image_url
-        description
-        hero_image_url
-        integration_url
-        is_android_only
-        app_website_url
-        is_for_humans_only
-        logo_img_url
-        meta_tag_image_url
-        support_link
-        showcase_img_urls
-        world_app_description
-        world_app_button_text
-        verification_status
-        is_developer_allow_listing
-        supported_countries
-        supported_languages
-      }
-      rp_registration {
-        rp_id
-        mode
-        status
-        signer_address
-        staging_status
-        actions_v4(order_by: { created_at: desc }) {
-          id
-          action
-          description
-          environment
-        }
-      }
-    }
-  }
-`;
-
-const CREATE_APP = gql`
-  mutation McpCreateApp(
-    $team_id: String!
-    $name: String!
-    $engine: String!
-    $is_staging: Boolean!
-    $category: String!
-    $integration_url: String!
-    $app_mode: String!
-  ) {
-    insert_app_one(
-      object: {
-        engine: $engine
-        name: $name
-        is_staging: $is_staging
-        team_id: $team_id
-        app_metadata: {
-          data: {
-            name: $name
-            integration_url: $integration_url
-            app_mode: $app_mode
-            category: $category
-          }
-        }
-      }
-    ) {
-      id
-      name
-      is_staging
-      engine
-      app_metadata(order_by: { created_at: desc }, limit: 1) {
-        id
-        app_mode
-        category
-        integration_url
-      }
-    }
-  }
-`;
-
-const UPSERT_RP_REGISTRATION = gql`
-  mutation McpUpsertRpRegistration(
-    $rp_id: String!
-    $app_id: String!
-    $mode: rp_registration_mode!
-    $signer_address: String
-  ) {
-    insert_rp_registration_one(
-      object: {
-        rp_id: $rp_id
-        app_id: $app_id
-        mode: $mode
-        signer_address: $signer_address
-        status: pending
-      }
-      on_conflict: {
-        constraint: rp_registration_app_id_key
-        update_columns: [mode, signer_address, status]
-      }
-    ) {
-      rp_id
-      app_id
-      mode
-      signer_address
-      status
-    }
-  }
-`;
-
-const UPSERT_ACTION_V4 = gql`
-  mutation McpUpsertActionV4(
-    $rp_id: String!
-    $action: String!
-    $description: String!
-    $environment: action_environment!
-  ) {
-    insert_action_v4_one(
-      object: {
-        rp_id: $rp_id
-        action: $action
-        description: $description
-        environment: $environment
-      }
-      on_conflict: {
-        constraint: action_v4_rp_id_action_environment_key
-        update_columns: [description]
-      }
-    ) {
-      id
-      rp_id
-      action
-      description
-      environment
-    }
-  }
-`;
-
-const UPDATE_APP_METADATA = gql`
-  mutation McpUpdateAppMetadata(
-    $app_metadata_id: String!
-    $set: app_metadata_set_input!
-  ) {
-    update_app_metadata_by_pk(
-      pk_columns: { id: $app_metadata_id }
-      _set: $set
-    ) {
-      id
-      app_id
-      name
-      short_name
-      app_mode
-      category
-      integration_url
-      app_website_url
-      support_link
-      content_card_image_url
-      description
-      hero_image_url
-      is_android_only
-      is_for_humans_only
-      logo_img_url
-      meta_tag_image_url
-      showcase_img_urls
-      world_app_description
-      world_app_button_text
-      verification_status
-      supported_countries
-      supported_languages
-      is_developer_allow_listing
-    }
-  }
-`;
-
-const SUBMIT_APP_FOR_REVIEW = gql`
-  mutation McpSubmitAppForReview(
-    $app_metadata_id: String!
-    $is_developer_allow_listing: Boolean!
-    $changelog: String!
-  ) {
-    update_app_metadata_by_pk(
-      pk_columns: { id: $app_metadata_id }
-      _set: {
-        verification_status: "awaiting_review"
-        is_developer_allow_listing: $is_developer_allow_listing
-        changelog: $changelog
-      }
-    ) {
-      id
-      app_id
-      verification_status
-      is_developer_allow_listing
-    }
-  }
-`;
 
 const toolDefinitions = [
   {
@@ -521,48 +262,30 @@ const submitAppSchema = yup
   })
   .noUnknown();
 
-const parseApiKey = (req: NextRequest) => {
-  const raw = req.headers.get("authorization")?.split(/\s+/).at(-1);
-  if (!raw) {
+const authenticate = async (req: NextRequest): Promise<McpAuthContext> => {
+  const authorization = req.headers.get("authorization");
+  if (!authorization) {
     throw new McpError("API key is required.", -32001);
   }
 
-  const decoded = Buffer.from(raw.replace(/^api_/, ""), "base64").toString(
-    "utf8",
-  );
-  const [id, secret] = decoded.split(":");
+  const client = new GraphQLClient(`${req.nextUrl.origin}/api/v1/graphql`, {
+    fetch,
+    headers: { Authorization: authorization },
+  });
 
-  if (!id || !secret) {
-    throw new McpError("Invalid API key format.", -32001);
-  }
-
-  return { id, secret };
-};
-
-const authenticate = async (req: NextRequest): Promise<McpAuthContext> => {
-  const { id, secret } = parseApiKey(req);
-  const client = await getAPIServiceGraphqlClient();
-  const result = await client.request<{
-    api_key_by_pk?: {
-      id: string;
-      api_key: string;
-      is_active: boolean;
-      team_id: string;
-    } | null;
-  }>(AUTHENTICATE_API_KEY, { id });
-
-  const apiKey = result.api_key_by_pk;
-  if (!apiKey) {
-    throw new McpError("API key not found.", -32001);
-  }
-  if (!apiKey.is_active) {
-    throw new McpError("API key is inactive.", -32001);
-  }
-  if (!verifyHashedSecret(apiKey.id, secret, apiKey.api_key)) {
+  let result;
+  try {
+    result = await getMcpAuthenticateTeamSdk(client).McpAuthenticateTeam();
+  } catch {
     throw new McpError("API key is not valid.", -32001);
   }
 
-  return { apiKeyId: apiKey.id, teamId: apiKey.team_id };
+  const teamId = result.team[0]?.id;
+  if (!teamId) {
+    throw new McpError("API key is not valid.", -32001);
+  }
+
+  return { teamId };
 };
 
 const parseInput = async <T>(schema: yup.Schema<T>, value: unknown) => {
@@ -588,7 +311,7 @@ const requireApp = async (
   teamId: string,
   appId: string,
 ) => {
-  const data = await client.request<{ app: any[] }>(GET_APP_CONTEXT, {
+  const data = await getMcpAppContextSdk(client).McpAppContext({
     team_id: teamId,
     app_id: appId,
   });
@@ -619,15 +342,14 @@ const rotateWorldIdSigningKey = async (input: unknown, ctx: ToolContext) => {
   }
 
   const signingKey = makeWallet(args.signer_private_key);
-  const data = await ctx.client.request<{ insert_rp_registration_one: any }>(
-    UPSERT_RP_REGISTRATION,
-    {
-      rp_id: registration.rp_id,
-      app_id: args.app_id,
-      mode: registration.mode,
-      signer_address: signingKey.signer_address,
-    },
-  );
+  const data = await getMcpUpsertRpRegistrationSdk(
+    ctx.client,
+  ).McpUpsertRpRegistration({
+    rp_id: registration.rp_id,
+    app_id: args.app_id,
+    mode: registration.mode,
+    signer_address: signingKey.signer_address,
+  });
 
   return content({
     rp_registration: data.insert_rp_registration_one,
@@ -639,7 +361,7 @@ const rotateWorldIdSigningKey = async (input: unknown, ctx: ToolContext) => {
 
 const tools = {
   get_team_context: async (_input, ctx) => {
-    const data = await ctx.client.request(GET_TEAM_CONTEXT, {
+    const data = await getMcpTeamContextSdk(ctx.client).McpTeamContext({
       team_id: ctx.teamId,
     });
     return content(data);
@@ -668,7 +390,7 @@ const tools = {
       throw new McpError("Invalid app category.", -32602);
     }
 
-    const data = await ctx.client.request<{ insert_app_one: any }>(CREATE_APP, {
+    const data = await getMcpCreateAppSdk(ctx.client).McpCreateApp({
       team_id: ctx.teamId,
       name: args.name,
       is_staging: args.build === "staging",
@@ -716,21 +438,24 @@ const tools = {
           ? makeWallet(args.signer_private_key)
           : null;
 
-    const data = await ctx.client.request<{ insert_rp_registration_one: any }>(
-      UPSERT_RP_REGISTRATION,
-      {
-        rp_id: generateRpIdString(args.app_id),
-        app_id: args.app_id,
-        mode: args.mode,
-        signer_address: signingKey?.signer_address ?? null,
-      },
-    );
+    const data = await getMcpUpsertRpRegistrationSdk(
+      ctx.client,
+    ).McpUpsertRpRegistration({
+      rp_id: generateRpIdString(args.app_id),
+      app_id: args.app_id,
+      mode: args.mode,
+      signer_address: signingKey?.signer_address ?? null,
+    });
+    const rpRegistration = data.insert_rp_registration_one;
+    if (!rpRegistration) {
+      throw new McpError("Unable to configure World ID for this app.", -32000);
+    }
 
     return content({
-      rp_registration: data.insert_rp_registration_one,
+      rp_registration: rpRegistration,
       signing_key: signingKey,
-      verify_endpoint: `/api/v4/verify/${data.insert_rp_registration_one.rp_id}`,
-      proof_context_endpoint: `/api/v4/proof-context/${data.insert_rp_registration_one.rp_id}`,
+      verify_endpoint: `/api/v4/verify/${rpRegistration.rp_id}`,
+      proof_context_endpoint: `/api/v4/proof-context/${rpRegistration.rp_id}`,
       warning:
         "Private keys are returned only at generation/rotation time. Store the private_key securely in the app environment.",
     });
@@ -772,15 +497,12 @@ const tools = {
       throw new McpError("World ID is not configured for this app.", -32004);
     }
 
-    const data = await ctx.client.request<{ insert_action_v4_one: any }>(
-      UPSERT_ACTION_V4,
-      {
-        rp_id: registration.rp_id,
-        action: args.action,
-        description: args.description,
-        environment: args.environment,
-      },
-    );
+    const data = await getMcpUpsertActionV4Sdk(ctx.client).McpUpsertActionV4({
+      rp_id: registration.rp_id,
+      action: args.action,
+      description: args.description,
+      environment: args.environment,
+    });
 
     logPortalEvent({
       event: "action_creation",
@@ -816,13 +538,12 @@ const tools = {
       }).filter(([, value]) => value !== undefined),
     );
 
-    const data = await ctx.client.request<{ update_app_metadata_by_pk: any }>(
-      UPDATE_APP_METADATA,
-      {
-        app_metadata_id: metadata.id,
-        set,
-      },
-    );
+    const data = await getMcpUpdateAppMetadataSdk(
+      ctx.client,
+    ).McpUpdateAppMetadata({
+      app_metadata_id: metadata.id,
+      set,
+    });
 
     return content({ app_metadata: data.update_app_metadata_by_pk });
   },
@@ -845,9 +566,9 @@ const tools = {
       throw new McpError("Only unverified apps can be submitted.", -32004);
     }
 
-    const data = await ctx.client.request<{
-      update_app_metadata_by_pk: any;
-    }>(SUBMIT_APP_FOR_REVIEW, {
+    const data = await getMcpSubmitAppForReviewSdk(
+      ctx.client,
+    ).McpSubmitAppForReview({
       app_metadata_id: metadata.id,
       is_developer_allow_listing: args.is_developer_allow_listing,
       changelog: args.changelog,

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -810,7 +810,7 @@ export const POST = async (req: NextRequest) => {
   }
 
   if (message.id === undefined || message.id === null) {
-    return new NextResponse(null, { status: 204 });
+    return new NextResponse(null, { status: 202 });
   }
 
   try {

--- a/web/app/api/mcp/route.ts
+++ b/web/app/api/mcp/route.ts
@@ -1,0 +1,3 @@
+export const runtime = "nodejs";
+
+export { GET, OPTIONS, POST } from "@/api/mcp";

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/index.ts
@@ -2,6 +2,7 @@
 
 import { errorFormAction } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { logPortalEvent } from "@/api/helpers/portal-events";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { normalizePublicKey } from "@/lib/crypto.server";
 import { generateExternalNullifier } from "@/lib/hashing";
@@ -92,6 +93,15 @@ export async function createActionServerSide(
         appId,
         parsedInitialValues.action,
       ).digest,
+    });
+
+    logPortalEvent({
+      event: "action_creation",
+      actor: "human",
+      team_id: teamId,
+      app_id: appId,
+      action: parsedInitialValues.action,
+      metadata: { action_version: "legacy" },
     });
 
     return {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/server/submit.ts
@@ -2,6 +2,7 @@
 
 import { errorFormAction } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { logPortalEvent } from "@/api/helpers/portal-events";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { getIsUserAllowedToUpdateAppMetadata } from "@/lib/permissions";
 import { extractIdsFromPath, getPathFromHeaders } from "@/lib/server-utils";
@@ -145,6 +146,16 @@ export async function submitAppForReviewFormServerSide({
         parsedInput.is_developer_allow_listing ?? false,
       verification_status: "awaiting_review",
       changelog: parsedInput.changelog,
+    });
+
+    logPortalEvent({
+      event: "app_submission",
+      actor: "human",
+      team_id: parsedInput.team_id,
+      app_id: appId,
+      metadata: {
+        is_developer_allow_listing: parsedInput.is_developer_allow_listing,
+      },
     });
 
     return {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/CreateActionDialogV4/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/CreateActionDialogV4/server/index.ts
@@ -2,6 +2,7 @@
 
 import { errorFormAction } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { logPortalEvent } from "@/api/helpers/portal-events";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { getIsUserAllowedToUpdateApp } from "@/lib/permissions";
 import { FormActionResult } from "@/lib/types";
@@ -77,6 +78,14 @@ export async function validateAndInsertActionV4(
         description: parsedParams.description || "",
         environment: "production",
       },
+    });
+
+    logPortalEvent({
+      event: "action_creation",
+      actor: "human",
+      app_id,
+      action: parsedParams.action,
+      metadata: { action_version: "v4", environment: "production" },
     });
 
     return {

--- a/web/scenes/Portal/layout/CreateAppDialog/server/submit.ts
+++ b/web/scenes/Portal/layout/CreateAppDialog/server/submit.ts
@@ -1,6 +1,7 @@
 "use server";
 import { errorFormAction } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { logPortalEvent } from "@/api/helpers/portal-events";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { getIsUserAllowedToInsertApp } from "@/lib/permissions";
 import { FormActionResult } from "@/lib/types";
@@ -37,7 +38,7 @@ export async function validateAndInsertAppServerSide(
     }
 
     const client = await getAPIServiceGraphqlClient();
-    await getInsertAppSdk(client).InsertApp({
+    const result = await getInsertAppSdk(client).InsertApp({
       team_id,
       name: parsedInitialValues.name,
       is_staging: parsedInitialValues.build === "staging",
@@ -46,6 +47,18 @@ export async function validateAndInsertAppServerSide(
       integration_url:
         parsedInitialValues.integration_url ?? "https://docs.world.org/",
       app_mode: parsedInitialValues.app_mode,
+    });
+
+    logPortalEvent({
+      event: "app_creation",
+      actor: "human",
+      team_id,
+      app_id: result.insert_app_one?.id,
+      metadata: {
+        environment: parsedInitialValues.build,
+        engine: parsedInitialValues.verification,
+        app_mode: parsedInitialValues.app_mode,
+      },
     });
 
     return {

--- a/web/scenes/Portal/layout/CreateAppDialog/server/v4/submit.ts
+++ b/web/scenes/Portal/layout/CreateAppDialog/server/v4/submit.ts
@@ -1,6 +1,7 @@
 "use server";
 import { errorFormAction } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { logPortalEvent } from "@/api/helpers/portal-events";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { getIsUserAllowedToInsertApp } from "@/lib/permissions";
 import { FormActionResult } from "@/lib/types";
@@ -40,7 +41,7 @@ export async function validateAndInsertAppServerSideV4(
     const app_mode = parsedInitialValues.is_miniapp ? "mini-app" : "external";
 
     const client = await getAPIServiceGraphqlClient();
-    await getInsertAppSdk(client).InsertApp({
+    const result = await getInsertAppSdk(client).InsertApp({
       team_id,
       name: parsedInitialValues.name,
       is_staging: parsedInitialValues.build === "staging",
@@ -49,6 +50,18 @@ export async function validateAndInsertAppServerSideV4(
       integration_url:
         parsedInitialValues.integration_url ?? "https://docs.world.org/",
       app_mode,
+    });
+
+    logPortalEvent({
+      event: "app_creation",
+      actor: "human",
+      team_id,
+      app_id: result.insert_app_one?.id,
+      metadata: {
+        environment: parsedInitialValues.build,
+        engine: parsedInitialValues.verification,
+        app_mode,
+      },
     });
 
     return {

--- a/web/tests/api/hasura/upload-image/index.test.ts
+++ b/web/tests/api/hasura/upload-image/index.test.ts
@@ -1,0 +1,188 @@
+import { POST } from "@/api/hasura/upload-image";
+import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
+import { NextRequest } from "next/server";
+
+const requestMock = jest.fn();
+
+jest.mock("../../../../api/helpers/graphql", () => ({
+  getAPIServiceGraphqlClient: jest.fn(),
+}));
+
+jest.mock("../../../../lib/logger", () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock("@aws-sdk/client-s3", () => ({
+  S3Client: jest.fn(),
+}));
+
+jest.mock("@aws-sdk/s3-presigned-post", () => ({
+  createPresignedPost: jest.fn(),
+}));
+
+const teamId = "team_dd2ecd36c6c45f645e8e5d9a31abdee1";
+const otherTeamId = "team_69ee87c992c40b111e896248fd00cd04";
+const appId = "app_staging_9cdd0a714aec9ed17dca660bc9ffe72a";
+const userId = "user_7acdfce5eeadc33955460dcbc1c463dd";
+
+const mockGetAPIServiceGraphqlClient =
+  getAPIServiceGraphqlClient as jest.MockedFunction<
+    typeof getAPIServiceGraphqlClient
+  >;
+const mockCreatePresignedPost = createPresignedPost as jest.MockedFunction<
+  typeof createPresignedPost
+>;
+
+const operationName = (query: unknown) => {
+  if (typeof query === "string") {
+    return query;
+  }
+
+  const document = query as {
+    definitions?: Array<{ name?: { value?: string } }>;
+  };
+
+  return document.definitions?.[0]?.name?.value;
+};
+
+const createRequest = ({
+  role = "api_key",
+  inputTeamId = teamId,
+  sessionTeamId = teamId,
+}: {
+  role?: "api_key" | "user";
+  inputTeamId?: string;
+  sessionTeamId?: string;
+} = {}) =>
+  new NextRequest(
+    `http://localhost:3000/api/hasura/upload-image?app_id=${appId}&image_type=logo_img&content_type_ending=png`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.INTERNAL_ENDPOINTS_SECRET}`,
+      },
+      body: JSON.stringify({
+        action: { name: "upload_image" },
+        input: { team_id: inputTeamId },
+        session_variables: {
+          "x-hasura-role": role,
+          "x-hasura-team-id": sessionTeamId,
+          "x-hasura-user-id": userId,
+        },
+      }),
+    },
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.INTERNAL_ENDPOINTS_SECRET = "internal-secret";
+  process.env.ASSETS_S3_REGION = "us-east-1";
+  process.env.ASSETS_S3_BUCKET_NAME = "assets-bucket";
+
+  mockGetAPIServiceGraphqlClient.mockResolvedValue({
+    request: requestMock,
+  } as any);
+  mockCreatePresignedPost.mockResolvedValue({
+    url: "https://assets.example.com",
+    fields: { key: "unverified/test/logo_img.png" },
+  });
+  requestMock.mockImplementation(async (query: unknown) => {
+    switch (operationName(query)) {
+      case "CheckAppInTeam":
+        return {
+          app: [
+            {
+              id: appId,
+              app_metadata: [{ id: "meta_123" }],
+            },
+          ],
+        };
+      case "CheckUserInApp":
+        return { team: [{ id: teamId }] };
+      default:
+        throw new Error(`Unexpected query: ${operationName(query)}`);
+    }
+  });
+});
+
+describe("/api/hasura/upload-image", () => {
+  it("rejects API-key uploads when the input team does not match the session team", async () => {
+    const res = (await POST(
+      createRequest({ inputTeamId: otherTeamId, sessionTeamId: teamId }),
+    ))!;
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      message: "App not found.",
+      extensions: { code: "not_found" },
+    });
+    expect(requestMock).not.toHaveBeenCalled();
+    expect(mockCreatePresignedPost).not.toHaveBeenCalled();
+  });
+
+  it("rejects uploads when the app has no unverified metadata", async () => {
+    requestMock.mockImplementation(async (query: unknown) => {
+      if (operationName(query) === "CheckAppInTeam") {
+        return { app: [{ id: appId, app_metadata: [] }] };
+      }
+
+      throw new Error(`Unexpected query: ${operationName(query)}`);
+    });
+
+    const res = (await POST(createRequest()))!;
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      message: "App not found.",
+      extensions: { code: "not_found" },
+    });
+    expect(mockCreatePresignedPost).not.toHaveBeenCalled();
+  });
+
+  it("allows uploads only for an app in the session team with unverified metadata", async () => {
+    const res = (await POST(createRequest()))!;
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      url: "https://assets.example.com",
+      stringifiedFields: JSON.stringify({
+        key: "unverified/test/logo_img.png",
+      }),
+    });
+    expect(mockCreatePresignedPost).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        Bucket: "assets-bucket",
+        Key: `unverified/${appId}/logo_img.png`,
+      }),
+    );
+  });
+
+  it("rejects dashboard user uploads when the app has no unverified metadata", async () => {
+    requestMock.mockImplementation(async (query: unknown) => {
+      switch (operationName(query)) {
+        case "CheckUserInApp":
+          return { team: [{ id: teamId }] };
+        case "CheckAppInTeam":
+          return { app: [{ id: appId, app_metadata: [] }] };
+        default:
+          throw new Error(`Unexpected query: ${operationName(query)}`);
+      }
+    });
+
+    const res = (await POST(createRequest({ role: "user" })))!;
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      message: "App not found.",
+      extensions: { code: "not_found" },
+    });
+    expect(mockCreatePresignedPost).not.toHaveBeenCalled();
+  });
+});

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -324,7 +324,21 @@ describe("/api/mcp", () => {
     expect(payload.signing_key.signer_address).toMatch(/^0x/);
   });
 
-  it("rotates the signing key when requested from get_world_id_signing_key", async () => {
+  it("rotates the signing key when one is missing and rotate_if_unavailable is set", async () => {
+    const baseRegistration = appContextResponse.app[0].rp_registration[0];
+    const { signer_address: _signerAddress, ...registrationWithoutSigner } =
+      baseRegistration;
+    currentAppContextResponse = {
+      app: [
+        {
+          ...appContextResponse.app[0],
+          rp_registration: [
+            registrationWithoutSigner as typeof baseRegistration,
+          ],
+        },
+      ],
+    };
+
     const res = await POST(
       callTool("get_world_id_signing_key", {
         app_id: appId,
@@ -338,6 +352,42 @@ describe("/api/mcp", () => {
     expect(payload.rp_registration.rp_id).toBe(rpId);
     expect(payload.signing_key.private_key).toMatch(/^0x/);
     expect(payload.signing_key.signer_address).toMatch(/^0x/);
+  });
+
+  it("does not rotate when a signer is already configured", async () => {
+    const res = await POST(
+      callTool("get_world_id_signing_key", {
+        app_id: appId,
+        rotate_if_unavailable: true,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.signer_address).toBe(
+      "0x0000000000000000000000000000000000000001",
+    );
+    expect(payload.private_key).toBeNull();
+    expect(
+      requestMock.mock.calls.some(
+        ([query]) => getOperationName(query) === "McpUpsertRpRegistration",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns -32602 for malformed signer_private_key", async () => {
+    const res = await POST(
+      callTool("rotate_world_id_signing_key", {
+        app_id: appId,
+        signer_private_key: "not-a-valid-key",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32602);
+    expect(body.error.message).toMatch(/signer_private_key/);
   });
 
   it("refuses to rotate signing keys for managed RPs", async () => {

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -1,0 +1,314 @@
+import { generateHashedSecret } from "@/api/helpers/utils";
+import { POST } from "@/api/mcp";
+import { logger } from "@/lib/logger";
+import { generateRpIdString } from "@/lib/rp";
+import { NextRequest } from "next/server";
+
+const requestMock = jest.fn();
+
+jest.mock("../../api/helpers/graphql", () => ({
+  getAPIServiceGraphqlClient: jest.fn(async () => ({ request: requestMock })),
+}));
+
+jest.mock("../../lib/logger", () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const mockLoggerInfo = logger.info as jest.Mock;
+
+const teamId = "team_dd2ecd36c6c45f645e8e5d9a31abdee1";
+const apiKeyId = "key_667f5fbd4ad943622b4b2d3eb258f89c";
+const hashedSecret = generateHashedSecret(apiKeyId);
+const validApiKey = `api_${Buffer.from(`${apiKeyId}:${hashedSecret.secret}`)
+  .toString("base64")
+  .replace(/=/g, "")}`;
+
+const appId = "app_staging_9cdd0a714aec9ed17dca660bc9ffe72a";
+const rpId = generateRpIdString(appId);
+
+const authResponse = {
+  api_key_by_pk: {
+    id: apiKeyId,
+    api_key: hashedSecret.hashed_secret,
+    is_active: true,
+    team_id: teamId,
+  },
+};
+
+const appContextResponse = {
+  app: [
+    {
+      id: appId,
+      name: "Test App",
+      engine: "cloud",
+      is_staging: false,
+      status: "active",
+      app_metadata: [
+        {
+          id: "meta_123",
+          app_mode: "mini-app",
+          verification_status: "unverified",
+        },
+      ],
+      rp_registration: [
+        {
+          rp_id: rpId,
+          mode: "managed",
+          status: "registered",
+          signer_address: "0x0000000000000000000000000000000000000001",
+          actions_v4: [],
+        },
+      ],
+    },
+  ],
+};
+let currentAppContextResponse = appContextResponse;
+
+const createRequest = (body: Record<string, unknown>, apiKey = validApiKey) =>
+  new NextRequest("http://localhost:3000/api/mcp", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+const callTool = (name: string, args: Record<string, unknown>) =>
+  createRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name, arguments: args },
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  currentAppContextResponse = appContextResponse;
+  requestMock.mockImplementation(async (query: string, variables: any) => {
+    if (query.includes("AuthenticateApiKey")) return authResponse;
+    if (query.includes("McpTeamContext")) {
+      return { team_by_pk: { id: teamId, name: "Team", apps: [] } };
+    }
+    if (query.includes("McpCreateApp")) {
+      return {
+        insert_app_one: {
+          id: appId,
+          name: variables.name,
+          is_staging: variables.is_staging,
+          engine: variables.engine,
+          app_metadata: [
+            {
+              id: "meta_123",
+              app_mode: variables.app_mode,
+              category: variables.category,
+              integration_url: variables.integration_url,
+            },
+          ],
+        },
+      };
+    }
+    if (query.includes("McpAppContext")) return currentAppContextResponse;
+    if (query.includes("McpUpsertActionV4")) {
+      return {
+        insert_action_v4_one: {
+          id: "action_v4_123",
+          rp_id: variables.rp_id,
+          action: variables.action,
+          description: variables.description,
+          environment: variables.environment,
+        },
+      };
+    }
+    if (query.includes("McpUpsertRpRegistration")) {
+      return {
+        insert_rp_registration_one: {
+          rp_id: variables.rp_id,
+          app_id: variables.app_id,
+          mode: variables.mode,
+          signer_address: variables.signer_address,
+          status: "pending",
+        },
+      };
+    }
+    if (query.includes("McpUpdateAppMetadata")) {
+      return {
+        update_app_metadata_by_pk: {
+          id: variables.app_metadata_id,
+          app_id: appId,
+          ...variables.set,
+          verification_status: "unverified",
+        },
+      };
+    }
+    if (query.includes("McpSubmitAppForReview")) {
+      return {
+        update_app_metadata_by_pk: {
+          id: variables.app_metadata_id,
+          app_id: appId,
+          verification_status: "awaiting_review",
+          is_developer_allow_listing: variables.is_developer_allow_listing,
+        },
+      };
+    }
+    throw new Error(`Unexpected query: ${query}`);
+  });
+});
+
+describe("/api/mcp", () => {
+  it("returns MCP initialize metadata without auth", async () => {
+    const res = await POST(
+      createRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result.serverInfo.name).toBe("world-developer-portal");
+  });
+
+  it("lists tools with a valid dev portal API key", async () => {
+    const res = await POST(
+      createRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result.tools.map((tool: any) => tool.name)).toContain(
+      "create_app",
+    );
+  });
+
+  it("creates an app and logs MCP app creation", async () => {
+    const res = await POST(
+      callTool("create_app", {
+        name: "MCP App",
+        app_mode: "mini-app",
+        integration_url: "https://example.com",
+        category: "Other",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.app.id).toBe(appId);
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      "portal_app_creation",
+      expect.objectContaining({ actor: "mcp", app_id: appId, team_id: teamId }),
+    );
+  });
+
+  it("creates a World ID action and logs MCP action creation", async () => {
+    const res = await POST(
+      callTool("create_world_id_action", {
+        app_id: appId,
+        action: "verify-account",
+        description: "Verify account ownership",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.action.action).toBe("verify-account");
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      "portal_action_creation",
+      expect.objectContaining({
+        actor: "mcp",
+        app_id: appId,
+        action: "verify-account",
+      }),
+    );
+  });
+
+  it("configures World ID and returns a one-time signing key", async () => {
+    currentAppContextResponse = {
+      app: [{ ...appContextResponse.app[0], rp_registration: [] }],
+    };
+
+    const res = await POST(
+      callTool("configure_world_id", {
+        app_id: appId,
+        mode: "managed",
+        generate_signing_key: true,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.rp_registration.rp_id).toBe(rpId);
+    expect(payload.signing_key.private_key).toMatch(/^0x/);
+    expect(payload.signing_key.signer_address).toMatch(/^0x/);
+  });
+
+  it("updates Mini App metadata through an app-owned context", async () => {
+    const res = await POST(
+      callTool("configure_mini_app", {
+        app_id: appId,
+        short_name: "MCP",
+        integration_url: "https://example.com/mini",
+        category: "Other",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.app_metadata.app_mode).toBe("mini-app");
+    expect(payload.app_metadata.short_name).toBe("MCP");
+  });
+
+  it("submits an app for review only with explicit confirmation", async () => {
+    const res = await POST(
+      callTool("submit_app_for_review", {
+        app_id: appId,
+        confirm_submission: true,
+        is_developer_allow_listing: true,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.app_metadata.verification_status).toBe("awaiting_review");
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      "portal_app_submission",
+      expect.objectContaining({ actor: "mcp", app_id: appId, team_id: teamId }),
+    );
+  });
+
+  it("rejects tool calls with an invalid API key", async () => {
+    const invalidApiKey = `api_${Buffer.from(`${apiKeyId}:bad`).toString(
+      "base64",
+    )}`;
+    const res = await POST(
+      createRequest(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "get_team_context", arguments: {} },
+        },
+        invalidApiKey,
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.message).toBe("API key is not valid.");
+  });
+});

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -5,6 +5,7 @@ import { generateRpIdString } from "@/lib/rp";
 import { NextRequest } from "next/server";
 
 const requestMock = jest.fn();
+const fetchMock = jest.fn();
 
 jest.mock("../../api/helpers/graphql", () => ({
   getAPIServiceGraphqlClient: jest.fn(async () => ({ request: requestMock })),
@@ -30,15 +31,6 @@ const validApiKey = `api_${Buffer.from(`${apiKeyId}:${hashedSecret.secret}`)
 
 const appId = "app_staging_9cdd0a714aec9ed17dca660bc9ffe72a";
 const rpId = generateRpIdString(appId);
-
-const authResponse = {
-  api_key_by_pk: {
-    id: apiKeyId,
-    api_key: hashedSecret.hashed_secret,
-    is_active: true,
-    team_id: teamId,
-  },
-};
 
 const appContextResponse = {
   app: [
@@ -69,6 +61,17 @@ const appContextResponse = {
 };
 let currentAppContextResponse = appContextResponse;
 
+const getOperationName = (query: unknown) => {
+  if (typeof query === "string") {
+    return query;
+  }
+
+  return (
+    (query as { definitions?: { name?: { value?: string } }[] })
+      .definitions?.[0]?.name?.value ?? ""
+  );
+};
+
 const createRequest = (body: Record<string, unknown>, apiKey = validApiKey) =>
   new NextRequest("http://localhost:3000/api/mcp", {
     method: "POST",
@@ -89,13 +92,27 @@ const callTool = (name: string, args: Record<string, unknown>) =>
 
 beforeEach(() => {
   jest.clearAllMocks();
+  global.fetch = fetchMock;
+  fetchMock.mockImplementation(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(
+        init?.headers ?? (input instanceof Request ? input.headers : undefined),
+      );
+      if (headers.get("authorization") !== `Bearer ${validApiKey}`) {
+        return Response.json({ errors: [{ message: "Invalid API key" }] });
+      }
+
+      return Response.json({ data: { team: [{ id: teamId }] } });
+    },
+  );
   currentAppContextResponse = appContextResponse;
-  requestMock.mockImplementation(async (query: string, variables: any) => {
-    if (query.includes("AuthenticateApiKey")) return authResponse;
-    if (query.includes("McpTeamContext")) {
+  requestMock.mockImplementation(async (query: unknown, variables: any) => {
+    const operationName = getOperationName(query);
+
+    if (operationName.includes("McpTeamContext")) {
       return { team_by_pk: { id: teamId, name: "Team", apps: [] } };
     }
-    if (query.includes("McpCreateApp")) {
+    if (operationName.includes("McpCreateApp")) {
       return {
         insert_app_one: {
           id: appId,
@@ -113,8 +130,9 @@ beforeEach(() => {
         },
       };
     }
-    if (query.includes("McpAppContext")) return currentAppContextResponse;
-    if (query.includes("McpUpsertActionV4")) {
+    if (operationName.includes("McpAppContext"))
+      return currentAppContextResponse;
+    if (operationName.includes("McpUpsertActionV4")) {
       return {
         insert_action_v4_one: {
           id: "action_v4_123",
@@ -125,7 +143,7 @@ beforeEach(() => {
         },
       };
     }
-    if (query.includes("McpUpsertRpRegistration")) {
+    if (operationName.includes("McpUpsertRpRegistration")) {
       return {
         insert_rp_registration_one: {
           rp_id: variables.rp_id,
@@ -136,7 +154,7 @@ beforeEach(() => {
         },
       };
     }
-    if (query.includes("McpUpdateAppMetadata")) {
+    if (operationName.includes("McpUpdateAppMetadata")) {
       return {
         update_app_metadata_by_pk: {
           id: variables.app_metadata_id,
@@ -146,7 +164,7 @@ beforeEach(() => {
         },
       };
     }
-    if (query.includes("McpSubmitAppForReview")) {
+    if (operationName.includes("McpSubmitAppForReview")) {
       return {
         update_app_metadata_by_pk: {
           id: variables.app_metadata_id,
@@ -156,7 +174,7 @@ beforeEach(() => {
         },
       };
     }
-    throw new Error(`Unexpected query: ${query}`);
+    throw new Error(`Unexpected query: ${operationName}`);
   });
 });
 

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -161,7 +161,7 @@ beforeEach(() => {
 });
 
 describe("/api/mcp", () => {
-  it("returns MCP initialize metadata without auth", async () => {
+  it("returns MCP initialize metadata with a valid dev portal API key", async () => {
     const res = await POST(
       createRequest({
         jsonrpc: "2.0",
@@ -211,6 +211,27 @@ describe("/api/mcp", () => {
     );
   });
 
+  it("applies defaults when creating an app with only a name", async () => {
+    const res = await POST(
+      callTool("create_app", {
+        name: "MCP Defaults",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.app.engine).toBe("cloud");
+    expect(payload.app.is_staging).toBe(false);
+    expect(payload.app.app_metadata[0]).toEqual(
+      expect.objectContaining({
+        app_mode: "external",
+        category: "External",
+        integration_url: "https://docs.world.org/",
+      }),
+    );
+  });
+
   it("creates a World ID action and logs MCP action creation", async () => {
     const res = await POST(
       callTool("create_world_id_action", {
@@ -244,6 +265,22 @@ describe("/api/mcp", () => {
         app_id: appId,
         mode: "managed",
         generate_signing_key: true,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.rp_registration.rp_id).toBe(rpId);
+    expect(payload.signing_key.private_key).toMatch(/^0x/);
+    expect(payload.signing_key.signer_address).toMatch(/^0x/);
+  });
+
+  it("rotates the signing key when requested from get_world_id_signing_key", async () => {
+    const res = await POST(
+      callTool("get_world_id_signing_key", {
+        app_id: appId,
+        rotate_if_unavailable: true,
       }),
     );
 

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -558,6 +558,18 @@ describe("/api/mcp", () => {
     expect(requestMock).not.toHaveBeenCalled();
   });
 
+  it("returns 202 with no body for accepted notifications", async () => {
+    const res = await POST(
+      createRequest({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      }),
+    );
+
+    expect(res.status).toBe(202);
+    expect(await res.text()).toBe("");
+  });
+
   it("returns a JSON-RPC parse error for malformed request bodies", async () => {
     const req = new NextRequest("http://localhost:3000/api/mcp", {
       method: "POST",

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -5,7 +5,6 @@ import { generateRpIdString } from "@/lib/rp";
 import { NextRequest } from "next/server";
 
 const requestMock = jest.fn();
-const fetchMock = jest.fn();
 
 jest.mock("../../api/helpers/graphql", () => ({
   getAPIServiceGraphqlClient: jest.fn(async () => ({ request: requestMock })),
@@ -45,6 +44,7 @@ const appContextResponse = {
           id: "meta_123",
           app_mode: "mini-app",
           verification_status: "unverified",
+          is_developer_allow_listing: false,
         },
       ],
       rp_registration: [
@@ -117,23 +117,23 @@ const callTool = (name: string, args: Record<string, unknown>) =>
 
 beforeEach(() => {
   jest.clearAllMocks();
-  global.fetch = fetchMock;
-  fetchMock.mockImplementation(
-    async (input: RequestInfo | URL, init?: RequestInit) => {
-      const headers = new Headers(
-        init?.headers ?? (input instanceof Request ? input.headers : undefined),
-      );
-      if (headers.get("authorization") !== `Bearer ${validApiKey}`) {
-        return Response.json({ errors: [{ message: "Invalid API key" }] });
-      }
-
-      return Response.json({ data: { team: [{ id: teamId }] } });
-    },
-  );
   currentAppContextResponse = appContextResponse;
   requestMock.mockImplementation(async (query: unknown, variables: any) => {
     const operationName = getOperationName(query);
 
+    if (operationName.includes("McpAuthenticateTeam")) {
+      if (variables.id !== apiKeyId) {
+        return { api_key_by_pk: null };
+      }
+      return {
+        api_key_by_pk: {
+          id: apiKeyId,
+          api_key: hashedSecret.hashed_secret,
+          is_active: true,
+          team_id: teamId,
+        },
+      };
+    }
     if (operationName.includes("McpTeamContext")) {
       return { team_by_pk: { id: teamId, name: "Team", apps: [] } };
     }
@@ -433,6 +433,16 @@ describe("/api/mcp", () => {
     const incompleteMetadata = { ...reviewMetadata, logo_img_url: "" };
     requestMock.mockImplementation(async (query: unknown, variables: any) => {
       const operationName = getOperationName(query);
+      if (operationName.includes("McpAuthenticateTeam")) {
+        return {
+          api_key_by_pk: {
+            id: apiKeyId,
+            api_key: hashedSecret.hashed_secret,
+            is_active: true,
+            team_id: teamId,
+          },
+        };
+      }
       if (operationName.includes("McpAppContext"))
         return currentAppContextResponse;
       if (operationName.includes("FetchAppMetadataById")) {
@@ -476,5 +486,74 @@ describe("/api/mcp", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.error.message).toBe("API key is not valid.");
+  });
+
+  it("rejects bearer tokens that are not API keys", async () => {
+    const jwtToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.fake.fake";
+    const res = await POST(
+      createRequest(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "get_team_context", arguments: {} },
+        },
+        jwtToken,
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32001);
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a JSON-RPC parse error for malformed request bodies", async () => {
+    const req = new NextRequest("http://localhost:3000/api/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${validApiKey}`,
+      },
+      body: "{not json",
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.error.code).toBe(-32700);
+  });
+
+  it("preserves is_developer_allow_listing when submitter omits it", async () => {
+    currentAppContextResponse = {
+      app: [
+        {
+          ...appContextResponse.app[0],
+          app_metadata: [
+            {
+              ...appContextResponse.app[0].app_metadata[0],
+              is_developer_allow_listing: true,
+            },
+          ],
+        },
+      ],
+    };
+
+    const res = await POST(
+      callTool("submit_app_for_review", {
+        app_id: appId,
+        confirm_submission: true,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const submitCall = requestMock.mock.calls.find(
+      ([query]) => getOperationName(query) === "McpSubmitAppForReview",
+    );
+    expect(submitCall?.[1]).toEqual(
+      expect.objectContaining({ is_developer_allow_listing: true }),
+    );
   });
 });

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -3,6 +3,7 @@ import { POST } from "@/api/mcp";
 import { logger } from "@/lib/logger";
 import { generateRpIdString } from "@/lib/rp";
 import { NextRequest } from "next/server";
+import { getRpFromContract } from "../../api/helpers/temporal-rpc";
 
 const requestMock = jest.fn();
 
@@ -19,7 +20,12 @@ jest.mock("../../lib/logger", () => ({
   },
 }));
 
+jest.mock("../../api/helpers/temporal-rpc", () => ({
+  getRpFromContract: jest.fn(),
+}));
+
 const mockLoggerInfo = logger.info as jest.Mock;
+const mockGetRpFromContract = getRpFromContract as jest.Mock;
 
 const teamId = "team_dd2ecd36c6c45f645e8e5d9a31abdee1";
 const apiKeyId = "key_667f5fbd4ad943622b4b2d3eb258f89c";
@@ -53,6 +59,7 @@ const appContextResponse = {
           mode: "self_managed",
           status: "registered",
           signer_address: "0x0000000000000000000000000000000000000001",
+          staging_status: null,
           actions_v4: [],
         },
       ],
@@ -117,7 +124,18 @@ const callTool = (name: string, args: Record<string, unknown>) =>
 
 beforeEach(() => {
   jest.clearAllMocks();
+  process.env.RP_REGISTRY_CONTRACT_ADDRESS =
+    "0x0000000000000000000000000000000000000048";
+  delete process.env.RP_REGISTRY_STAGING_CONTRACT_ADDRESS;
   currentAppContextResponse = appContextResponse;
+  mockGetRpFromContract.mockResolvedValue({
+    initialized: true,
+    active: true,
+    manager: "0x0000000000000000000000000000000000000002",
+    signer: "0x0000000000000000000000000000000000000001",
+    oprfKeyId: 0n,
+    unverifiedWellKnownDomain: "Test App",
+  });
   requestMock.mockImplementation(async (query: unknown, variables: any) => {
     const operationName = getOperationName(query);
 
@@ -199,6 +217,24 @@ beforeEach(() => {
         },
       };
     }
+    if (operationName.includes("UpdateRpStatus")) {
+      return {
+        update_rp_registration_by_pk: {
+          rp_id: variables.rp_id,
+          status: variables.status,
+          updated_at: "2026-04-29T00:00:00.000Z",
+        },
+      };
+    }
+    if (operationName.includes("UpdateStagingStatus")) {
+      return {
+        update_rp_registration_by_pk: {
+          rp_id: variables.rp_id,
+          staging_status: variables.staging_status,
+          updated_at: "2026-04-29T00:00:00.000Z",
+        },
+      };
+    }
     if (operationName.includes("FetchAppMetadataById")) {
       return {
         app_metadata: [reviewMetadata],
@@ -237,6 +273,9 @@ describe("/api/mcp", () => {
     const body = await res.json();
     expect(body.result.tools.map((tool: any) => tool.name)).toContain(
       "create_app",
+    );
+    expect(body.result.tools.map((tool: any) => tool.name)).toContain(
+      "get_world_id_registration_status",
     );
   });
 
@@ -374,6 +413,44 @@ describe("/api/mcp", () => {
         ([query]) => getOperationName(query) === "McpUpsertRpRegistration",
       ),
     ).toBe(false);
+  });
+
+  it("syncs World ID registration status from the production registry", async () => {
+    currentAppContextResponse = {
+      app: [
+        {
+          ...appContextResponse.app[0],
+          rp_registration: [
+            {
+              ...appContextResponse.app[0].rp_registration[0],
+              status: "pending",
+            },
+          ],
+        },
+      ],
+    };
+
+    const res = await POST(
+      callTool("get_world_id_registration_status", { app_id: appId }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload).toEqual(
+      expect.objectContaining({
+        rp_id: rpId,
+        production_status: "registered",
+        status_endpoint: `/api/v4/rp-status/${rpId}`,
+      }),
+    );
+
+    const updateCall = requestMock.mock.calls.find(
+      ([query]) => getOperationName(query) === "UpdateRpStatus",
+    );
+    expect(updateCall?.[1]).toEqual(
+      expect.objectContaining({ rp_id: rpId, status: "registered" }),
+    );
   });
 
   it("returns -32602 for malformed signer_private_key", async () => {

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -50,7 +50,7 @@ const appContextResponse = {
       rp_registration: [
         {
           rp_id: rpId,
-          mode: "managed",
+          mode: "self_managed",
           status: "registered",
           signer_address: "0x0000000000000000000000000000000000000001",
           actions_v4: [],
@@ -59,6 +59,31 @@ const appContextResponse = {
     },
   ],
 };
+
+const reviewMetadata = {
+  id: "meta_123",
+  app_id: appId,
+  name: "Test App",
+  short_name: "Test",
+  logo_img_url: "logo.png",
+  showcase_img_urls: ["showcase.png"],
+  meta_tag_image_url: "meta.png",
+  world_app_description: "World tagline",
+  description:
+    '{"description_overview":"An overview that is long enough to satisfy the schema.","description_how_it_works":"","description_connect":""}',
+  category: "Other",
+  app_website_url: "https://example.com",
+  support_link: "mailto:support@example.com",
+  supported_countries: ["us"],
+  supported_languages: ["en"],
+  is_android_only: false,
+  is_for_humans_only: false,
+  app_mode: "mini-app",
+  verification_status: "unverified",
+  content_card_image_url: "card.png",
+  app: { is_staging: false },
+};
+const reviewLocalisations: Array<Record<string, unknown>> = [];
 let currentAppContextResponse = appContextResponse;
 
 const getOperationName = (query: unknown) => {
@@ -172,6 +197,12 @@ beforeEach(() => {
           verification_status: "awaiting_review",
           is_developer_allow_listing: variables.is_developer_allow_listing,
         },
+      };
+    }
+    if (operationName.includes("FetchAppMetadataById")) {
+      return {
+        app_metadata: [reviewMetadata],
+        localisations: reviewLocalisations,
       };
     }
     throw new Error(`Unexpected query: ${operationName}`);
@@ -309,6 +340,30 @@ describe("/api/mcp", () => {
     expect(payload.signing_key.signer_address).toMatch(/^0x/);
   });
 
+  it("refuses to rotate signing keys for managed RPs", async () => {
+    currentAppContextResponse = {
+      app: [
+        {
+          ...appContextResponse.app[0],
+          rp_registration: [
+            {
+              ...appContextResponse.app[0].rp_registration[0],
+              mode: "managed",
+            },
+          ],
+        },
+      ],
+    };
+
+    const res = await POST(
+      callTool("rotate_world_id_signing_key", { app_id: appId }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/developer portal UI/);
+  });
+
   it("updates Mini App metadata through an app-owned context", async () => {
     const res = await POST(
       callTool("configure_mini_app", {
@@ -372,6 +427,34 @@ describe("/api/mcp", () => {
       "portal_app_submission",
       expect.objectContaining({ actor: "mcp", app_id: appId, team_id: teamId }),
     );
+  });
+
+  it("rejects review submission when metadata is incomplete", async () => {
+    const incompleteMetadata = { ...reviewMetadata, logo_img_url: "" };
+    requestMock.mockImplementation(async (query: unknown, variables: any) => {
+      const operationName = getOperationName(query);
+      if (operationName.includes("McpAppContext"))
+        return currentAppContextResponse;
+      if (operationName.includes("FetchAppMetadataById")) {
+        return {
+          app_metadata: [incompleteMetadata],
+          localisations: reviewLocalisations,
+        };
+      }
+      throw new Error(`Unexpected query: ${operationName}`);
+    });
+
+    const res = await POST(
+      callTool("submit_app_for_review", {
+        app_id: appId,
+        confirm_submission: true,
+        is_developer_allow_listing: true,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/incomplete/i);
   });
 
   it("rejects tool calls with an invalid API key", async () => {

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -570,6 +570,22 @@ describe("/api/mcp", () => {
     expect(await res.text()).toBe("");
   });
 
+  it("treats requests with id: null as regular calls and responds in kind", async () => {
+    const res = await POST(
+      createRequest({
+        jsonrpc: "2.0",
+        id: null,
+        method: "initialize",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.id).toBeNull();
+    expect(body.result.serverInfo.name).toBe("world-developer-portal");
+  });
+
   it("returns a JSON-RPC parse error for malformed request bodies", async () => {
     const req = new NextRequest("http://localhost:3000/api/mcp", {
       method: "POST",

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -281,7 +281,6 @@ describe("/api/mcp", () => {
     const res = await POST(
       callTool("configure_world_id", {
         app_id: appId,
-        mode: "managed",
         generate_signing_key: true,
       }),
     );

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -272,6 +272,35 @@ describe("/api/mcp", () => {
     expect(payload.app_metadata.short_name).toBe("MCP");
   });
 
+  it("rejects Mini App metadata updates after review submission", async () => {
+    currentAppContextResponse = {
+      app: [
+        {
+          ...appContextResponse.app[0],
+          app_metadata: [
+            {
+              ...appContextResponse.app[0].app_metadata[0],
+              verification_status: "awaiting_review",
+            },
+          ],
+        },
+      ],
+    };
+
+    const res = await POST(
+      callTool("configure_mini_app", {
+        app_id: appId,
+        short_name: "MCP",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.message).toBe(
+      "Only unverified app metadata can be edited.",
+    );
+  });
+
   it("submits an app for review only with explicit confirmation", async () => {
     const res = await POST(
       callTool("submit_app_for_review", {


### PR DESCRIPTION
## Summary

- Add a stateless `/api/mcp` JSON-RPC endpoint for MCP clients authenticated with existing Dev Portal team API keys.
- Add MCP tools for team/app lookup, app creation, World ID configuration, signing key lookup and rotation, World ID action creation, mini app configuration, and app review submission.
- Add Datadog/log events for app creation, action creation, and app submission with `actor: human | mcp` so portal usage can be attributed.
- Add API coverage for MCP auth, tool listing, app/action creation, World ID signing key flow, mini app config, app submission guardrails, and telemetry.

## Notes

- Private signing keys are only returned when generated or rotated. Existing private keys are not recoverable through the MCP endpoint.
- App submission requires explicit `confirm_submission: true` to avoid accidental review submissions.

## Testing

- `pnpm --dir web typecheck`
- `pnpm --dir web lint`
- `pnpm --dir web exec prettier --check ...`
- `pnpm --dir web exec jest web/tests/api/mcp.test.ts web/tests/api/v2/create-action.test.ts web/tests/api/v2/app/submit-app-review.test.ts --runInBand`
- `pnpm --dir web exec jest web/tests/api --runInBand`
- `pnpm --dir tests/api exec jest specs/public --runInBand`

Full `tests/api` e2e beyond the public suite requires populated staging/internal secrets (`INTERNAL_ENDPOINTS_SECRET`, `HASURA_GRAPHQL_ADMIN_SECRET`, `AUTH0_SECRET`, AWS credentials), which are blank in the local e2e env file.