### PR TITLE
test(e2e): create app_metadata row before upload-image tests

### DIFF
--- a/tests/api/specs/hasura/upload-image.spec.ts
+++ b/tests/api/specs/hasura/upload-image.spec.ts
@@ -1,10 +1,12 @@
 import axios from "axios";
 import {
   createTestApp,
+  createTestAppMetadata,
   createTestMembership,
   createTestTeam,
   createTestUser,
   deleteTestApp,
+  deleteTestAppMetadata,
   deleteTestMembership,
   deleteTestTeam,
   deleteTestUser,
@@ -13,6 +15,7 @@ import {
 describe("Hasura API - Upload Image", () => {
   describe("POST /api/hasura/upload-image", () => {
     let testAppId: string;
+    let testAppMetadataId: string;
     let testTeamId: string;
     let testUserId: string;
     let testMembershipId: string;
@@ -37,8 +40,15 @@ describe("Hasura API - Upload Image", () => {
         "OWNER",
       );
 
-      // Create test app
+      // Create test app with an unverified app_metadata row, which the
+      // upload-image handler requires to confirm the app is editable.
       testAppId = await createTestApp("Test App for Image Upload", testTeamId);
+      const metadata = await createTestAppMetadata(
+        testAppId,
+        "Test App for Image Upload",
+        "unverified",
+      );
+      testAppMetadataId = metadata.id;
     });
 
     it("Generate Presigned URL for PNG Image Successfully", async () => {
@@ -168,6 +178,7 @@ describe("Hasura API - Upload Image", () => {
 
     afterAll(async () => {
       // Clean up test data
+      await deleteTestAppMetadata(testAppMetadataId);
       await deleteTestApp(testAppId);
       await deleteTestMembership(testMembershipId);
       await deleteTestUser(testUserId);


### PR DESCRIPTION
## Summary

After PR #1874 landed on main, the e2e suite (`pnpm --dir tests/api test specs/hasura/upload-image.spec.ts`) started failing on the two happy-path presigned-URL tests with HTTP 400 `not_found`. The new \`getUploadableApp()\` check in \`web/api/hasura/upload-image/index.ts\` requires the target app to have an \`app_metadata\` row with \`verification_status: \"unverified\"\`. The e2e \`createTestApp\` helper only inserts the \`app\` row — it does not auto-create metadata — so the upload check began rejecting the synthetic test app.

## Fix

Extend the e2e \`beforeAll\` to also call \`createTestAppMetadata(testAppId, ..., \"unverified\")\` and clean it up via \`deleteTestAppMetadata\` in \`afterAll\`. This mirrors the shape of an app created via the dashboard, which is what the production handler now expects.

## Test plan

- [ ] CodeBuild runs the API tests; \`specs/hasura/upload-image.spec.ts\` reports 4/4 passing
- [ ] Run locally against staging:
  \`pnpm --dir tests/api test specs/hasura/upload-image.spec.ts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)