### PR TITLE
fix: downgrade malformed-proof verify logs from error to warn/debug

### DIFF
--- a/web/api/helpers/verify.ts
+++ b/web/api/helpers/verify.ts
@@ -139,7 +139,10 @@ export function decodeProof(proof: string): NestedProof {
         ];
       }
     } catch (error) {
-      logger.debug("Error processing JSON-encoded proof", { error });
+      // Pass error.message, not the Error: logger.ts tags the active span as errored when data.error is an Error.
+      logger.debug("Error processing JSON-encoded proof", {
+        error: error instanceof Error ? error.message : String(error),
+      });
       // If there's an error processing the JSON-encoded proof, fall through to try decoding it as ABI
     }
   }
@@ -149,7 +152,9 @@ export function decodeProof(proof: string): NestedProof {
     const flatProof = decodeAbiEncodedProof(cleanedProof);
     return convertToNestedFormat(flatProof);
   } catch (error) {
-    logger.warn("Error decoding ABI-encoded proof", { error });
+    logger.warn("Error decoding ABI-encoded proof", {
+      error: error instanceof Error ? error.message : String(error),
+    });
     throw new Error("Invalid proof format");
   }
 }

--- a/web/api/helpers/verify.ts
+++ b/web/api/helpers/verify.ts
@@ -139,7 +139,7 @@ export function decodeProof(proof: string): NestedProof {
         ];
       }
     } catch (error) {
-      logger.error("Error processing JSON-encoded proof", { error });
+      logger.debug("Error processing JSON-encoded proof", { error });
       // If there's an error processing the JSON-encoded proof, fall through to try decoding it as ABI
     }
   }
@@ -149,7 +149,7 @@ export function decodeProof(proof: string): NestedProof {
     const flatProof = decodeAbiEncodedProof(cleanedProof);
     return convertToNestedFormat(flatProof);
   } catch (error) {
-    logger.error("Error decoding ABI-encoded proof", { error });
+    logger.warn("Error decoding ABI-encoded proof", { error });
     throw new Error("Invalid proof format");
   }
 }
@@ -220,8 +220,7 @@ export const parseProofInputs = (params: IInputParams) => {
 
   try {
     proof = decodeProof(params.proof);
-  } catch (error) {
-    logger.error("Error decode proof", { error });
+  } catch {
     return {
       error: {
         message:


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Malformed `proof` inputs to `/api/v2/verify/{app_id}` are HTTP 400 client errors, but `decodeProof`/`parseProofInputs` were logging them at `error` level — up to three error lines per single bad request. Because `web/lib/logger.ts` tags the active Datadog span as errored on every `logger.error`, these client-input failures were inflating APM error rates and noise on the verify endpoint.

This downgrades the JSON-parse fallback to `debug` (it's an intermediate path the code recovers from), the terminal ABI-decode failure to `warn` (matching the existing convention from #1497), and removes the redundant rethrow log in `parseProofInputs`.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.