### PR TITLE
fix: send PostHog events directly to us.i.posthog.com

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -90,10 +90,6 @@ const nextConfig = {
         source: "/.well-known/openid-configuration",
         destination: "/api/v1/oidc/openid-configuration",
       },
-      {
-        source: "/ingest/:path*",
-        destination: "https://app.posthog.com/:path*",
-      },
     ];
   },
 };

--- a/web/scenes/Root/providers/providers.tsx
+++ b/web/scenes/Root/providers/providers.tsx
@@ -20,7 +20,7 @@ interface HasuraUserData {
 
 if (typeof window !== "undefined") {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_API_KEY!, {
-    api_host: `${window.location.origin}/ingest`,
+    api_host: "https://us.i.posthog.com",
     ui_host: "https://app.posthog.com",
     loaded: (posthog) => {
       if (process.env.NODE_ENV === "development") posthog.debug();


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Follow-up to #1870. After that PR shipped, posthog-js requests still intermittently returned 403 on `developer.world.org/ingest/e/`. Inspecting the response headers showed Cloudflare's HTML error page (`server: cloudflare`, `content-type: text/html`, no `x-envoy-upstream-service-time`, no `access-control-allow-origin`), with `__cf_bm` and `cf_clearance` cookies on the request — so Cloudflare Bot Management was scoring some events as bot traffic and blocking them at the edge before they could reach PostHog.

Drop the `/ingest -> app.posthog.com` rewrite and point posthog-js at PostHog's official ingestion host directly (`https://us.i.posthog.com`, already allowed in the middleware CSP `connect-src`). PostHog returns CORS allowing both production origins, so requests no longer transit our Cloudflare zone, and we also lose a 308 trailing-slash redirect that was firing on every event.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.