### PR TITLE
fix: add App Router route.ts for backfill endpoint

### DIFF
--- a/web/app/api/backfill-staging-signers/route.ts
+++ b/web/app/api/backfill-staging-signers/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "@/api/backfill-staging-signers";


### PR DESCRIPTION
The handler merged in #1873 was missing the route.ts wiring in web/app/api/, causing
   404. One-liner fix.