### PR TITLE
fix: seed staging RP status from SSR to avoid pending flicker

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/WorldId40Content.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/WorldId40Content.tsx
@@ -48,6 +48,7 @@ type WorldId40ContentProps = {
   appId: string;
   rpId: string;
   initialStatus: RpStatus;
+  initialStagingStatus: RpStatus | null;
   mode: string;
   signerAddress?: string | null;
   createdAt: string;
@@ -57,6 +58,7 @@ export const WorldId40Content = ({
   appId,
   rpId,
   initialStatus,
+  initialStagingStatus,
   mode,
   createdAt,
 }: WorldId40ContentProps) => {
@@ -64,7 +66,9 @@ export const WorldId40Content = ({
   const router = useRouter();
   const [productionStatus, setProductionStatus] =
     useState<RpStatus>(initialStatus);
-  const [stagingStatus, setStagingStatus] = useState<RpStatus | null>(null);
+  const [stagingStatus, setStagingStatus] = useState<RpStatus | null>(
+    initialStagingStatus,
+  );
   const [isRotateDialogOpen, setIsRotateDialogOpen] = useState(false);
   const [isSwitchDialogOpen, setIsSwitchDialogOpen] = useState(false);
   const [retryingEnvironment, setRetryingEnvironment] = useState<string | null>(

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/graphql/server/fetch-rp-registration.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/graphql/server/fetch-rp-registration.generated.ts
@@ -15,6 +15,7 @@ export type FetchRpRegistrationQuery = {
     rp_id: string;
     app_id: string;
     status: unknown;
+    staging_status?: unknown | null;
     mode: unknown;
     signer_address?: string | null;
     created_at: string;
@@ -28,6 +29,7 @@ export const FetchRpRegistrationDocument = gql`
       rp_id
       app_id
       status
+      staging_status
       mode
       signer_address
       created_at

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/graphql/server/fetch-rp-registration.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/graphql/server/fetch-rp-registration.graphql
@@ -3,6 +3,7 @@ query FetchRpRegistration($appId: String!) {
     rp_id
     app_id
     status
+    staging_status
     mode
     signer_address
     created_at

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/index.tsx
@@ -41,6 +41,15 @@ export const WorldId40Page = async ({ params }: Props) => {
       initialStatus={
         rpData.status as "pending" | "registered" | "failed" | "deactivated"
       }
+      initialStagingStatus={
+        (rpData.staging_status as
+          | "pending"
+          | "registered"
+          | "failed"
+          | "deactivated"
+          | null
+          | undefined) ?? null
+      }
       mode={rpData.mode as string}
       signerAddress={rpData.signer_address ?? null}
       createdAt={rpData.created_at}


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

On the World ID 4.0 page, the staging RP registration status briefly showed "Pending" on every refresh before flipping to "Active", while production rendered correctly. The cause was that `WorldId40Content` initialized `stagingStatus` to `null` and rendered `stagingStatus ?? "pending"` until the client-side `/api/v4/rp-status/[rp_id]` fetch resolved — production didn't flicker because its initial value was seeded from the SSR GraphQL query. This PR adds `staging_status` to the SSR `FetchRpRegistration` query and threads it as `initialStagingStatus` into the client component so the staging row paints with the real DB value on first render.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.