### PR TITLE
feat(mcp): add upload_app_image tool for fully E2E agent flow

### DIFF
--- a/web/api/hasura/register-rp/index.ts
+++ b/web/api/hasura/register-rp/index.ts
@@ -1,32 +1,24 @@
 import { getSdk as getCheckUserSdk } from "@/api/hasura/graphql/checkUserInApp.generated";
 import { errorHasuraQuery } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
-import { getKMSClient, scheduleKeyDeletion } from "@/api/helpers/kms";
-import { createManagerKey } from "@/api/helpers/kms-eth";
-import { submitRegisterRpTransaction } from "@/api/helpers/rp-transactions";
+import {
+  submitManagedRpRegistration,
+  type ManagedRegistrationResult,
+} from "@/api/helpers/rp-registration-flows";
 import {
   generateRpIdString,
-  getRpRegistryConfig,
-  getStagingRpRegistryConfig,
   normalizeAddress,
-  parseRpId,
   RpRegistrationStatus,
 } from "@/api/helpers/rp-utils";
 import { protectInternalEndpoint } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
-import { isWorldId40EnabledServer } from "@/lib/feature-flags/world-id-4-0/server";
 import { logger } from "@/lib/logger";
 import { isAddress } from "ethers";
 import { NextRequest, NextResponse } from "next/server";
 import * as yup from "yup";
 import { getSdk as getClaimRpSdk } from "./graphql/claim-rp-registration.generated";
-import { getSdk as getDeleteRpSdk } from "./graphql/delete-rp-registration.generated";
 import { getSdk as getAppInfoSdk } from "./graphql/get-app-info.generated";
-import { getSdk as getUpdateRpSdk } from "./graphql/update-rp-registration.generated";
 
-/**
- * Input schema for the register_rp action.
- */
 const schema = yup
   .object({
     app_id: yup.string().strict().required(),
@@ -54,16 +46,24 @@ const schema = yup
   })
   .noUnknown();
 
+const REGISTRATION_ERROR_HTTP_CODE: Record<
+  Exclude<ManagedRegistrationResult, { ok: true }>["code"],
+  string
+> = {
+  feature_not_enabled: "feature_not_enabled",
+  config_error: "config_error",
+  already_registered: "already_registered",
+  kms_error: "kms_error",
+  submission_error: "submission_error",
+  db_error: "db_error",
+};
+
 /**
  * POST handler for the register_rp Hasura action.
  *
- * This endpoint:
- * 1. Validates the user owns the app
- * 2. Claims the registration slot (prevents concurrent registrations)
- * 3. Creates a KMS manager key for the RP
- * 4. Builds and signs a UserOperation to register the RP
- * 5. Submits to the temporal bundler
- * 6. Updates the registration with KMS key ID and tx hash
+ * Auth path: dashboard user with ADMIN/OWNER on the team. The actual KMS +
+ * on-chain + DB-update pipeline lives in submitManagedRpRegistration so the
+ * MCP path (api_key auth) can share it.
  */
 export const POST = async (req: NextRequest) => {
   const { isAuthenticated, errorResponse } = protectInternalEndpoint(req);
@@ -93,7 +93,6 @@ export const POST = async (req: NextRequest) => {
     value: body.input,
     schema,
   });
-
   if (!isValid || !parsedParams) {
     return errorHasuraQuery({
       req,
@@ -116,17 +115,15 @@ export const POST = async (req: NextRequest) => {
       app_id,
     });
   }
-
   const appInfo = app[0];
   const teamId = appInfo.team_id;
 
-  // Verify user has permission (ADMIN or OWNER) before revealing feature state
+  // Permission check before revealing feature state.
   const { team } = await getCheckUserSdk(client).CheckUserInApp({
     team_id: teamId,
     app_id,
     user_id: userId,
   });
-
   if (!team || team.length === 0) {
     return errorHasuraQuery({
       req,
@@ -136,47 +133,29 @@ export const POST = async (req: NextRequest) => {
     });
   }
 
-  // Check if team is enabled for World ID 4.0
-  if (!(await isWorldId40EnabledServer(teamId))) {
-    return errorHasuraQuery({
-      req,
-      detail: "World ID 4.0 is not enabled for this team.",
-      code: "feature_not_enabled",
-      app_id,
-    });
-  }
-
-  const rpIdString = generateRpIdString(app_id);
-
-  // STEP 1: Claim the registration slot
-  // This prevents race conditions by using the database's unique constraint
-  // on_conflict with empty update_columns means: if exists, return null
-  const { insert_rp_registration_one: claimedSlot } = await getClaimRpSdk(
-    client,
-  ).ClaimRpRegistration({
-    rp_id: rpIdString,
-    app_id,
-    mode: mode as "managed" | "self_managed",
-    signer_address: mode === "self_managed" ? null : signer_address ?? null,
-  });
-
-  // Another registration already exists for this app
-  if (!claimedSlot) {
-    return errorHasuraQuery({
-      req,
-      detail: "Registration already in progress or completed for this app.",
-      code: "already_registered",
-      app_id,
-    });
-  }
-
-  // Self-managed: just create the DB record, no KMS or transactions
+  // Self-managed: just create the DB record. No KMS / on-chain work.
   if (mode === "self_managed") {
+    const rpIdString = generateRpIdString(app_id);
+    const { insert_rp_registration_one: claimedSlot } = await getClaimRpSdk(
+      client,
+    ).ClaimRpRegistration({
+      rp_id: rpIdString,
+      app_id,
+      mode: "self_managed",
+      signer_address: null,
+    });
+    if (!claimedSlot) {
+      return errorHasuraQuery({
+        req,
+        detail: "Registration already in progress or completed for this app.",
+        code: "already_registered",
+        app_id,
+      });
+    }
     logger.info("Self-managed RP registration created", {
       app_id,
       rpIdString,
     });
-
     return NextResponse.json({
       rp_id: rpIdString,
       manager_address: null,
@@ -186,133 +165,30 @@ export const POST = async (req: NextRequest) => {
     });
   }
 
-  // --- Managed mode: create KMS key and submit on-chain transactions ---
-
-  const primaryConfig = getRpRegistryConfig();
-  if (!primaryConfig) {
-    await getDeleteRpSdk(client).DeleteRpRegistration({ rp_id: rpIdString });
-    return errorHasuraQuery({
-      req,
-      detail: "Missing required environment variables for RP Registry.",
-      code: "config_error",
-    });
-  }
-
-  const rpId = parseRpId(rpIdString);
-
-  // STEP 2: Create KMS manager key
-  const kmsClient = await getKMSClient(primaryConfig.kmsRegion);
-  const managerKeyResult = await createManagerKey(kmsClient, rpIdString);
-
-  if (!managerKeyResult) {
-    await getDeleteRpSdk(client).DeleteRpRegistration({ rp_id: rpIdString });
-    return errorHasuraQuery({
-      req,
-      detail: "Failed to create manager key.",
-      code: "kms_error",
-      app_id,
-    });
-  }
-
-  const { keyId: managerKmsKeyId, address: managerAddress } = managerKeyResult;
-
-  // Get the domain (app name)
+  // Managed mode: delegate to the shared pipeline.
   const appName = appInfo.app_metadata?.[0]?.name || "";
-
-  // STEP 3a: Submit primary registration (required)
-  let operationHash: string;
-
-  try {
-    operationHash = await submitRegisterRpTransaction(primaryConfig, {
-      rpId,
-      managerAddress,
-      signerAddress: signer_address!,
-      appName,
-      kmsClient,
-    });
-  } catch (error) {
-    logger.error("Failed to submit registration transaction", {
-      error,
-      app_id,
-    });
-    await scheduleKeyDeletion(kmsClient, managerKmsKeyId);
-    await getDeleteRpSdk(client).DeleteRpRegistration({
-      rp_id: rpIdString,
-    });
-    return errorHasuraQuery({
-      req,
-      detail: "Failed to submit registration transaction.",
-      code: "submission_error",
-      app_id,
-    });
-  }
-
-  // STEP 3b: Duplicate to staging contract (best-effort, production only)
-  let stagingOperationHash: string | null = null;
-  let stagingStatus: string | null = null;
-  if (process.env.NEXT_PUBLIC_APP_ENV === "production") {
-    const stagingConfig = getStagingRpRegistryConfig();
-    if (stagingConfig) {
-      try {
-        stagingOperationHash = await submitRegisterRpTransaction(
-          stagingConfig,
-          {
-            rpId,
-            managerAddress,
-            signerAddress: signer_address!,
-            appName,
-            kmsClient,
-          },
-        );
-        stagingStatus = RpRegistrationStatus.Pending;
-        logger.info("Staging registration submitted", {
-          rpIdString,
-          operationHash: stagingOperationHash,
-          contractAddress: stagingConfig.contractAddress,
-        });
-      } catch (error) {
-        stagingStatus = RpRegistrationStatus.Failed;
-        logger.error("Staging registration failed", {
-          error,
-          rpIdString,
-          contractAddress: stagingConfig.contractAddress,
-        });
-      }
-    }
-  }
-
-  // STEP 4: Update the registration with KMS key ID and operation hash
-  const { update_rp_registration_by_pk: updatedRegistration } =
-    await getUpdateRpSdk(client).UpdateRpRegistration({
-      rp_id: rpIdString,
-      manager_kms_key_id: managerKmsKeyId,
-      operation_hash: operationHash,
-      staging_operation_hash: stagingOperationHash,
-      staging_status: stagingStatus,
-    });
-
-  if (!updatedRegistration) {
-    // On-chain tx may succeed; manual intervention needed to reconcile state
-    return errorHasuraQuery({
-      req,
-      detail: "Failed to update registration record.",
-      code: "db_error",
-      app_id,
-    });
-  }
-
-  logger.info("RP registration successful", {
-    app_id,
-    rpIdString,
-    managerAddress,
-    operationHash,
+  const result = await submitManagedRpRegistration({
+    client,
+    appId: app_id,
+    teamId,
+    signerAddress: signer_address!,
+    appName,
   });
 
+  if (!result.ok) {
+    return errorHasuraQuery({
+      req,
+      detail: result.detail,
+      code: REGISTRATION_ERROR_HTTP_CODE[result.code],
+      app_id,
+    });
+  }
+
   return NextResponse.json({
-    rp_id: rpIdString,
-    manager_address: managerAddress,
-    signer_address,
-    status: RpRegistrationStatus.Pending,
-    operation_hash: operationHash,
+    rp_id: result.rpIdString,
+    manager_address: result.managerAddress,
+    signer_address: result.signerAddress,
+    status: result.status,
+    operation_hash: result.operationHash,
   });
 };

--- a/web/api/hasura/register-rp/index.ts
+++ b/web/api/hasura/register-rp/index.ts
@@ -12,6 +12,7 @@ import {
 } from "@/api/helpers/rp-utils";
 import { protectInternalEndpoint } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
+import { isWorldId40EnabledServer } from "@/lib/feature-flags/world-id-4-0/server";
 import { logger } from "@/lib/logger";
 import { isAddress } from "ethers";
 import { NextRequest, NextResponse } from "next/server";
@@ -129,6 +130,18 @@ export const POST = async (req: NextRequest) => {
       req,
       detail: "User does not have permission to register this app.",
       code: "unauthorized",
+      app_id,
+    });
+  }
+
+  // World ID 4.0 rollout flag still gates BOTH modes — the managed helper
+  // checks it internally, but the self_managed branch below skips the
+  // helper, so we explicitly check here to match prior behavior.
+  if (!(await isWorldId40EnabledServer(teamId))) {
+    return errorHasuraQuery({
+      req,
+      detail: "World ID 4.0 is not enabled for this team.",
+      code: "feature_not_enabled",
       app_id,
     });
   }

--- a/web/api/hasura/rotate-signer-key/index.ts
+++ b/web/api/hasura/rotate-signer-key/index.ts
@@ -1,31 +1,18 @@
 import { getSdk as getCheckUserSdk } from "@/api/hasura/graphql/checkUserInApp.generated";
 import { errorHasuraQuery } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
-import { getKMSClient } from "@/api/helpers/kms";
 import {
-  getRpRegistryConfig,
-  getStagingRpRegistryConfig,
-  normalizeAddress,
-  parseRpId,
-  RpRegistrationStatus,
-} from "@/api/helpers/rp-utils";
-import { submitRotateSignerTransaction } from "@/api/helpers/rp-transactions";
+  submitManagedSignerRotation,
+  type ManagedRotationResult,
+} from "@/api/helpers/rp-registration-flows";
+import { normalizeAddress } from "@/api/helpers/rp-utils";
 import { protectInternalEndpoint } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
-import { isWorldId40EnabledServer } from "@/lib/feature-flags/world-id-4-0/server";
-import { logger } from "@/lib/logger";
 import { isAddress } from "ethers";
 import { NextRequest, NextResponse } from "next/server";
 import * as yup from "yup";
-import { getSdk as getClaimRotationSdk } from "./graphql/claim-rotation-slot.generated";
 import { getSdk as getRpRegistrationSdk } from "./graphql/get-rp-registration.generated";
-import { getSdk as getRevertStatusSdk } from "./graphql/revert-rotation-status.generated";
-import { getSdk as getUpdateResultSdk } from "./graphql/update-rotation-result.generated";
-import { getSdk as getUpdateStagingResultSdk } from "./graphql/update-staging-rotation-result.generated";
 
-/**
- * Input schema for the rotate_signer_key action.
- */
 const schema = yup
   .object({
     app_id: yup.string().strict().required(),
@@ -42,17 +29,25 @@ const schema = yup
   })
   .noUnknown();
 
+const ROTATION_ERROR_HTTP_CODE: Record<
+  Exclude<ManagedRotationResult, { ok: true }>["code"],
+  string
+> = {
+  feature_not_enabled: "feature_not_enabled",
+  config_error: "config_error",
+  rp_not_registered: "rp_not_registered",
+  self_managed_mode: "self_managed_mode",
+  rotation_in_progress: "rotation_in_progress",
+  submission_error: "submission_error",
+  db_error: "db_error",
+};
+
 /**
  * POST handler for the rotate_signer_key Hasura action.
  *
- * This endpoint:
- * 1. Validates the user owns the app (ADMIN/OWNER)
- * 2. Verifies the RP is in managed mode
- * 3. Claims the rotation slot (prevents concurrent rotations)
- * 4. Builds and signs the updateRp transaction
- * 5. Submits to the temporal bundler (production + staging best-effort)
- * 6. Updates the registration with new signer address
- * 7. Invalidates the rp_status cache so polling syncs DB from on-chain
+ * Auth path: dashboard user with ADMIN/OWNER on the team. The KMS +
+ * on-chain + DB-update pipeline lives in submitManagedSignerRotation so the
+ * MCP path (api_key auth) can share it.
  */
 export const POST = async (req: NextRequest) => {
   const { isAuthenticated, errorResponse } = protectInternalEndpoint(req);
@@ -82,7 +77,6 @@ export const POST = async (req: NextRequest) => {
     value: body.input,
     schema,
   });
-
   if (!isValid || !parsedParams) {
     return errorHasuraQuery({
       req,
@@ -92,23 +86,13 @@ export const POST = async (req: NextRequest) => {
   }
 
   const { app_id, new_signer_address } = parsedParams;
-
-  const primaryConfig = getRpRegistryConfig();
-  if (!primaryConfig) {
-    return errorHasuraQuery({
-      req,
-      detail: "Missing required environment variables for RP Registry.",
-      code: "config_error",
-    });
-  }
-
   const client = await getAPIServiceGraphqlClient();
 
-  // STEP 1: Fetch RP registration
+  // Resolve team_id up front so we can scope the permission check before
+  // running the rotation flow (which also fetches the registration).
   const { rp_registration } = await getRpRegistrationSdk(
     client,
   ).GetRpRegistration({ app_id });
-
   if (!rp_registration || rp_registration.length === 0) {
     return errorHasuraQuery({
       req,
@@ -117,19 +101,13 @@ export const POST = async (req: NextRequest) => {
       app_id,
     });
   }
+  const teamId = rp_registration[0].app.team_id;
 
-  const registration = rp_registration[0];
-  const rpIdString = registration.rp_id;
-  const teamId = registration.app.team_id;
-  const oldSignerAddress = registration.signer_address || "";
-
-  // STEP 2: Verify user has permission (ADMIN or OWNER) before revealing feature state
   const { team } = await getCheckUserSdk(client).CheckUserInApp({
     team_id: teamId,
     app_id,
     user_id: userId,
   });
-
   if (!team || team.length === 0) {
     return errorHasuraQuery({
       req,
@@ -139,200 +117,26 @@ export const POST = async (req: NextRequest) => {
     });
   }
 
-  // Check if team is enabled for World ID 4.0
-  if (!(await isWorldId40EnabledServer(teamId))) {
-    return errorHasuraQuery({
-      req,
-      detail: "World ID 4.0 is not enabled for this team.",
-      code: "feature_not_enabled",
-      app_id,
-    });
-  }
-
-  // STEP 3: Verify mode is managed
-  if (registration.mode !== "managed" || !registration.manager_kms_key_id) {
-    return errorHasuraQuery({
-      req,
-      detail:
-        "RP is in self-managed mode. You must handle signer key rotation yourself.",
-      code: "self_managed_mode",
-      app_id,
-    });
-  }
-
-  const managerKmsKeyId = registration.manager_kms_key_id;
-
-  // STEP 4: Atomically claim rotation slot (status: registered → pending)
-  const { update_rp_registration: claimResult } = await getClaimRotationSdk(
+  const result = await submitManagedSignerRotation({
     client,
-  ).ClaimRotationSlot({ rp_id: rpIdString });
+    appId: app_id,
+    newSignerAddress: new_signer_address,
+  });
 
-  if (!claimResult || claimResult.affected_rows === 0) {
+  if (!result.ok) {
     return errorHasuraQuery({
       req,
-      detail:
-        "Cannot rotate signer key. RP status is not 'registered' (rotation may already be in progress).",
-      code: "rotation_in_progress",
+      detail: result.detail,
+      code: ROTATION_ERROR_HTTP_CODE[result.code],
       app_id,
     });
   }
 
-  const rpId = parseRpId(rpIdString);
-
-  // Helper to revert status on failure
-  const revertStatus = async () => {
-    try {
-      await getRevertStatusSdk(client).RevertRotationStatus({
-        rp_id: rpIdString,
-      });
-    } catch (revertError) {
-      logger.error("Failed to revert rotation status", {
-        error: revertError,
-        app_id,
-        rpIdString,
-      });
-    }
-  };
-
-  try {
-    // STEP 5a: Submit primary signer rotation (required)
-    const kmsClient = await getKMSClient(primaryConfig.kmsRegion);
-    let operationHash: string;
-
-    try {
-      operationHash = await submitRotateSignerTransaction(primaryConfig, {
-        rpId,
-        newSignerAddress: new_signer_address,
-        managerKmsKeyId,
-        kmsClient,
-      });
-    } catch (error) {
-      logger.error("Failed to submit signer rotation transaction", {
-        error,
-        app_id,
-      });
-      await revertStatus();
-      return errorHasuraQuery({
-        req,
-        detail: "Failed to submit signer rotation transaction.",
-        code: "submission_error",
-        app_id,
-      });
-    }
-
-    // STEP 5b: Duplicate to staging contract (best-effort, production only)
-    let stagingHash: string | null = null;
-    let stagingStatusToWrite: RpRegistrationStatus | null = null;
-    if (process.env.NEXT_PUBLIC_APP_ENV === "production") {
-      const stagingConfig = getStagingRpRegistryConfig();
-      if (stagingConfig) {
-        try {
-          stagingHash = await submitRotateSignerTransaction(stagingConfig, {
-            rpId,
-            newSignerAddress: new_signer_address,
-            managerKmsKeyId,
-            kmsClient,
-          });
-          stagingStatusToWrite = RpRegistrationStatus.Pending;
-          logger.info("Staging signer rotation submitted", {
-            rpIdString,
-            operationHash: stagingHash,
-            contractAddress: stagingConfig.contractAddress,
-          });
-        } catch (error) {
-          stagingStatusToWrite = RpRegistrationStatus.Failed;
-          logger.error("Staging signer rotation failed", {
-            error,
-            rpIdString,
-            contractAddress: stagingConfig.contractAddress,
-          });
-        }
-      }
-    }
-
-    // STEP 6: Update the registration with new signer address and operation hash
-    const { update_rp_registration_by_pk: updatedRegistration } =
-      await getUpdateResultSdk(client).UpdateRotationResult({
-        rp_id: rpIdString,
-        signer_address: new_signer_address,
-        operation_hash: operationHash,
-      });
-
-    if (!updatedRegistration) {
-      // On-chain tx may succeed; manual intervention needed to reconcile state
-      logger.error("Failed to update registration record after submission", {
-        app_id,
-        rpIdString,
-        operationHash,
-      });
-      return errorHasuraQuery({
-        req,
-        detail: "Failed to update registration record.",
-        code: "db_error",
-        app_id,
-      });
-    }
-
-    // Persist staging rotation outcome so the UI surfaces a retry button on
-    // failure and doesn't keep showing the registration's stale operation hash
-    // on success. Best-effort: a DB error here doesn't fail the rotation.
-    if (stagingStatusToWrite) {
-      try {
-        await getUpdateStagingResultSdk(client).UpdateStagingRotationResult({
-          rp_id: rpIdString,
-          staging_status: stagingStatusToWrite,
-          staging_operation_hash: stagingHash,
-        });
-      } catch (error) {
-        logger.error("Failed to persist staging rotation result", {
-          error,
-          rpIdString,
-          staging_status: stagingStatusToWrite,
-        });
-      }
-    }
-
-    // Invalidate status cache so the next rp-status poll does a real
-    // on-chain check and syncs the DB status back to "registered".
-    const redis = global.RedisClient;
-    if (redis) {
-      try {
-        const cacheKey = `rp_status:v2:${rpIdString}`;
-        await redis.del(cacheKey);
-      } catch (cacheError) {
-        logger.warn("Failed to invalidate rp_status cache", {
-          error: cacheError,
-          rpIdString,
-        });
-      }
-    }
-
-    logger.info("Signer key rotation successful", {
-      app_id,
-      rpIdString,
-      oldSignerAddress,
-      new_signer_address,
-      operationHash,
-    });
-
-    return NextResponse.json({
-      rp_id: rpIdString,
-      new_signer_address,
-      old_signer_address: oldSignerAddress,
-      status: "pending",
-      operation_hash: operationHash,
-    });
-  } catch (error) {
-    logger.error("Unexpected error during signer key rotation", {
-      error,
-      app_id,
-    });
-    await revertStatus();
-    return errorHasuraQuery({
-      req,
-      detail: "An unexpected error occurred.",
-      code: "internal_error",
-      app_id,
-    });
-  }
+  return NextResponse.json({
+    rp_id: result.rpIdString,
+    new_signer_address: result.newSignerAddress,
+    old_signer_address: result.oldSignerAddress,
+    status: result.status,
+    operation_hash: result.operationHash,
+  });
 };

--- a/web/api/hasura/upload-image/index.ts
+++ b/web/api/hasura/upload-image/index.ts
@@ -1,3 +1,4 @@
+import { generateAppImagePresignedPost } from "@/api/helpers/app-image-storage";
 import { getSdk as checkAppInTeamDocumentSDK } from "@/api/hasura/graphql/checkAppInTeam.generated";
 import { getSdk as checkUserInAppDocumentSDK } from "@/api/hasura/graphql/checkUserInApp.generated";
 import { errorHasuraQuery } from "@/api/helpers/errors";
@@ -5,8 +6,6 @@ import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { protectInternalEndpoint } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { logger } from "@/lib/logger";
-import { S3Client } from "@aws-sdk/client-s3";
-import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 import { NextRequest, NextResponse } from "next/server";
 import * as yup from "yup";
 
@@ -154,40 +153,15 @@ export const POST = async (req: NextRequest) => {
       }
     }
 
-    if (!process.env.ASSETS_S3_REGION) {
-      throw new Error("AWS Region must be set.");
-    }
-
-    const s3Client = new S3Client({
-      region: process.env.ASSETS_S3_REGION,
+    const { url, fields } = await generateAppImagePresignedPost({
+      appId: app_id,
+      imageType: image_type,
+      contentTypeEnding: content_type_ending,
+      locale,
     });
-
-    if (!process.env.ASSETS_S3_BUCKET_NAME) {
-      throw new Error("AWS Bucket Name must be set.");
-    }
-
-    const bucketName = process.env.ASSETS_S3_BUCKET_NAME;
-
-    // Standardize JPEG to jpg
-    const objectKey = `unverified/${app_id}${locale && locale !== "en" ? `/${locale}` : ""}/${image_type}.${
-      content_type_ending === "jpeg" ? "jpg" : content_type_ending
-    }`;
-
-    const contentType = `image/${content_type_ending}`;
-    const signedUrl = await createPresignedPost(s3Client, {
-      Bucket: bucketName,
-      Key: objectKey,
-      Expires: 600, // URL expires in 10 minutes
-      Conditions: [
-        ["content-length-range", 0, 500 * 1024],
-        ["eq", "$Content-Type", contentType],
-      ],
-    });
-
-    const { url, fields } = signedUrl;
 
     return NextResponse.json({
-      url: url,
+      url,
       stringifiedFields: JSON.stringify(fields),
     });
   } catch (error) {

--- a/web/api/helpers/app-image-storage.ts
+++ b/web/api/helpers/app-image-storage.ts
@@ -1,0 +1,158 @@
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  createPresignedPost,
+  type PresignedPost,
+} from "@aws-sdk/s3-presigned-post";
+
+// Image-type identifier the dashboard / Hasura action / MCP all share. The
+// values match the basenames the dashboard uses on disk so the existing image
+// upload flow keeps working.
+export const APP_IMAGE_BASENAMES = {
+  logo_img: "logo_img",
+  hero_image: "hero_image",
+  content_card_image: "content_card_image",
+  meta_tag_image: "meta_tag_image",
+  showcase_img_1: "showcase_img_1",
+  showcase_img_2: "showcase_img_2",
+  showcase_img_3: "showcase_img_3",
+} as const;
+
+export type AppImageBasename = keyof typeof APP_IMAGE_BASENAMES;
+
+// MCP-facing alias map: short, human-friendly image_type values that map onto
+// the basenames + the app_metadata column the upload should patch.
+export const MCP_APP_IMAGE_MAP = {
+  logo: { basename: "logo_img", field: "logo_img_url" },
+  hero: { basename: "hero_image", field: "hero_image_url" },
+  content_card: {
+    basename: "content_card_image",
+    field: "content_card_image_url",
+  },
+  meta_tag: { basename: "meta_tag_image", field: "meta_tag_image_url" },
+  showcase_1: {
+    basename: "showcase_img_1",
+    field: "showcase_img_urls",
+    arrayIndex: 0,
+  },
+  showcase_2: {
+    basename: "showcase_img_2",
+    field: "showcase_img_urls",
+    arrayIndex: 1,
+  },
+  showcase_3: {
+    basename: "showcase_img_3",
+    field: "showcase_img_urls",
+    arrayIndex: 2,
+  },
+} as const;
+
+export type McpAppImageType = keyof typeof MCP_APP_IMAGE_MAP;
+
+export const MAX_APP_IMAGE_BYTES = 500 * 1024;
+
+const normalizeExtension = (contentTypeEnding: string) =>
+  contentTypeEnding === "jpeg" ? "jpg" : contentTypeEnding;
+
+export const buildAppImageObjectKey = ({
+  appId,
+  fileName,
+  locale,
+}: {
+  appId: string;
+  fileName: string;
+  locale?: string;
+}) => {
+  const localePrefix = locale && locale !== "en" ? `${locale}/` : "";
+  return `unverified/${appId}/${localePrefix}${fileName}`;
+};
+
+const getS3Config = () => {
+  const region = process.env.ASSETS_S3_REGION;
+  const bucket = process.env.ASSETS_S3_BUCKET_NAME;
+  if (!region) {
+    throw new Error("ASSETS_S3_REGION is not configured.");
+  }
+  if (!bucket) {
+    throw new Error("ASSETS_S3_BUCKET_NAME is not configured.");
+  }
+  return { region, bucket };
+};
+
+/**
+ * Generate a presigned multipart POST that callers can use to upload directly
+ * to S3 from the browser (or any client). Used by the Hasura upload-image
+ * action. Mirrors the dashboard's upload contract.
+ */
+export const generateAppImagePresignedPost = async ({
+  appId,
+  imageType,
+  contentTypeEnding,
+  locale,
+}: {
+  appId: string;
+  imageType: string;
+  contentTypeEnding: string;
+  locale?: string;
+}): Promise<PresignedPost> => {
+  const { region, bucket } = getS3Config();
+  const client = new S3Client({ region });
+  const ext = normalizeExtension(contentTypeEnding);
+  const fileName = `${imageType}.${ext}`;
+  const objectKey = buildAppImageObjectKey({ appId, fileName, locale });
+  const contentType = `image/${contentTypeEnding}`;
+  return createPresignedPost(client, {
+    Bucket: bucket,
+    Key: objectKey,
+    Expires: 600, // 10 minutes
+    Conditions: [
+      ["content-length-range", 0, MAX_APP_IMAGE_BYTES],
+      ["eq", "$Content-Type", contentType],
+    ],
+  });
+};
+
+/**
+ * Upload an image directly from the server (used by the MCP upload_app_image
+ * tool). Returns the resulting object key + filename so the caller can patch
+ * the matching app_metadata field.
+ */
+export const uploadAppImage = async ({
+  appId,
+  imageType,
+  body,
+  contentType,
+  locale,
+}: {
+  appId: string;
+  imageType: McpAppImageType;
+  body: Buffer;
+  contentType: "image/png" | "image/jpeg";
+  locale?: string;
+}) => {
+  if (body.byteLength === 0) {
+    throw new Error("Image is empty.");
+  }
+  if (body.byteLength > MAX_APP_IMAGE_BYTES) {
+    throw new Error(
+      `Image is ${body.byteLength} bytes; maximum is ${MAX_APP_IMAGE_BYTES} (500KB).`,
+    );
+  }
+
+  const { region, bucket } = getS3Config();
+  const client = new S3Client({ region });
+  const ext = contentType === "image/png" ? "png" : "jpg";
+  const mapping = MCP_APP_IMAGE_MAP[imageType];
+  const fileName = `${mapping.basename}.${ext}`;
+  const objectKey = buildAppImageObjectKey({ appId, fileName, locale });
+
+  await client.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: objectKey,
+      Body: body,
+      ContentType: contentType,
+    }),
+  );
+
+  return { fileName, objectKey, mapping, sizeBytes: body.byteLength };
+};

--- a/web/api/helpers/app-image-storage.ts
+++ b/web/api/helpers/app-image-storage.ts
@@ -1,4 +1,8 @@
-import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  DeleteObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
 import {
   createPresignedPost,
   type PresignedPost,
@@ -157,6 +161,24 @@ export const uploadAppImage = async ({
   );
 
   return { fileName, objectKey, mapping, sizeBytes: body.byteLength };
+};
+
+/**
+ * Best-effort delete of an object we just wrote, used to compensate when a
+ * downstream step (e.g. an app_metadata GraphQL update) fails after the S3
+ * PUT succeeded. Swallows errors — the caller has already decided to surface
+ * the original failure; we just don't want orphaned bytes if we can help it.
+ */
+export const tryDeleteAppImage = async (objectKey: string): Promise<void> => {
+  try {
+    const { region, bucket } = getS3Config();
+    const client = new S3Client({ region });
+    await client.send(
+      new DeleteObjectCommand({ Bucket: bucket, Key: objectKey }),
+    );
+  } catch {
+    // intentionally ignored — the caller logs the original failure.
+  }
 };
 
 // ---------------------------------------------------------------------------

--- a/web/api/helpers/app-image-storage.ts
+++ b/web/api/helpers/app-image-storage.ts
@@ -346,6 +346,13 @@ type FetchedImage = {
   body: Buffer;
 };
 
+// Bound the time a single source_url fetch can occupy a worker. The total
+// budget covers DNS + connect + body read end-to-end; the idle timer fires
+// when the socket goes silent for too long mid-transfer (slow-trickle
+// attack). 10s is generous for a 500KB image even on slow public links.
+const FETCH_TOTAL_TIMEOUT_MS = 10_000;
+const FETCH_SOCKET_IDLE_TIMEOUT_MS = 5_000;
+
 // Fetch over https using a custom DNS lookup that always returns the
 // pre-validated IP. This guarantees the connection lands on the address we
 // already proved is public. Streams the body, aborts past the cap, and
@@ -383,6 +390,33 @@ const httpsRequestPinned = ({
   };
 
   return new Promise<FetchedImage>((resolve, reject) => {
+    let settled = false;
+    let totalTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const cleanup = () => {
+      if (totalTimer) {
+        clearTimeout(totalTimer);
+        totalTimer = null;
+      }
+    };
+    const succeed = (value: FetchedImage) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      try {
+        req.destroy();
+      } catch {
+        // ignore — best-effort socket teardown.
+      }
+      reject(error);
+    };
+
     const req = httpsRequest(options, (res) => {
       const status = res.statusCode ?? 0;
       // We never follow redirects: the new Location could resolve to a
@@ -390,7 +424,7 @@ const httpsRequestPinned = ({
       // client-side first.
       if (status >= 300 && status < 400) {
         res.resume();
-        reject(
+        fail(
           new ImageInputError(
             `source_url returned ${status} ${res.statusMessage ?? ""}; redirects are not followed.`,
           ),
@@ -399,7 +433,7 @@ const httpsRequestPinned = ({
       }
       if (status < 200 || status >= 300) {
         res.resume();
-        reject(
+        fail(
           new ImageInputError(
             `Failed to fetch source_url: ${status} ${res.statusMessage ?? ""}`,
           ),
@@ -416,7 +450,7 @@ const httpsRequestPinned = ({
         contentLength > cap
       ) {
         res.destroy();
-        reject(
+        fail(
           new ImageInputError(
             `source_url Content-Length (${contentLength}) exceeds ${cap} bytes.`,
           ),
@@ -430,7 +464,7 @@ const httpsRequestPinned = ({
         total += chunk.byteLength;
         if (total > cap) {
           res.destroy();
-          reject(
+          fail(
             new ImageInputError(
               `source_url body exceeds ${cap} bytes (read ${total}).`,
             ),
@@ -440,15 +474,31 @@ const httpsRequestPinned = ({
         chunks.push(chunk);
       });
       res.on("end", () => {
-        resolve({
+        succeed({
           status,
           contentLength,
           body: Buffer.concat(chunks, total),
         });
       });
-      res.on("error", reject);
+      res.on("error", fail);
     });
-    req.on("error", reject);
+
+    totalTimer = setTimeout(() => {
+      fail(
+        new ImageInputError(
+          `source_url fetch exceeded ${FETCH_TOTAL_TIMEOUT_MS}ms.`,
+        ),
+      );
+    }, FETCH_TOTAL_TIMEOUT_MS);
+
+    req.setTimeout(FETCH_SOCKET_IDLE_TIMEOUT_MS, () => {
+      fail(
+        new ImageInputError(
+          `source_url socket was idle for ${FETCH_SOCKET_IDLE_TIMEOUT_MS}ms.`,
+        ),
+      );
+    });
+    req.on("error", fail);
     req.end();
   });
 };

--- a/web/api/helpers/app-image-storage.ts
+++ b/web/api/helpers/app-image-storage.ts
@@ -8,6 +8,7 @@ import {
   type PresignedPost,
 } from "@aws-sdk/s3-presigned-post";
 import { lookup } from "node:dns/promises";
+import { request as httpsRequest, type RequestOptions } from "node:https";
 import { isIP } from "node:net";
 
 // Image-type identifier the dashboard / Hasura action / MCP all share. The
@@ -272,7 +273,17 @@ const isPrivateIp = (addr: string, family: 4 | 6): boolean => {
   return false;
 };
 
-const assertSafeImageUrl = async (rawUrl: string): Promise<URL> => {
+type ResolvedSafeUrl = {
+  url: URL;
+  // The pre-validated address we'll force the connection to use. Pinning
+  // here closes the DNS-rebinding TOCTOU window: if the hostname's records
+  // change between our `lookup` and the actual TCP connect, the connect
+  // still goes to the IP we already proved is public.
+  pinnedAddress: string;
+  pinnedFamily: 4 | 6;
+};
+
+const assertSafeImageUrl = async (rawUrl: string): Promise<ResolvedSafeUrl> => {
   let url: URL;
   try {
     url = new URL(rawUrl);
@@ -286,7 +297,6 @@ const assertSafeImageUrl = async (rawUrl: string): Promise<URL> => {
   if (url.username || url.password) {
     throw new ImageInputError("source_url must not embed credentials.");
   }
-  // Resolve hostname → reject private / loopback / link-local / multicast.
   const hostname = url.hostname.replace(/^\[|\]$/g, "");
   const directIpFamily = isIP(hostname) as 0 | 4 | 6;
   if (directIpFamily) {
@@ -295,11 +305,10 @@ const assertSafeImageUrl = async (rawUrl: string): Promise<URL> => {
         "source_url resolves to a private/internal address.",
       );
     }
-    return url;
+    return { url, pinnedAddress: hostname, pinnedFamily: directIpFamily };
   }
-  // Validate every A/AAAA record. fetch performs its own resolution and may
-  // pick a different record than we did, so any single private address in
-  // the result set is grounds for refusal — not just the first one we see.
+  // Resolve every A/AAAA record so we can reject hostnames that mix public
+  // and private answers. Any single private record fails the whole URL.
   let resolvedAll: Array<{ address: string; family: number }>;
   try {
     resolvedAll = await lookup(hostname, { all: true });
@@ -321,75 +330,153 @@ const assertSafeImageUrl = async (rawUrl: string): Promise<URL> => {
       );
     }
   }
-  return url;
+  // Pin to the first record. The set is fully validated either way; picking
+  // one is fine since the connection only needs one IP.
+  const pin = resolvedAll[0];
+  return {
+    url,
+    pinnedAddress: pin.address,
+    pinnedFamily: pin.family === 6 ? 6 : 4,
+  };
 };
 
-const readWithCap = async (
-  body: ReadableStream<Uint8Array>,
-  cap: number,
-): Promise<Buffer> => {
-  const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      total += value.byteLength;
-      if (total > cap) {
-        await reader.cancel().catch(() => {});
-        throw new ImageInputError(
-          `source_url body exceeds ${cap} bytes (read ${total}).`,
+type FetchedImage = {
+  status: number;
+  contentLength: number | null;
+  body: Buffer;
+};
+
+// Fetch over https using a custom DNS lookup that always returns the
+// pre-validated IP. This guarantees the connection lands on the address we
+// already proved is public. Streams the body, aborts past the cap, and
+// rejects redirects by returning an error on any 30x status.
+const httpsRequestPinned = ({
+  url,
+  pinnedAddress,
+  pinnedFamily,
+  cap,
+}: {
+  url: URL;
+  pinnedAddress: string;
+  pinnedFamily: 4 | 6;
+  cap: number;
+}): Promise<FetchedImage> => {
+  const options: RequestOptions = {
+    method: "GET",
+    host: url.hostname,
+    port: url.port ? Number(url.port) : 443,
+    path: `${url.pathname}${url.search}`,
+    headers: { Host: url.host, "User-Agent": "world-developer-portal-mcp" },
+    lookup: (_hostname, _options, callback) => {
+      // Ignore the hostname argument — we always return the pinned IP.
+      // Cast trick: dns.lookup callback takes either (err, addresses)
+      // or (err, address, family) depending on options.all. The
+      // https.request connect path uses the single-result form.
+      (
+        callback as (
+          err: NodeJS.ErrnoException | null,
+          address: string,
+          family: number,
+        ) => void
+      )(null, pinnedAddress, pinnedFamily);
+    },
+  };
+
+  return new Promise<FetchedImage>((resolve, reject) => {
+    const req = httpsRequest(options, (res) => {
+      const status = res.statusCode ?? 0;
+      // We never follow redirects: the new Location could resolve to a
+      // private host. Surface the redirect so the caller resolves it
+      // client-side first.
+      if (status >= 300 && status < 400) {
+        res.resume();
+        reject(
+          new ImageInputError(
+            `source_url returned ${status} ${res.statusMessage ?? ""}; redirects are not followed.`,
+          ),
         );
+        return;
       }
-      chunks.push(value);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  return Buffer.concat(
-    chunks.map((c) => Buffer.from(c)),
-    total,
-  );
+      if (status < 200 || status >= 300) {
+        res.resume();
+        reject(
+          new ImageInputError(
+            `Failed to fetch source_url: ${status} ${res.statusMessage ?? ""}`,
+          ),
+        );
+        return;
+      }
+
+      const declared = res.headers["content-length"];
+      const contentLength =
+        typeof declared === "string" ? Number.parseInt(declared, 10) : null;
+      if (
+        contentLength !== null &&
+        Number.isFinite(contentLength) &&
+        contentLength > cap
+      ) {
+        res.destroy();
+        reject(
+          new ImageInputError(
+            `source_url Content-Length (${contentLength}) exceeds ${cap} bytes.`,
+          ),
+        );
+        return;
+      }
+
+      const chunks: Buffer[] = [];
+      let total = 0;
+      res.on("data", (chunk: Buffer) => {
+        total += chunk.byteLength;
+        if (total > cap) {
+          res.destroy();
+          reject(
+            new ImageInputError(
+              `source_url body exceeds ${cap} bytes (read ${total}).`,
+            ),
+          );
+          return;
+        }
+        chunks.push(chunk);
+      });
+      res.on("end", () => {
+        resolve({
+          status,
+          contentLength,
+          body: Buffer.concat(chunks, total),
+        });
+      });
+      res.on("error", reject);
+    });
+    req.on("error", reject);
+    req.end();
+  });
 };
 
 export const fetchImageFromUrl = async (
   rawUrl: string,
 ): Promise<{ body: Buffer; contentType: "image/png" | "image/jpeg" }> => {
-  const url = await assertSafeImageUrl(rawUrl);
-  let response;
+  const { url, pinnedAddress, pinnedFamily } = await assertSafeImageUrl(rawUrl);
+  let result: FetchedImage;
   try {
-    response = await fetch(url, { redirect: "error" });
+    result = await httpsRequestPinned({
+      url,
+      pinnedAddress,
+      pinnedFamily,
+      cap: MAX_APP_IMAGE_BYTES,
+    });
   } catch (error) {
+    if (error instanceof ImageInputError) throw error;
     const message = error instanceof Error ? error.message : String(error);
     throw new ImageInputError(`Failed to fetch source_url: ${message}`);
   }
-  if (!response.ok) {
-    throw new ImageInputError(
-      `Failed to fetch source_url: ${response.status} ${response.statusText}`,
-    );
-  }
-  // Bail early if the server tells us the body is too big up front.
-  const declared = response.headers.get("content-length");
-  if (declared) {
-    const declaredBytes = Number.parseInt(declared, 10);
-    if (Number.isFinite(declaredBytes) && declaredBytes > MAX_APP_IMAGE_BYTES) {
-      throw new ImageInputError(
-        `source_url Content-Length (${declaredBytes}) exceeds ${MAX_APP_IMAGE_BYTES} bytes.`,
-      );
-    }
-  }
-  if (!response.body) {
-    throw new ImageInputError("source_url response had no body.");
-  }
-  const body = await readWithCap(response.body, MAX_APP_IMAGE_BYTES);
-  const contentType = detectImageContentType(body);
+  const contentType = detectImageContentType(result.body);
   if (!contentType) {
     throw new ImageInputError(
       "source_url body is not a valid PNG or JPEG image.",
     );
   }
-  return { body, contentType };
+  return { body: result.body, contentType };
 };
 
 export const decodeImageBase64 = (

--- a/web/api/helpers/app-image-storage.ts
+++ b/web/api/helpers/app-image-storage.ts
@@ -3,6 +3,8 @@ import {
   createPresignedPost,
   type PresignedPost,
 } from "@aws-sdk/s3-presigned-post";
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
 
 // Image-type identifier the dashboard / Hasura action / MCP all share. The
 // values match the basenames the dashboard uses on disk so the existing image
@@ -155,4 +157,207 @@ export const uploadAppImage = async ({
   );
 
   return { fileName, objectKey, mapping, sizeBytes: body.byteLength };
+};
+
+// ---------------------------------------------------------------------------
+// Source-image fetch + decode helpers (used by MCP upload_app_image).
+//
+// We need to (a) avoid SSRF when an authenticated caller asks the server to
+// fetch an arbitrary URL, (b) cap the bytes we read so we don't OOM on a 1GB
+// response, and (c) authoritatively detect the image format from the bytes
+// themselves rather than trusting caller-provided metadata.
+// ---------------------------------------------------------------------------
+
+export class ImageInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ImageInputError";
+  }
+}
+
+export const detectImageContentType = (
+  body: Buffer,
+): "image/png" | "image/jpeg" | null => {
+  if (body.length >= 8) {
+    // PNG signature: 89 50 4E 47 0D 0A 1A 0A
+    if (
+      body[0] === 0x89 &&
+      body[1] === 0x50 &&
+      body[2] === 0x4e &&
+      body[3] === 0x47 &&
+      body[4] === 0x0d &&
+      body[5] === 0x0a &&
+      body[6] === 0x1a &&
+      body[7] === 0x0a
+    ) {
+      return "image/png";
+    }
+  }
+  if (body.length >= 3) {
+    // JPEG SOI marker: FF D8 FF (any third byte)
+    if (body[0] === 0xff && body[1] === 0xd8 && body[2] === 0xff) {
+      return "image/jpeg";
+    }
+  }
+  return null;
+};
+
+const isPrivateIp = (addr: string, family: 4 | 6): boolean => {
+  if (family === 4) {
+    const parts = addr.split(".").map((n) => parseInt(n, 10));
+    if (parts.length !== 4 || parts.some(Number.isNaN)) return true;
+    const [a, b] = parts;
+    if (a === 10) return true; // RFC1918 10/8
+    if (a === 127) return true; // loopback
+    if (a === 0) return true; // 0.0.0.0/8
+    if (a === 169 && b === 254) return true; // link-local
+    if (a === 172 && b >= 16 && b <= 31) return true; // RFC1918 172.16/12
+    if (a === 192 && b === 168) return true; // RFC1918 192.168/16
+    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64/10
+    if (a >= 224) return true; // multicast / reserved
+    return false;
+  }
+  // IPv6
+  const lower = addr.toLowerCase();
+  if (lower === "::1" || lower === "::") return true; // loopback / unspec
+  if (lower.startsWith("fe80:")) return true; // link-local
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // unique local
+  if (lower.startsWith("ff")) return true; // multicast
+  if (lower.startsWith("::ffff:")) {
+    // IPv4-mapped IPv6 — re-check the embedded v4
+    const embedded = lower.slice("::ffff:".length);
+    if (isIP(embedded) === 4) return isPrivateIp(embedded, 4);
+  }
+  return false;
+};
+
+const assertSafeImageUrl = async (rawUrl: string): Promise<URL> => {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new ImageInputError("source_url is not a valid URL.");
+  }
+  if (url.protocol !== "https:") {
+    throw new ImageInputError("source_url must use https://.");
+  }
+  // Disallow embedded auth — they have no business here and can mask hosts.
+  if (url.username || url.password) {
+    throw new ImageInputError("source_url must not embed credentials.");
+  }
+  // Resolve hostname → reject private / loopback / link-local / multicast.
+  const hostname = url.hostname.replace(/^\[|\]$/g, "");
+  const directIpFamily = isIP(hostname) as 0 | 4 | 6;
+  if (directIpFamily) {
+    if (isPrivateIp(hostname, directIpFamily)) {
+      throw new ImageInputError(
+        "source_url resolves to a private/internal address.",
+      );
+    }
+    return url;
+  }
+  let resolved;
+  try {
+    resolved = await lookup(hostname, { all: false });
+  } catch {
+    throw new ImageInputError(
+      `source_url hostname (${hostname}) could not be resolved.`,
+    );
+  }
+  const family = resolved.family === 6 ? 6 : 4;
+  if (isPrivateIp(resolved.address, family)) {
+    throw new ImageInputError(
+      "source_url resolves to a private/internal address.",
+    );
+  }
+  return url;
+};
+
+const readWithCap = async (
+  body: ReadableStream<Uint8Array>,
+  cap: number,
+): Promise<Buffer> => {
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > cap) {
+        await reader.cancel().catch(() => {});
+        throw new ImageInputError(
+          `source_url body exceeds ${cap} bytes (read ${total}).`,
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(
+    chunks.map((c) => Buffer.from(c)),
+    total,
+  );
+};
+
+export const fetchImageFromUrl = async (
+  rawUrl: string,
+): Promise<{ body: Buffer; contentType: "image/png" | "image/jpeg" }> => {
+  const url = await assertSafeImageUrl(rawUrl);
+  let response;
+  try {
+    response = await fetch(url, { redirect: "error" });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ImageInputError(`Failed to fetch source_url: ${message}`);
+  }
+  if (!response.ok) {
+    throw new ImageInputError(
+      `Failed to fetch source_url: ${response.status} ${response.statusText}`,
+    );
+  }
+  // Bail early if the server tells us the body is too big up front.
+  const declared = response.headers.get("content-length");
+  if (declared) {
+    const declaredBytes = Number.parseInt(declared, 10);
+    if (Number.isFinite(declaredBytes) && declaredBytes > MAX_APP_IMAGE_BYTES) {
+      throw new ImageInputError(
+        `source_url Content-Length (${declaredBytes}) exceeds ${MAX_APP_IMAGE_BYTES} bytes.`,
+      );
+    }
+  }
+  if (!response.body) {
+    throw new ImageInputError("source_url response had no body.");
+  }
+  const body = await readWithCap(response.body, MAX_APP_IMAGE_BYTES);
+  const contentType = detectImageContentType(body);
+  if (!contentType) {
+    throw new ImageInputError(
+      "source_url body is not a valid PNG or JPEG image.",
+    );
+  }
+  return { body, contentType };
+};
+
+export const decodeImageBase64 = (
+  b64: string,
+): { body: Buffer; contentType: "image/png" | "image/jpeg" } => {
+  const body = Buffer.from(b64, "base64");
+  if (body.length === 0) {
+    throw new ImageInputError("image_base64 decoded to zero bytes.");
+  }
+  if (body.length > MAX_APP_IMAGE_BYTES) {
+    throw new ImageInputError(
+      `image_base64 decoded to ${body.length} bytes; maximum is ${MAX_APP_IMAGE_BYTES}.`,
+    );
+  }
+  const contentType = detectImageContentType(body);
+  if (!contentType) {
+    throw new ImageInputError(
+      "image_base64 bytes are not a valid PNG or JPEG image.",
+    );
+  }
+  return { body, contentType };
 };

--- a/web/api/helpers/app-image-storage.ts
+++ b/web/api/helpers/app-image-storage.ts
@@ -198,6 +198,18 @@ export class ImageInputError extends Error {
   }
 }
 
+// Subclass for "we never received an HTTP response from this address" —
+// connect refused, network unreachable, idle timeout before headers, etc.
+// fetchImageFromUrl uses this to know whether retrying the next validated
+// A/AAAA record could plausibly help. Once a host has responded (even with
+// an error status or oversize body), trying a sibling address is pointless.
+class ConnectError extends ImageInputError {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConnectError";
+  }
+}
+
 export const detectImageContentType = (
   body: Buffer,
 ): "image/png" | "image/jpeg" | null => {
@@ -275,12 +287,14 @@ const isPrivateIp = (addr: string, family: 4 | 6): boolean => {
 
 type ResolvedSafeUrl = {
   url: URL;
-  // The pre-validated address we'll force the connection to use. Pinning
-  // here closes the DNS-rebinding TOCTOU window: if the hostname's records
-  // change between our `lookup` and the actual TCP connect, the connect
-  // still goes to the IP we already proved is public.
-  pinnedAddress: string;
-  pinnedFamily: 4 | 6;
+  // Pre-validated addresses we'll try in order. Pinning closes the
+  // DNS-rebinding TOCTOU window: even if the hostname's records change
+  // between our `lookup` and the actual TCP connect, the connect goes to
+  // an IP we already proved is public. We keep the full validated set
+  // (instead of pinning a single record) so a dual-stack hostname whose
+  // first record is unreachable from this egress (e.g. an AAAA record in
+  // an IPv4-only network) can still resolve via a later A record.
+  pinnedAddresses: Array<{ address: string; family: 4 | 6 }>;
 };
 
 const assertSafeImageUrl = async (rawUrl: string): Promise<ResolvedSafeUrl> => {
@@ -305,7 +319,10 @@ const assertSafeImageUrl = async (rawUrl: string): Promise<ResolvedSafeUrl> => {
         "source_url resolves to a private/internal address.",
       );
     }
-    return { url, pinnedAddress: hostname, pinnedFamily: directIpFamily };
+    return {
+      url,
+      pinnedAddresses: [{ address: hostname, family: directIpFamily }],
+    };
   }
   // Resolve every A/AAAA record so we can reject hostnames that mix public
   // and private answers. Any single private record fails the whole URL.
@@ -330,13 +347,12 @@ const assertSafeImageUrl = async (rawUrl: string): Promise<ResolvedSafeUrl> => {
       );
     }
   }
-  // Pin to the first record. The set is fully validated either way; picking
-  // one is fine since the connection only needs one IP.
-  const pin = resolvedAll[0];
   return {
     url,
-    pinnedAddress: pin.address,
-    pinnedFamily: pin.family === 6 ? 6 : 4,
+    pinnedAddresses: resolvedAll.map((r) => ({
+      address: r.address,
+      family: r.family === 6 ? 6 : 4,
+    })),
   };
 };
 
@@ -392,6 +408,7 @@ const httpsRequestPinned = ({
   return new Promise<FetchedImage>((resolve, reject) => {
     let settled = false;
     let totalTimer: ReturnType<typeof setTimeout> | null = null;
+    let responseReceived = false;
 
     const cleanup = () => {
       if (totalTimer) {
@@ -418,6 +435,7 @@ const httpsRequestPinned = ({
     };
 
     const req = httpsRequest(options, (res) => {
+      responseReceived = true;
       const status = res.statusCode ?? 0;
       // We never follow redirects: the new Location could resolve to a
       // private host. Surface the redirect so the caller resolves it
@@ -485,20 +503,36 @@ const httpsRequestPinned = ({
 
     totalTimer = setTimeout(() => {
       fail(
-        new ImageInputError(
-          `source_url fetch exceeded ${FETCH_TOTAL_TIMEOUT_MS}ms.`,
-        ),
+        responseReceived
+          ? new ImageInputError(
+              `source_url fetch exceeded ${FETCH_TOTAL_TIMEOUT_MS}ms.`,
+            )
+          : new ConnectError(
+              `source_url did not respond within ${FETCH_TOTAL_TIMEOUT_MS}ms.`,
+            ),
       );
     }, FETCH_TOTAL_TIMEOUT_MS);
 
     req.setTimeout(FETCH_SOCKET_IDLE_TIMEOUT_MS, () => {
       fail(
-        new ImageInputError(
-          `source_url socket was idle for ${FETCH_SOCKET_IDLE_TIMEOUT_MS}ms.`,
-        ),
+        responseReceived
+          ? new ImageInputError(
+              `source_url socket was idle for ${FETCH_SOCKET_IDLE_TIMEOUT_MS}ms.`,
+            )
+          : new ConnectError(
+              `source_url socket idle for ${FETCH_SOCKET_IDLE_TIMEOUT_MS}ms before any response.`,
+            ),
       );
     });
-    req.on("error", fail);
+    req.on("error", (err) => {
+      fail(
+        responseReceived
+          ? new ImageInputError(`source_url socket error: ${err.message}`)
+          : new ConnectError(
+              `source_url could not connect to ${pinnedAddress}: ${err.message}`,
+            ),
+      );
+    });
     req.end();
   });
 };
@@ -506,27 +540,42 @@ const httpsRequestPinned = ({
 export const fetchImageFromUrl = async (
   rawUrl: string,
 ): Promise<{ body: Buffer; contentType: "image/png" | "image/jpeg" }> => {
-  const { url, pinnedAddress, pinnedFamily } = await assertSafeImageUrl(rawUrl);
-  let result: FetchedImage;
-  try {
-    result = await httpsRequestPinned({
-      url,
-      pinnedAddress,
-      pinnedFamily,
-      cap: MAX_APP_IMAGE_BYTES,
-    });
-  } catch (error) {
-    if (error instanceof ImageInputError) throw error;
-    const message = error instanceof Error ? error.message : String(error);
-    throw new ImageInputError(`Failed to fetch source_url: ${message}`);
+  const { url, pinnedAddresses } = await assertSafeImageUrl(rawUrl);
+  // Try the validated A/AAAA records in order. Fall through to the next
+  // entry on a transport-level failure (host unreachable, idle before
+  // headers, etc. — surfaced by httpsRequestPinned as ConnectError); any
+  // other failure means the host responded, so trying a sibling address
+  // wouldn't change the outcome.
+  const connectErrors: string[] = [];
+  for (const pin of pinnedAddresses) {
+    let result: FetchedImage;
+    try {
+      result = await httpsRequestPinned({
+        url,
+        pinnedAddress: pin.address,
+        pinnedFamily: pin.family,
+        cap: MAX_APP_IMAGE_BYTES,
+      });
+    } catch (error) {
+      if (error instanceof ConnectError) {
+        connectErrors.push(`${pin.address}: ${error.message}`);
+        continue;
+      }
+      if (error instanceof ImageInputError) throw error;
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ImageInputError(`Failed to fetch source_url: ${message}`);
+    }
+    const contentType = detectImageContentType(result.body);
+    if (!contentType) {
+      throw new ImageInputError(
+        "source_url body is not a valid PNG or JPEG image.",
+      );
+    }
+    return { body: result.body, contentType };
   }
-  const contentType = detectImageContentType(result.body);
-  if (!contentType) {
-    throw new ImageInputError(
-      "source_url body is not a valid PNG or JPEG image.",
-    );
-  }
-  return { body: result.body, contentType };
+  throw new ImageInputError(
+    `Failed to fetch source_url after trying ${pinnedAddresses.length} validated address(es): ${connectErrors.join("; ")}`,
+  );
 };
 
 export const decodeImageBase64 = (

--- a/web/api/helpers/app-image-storage.ts
+++ b/web/api/helpers/app-image-storage.ts
@@ -224,6 +224,27 @@ export const detectImageContentType = (
   return null;
 };
 
+// Convert any IPv4-mapped IPv6 form (dotted `::ffff:127.0.0.1` OR hex
+// `::ffff:7f00:1`) back to the underlying dotted IPv4. Returns null for
+// non-mapped IPv6.
+const ipv4FromMapped = (ipv6: string): string | null => {
+  const lower = ipv6.toLowerCase();
+  // Some forms include an extra `::ffff:0:` prefix; normalize the leader to
+  // `::ffff:` only.
+  const mapped = lower.replace(/^::ffff:0+:/, "::ffff:");
+  const dotted = mapped.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (dotted) return isIP(dotted[1]) === 4 ? dotted[1] : null;
+  const hex = mapped.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (hex) {
+    const high = parseInt(hex[1], 16);
+    const low = parseInt(hex[2], 16);
+    if (Number.isNaN(high) || Number.isNaN(low)) return null;
+    const v4 = `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+    return isIP(v4) === 4 ? v4 : null;
+  }
+  return null;
+};
+
 const isPrivateIp = (addr: string, family: 4 | 6): boolean => {
   if (family === 4) {
     const parts = addr.split(".").map((n) => parseInt(n, 10));
@@ -239,17 +260,15 @@ const isPrivateIp = (addr: string, family: 4 | 6): boolean => {
     if (a >= 224) return true; // multicast / reserved
     return false;
   }
-  // IPv6
+  // IPv6 — check the well-known internal prefixes first, then fall through
+  // to IPv4-mapped detection for any of the dotted/hex variants.
   const lower = addr.toLowerCase();
   if (lower === "::1" || lower === "::") return true; // loopback / unspec
   if (lower.startsWith("fe80:")) return true; // link-local
   if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // unique local
   if (lower.startsWith("ff")) return true; // multicast
-  if (lower.startsWith("::ffff:")) {
-    // IPv4-mapped IPv6 — re-check the embedded v4
-    const embedded = lower.slice("::ffff:".length);
-    if (isIP(embedded) === 4) return isPrivateIp(embedded, 4);
-  }
+  const embeddedV4 = ipv4FromMapped(lower);
+  if (embeddedV4) return isPrivateIp(embeddedV4, 4);
   return false;
 };
 
@@ -278,19 +297,29 @@ const assertSafeImageUrl = async (rawUrl: string): Promise<URL> => {
     }
     return url;
   }
-  let resolved;
+  // Validate every A/AAAA record. fetch performs its own resolution and may
+  // pick a different record than we did, so any single private address in
+  // the result set is grounds for refusal — not just the first one we see.
+  let resolvedAll: Array<{ address: string; family: number }>;
   try {
-    resolved = await lookup(hostname, { all: false });
+    resolvedAll = await lookup(hostname, { all: true });
   } catch {
     throw new ImageInputError(
       `source_url hostname (${hostname}) could not be resolved.`,
     );
   }
-  const family = resolved.family === 6 ? 6 : 4;
-  if (isPrivateIp(resolved.address, family)) {
+  if (!resolvedAll || resolvedAll.length === 0) {
     throw new ImageInputError(
-      "source_url resolves to a private/internal address.",
+      `source_url hostname (${hostname}) returned no DNS records.`,
     );
+  }
+  for (const record of resolvedAll) {
+    const family = record.family === 6 ? 6 : 4;
+    if (isPrivateIp(record.address, family)) {
+      throw new ImageInputError(
+        "source_url resolves to a private/internal address.",
+      );
+    }
   }
   return url;
 };

--- a/web/api/helpers/rate-limit.ts
+++ b/web/api/helpers/rate-limit.ts
@@ -17,10 +17,22 @@ export type RateLimitDecision =
       resetIn: number;
     };
 
+// Atomic INCR + first-hit EXPIRE. Running them in a single Redis call
+// (Lua under EVAL) means we can never end up in the "counter exists, no
+// TTL" state that would otherwise leave a key incrementing forever after
+// a transient EXPIRE failure. Returns the post-INCR value.
+const INCR_WITH_EXPIRE_SCRIPT = `
+  local v = redis.call('INCR', KEYS[1])
+  if v == 1 then
+    redis.call('EXPIRE', KEYS[1], ARGV[1])
+  end
+  return v
+`;
+
 /**
- * Tiered token-bucket rate limiter backed by Redis. Each window is a separate
- * INCR/EXPIRE pair keyed by (label, key). The first window to exceed its
- * limit short-circuits with the remaining TTL.
+ * Tiered token-bucket rate limiter backed by Redis. Each window is a fixed
+ * counter keyed by (label, key); the first window to exceed its limit
+ * short-circuits with the remaining TTL.
  *
  * Fails open if `global.RedisClient` is unavailable — production should always
  * have Redis, but we log a warning and continue rather than blocking legit
@@ -49,10 +61,13 @@ export const checkRateLimit = async ({
     const fullKey = `ratelimit:${scope}:${window.label}:${key}`;
     let count: number;
     try {
-      count = await redis.incr(fullKey);
-      if (count === 1) {
-        await redis.expire(fullKey, window.periodSeconds);
-      }
+      const raw = await redis.eval(
+        INCR_WITH_EXPIRE_SCRIPT,
+        1,
+        fullKey,
+        String(window.periodSeconds),
+      );
+      count = Number(raw);
     } catch (error) {
       logger.warn("Rate limiter Redis failure — falling open", {
         scope,
@@ -64,11 +79,24 @@ export const checkRateLimit = async ({
     }
 
     if (count > window.limit) {
-      let ttl = window.periodSeconds;
+      let ttl: number;
       try {
         ttl = await redis.ttl(fullKey);
       } catch {
-        // ignore — keep the conservative ttl above.
+        ttl = -1;
+      }
+      // ttl < 0 means either -1 (key has no expiry) or -2 (key gone).
+      // The atomic eval above shouldn't leave a fresh counter without
+      // a TTL, but a stale key from a pre-fix deploy could land here.
+      // Self-heal by setting the TTL so the bucket eventually resets,
+      // and surface a full-window retry instead of a misleading 1s.
+      if (ttl < 0) {
+        try {
+          await redis.expire(fullKey, window.periodSeconds);
+        } catch {
+          // best effort — outer caller still gets a sensible resetIn.
+        }
+        ttl = window.periodSeconds;
       }
       return { ok: false, window, resetIn: Math.max(ttl, 1) };
     }

--- a/web/api/helpers/rate-limit.ts
+++ b/web/api/helpers/rate-limit.ts
@@ -1,0 +1,78 @@
+import { logger } from "@/lib/logger";
+
+export type RateLimitWindow = {
+  limit: number;
+  periodSeconds: number;
+  // Used to scope keys (e.g. "minute", "day") and shows up in error messages.
+  label: string;
+};
+
+export type RateLimitDecision =
+  | { ok: true }
+  | {
+      ok: false;
+      window: RateLimitWindow;
+      // Seconds remaining until the window resets, clamped to ≥ 1 so callers
+      // never advise a 0-second retry.
+      resetIn: number;
+    };
+
+/**
+ * Tiered token-bucket rate limiter backed by Redis. Each window is a separate
+ * INCR/EXPIRE pair keyed by (label, key). The first window to exceed its
+ * limit short-circuits with the remaining TTL.
+ *
+ * Fails open if `global.RedisClient` is unavailable — production should always
+ * have Redis, but we log a warning and continue rather than blocking legit
+ * traffic on a single infra dependency. Test environments use ioredis-mock
+ * which provides the same surface.
+ */
+export const checkRateLimit = async ({
+  scope,
+  key,
+  windows,
+}: {
+  scope: string;
+  key: string;
+  windows: RateLimitWindow[];
+}): Promise<RateLimitDecision> => {
+  const redis = global.RedisClient;
+  if (!redis) {
+    logger.warn("Rate limiter falling open — Redis unavailable", {
+      scope,
+      key,
+    });
+    return { ok: true };
+  }
+
+  for (const window of windows) {
+    const fullKey = `ratelimit:${scope}:${window.label}:${key}`;
+    let count: number;
+    try {
+      count = await redis.incr(fullKey);
+      if (count === 1) {
+        await redis.expire(fullKey, window.periodSeconds);
+      }
+    } catch (error) {
+      logger.warn("Rate limiter Redis failure — falling open", {
+        scope,
+        key,
+        label: window.label,
+        error,
+      });
+      return { ok: true };
+    }
+
+    if (count > window.limit) {
+      let ttl = window.periodSeconds;
+      try {
+        ttl = await redis.ttl(fullKey);
+      } catch {
+        // ignore — keep the conservative ttl above.
+      }
+      return { ok: false, window, resetIn: Math.max(ttl, 1) };
+    }
+  }
+
+  return { ok: true };
+};

--- a/web/api/helpers/rp-registration-flows.ts
+++ b/web/api/helpers/rp-registration-flows.ts
@@ -116,7 +116,24 @@ export async function submitManagedRpRegistration({
 
   const rpId = parseRpId(rpIdString);
 
-  const kmsClient = await getKMSClient(primaryConfig.kmsRegion);
+  // Slot is now claimed; any failure between here and the final DB write
+  // must release it so retries don't bounce off `already_registered`.
+  let kmsClient;
+  try {
+    kmsClient = await getKMSClient(primaryConfig.kmsRegion);
+  } catch (error) {
+    logger.error("Failed to initialize KMS client for registration", {
+      error,
+      app_id: appId,
+    });
+    await getDeleteRpSdk(client).DeleteRpRegistration({ rp_id: rpIdString });
+    return {
+      ok: false,
+      code: "kms_error",
+      detail: "Failed to initialize KMS client.",
+    };
+  }
+
   const managerKeyResult = await createManagerKey(kmsClient, rpIdString);
   if (!managerKeyResult) {
     await getDeleteRpSdk(client).DeleteRpRegistration({ rp_id: rpIdString });
@@ -188,18 +205,40 @@ export async function submitManagedRpRegistration({
     }
   }
 
-  const { update_rp_registration_by_pk: updatedRegistration } =
-    await getUpdateRpSdk(client).UpdateRpRegistration({
+  let updatedRegistration;
+  try {
+    const { update_rp_registration_by_pk } = await getUpdateRpSdk(
+      client,
+    ).UpdateRpRegistration({
       rp_id: rpIdString,
       manager_kms_key_id: managerKmsKeyId,
       operation_hash: operationHash,
       staging_operation_hash: stagingOperationHash,
       staging_status: stagingStatus,
     });
+    updatedRegistration = update_rp_registration_by_pk;
+  } catch (error) {
+    // On-chain TX is already in flight; the DB write threw, leaving the
+    // slot held without manager_kms_key_id / operation_hash. Logging the
+    // op hash here gives ops a way to reconcile the on-chain state. We
+    // intentionally do NOT delete the slot — the row's existence prevents
+    // a second registerRp transaction from being submitted on retry.
+    logger.error("DB write failed after registration submission", {
+      error,
+      app_id: appId,
+      rpIdString,
+      managerAddress,
+      operationHash,
+    });
+    return {
+      ok: false,
+      code: "db_error",
+      detail: "Failed to update registration record.",
+    };
+  }
 
   if (!updatedRegistration) {
-    // On-chain TX may have succeeded; the DB just lost the keyId/op_hash.
-    // The caller must surface this clearly so an operator can reconcile.
+    // Same situation, just no exception.
     return {
       ok: false,
       code: "db_error",
@@ -335,8 +374,28 @@ export async function submitManagedSignerRotation({
     }
   };
 
-  const kmsClient = await getKMSClient(primaryConfig.kmsRegion);
+  // From here on the RP status is `pending`; any unhandled exception or
+  // tagged failure must revert it so the user can retry. Otherwise a
+  // transient KMS / Hasura blip would leave the RP wedged in `pending`
+  // and every subsequent rotate would short-circuit on
+  // rotation_in_progress until an operator reset it manually.
+  let kmsClient;
   let operationHash: string;
+  try {
+    kmsClient = await getKMSClient(primaryConfig.kmsRegion);
+  } catch (error) {
+    logger.error("Failed to initialize KMS client for rotation", {
+      error,
+      app_id: appId,
+    });
+    await revertStatus();
+    return {
+      ok: false,
+      code: "submission_error",
+      detail: "Failed to initialize KMS client.",
+    };
+  }
+
   try {
     operationHash = await submitRotateSignerTransaction(primaryConfig, {
       rpId,
@@ -387,18 +446,40 @@ export async function submitManagedSignerRotation({
     }
   }
 
-  const { update_rp_registration_by_pk: updatedRegistration } =
-    await getUpdateResultSdk(client).UpdateRotationResult({
+  let updatedRegistration;
+  try {
+    const { update_rp_registration_by_pk } = await getUpdateResultSdk(
+      client,
+    ).UpdateRotationResult({
       rp_id: rpIdString,
       signer_address: newSignerAddress,
       operation_hash: operationHash,
     });
+    updatedRegistration = update_rp_registration_by_pk;
+  } catch (error) {
+    // On-chain TX already submitted; we still revert so the user can
+    // retry instead of being stuck on rotation_in_progress. Operations
+    // can dedupe via the operation_hash logged here.
+    logger.error("DB write failed after rotation submission; reverting", {
+      error,
+      app_id: appId,
+      rpIdString,
+      operationHash,
+    });
+    await revertStatus();
+    return {
+      ok: false,
+      code: "db_error",
+      detail: "Failed to update registration record.",
+    };
+  }
   if (!updatedRegistration) {
     logger.error("Failed to update registration record after submission", {
       app_id: appId,
       rpIdString,
       operationHash,
     });
+    await revertStatus();
     return {
       ok: false,
       code: "db_error",

--- a/web/api/helpers/rp-registration-flows.ts
+++ b/web/api/helpers/rp-registration-flows.ts
@@ -1,0 +1,454 @@
+// Shared managed-mode RP registration + signer-rotation flows.
+//
+// These functions own the KMS + on-chain + DB-update plumbing that used to
+// live inline in the Hasura action handlers. Both the Hasura action routes
+// and the MCP tool reuse them so we don't have two divergent copies of the
+// "register an RP / rotate its signer" pipeline.
+//
+// Helpers do not throw on caller-fixable errors — they return a tagged
+// result so each caller (Hasura action vs JSON-RPC) can format its own
+// error envelope without parsing exception messages.
+
+import { getKMSClient, scheduleKeyDeletion } from "@/api/helpers/kms";
+import { createManagerKey } from "@/api/helpers/kms-eth";
+import {
+  submitRegisterRpTransaction,
+  submitRotateSignerTransaction,
+} from "@/api/helpers/rp-transactions";
+import {
+  generateRpIdString,
+  getRpRegistryConfig,
+  getStagingRpRegistryConfig,
+  parseRpId,
+  RpRegistrationStatus,
+} from "@/api/helpers/rp-utils";
+import { getSdk as getClaimRpSdk } from "@/api/hasura/register-rp/graphql/claim-rp-registration.generated";
+import { getSdk as getDeleteRpSdk } from "@/api/hasura/register-rp/graphql/delete-rp-registration.generated";
+import { getSdk as getUpdateRpSdk } from "@/api/hasura/register-rp/graphql/update-rp-registration.generated";
+import { getSdk as getClaimRotationSdk } from "@/api/hasura/rotate-signer-key/graphql/claim-rotation-slot.generated";
+import { getSdk as getRpRegistrationSdk } from "@/api/hasura/rotate-signer-key/graphql/get-rp-registration.generated";
+import { getSdk as getRevertStatusSdk } from "@/api/hasura/rotate-signer-key/graphql/revert-rotation-status.generated";
+import { getSdk as getUpdateResultSdk } from "@/api/hasura/rotate-signer-key/graphql/update-rotation-result.generated";
+import { getSdk as getUpdateStagingResultSdk } from "@/api/hasura/rotate-signer-key/graphql/update-staging-rotation-result.generated";
+import { isWorldId40EnabledServer } from "@/lib/feature-flags/world-id-4-0/server";
+import { logger } from "@/lib/logger";
+import { GraphQLClient } from "graphql-request";
+
+export type ManagedRegistrationResult =
+  | {
+      ok: true;
+      rpIdString: string;
+      managerAddress: string;
+      signerAddress: string;
+      operationHash: string;
+      status: RpRegistrationStatus;
+      stagingOperationHash: string | null;
+      stagingStatus: string | null;
+    }
+  | {
+      ok: false;
+      code:
+        | "feature_not_enabled"
+        | "config_error"
+        | "already_registered"
+        | "kms_error"
+        | "submission_error"
+        | "db_error";
+      detail: string;
+    };
+
+/**
+ * Run the full managed-mode RP registration pipeline (slot claim → KMS
+ * manager key → on-chain submission [primary + best-effort staging] → DB
+ * update). Caller is responsible for upstream auth: the Hasura action
+ * verifies the user has ADMIN/OWNER on the team; the MCP verifies the
+ * api_key is scoped to the team.
+ */
+export async function submitManagedRpRegistration({
+  client,
+  appId,
+  teamId,
+  signerAddress,
+  appName,
+}: {
+  client: GraphQLClient;
+  appId: string;
+  teamId: string;
+  signerAddress: string;
+  appName: string;
+}): Promise<ManagedRegistrationResult> {
+  if (!(await isWorldId40EnabledServer(teamId))) {
+    return {
+      ok: false,
+      code: "feature_not_enabled",
+      detail: "World ID 4.0 is not enabled for this team.",
+    };
+  }
+
+  const primaryConfig = getRpRegistryConfig();
+  if (!primaryConfig) {
+    return {
+      ok: false,
+      code: "config_error",
+      detail: "Missing required environment variables for RP Registry.",
+    };
+  }
+
+  const rpIdString = generateRpIdString(appId);
+
+  // Claim the registration slot. on_conflict with empty update_columns
+  // means: if a row already exists, return null and we bail.
+  const { insert_rp_registration_one: claimedSlot } = await getClaimRpSdk(
+    client,
+  ).ClaimRpRegistration({
+    rp_id: rpIdString,
+    app_id: appId,
+    mode: "managed",
+    signer_address: signerAddress,
+  });
+  if (!claimedSlot) {
+    return {
+      ok: false,
+      code: "already_registered",
+      detail: "Registration already in progress or completed for this app.",
+    };
+  }
+
+  const rpId = parseRpId(rpIdString);
+
+  const kmsClient = await getKMSClient(primaryConfig.kmsRegion);
+  const managerKeyResult = await createManagerKey(kmsClient, rpIdString);
+  if (!managerKeyResult) {
+    await getDeleteRpSdk(client).DeleteRpRegistration({ rp_id: rpIdString });
+    return {
+      ok: false,
+      code: "kms_error",
+      detail: "Failed to create manager key.",
+    };
+  }
+
+  const { keyId: managerKmsKeyId, address: managerAddress } = managerKeyResult;
+
+  let operationHash: string;
+  try {
+    operationHash = await submitRegisterRpTransaction(primaryConfig, {
+      rpId,
+      managerAddress,
+      signerAddress,
+      appName,
+      kmsClient,
+    });
+  } catch (error) {
+    logger.error("Failed to submit registration transaction", {
+      error,
+      app_id: appId,
+    });
+    await scheduleKeyDeletion(kmsClient, managerKmsKeyId);
+    await getDeleteRpSdk(client).DeleteRpRegistration({ rp_id: rpIdString });
+    return {
+      ok: false,
+      code: "submission_error",
+      detail: "Failed to submit registration transaction.",
+    };
+  }
+
+  // Best-effort duplicate to staging contract on production deployments.
+  // A failure here doesn't fail the whole registration; we just record the
+  // staging status so the UI can surface a retry button.
+  let stagingOperationHash: string | null = null;
+  let stagingStatus: string | null = null;
+  if (process.env.NEXT_PUBLIC_APP_ENV === "production") {
+    const stagingConfig = getStagingRpRegistryConfig();
+    if (stagingConfig) {
+      try {
+        stagingOperationHash = await submitRegisterRpTransaction(
+          stagingConfig,
+          {
+            rpId,
+            managerAddress,
+            signerAddress,
+            appName,
+            kmsClient,
+          },
+        );
+        stagingStatus = RpRegistrationStatus.Pending;
+        logger.info("Staging registration submitted", {
+          rpIdString,
+          operationHash: stagingOperationHash,
+          contractAddress: stagingConfig.contractAddress,
+        });
+      } catch (error) {
+        stagingStatus = RpRegistrationStatus.Failed;
+        logger.error("Staging registration failed", {
+          error,
+          rpIdString,
+          contractAddress: stagingConfig.contractAddress,
+        });
+      }
+    }
+  }
+
+  const { update_rp_registration_by_pk: updatedRegistration } =
+    await getUpdateRpSdk(client).UpdateRpRegistration({
+      rp_id: rpIdString,
+      manager_kms_key_id: managerKmsKeyId,
+      operation_hash: operationHash,
+      staging_operation_hash: stagingOperationHash,
+      staging_status: stagingStatus,
+    });
+
+  if (!updatedRegistration) {
+    // On-chain TX may have succeeded; the DB just lost the keyId/op_hash.
+    // The caller must surface this clearly so an operator can reconcile.
+    return {
+      ok: false,
+      code: "db_error",
+      detail: "Failed to update registration record.",
+    };
+  }
+
+  logger.info("RP registration successful", {
+    app_id: appId,
+    rpIdString,
+    managerAddress,
+    operationHash,
+  });
+
+  return {
+    ok: true,
+    rpIdString,
+    managerAddress,
+    signerAddress,
+    operationHash,
+    status: RpRegistrationStatus.Pending,
+    stagingOperationHash,
+    stagingStatus,
+  };
+}
+
+export type ManagedRotationResult =
+  | {
+      ok: true;
+      rpIdString: string;
+      newSignerAddress: string;
+      oldSignerAddress: string;
+      operationHash: string;
+      status: "pending";
+    }
+  | {
+      ok: false;
+      code:
+        | "feature_not_enabled"
+        | "config_error"
+        | "rp_not_registered"
+        | "self_managed_mode"
+        | "rotation_in_progress"
+        | "submission_error"
+        | "db_error";
+      detail: string;
+    };
+
+/**
+ * Run the full managed-mode signer-rotation pipeline (slot claim → on-chain
+ * submission [primary + staging best-effort] → DB update → cache bust).
+ * Caller is responsible for upstream auth.
+ */
+export async function submitManagedSignerRotation({
+  client,
+  appId,
+  newSignerAddress,
+}: {
+  client: GraphQLClient;
+  appId: string;
+  newSignerAddress: string;
+}): Promise<ManagedRotationResult> {
+  const primaryConfig = getRpRegistryConfig();
+  if (!primaryConfig) {
+    return {
+      ok: false,
+      code: "config_error",
+      detail: "Missing required environment variables for RP Registry.",
+    };
+  }
+
+  const { rp_registration } = await getRpRegistrationSdk(
+    client,
+  ).GetRpRegistration({ app_id: appId });
+
+  if (!rp_registration || rp_registration.length === 0) {
+    return {
+      ok: false,
+      code: "rp_not_registered",
+      detail: "RP registration not found for this app.",
+    };
+  }
+
+  const registration = rp_registration[0];
+  const rpIdString = registration.rp_id;
+  const teamId = registration.app.team_id;
+  const oldSignerAddress = registration.signer_address || "";
+
+  if (!(await isWorldId40EnabledServer(teamId))) {
+    return {
+      ok: false,
+      code: "feature_not_enabled",
+      detail: "World ID 4.0 is not enabled for this team.",
+    };
+  }
+
+  if (registration.mode !== "managed" || !registration.manager_kms_key_id) {
+    return {
+      ok: false,
+      code: "self_managed_mode",
+      detail:
+        "RP is in self-managed mode. You must handle signer key rotation yourself.",
+    };
+  }
+
+  const managerKmsKeyId = registration.manager_kms_key_id;
+
+  const { update_rp_registration: claimResult } = await getClaimRotationSdk(
+    client,
+  ).ClaimRotationSlot({ rp_id: rpIdString });
+  if (!claimResult || claimResult.affected_rows === 0) {
+    return {
+      ok: false,
+      code: "rotation_in_progress",
+      detail:
+        "Cannot rotate signer key. RP status is not 'registered' (rotation may already be in progress).",
+    };
+  }
+
+  const rpId = parseRpId(rpIdString);
+
+  const revertStatus = async () => {
+    try {
+      await getRevertStatusSdk(client).RevertRotationStatus({
+        rp_id: rpIdString,
+      });
+    } catch (revertError) {
+      logger.error("Failed to revert rotation status", {
+        error: revertError,
+        app_id: appId,
+        rpIdString,
+      });
+    }
+  };
+
+  const kmsClient = await getKMSClient(primaryConfig.kmsRegion);
+  let operationHash: string;
+  try {
+    operationHash = await submitRotateSignerTransaction(primaryConfig, {
+      rpId,
+      newSignerAddress,
+      managerKmsKeyId,
+      kmsClient,
+    });
+  } catch (error) {
+    logger.error("Failed to submit signer rotation transaction", {
+      error,
+      app_id: appId,
+    });
+    await revertStatus();
+    return {
+      ok: false,
+      code: "submission_error",
+      detail: "Failed to submit signer rotation transaction.",
+    };
+  }
+
+  // Best-effort staging duplication on production.
+  let stagingHash: string | null = null;
+  let stagingStatusToWrite: RpRegistrationStatus | null = null;
+  if (process.env.NEXT_PUBLIC_APP_ENV === "production") {
+    const stagingConfig = getStagingRpRegistryConfig();
+    if (stagingConfig) {
+      try {
+        stagingHash = await submitRotateSignerTransaction(stagingConfig, {
+          rpId,
+          newSignerAddress,
+          managerKmsKeyId,
+          kmsClient,
+        });
+        stagingStatusToWrite = RpRegistrationStatus.Pending;
+        logger.info("Staging signer rotation submitted", {
+          rpIdString,
+          operationHash: stagingHash,
+          contractAddress: stagingConfig.contractAddress,
+        });
+      } catch (error) {
+        stagingStatusToWrite = RpRegistrationStatus.Failed;
+        logger.error("Staging signer rotation failed", {
+          error,
+          rpIdString,
+          contractAddress: stagingConfig.contractAddress,
+        });
+      }
+    }
+  }
+
+  const { update_rp_registration_by_pk: updatedRegistration } =
+    await getUpdateResultSdk(client).UpdateRotationResult({
+      rp_id: rpIdString,
+      signer_address: newSignerAddress,
+      operation_hash: operationHash,
+    });
+  if (!updatedRegistration) {
+    logger.error("Failed to update registration record after submission", {
+      app_id: appId,
+      rpIdString,
+      operationHash,
+    });
+    return {
+      ok: false,
+      code: "db_error",
+      detail: "Failed to update registration record.",
+    };
+  }
+
+  if (stagingStatusToWrite) {
+    try {
+      await getUpdateStagingResultSdk(client).UpdateStagingRotationResult({
+        rp_id: rpIdString,
+        staging_status: stagingStatusToWrite,
+        staging_operation_hash: stagingHash,
+      });
+    } catch (error) {
+      logger.error("Failed to persist staging rotation result", {
+        error,
+        rpIdString,
+        staging_status: stagingStatusToWrite,
+      });
+    }
+  }
+
+  // Bust the rp_status cache so the next poll re-reads on-chain state.
+  const redis = global.RedisClient;
+  if (redis) {
+    try {
+      await redis.del(`rp_status:v2:${rpIdString}`);
+    } catch (cacheError) {
+      logger.warn("Failed to invalidate rp_status cache", {
+        error: cacheError,
+        rpIdString,
+      });
+    }
+  }
+
+  logger.info("Signer key rotation successful", {
+    app_id: appId,
+    rpIdString,
+    oldSignerAddress,
+    newSignerAddress,
+    operationHash,
+  });
+
+  return {
+    ok: true,
+    rpIdString,
+    newSignerAddress,
+    oldSignerAddress,
+    status: "pending",
+    operationHash,
+  };
+}

--- a/web/api/mcp/SKILL.md
+++ b/web/api/mcp/SKILL.md
@@ -20,7 +20,7 @@ This MCP authenticates with a developer-portal team API key and exposes 11 tools
 | `get_world_id_registration_status` | Sync the on-chain registry status for an RP                                                                   | `app_id`                                                                                                                                                           |
 | `create_world_id_action`           | Create / update a v4 action (the thing you `verify` against)                                                  | `app_id`, `action`; optional `description`, `environment`                                                                                                          |
 | `configure_mini_app`               | Update mini-app store metadata + Advanced/Permissions config                                                  | `app_id`; many optional fields, see below                                                                                                                          |
-| `upload_app_image`                 | Upload an app image (logo, hero, content_card, meta_tag, showcase_1/2/3) and patch the matching `*_url` field | `app_id`, `image_type`, one of `source_url` / `image_base64` (+ `content_type` for base64). PNG/JPEG ≤500KB.                                                       |
+| `upload_app_image`                 | Upload an app image (logo, hero, content_card, meta_tag, showcase_1/2/3) and patch the matching `*_url` field | `app_id`, `image_type`, one of `source_url` (https only, public addr, no redirects) / `image_base64`. Format detected from magic bytes. PNG/JPEG ≤500KB.           |
 | `submit_app_for_review`            | Submit an unverified app for review. Requires `confirm_submission: true`.                                     | `app_id`, `confirm_submission`; optional `changelog`, `is_developer_allow_listing`                                                                                 |
 
 ## Canonical flows
@@ -101,10 +101,14 @@ When the user gives you a **local file path**, base64-encode it client-side via 
 # in Bash:
 base64 -i ./logo.png
 # pipe / capture the output, then call upload_app_image:
-upload_app_image { app_id, image_type: "logo", image_base64: "<that string>", content_type: "png" }
+upload_app_image { app_id, image_type: "logo", image_base64: "<that string>" }
 ```
 
-The server validates ≤500KB PNG/JPEG either way, uploads to S3, and patches `app_metadata.{logo_img_url|hero_image_url|content_card_image_url|meta_tag_image_url|showcase_img_urls[N]}` in one call. No follow-up `configure_mini_app` is needed for images.
+You don't need to specify the format — the server inspects the magic bytes and stores the file as PNG or JPEG accordingly. Anything that isn't a real PNG/JPEG (or anything >500KB) is rejected with `-32602`.
+
+`source_url` is fetched server-side over HTTPS only, must resolve to a public address (loopback / private / link-local rejected), and **redirects are not followed** — if the user gives you a URL that redirects, resolve the final URL client-side first.
+
+The server uploads the bytes to S3 and patches `app_metadata.{logo_img_url|hero_image_url|content_card_image_url|meta_tag_image_url|showcase_img_urls[N]}` in one call. No follow-up `configure_mini_app` is needed for images.
 
 Image bytes flow through your context as base64 — fine for typical app icons (<100KB), wasteful for very large screenshots. Prefer `source_url` whenever the image is already on the web.
 

--- a/web/api/mcp/SKILL.md
+++ b/web/api/mcp/SKILL.md
@@ -5,22 +5,23 @@ description: Build, configure, and submit World ID 4.0 apps and Mini Apps via th
 
 # World ID developer portal MCP
 
-This MCP authenticates with a developer-portal team API key and exposes 10 tools for the full app lifecycle. Always use `get_team_context` first if the user hasn't given you an `app_id` — it returns the team and any existing apps so you can pick or confirm.
+This MCP authenticates with a developer-portal team API key and exposes 11 tools for the full app lifecycle. Always use `get_team_context` first if the user hasn't given you an `app_id` — it returns the team and any existing apps so you can pick or confirm.
 
 ## Tool reference
 
-| Tool                               | Purpose                                                                                    | Key inputs                                                                                                                                                         |
-| ---------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `get_team_context`                 | List the team's apps + status                                                              | (none)                                                                                                                                                             |
-| `get_app_config`                   | Snapshot of an app: World ID config, store metadata, mini-app settings                     | `app_id`                                                                                                                                                           |
-| `create_app`                       | Create a new app                                                                           | `name`; optional `app_mode` (`external` \| `mini-app`), `build` (`production` \| `staging`), `verification` (`cloud` \| `on-chain`), `category`, `integration_url` |
-| `configure_world_id`               | Create the World ID 4.0 RP and (optionally) generate a signing key. **Self-managed only.** | `app_id`; optional `signer_private_key`, `generate_signing_key`                                                                                                    |
-| `get_world_id_signing_key`         | Read the signer address for an app. Private key is never returned here.                    | `app_id`; optional `rotate_if_unavailable`                                                                                                                         |
-| `rotate_world_id_signing_key`      | Generate a new World ID signing key. Returns the private key once.                         | `app_id`; optional `signer_private_key`                                                                                                                            |
-| `get_world_id_registration_status` | Sync the on-chain registry status for an RP                                                | `app_id`                                                                                                                                                           |
-| `create_world_id_action`           | Create / update a v4 action (the thing you `verify` against)                               | `app_id`, `action`; optional `description`, `environment`                                                                                                          |
-| `configure_mini_app`               | Update mini-app store metadata + Advanced/Permissions config                               | `app_id`; many optional fields, see below                                                                                                                          |
-| `submit_app_for_review`            | Submit an unverified app for review. Requires `confirm_submission: true`.                  | `app_id`, `confirm_submission`; optional `changelog`, `is_developer_allow_listing`                                                                                 |
+| Tool                               | Purpose                                                                                                       | Key inputs                                                                                                                                                         |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `get_team_context`                 | List the team's apps + status                                                                                 | (none)                                                                                                                                                             |
+| `get_app_config`                   | Snapshot of an app: World ID config, store metadata, mini-app settings                                        | `app_id`                                                                                                                                                           |
+| `create_app`                       | Create a new app                                                                                              | `name`; optional `app_mode` (`external` \| `mini-app`), `build` (`production` \| `staging`), `verification` (`cloud` \| `on-chain`), `category`, `integration_url` |
+| `configure_world_id`               | Create the World ID 4.0 RP and (optionally) generate a signing key. **Self-managed only.**                    | `app_id`; optional `signer_private_key`, `generate_signing_key`                                                                                                    |
+| `get_world_id_signing_key`         | Read the signer address for an app. Private key is never returned here.                                       | `app_id`; optional `rotate_if_unavailable`                                                                                                                         |
+| `rotate_world_id_signing_key`      | Generate a new World ID signing key. Returns the private key once.                                            | `app_id`; optional `signer_private_key`                                                                                                                            |
+| `get_world_id_registration_status` | Sync the on-chain registry status for an RP                                                                   | `app_id`                                                                                                                                                           |
+| `create_world_id_action`           | Create / update a v4 action (the thing you `verify` against)                                                  | `app_id`, `action`; optional `description`, `environment`                                                                                                          |
+| `configure_mini_app`               | Update mini-app store metadata + Advanced/Permissions config                                                  | `app_id`; many optional fields, see below                                                                                                                          |
+| `upload_app_image`                 | Upload an app image (logo, hero, content_card, meta_tag, showcase_1/2/3) and patch the matching `*_url` field | `app_id`, `image_type`, one of `source_url` / `image_base64` (+ `content_type` for base64). PNG/JPEG ≤500KB.                                                       |
+| `submit_app_for_review`            | Submit an unverified app for review. Requires `confirm_submission: true`.                                     | `app_id`, `confirm_submission`; optional `changelog`, `is_developer_allow_listing`                                                                                 |
 
 ## Canonical flows
 
@@ -30,7 +31,9 @@ This MCP authenticates with a developer-portal team API key and exposes 10 tools
 1. create_app                  { name, app_mode: "external", build: "production", verification: "cloud" }
 2. configure_world_id          { app_id, generate_signing_key: true }      ← capture private_key, it's one-time
 3. create_world_id_action      { app_id, action: "verify-account" }
-4. submit_app_for_review       { app_id, confirm_submission: true }
+4. upload_app_image            { app_id, image_type: "logo", source_url } ← required before submit
+5. configure_mini_app          { app_id, app_website_url, support_link, supported_countries, supported_languages: ["en"] }
+6. submit_app_for_review       { app_id, confirm_submission: true }
 ```
 
 After step 2, store the returned `private_key` in the developer's app environment as `WORLD_ID_PRIVATE_KEY` (or whatever their app expects). The portal does not retain it.
@@ -40,8 +43,11 @@ After step 2, store the returned `private_key` in the developer's app environmen
 ```
 1. create_app                  { name, app_mode: "mini-app" }
 2. configure_world_id          { app_id, generate_signing_key: true }      ← only if the mini app verifies proofs itself
-3. configure_mini_app          { app_id, ...store metadata, ...advanced config }
-4. submit_app_for_review       { app_id, confirm_submission: true }
+3. upload_app_image            { app_id, image_type: "logo",         source_url }
+4. upload_app_image            { app_id, image_type: "content_card", source_url }   ← required for Mini Apps
+5. upload_app_image            { app_id, image_type: "showcase_1",   source_url }   ← optional but recommended
+6. configure_mini_app          { app_id, ...store metadata, ...advanced config }
+7. submit_app_for_review       { app_id, confirm_submission: true }
 ```
 
 `configure_mini_app` accepts both store metadata (logo, screenshots, descriptions, supported countries/languages, ...) **and** Advanced/Permissions config in a single call:
@@ -55,7 +61,27 @@ After step 2, store the returned `private_key` in the developer's app environmen
 
 All address arrays are validated as `0x` + 40 hex chars; URLs as `https://...`; reject any element with an embedded comma.
 
-### C. Rotate a leaked signing key
+### C. Upload images (logo / hero / content_card / meta_tag / showcase_N)
+
+`upload_app_image` accepts the bytes in two ways:
+
+- **`source_url`** — public HTTPS URL the server fetches (best for URLs the user already gave you, or staging asset CDNs)
+- **`image_base64`** — base64-encoded bytes (use for local files)
+
+When the user gives you a **local file path**, base64-encode it client-side via Bash and pass through:
+
+```
+# in Bash:
+base64 -i ./logo.png
+# pipe / capture the output, then call upload_app_image:
+upload_app_image { app_id, image_type: "logo", image_base64: "<that string>", content_type: "png" }
+```
+
+The server validates ≤500KB PNG/JPEG either way, uploads to S3, and patches `app_metadata.{logo_img_url|hero_image_url|content_card_image_url|meta_tag_image_url|showcase_img_urls[N]}` in one call. No follow-up `configure_mini_app` is needed for images.
+
+Image bytes flow through your context as base64 — fine for typical app icons (<100KB), wasteful for very large screenshots. Prefer `source_url` whenever the image is already on the web.
+
+### D. Rotate a leaked signing key
 
 ```
 1. rotate_world_id_signing_key { app_id }
@@ -63,7 +89,7 @@ All address arrays are validated as `0x` + 40 hex chars; URLs as `https://...`; 
 
 Returns a fresh `private_key` once. Updates the on-portal `signer_address`. **Only works for self-managed RPs.** If the registration is platform-managed, the call fails and the user has to rotate from the dashboard UI (it requires an on-chain signer-update transaction the API key path can't perform).
 
-### D. Read-only inspection
+### E. Read-only inspection
 
 ```
 get_team_context                    ← what apps exist, their status
@@ -76,7 +102,8 @@ get_world_id_registration_status { app_id }  ← on-chain registry sync
 
 - **Managed mode is dashboard-only.** `configure_world_id` and rotation only work in self-managed mode. If the user wants the platform to handle on-chain registration, point them at the dashboard.
 - **Private keys are returned once.** If the user loses the value from `configure_world_id` / `rotate_world_id_signing_key`, they must rotate again. The portal does not store private keys.
-- **Submission preconditions are strict.** `submit_app_for_review` runs the same Yup completeness check as the dashboard; missing `logo_img_url`, `app_website_url`, English locale, etc. will return a `-32602` with the exact validation errors. Fix and retry.
+- **Submission preconditions are strict.** `submit_app_for_review` runs the same Yup completeness check as the dashboard; missing `logo_img_url`, `app_website_url`, English locale, etc. will return a `-32602` with the exact validation errors. Fix and retry. For Mini Apps, `content_card_image_url` is also required.
+- **Use `upload_app_image`, not `configure_mini_app`, for image fields.** Image fields store filenames (`logo_img.png`), not full URLs — the dashboard reconstructs the CDN URL at view time. `upload_app_image` handles the S3 upload and stores the right filename automatically; passing a stray URL through `configure_mini_app.logo_img_url` will break the image.
 - **Staging apps cannot be submitted for review.** `create_app` with `build: "staging"` is for sandbox use; switch to `build: "production"` (a different app) for store submission.
 - **`is_developer_allow_listing` is optional on submit.** If you omit it, the existing value on `app_metadata` is preserved — the MCP will not silently un-list a previously listed app.
 - **Don't re-run `configure_world_id` on an already-configured app.** It returns the existing registration without rotating. Use `rotate_world_id_signing_key` if the user actually wants a new key.

--- a/web/api/mcp/SKILL.md
+++ b/web/api/mcp/SKILL.md
@@ -14,7 +14,7 @@ This MCP authenticates with a developer-portal team API key and exposes 11 tools
 | `get_team_context`                 | List the team's apps + status                                                                                 | (none)                                                                                                                                                             |
 | `get_app_config`                   | Snapshot of an app: World ID config, store metadata, mini-app settings                                        | `app_id`                                                                                                                                                           |
 | `create_app`                       | Create a new app                                                                                              | `name`; optional `app_mode` (`external` \| `mini-app`), `build` (`production` \| `staging`), `verification` (`cloud` \| `on-chain`), `category`, `integration_url` |
-| `configure_world_id`               | Create the World ID 4.0 RP and (optionally) generate a signing key. **Self-managed only.**                    | `app_id`; optional `signer_private_key`, `generate_signing_key`                                                                                                    |
+| `configure_world_id`               | Create a managed World ID 4.0 RP for the app: KMS manager key, on-chain registration, signer wallet           | `app_id`; optional `signer_private_key` (else the server generates one and returns it once)                                                                        |
 | `get_world_id_signing_key`         | Read the signer address for an app. Private key is never returned here.                                       | `app_id`; optional `rotate_if_unavailable`                                                                                                                         |
 | `rotate_world_id_signing_key`      | Generate a new World ID signing key. Returns the private key once.                                            | `app_id`; optional `signer_private_key`                                                                                                                            |
 | `get_world_id_registration_status` | Sync the on-chain registry status for an RP                                                                   | `app_id`                                                                                                                                                           |
@@ -122,7 +122,7 @@ Image bytes flow through your context as base64 — fine for typical app icons (
 1. rotate_world_id_signing_key { app_id }
 ```
 
-Returns a fresh `private_key` once. Updates the on-portal `signer_address`. **Only works for self-managed RPs.** If the registration is platform-managed, the call fails and the user has to rotate from the dashboard UI (it requires an on-chain signer-update transaction the API key path can't perform).
+Returns a fresh `private_key` once. Submits the on-chain `updateRp` transaction (primary registry, plus best-effort staging on production deployments) and updates `app_metadata.signer_address`. The status flips to `pending` until the on-chain TX confirms; poll `status_endpoint` to watch the transition back to `registered`. Self-managed RPs (e.g. legacy registrations not created via MCP) return `-32004` with `data.reason: "self_managed_mode"` — those have to be rotated by the developer themselves.
 
 ### E. Read-only inspection
 
@@ -135,7 +135,8 @@ get_world_id_registration_status { app_id }  ← on-chain registry sync
 
 ## Pitfalls and constraints
 
-- **Managed mode is dashboard-only.** `configure_world_id` and rotation only work in self-managed mode. If the user wants the platform to handle on-chain registration, point them at the dashboard.
+- **`configure_world_id` is asynchronous.** The on-chain registration is submitted to the bundler and returns immediately with `status: "pending"` and an `operation_hash`. Watch `status_endpoint` until it returns `production_status: "registered"` before relying on the RP for verifications.
+- **`configure_world_id` requires the team to be enabled for World ID 4.0.** A team without the feature flag gets `-32004` with `data.reason: "feature_not_enabled"`. Surface that to the user and point them at the dashboard for enrollment.
 - **Private keys are returned once.** If the user loses the value from `configure_world_id` / `rotate_world_id_signing_key`, they must rotate again. The portal does not store private keys.
 - **Submission preconditions are strict.** `submit_app_for_review` runs the same Yup completeness check as the dashboard. The full required set:
   - **Always required**: `name`, `logo_img_url`, `app_website_url`, `is_android_only`, `is_for_humans_only`, `supported_countries` (≥1), `supported_languages` (must include `"en"`), `description_overview` (encoded into the description JSON), and at least one entry in `showcase_img_urls` for the English locale.

--- a/web/api/mcp/SKILL.md
+++ b/web/api/mcp/SKILL.md
@@ -28,12 +28,21 @@ This MCP authenticates with a developer-portal team API key and exposes 11 tools
 ### A. Build an external (non-mini) World ID app end-to-end
 
 ```
-1. create_app                  { name, app_mode: "external", build: "production", verification: "cloud" }
-2. configure_world_id          { app_id, generate_signing_key: true }      ← capture private_key, it's one-time
-3. create_world_id_action      { app_id, action: "verify-account" }
-4. upload_app_image            { app_id, image_type: "logo", source_url } ← required before submit
-5. configure_mini_app          { app_id, app_website_url, support_link, supported_countries, supported_languages: ["en"] }
-6. submit_app_for_review       { app_id, confirm_submission: true }
+1. create_app             { name, app_mode: "external", build: "production", verification: "cloud" }
+2. configure_world_id     { app_id, generate_signing_key: true }      ← capture private_key, it's one-time
+3. create_world_id_action { app_id, action: "verify-account" }
+4. upload_app_image       { app_id, image_type: "logo",       source_url }   ← required: logo_img_url
+5. upload_app_image       { app_id, image_type: "showcase_1", source_url }   ← required: ≥1 showcase per locale
+6. configure_mini_app     {
+                            app_id,
+                            app_website_url:     "https://your-app.example",
+                            description_overview: "What the app does, in one paragraph.",
+                            supported_countries: ["us"],
+                            supported_languages: ["en"],
+                            is_android_only:     false,
+                            is_for_humans_only:  false,
+                          }
+7. submit_app_for_review  { app_id, confirm_submission: true }
 ```
 
 After step 2, store the returned `private_key` in the developer's app environment as `WORLD_ID_PRIVATE_KEY` (or whatever their app expects). The portal does not retain it.
@@ -41,17 +50,35 @@ After step 2, store the returned `private_key` in the developer's app environmen
 ### B. Build a Mini App with full Advanced settings
 
 ```
-1. create_app                  { name, app_mode: "mini-app" }
-2. configure_world_id          { app_id, generate_signing_key: true }      ← only if the mini app verifies proofs itself
-3. upload_app_image            { app_id, image_type: "logo",         source_url }
-4. upload_app_image            { app_id, image_type: "content_card", source_url }   ← required for Mini Apps
-5. upload_app_image            { app_id, image_type: "showcase_1",   source_url }   ← optional but recommended
-6. configure_mini_app          { app_id, ...store metadata, ...advanced config }
-7. submit_app_for_review       { app_id, confirm_submission: true }
+1. create_app             { name, app_mode: "mini-app" }
+2. configure_world_id     { app_id, generate_signing_key: true }      ← only if the mini app verifies proofs itself
+3. upload_app_image       { app_id, image_type: "logo",         source_url }   ← required
+4. upload_app_image       { app_id, image_type: "content_card", source_url }   ← required for Mini Apps
+5. upload_app_image       { app_id, image_type: "showcase_1",   source_url }   ← required: ≥1 showcase per locale
+6. configure_mini_app     {
+                            app_id,
+                            short_name:           "MyApp",
+                            category:             "Other",
+                            world_app_description: "One-line tag line",
+                            description_overview:  "What the mini app does, in one paragraph.",
+                            app_website_url:      "https://your-app.example",
+                            support_link:         "mailto:support@your-app.example",  // or "https://your-app.example/support"
+                            supported_countries:  ["us"],
+                            supported_languages:  ["en"],
+                            is_android_only:      false,
+                            is_for_humans_only:   false,
+                            // optional Advanced fields:
+                            contracts:            ["0x..."],
+                            permit2_tokens:       ["0x..."],
+                            max_notifications_per_day: 2,
+                          }
+7. submit_app_for_review  { app_id, confirm_submission: true }
 ```
 
-`configure_mini_app` accepts both store metadata (logo, screenshots, descriptions, supported countries/languages, ...) **and** Advanced/Permissions config in a single call:
+`configure_mini_app` accepts store metadata, Advanced/Permissions config, and the App Store description in a single call:
 
+- `description_overview: string` — required for review; the human-readable overview shown to users in the app store. Pass it as a plain string here; the server JSON-encodes it (with `description_how_it_works` and `description_connect`) into the underlying `app_metadata.description` column for you. Don't pre-construct the JSON yourself.
+- `description_how_it_works`, `description_connect` — optional companion sections (also stored inside the encoded description JSON).
 - `contracts: string[]` — Worldchain contract addresses the mini app calls
 - `permit2_tokens: string[]` — token addresses approved for Permit2 signing
 - `whitelisted_addresses: string[]` — wallets allowed to interact (pass `[]` to disable)
@@ -102,7 +129,10 @@ get_world_id_registration_status { app_id }  ← on-chain registry sync
 
 - **Managed mode is dashboard-only.** `configure_world_id` and rotation only work in self-managed mode. If the user wants the platform to handle on-chain registration, point them at the dashboard.
 - **Private keys are returned once.** If the user loses the value from `configure_world_id` / `rotate_world_id_signing_key`, they must rotate again. The portal does not store private keys.
-- **Submission preconditions are strict.** `submit_app_for_review` runs the same Yup completeness check as the dashboard; missing `logo_img_url`, `app_website_url`, English locale, etc. will return a `-32602` with the exact validation errors. Fix and retry. For Mini Apps, `content_card_image_url` is also required.
+- **Submission preconditions are strict.** `submit_app_for_review` runs the same Yup completeness check as the dashboard. The full required set:
+  - **Always required**: `name`, `logo_img_url`, `app_website_url`, `is_android_only`, `is_for_humans_only`, `supported_countries` (≥1), `supported_languages` (must include `"en"`), `description_overview` (encoded into the description JSON), and at least one entry in `showcase_img_urls` for the English locale.
+  - **Mini-app additional**: `short_name`, `category`, `world_app_description` (the tag line), `content_card_image_url`, and either `support_link` (HTTPS URL) or `support_link` set to a `mailto:` URL.
+  - On failure the server returns a `-32602` with the exact field path; surface that to the user verbatim.
 - **Use `upload_app_image`, not `configure_mini_app`, for image fields.** Image fields store filenames (`logo_img.png`), not full URLs — the dashboard reconstructs the CDN URL at view time. `upload_app_image` handles the S3 upload and stores the right filename automatically; passing a stray URL through `configure_mini_app.logo_img_url` will break the image.
 - **Staging apps cannot be submitted for review.** `create_app` with `build: "staging"` is for sandbox use; switch to `build: "production"` (a different app) for store submission.
 - **`is_developer_allow_listing` is optional on submit.** If you omit it, the existing value on `app_metadata` is preserved — the MCP will not silently un-list a previously listed app.

--- a/web/api/mcp/SKILL.md
+++ b/web/api/mcp/SKILL.md
@@ -108,7 +108,11 @@ You don't need to specify the format — the server inspects the magic bytes and
 
 `source_url` is fetched server-side over HTTPS only, must resolve to a public address (loopback / private / link-local rejected), and **redirects are not followed** — if the user gives you a URL that redirects, resolve the final URL client-side first.
 
-The server uploads the bytes to S3 and patches `app_metadata.{logo_img_url|hero_image_url|content_card_image_url|meta_tag_image_url|showcase_img_urls[N]}` in one call. No follow-up `configure_mini_app` is needed for images.
+The server uploads the bytes to S3 and patches `app_metadata.{logo_img_url|hero_image_url|content_card_image_url|meta_tag_image_url|showcase_img_urls[N]}` in one call. No follow-up `configure_mini_app` is needed for images. Successful responses include `committed: true`.
+
+If the metadata patch fails after the S3 upload (rare — typically a transient Hasura error), the server best-effort deletes the S3 object and returns `-32603` with `data: { committed: false }`. Retries are idempotent, so just call the same tool again.
+
+`upload_app_image` is rate-limited per API key: **60 uploads/minute, 500/day**. Hitting the cap returns `-32029` with `data.retry_after_seconds`.
 
 Image bytes flow through your context as base64 — fine for typical app icons (<100KB), wasteful for very large screenshots. Prefer `source_url` whenever the image is already on the web.
 

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -1114,21 +1114,30 @@ const tools = {
 
     const { fileName, objectKey, mapping, sizeBytes } = uploadResult;
     let set: Record<string, unknown>;
+    let priorReferencedFileName: string | undefined;
     if ("arrayIndex" in mapping) {
       const current = (metadata.showcase_img_urls ?? []) as string[];
+      const slot = current[mapping.arrayIndex];
+      priorReferencedFileName = typeof slot === "string" ? slot : undefined;
       const next = [...current];
       while (next.length < mapping.arrayIndex + 1) next.push("");
       next[mapping.arrayIndex] = fileName;
       set = { showcase_img_urls: next };
     } else {
+      const raw = (metadata as Record<string, unknown>)[mapping.field];
+      priorReferencedFileName = typeof raw === "string" ? raw : undefined;
       set = { [mapping.field]: fileName };
     }
 
-    // S3 upload already succeeded above. If the metadata patch fails we'd
-    // leave bytes in S3 that aren't referenced, so best-effort delete the
-    // freshly-uploaded object before surfacing the error. Retries are
-    // idempotent (deterministic key, same bytes), so the caller can safely
-    // re-run.
+    // S3 upload already succeeded above. The deterministic object key means
+    // a replace-upload may have just overwritten an asset that the existing
+    // metadata field already references; in that case deleting on failure
+    // would leave the existing reference dangling. The prior bytes are gone
+    // either way, so the safer rollback is to keep the new bytes in place
+    // (effectively partial success — the asset is updated even though the
+    // patch failed) and let the caller retry. When the prior metadata
+    // referenced something else (or nothing), we DELETE the orphan we just
+    // wrote. Retries are idempotent (same key, same bytes).
     let data;
     try {
       data = await getMcpUpdateAppMetadataSdk(ctx.client).McpUpdateAppMetadata({
@@ -1136,19 +1145,22 @@ const tools = {
         set,
       });
     } catch (error) {
-      await tryDeleteAppImage(objectKey);
-      logger.error(
-        "MCP app image uploaded to S3 but metadata patch failed; cleaned up.",
-        {
-          error,
-          app_id: args.app_id,
-          team_id: ctx.teamId,
-          image_type: args.image_type,
-          object_key: objectKey,
-        },
-      );
+      const wouldOrphanReference = priorReferencedFileName === fileName;
+      if (!wouldOrphanReference) {
+        await tryDeleteAppImage(objectKey);
+      }
+      logger.error("MCP app image uploaded to S3 but metadata patch failed.", {
+        error,
+        app_id: args.app_id,
+        team_id: ctx.teamId,
+        image_type: args.image_type,
+        object_key: objectKey,
+        cleanup_skipped: wouldOrphanReference,
+      });
       throw new McpError(
-        "Image was uploaded but the metadata update failed. The S3 object was rolled back; retry the same call.",
+        wouldOrphanReference
+          ? "Image was uploaded but the metadata update failed. The existing reference was preserved; retry the same call."
+          : "Image was uploaded but the metadata update failed. The S3 object was rolled back; retry the same call.",
         -32603,
         { committed: false, file_name: fileName },
       );

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -326,12 +326,6 @@ const configureWorldIdSchema = yup
   .object({
     app_id: yup.string().required(),
     signer_private_key: yup.string().optional(),
-    // Deprecated. Older skill snippets and previous MCP behavior treated
-    // this as "should the server generate a signer wallet?". The managed
-    // flow now always provides a wallet (caller-supplied if signer_private_
-    // key is set, generated server-side otherwise), so the value is
-    // ignored. Accepted here so existing clients don't break with -32602.
-    generate_signing_key: yup.boolean().optional(),
   })
   .noUnknown();
 

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -282,11 +282,6 @@ const toolDefinitions = [
           description:
             "Base64-encoded PNG/JPEG bytes. Use this OR source_url. The server detects the format from magic bytes; no separate content_type input is needed.",
         },
-        locale: {
-          type: "string",
-          description:
-            "Locale subfolder (e.g. 'es'). Defaults to root unverified/{app_id}/ when omitted or 'en'.",
-        },
       },
       required: ["app_id", "image_type"],
       additionalProperties: false,
@@ -331,6 +326,12 @@ const configureWorldIdSchema = yup
   .object({
     app_id: yup.string().required(),
     signer_private_key: yup.string().optional(),
+    // Deprecated. Older skill snippets and previous MCP behavior treated
+    // this as "should the server generate a signer wallet?". The managed
+    // flow now always provides a wallet (caller-supplied if signer_private_
+    // key is set, generated server-side otherwise), so the value is
+    // ignored. Accepted here so existing clients don't break with -32602.
+    generate_signing_key: yup.boolean().optional(),
   })
   .noUnknown();
 
@@ -455,7 +456,6 @@ const uploadAppImageSchema = yup
       .matches(/^https:\/\//, "source_url must use https://")
       .optional(),
     image_base64: yup.string().optional(),
-    locale: yup.string().optional(),
   })
   .test(
     "exactly-one-source",
@@ -1098,7 +1098,6 @@ const tools = {
         imageType: args.image_type as McpAppImageType,
         body,
         contentType,
-        locale: args.locale,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -1,11 +1,16 @@
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { logPortalEvent } from "@/api/helpers/portal-events";
 import {
-  generateRpIdString,
   mapOnChainToDbStatus,
   normalizeAddress,
   parseRpId,
 } from "@/api/helpers/rp-utils";
+import {
+  submitManagedRpRegistration,
+  submitManagedSignerRotation,
+  type ManagedRegistrationResult,
+  type ManagedRotationResult,
+} from "@/api/helpers/rp-registration-flows";
 import { getRpFromContract } from "@/api/helpers/temporal-rpc";
 import { verifyHashedSecret } from "@/api/helpers/utils";
 import { getSdk as getMcpAppContextSdk } from "@/api/mcp/graphql/app-context.generated";
@@ -15,7 +20,6 @@ import { getSdk as getMcpSubmitAppForReviewSdk } from "@/api/mcp/graphql/submit-
 import { getSdk as getMcpTeamContextSdk } from "@/api/mcp/graphql/team-context.generated";
 import { getSdk as getMcpUpdateAppMetadataSdk } from "@/api/mcp/graphql/update-app-metadata.generated";
 import { getSdk as getMcpUpsertActionV4Sdk } from "@/api/mcp/graphql/upsert-action-v4.generated";
-import { getSdk as getMcpUpsertRpRegistrationSdk } from "@/api/mcp/graphql/upsert-rp-registration.generated";
 import { SKILL_INSTRUCTIONS } from "@/api/mcp/skill";
 import { getSdk as getUpdateRpStatusSdk } from "@/api/v4/rp-status/[rp_id]/graphql/update-rp-status.generated";
 import { getSdk as getUpdateStagingStatusSdk } from "@/api/v4/rp-status/[rp_id]/graphql/update-staging-status.generated";
@@ -113,13 +117,16 @@ const toolDefinitions = [
   {
     name: "configure_world_id",
     description:
-      "Create World ID 4.0 RP config in self-managed mode and optionally generate a signing key. Managed mode (where the platform performs on-chain registration on the developer's behalf) requires user-session permissions and must be configured from the developer portal UI.",
+      "Create a managed World ID 4.0 RP for an app. The platform creates a KMS-backed manager key, submits the on-chain registration transaction, and (on production) duplicates to the staging contract. A new signer wallet is generated server-side; its private key is returned ONCE in the response — the portal does not retain it.",
     inputSchema: {
       type: "object",
       properties: {
         app_id: { type: "string" },
-        signer_private_key: { type: "string" },
-        generate_signing_key: { type: "boolean" },
+        signer_private_key: {
+          type: "string",
+          description:
+            "Optional. If provided, the resulting wallet's address is registered as the on-chain signer. If omitted, a fresh wallet is generated server-side and the private key is returned once.",
+        },
       },
       required: ["app_id"],
       additionalProperties: false,
@@ -323,7 +330,6 @@ const configureWorldIdSchema = yup
   .object({
     app_id: yup.string().required(),
     signer_private_key: yup.string().optional(),
-    generate_signing_key: yup.boolean().default(true),
   })
   .noUnknown();
 
@@ -684,39 +690,72 @@ const makeWallet = (privateKey?: string) => {
   };
 };
 
+// Map a managed-flow helper failure to the JSON-RPC error code the MCP
+// surfaces. Caller-fixable problems (already registered, wrong mode, feature
+// flag off) become -32004 (operation not allowed in current state); anything
+// platform-side becomes -32603 so clients know to retry / escalate.
+const REGISTRATION_FLOW_RPC_CODE: Record<
+  Exclude<ManagedRegistrationResult, { ok: true }>["code"],
+  number
+> = {
+  feature_not_enabled: -32004,
+  already_registered: -32004,
+  config_error: -32603,
+  kms_error: -32603,
+  submission_error: -32603,
+  db_error: -32603,
+};
+
+const ROTATION_FLOW_RPC_CODE: Record<
+  Exclude<ManagedRotationResult, { ok: true }>["code"],
+  number
+> = {
+  feature_not_enabled: -32004,
+  rp_not_registered: -32004,
+  self_managed_mode: -32004,
+  rotation_in_progress: -32004,
+  config_error: -32603,
+  submission_error: -32603,
+  db_error: -32603,
+};
+
 const rotateWorldIdSigningKey = async (input: unknown, ctx: ToolContext) => {
   const args = await parseInput(
     appIdSchema.shape({ signer_private_key: yup.string().optional() }),
     input,
   );
+  // requireApp validates the app belongs to the API key's team before we
+  // hand off to the rotation flow (which trusts the caller's auth).
   const app = await requireApp(ctx.client, ctx.teamId, args.app_id);
   const registration = app.rp_registration[0];
   if (!registration) {
     throw new McpError("World ID is not configured for this app.", -32004);
   }
 
-  if (registration.mode !== "self_managed") {
-    throw new McpError(
-      "Managed (platform) signing keys must be rotated from the developer portal UI so the on-chain signer is updated. The MCP can only rotate self-managed keys.",
-      -32004,
-    );
-  }
-
   const signingKey = makeWallet(args.signer_private_key);
-  const data = await getMcpUpsertRpRegistrationSdk(
-    ctx.client,
-  ).McpUpsertRpRegistration({
-    rp_id: registration.rp_id,
-    app_id: args.app_id,
-    mode: registration.mode,
-    signer_address: signingKey.signer_address,
+
+  const result = await submitManagedSignerRotation({
+    client: ctx.client,
+    appId: args.app_id,
+    newSignerAddress: signingKey.signer_address,
   });
 
+  if (!result.ok) {
+    throw new McpError(result.detail, ROTATION_FLOW_RPC_CODE[result.code], {
+      reason: result.code,
+    });
+  }
+
   return content({
-    rp_registration: data.insert_rp_registration_one,
+    rp_id: result.rpIdString,
+    new_signer_address: result.newSignerAddress,
+    old_signer_address: result.oldSignerAddress,
+    operation_hash: result.operationHash,
+    status: result.status,
     signing_key: signingKey,
+    status_endpoint: rpStatusEndpoint(result.rpIdString),
     warning:
-      "Store private_key securely. It is not recoverable after this response.",
+      "Store private_key securely. It is not recoverable after this response. The on-chain rotation is pending — poll status_endpoint until it returns 'registered'.",
   });
 };
 
@@ -796,32 +835,42 @@ const tools = {
       });
     }
 
-    const signingKey =
-      args.generate_signing_key || args.signer_private_key
-        ? makeWallet(args.signer_private_key)
-        : null;
+    // Always generate a wallet — managed mode requires a real signer
+    // address up front. If the caller passed a private key we honor it,
+    // otherwise we mint a fresh one and return it once.
+    const signingKey = makeWallet(args.signer_private_key);
+    const appName = app.app_metadata?.[0]?.name || app.name || "";
 
-    const data = await getMcpUpsertRpRegistrationSdk(
-      ctx.client,
-    ).McpUpsertRpRegistration({
-      rp_id: generateRpIdString(args.app_id),
-      app_id: args.app_id,
-      mode: "self_managed",
-      signer_address: signingKey?.signer_address ?? null,
+    const result = await submitManagedRpRegistration({
+      client: ctx.client,
+      appId: args.app_id,
+      teamId: ctx.teamId,
+      signerAddress: signingKey.signer_address,
+      appName,
     });
-    const rpRegistration = data.insert_rp_registration_one;
-    if (!rpRegistration) {
-      throw new McpError("Unable to configure World ID for this app.", -32000);
+
+    if (!result.ok) {
+      throw new McpError(
+        result.detail,
+        REGISTRATION_FLOW_RPC_CODE[result.code],
+        { reason: result.code },
+      );
     }
 
     return content({
-      rp_registration: rpRegistration,
+      rp_id: result.rpIdString,
+      manager_address: result.managerAddress,
+      signer_address: result.signerAddress,
+      operation_hash: result.operationHash,
+      status: result.status,
+      staging_operation_hash: result.stagingOperationHash,
+      staging_status: result.stagingStatus,
       signing_key: signingKey,
-      verify_endpoint: `/api/v4/verify/${rpRegistration.rp_id}`,
-      proof_context_endpoint: `/api/v4/proof-context/${rpRegistration.rp_id}`,
-      status_endpoint: rpStatusEndpoint(rpRegistration.rp_id),
+      verify_endpoint: `/api/v4/verify/${result.rpIdString}`,
+      proof_context_endpoint: `/api/v4/proof-context/${result.rpIdString}`,
+      status_endpoint: rpStatusEndpoint(result.rpIdString),
       warning:
-        "Private keys are returned only at generation/rotation time. Store the private_key securely in the app environment. To use platform-managed (on-chain) registration instead, configure the app from the developer portal UI.",
+        "Private keys are returned only at generation/rotation time. Store the private_key securely in the app environment. The on-chain registration is pending — poll status_endpoint until it returns 'registered' before relying on the RP for verifications.",
     });
   },
 

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -19,6 +19,11 @@ import { getSdk as getMcpUpsertRpRegistrationSdk } from "@/api/mcp/graphql/upser
 import { SKILL_INSTRUCTIONS } from "@/api/mcp/skill";
 import { getSdk as getUpdateRpStatusSdk } from "@/api/v4/rp-status/[rp_id]/graphql/update-rp-status.generated";
 import { getSdk as getUpdateStagingStatusSdk } from "@/api/v4/rp-status/[rp_id]/graphql/update-staging-status.generated";
+import {
+  MCP_APP_IMAGE_MAP,
+  type McpAppImageType,
+  uploadAppImage,
+} from "@/api/helpers/app-image-storage";
 import { CategoryNameIterable } from "@/lib/categories";
 import { logger } from "@/lib/logger";
 import { mainAppStoreFormReviewSubmitSchema } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/FormSchema/form-schema";
@@ -220,6 +225,51 @@ const toolDefinitions = [
     },
   },
   {
+    name: "upload_app_image",
+    description:
+      "Upload an app image (logo, hero, content_card, meta_tag, showcase_1/2/3) from a public HTTPS source URL or base64 data and set the corresponding app_metadata field. Image must be PNG or JPEG, ≤500KB. Required for app store submissions which gate on logo_img_url and (for Mini Apps) content_card_image_url.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        app_id: { type: "string" },
+        image_type: {
+          type: "string",
+          enum: [
+            "logo",
+            "hero",
+            "content_card",
+            "meta_tag",
+            "showcase_1",
+            "showcase_2",
+            "showcase_3",
+          ],
+        },
+        source_url: {
+          type: "string",
+          description:
+            "Public HTTPS URL the server will fetch. Use this OR image_base64.",
+        },
+        image_base64: {
+          type: "string",
+          description: "Base64-encoded PNG/JPEG bytes. Use this OR source_url.",
+        },
+        content_type: {
+          type: "string",
+          enum: ["png", "jpeg"],
+          description:
+            "Required when using image_base64. Optional with source_url (inferred from response Content-Type).",
+        },
+        locale: {
+          type: "string",
+          description:
+            "Locale subfolder (e.g. 'es'). Defaults to root unverified/{app_id}/ when omitted or 'en'.",
+        },
+      },
+      required: ["app_id", "image_type"],
+      additionalProperties: false,
+    },
+  },
+  {
     name: "submit_app_for_review",
     description:
       "Submit an app for review after explicit confirmation from the user.",
@@ -365,6 +415,38 @@ const submitAppSchema = yup
     changelog: yup.string().default("Submitted via MCP"),
     is_developer_allow_listing: yup.boolean().optional(),
   })
+  .noUnknown();
+
+const uploadAppImageSchema = yup
+  .object({
+    app_id: yup.string().required(),
+    image_type: yup
+      .string()
+      .oneOf(Object.keys(MCP_APP_IMAGE_MAP) as McpAppImageType[])
+      .required(),
+    source_url: yup
+      .string()
+      .url()
+      .matches(/^https:\/\//, "source_url must use https://")
+      .optional(),
+    image_base64: yup.string().optional(),
+    content_type: yup.string().oneOf(["png", "jpeg"]).optional(),
+    locale: yup.string().optional(),
+  })
+  .test(
+    "exactly-one-source",
+    "Provide exactly one of source_url or image_base64",
+    (value) => {
+      const hasUrl = Boolean(value?.source_url);
+      const hasBase64 = Boolean(value?.image_base64);
+      return hasUrl !== hasBase64;
+    },
+  )
+  .test(
+    "base64-needs-content-type",
+    "image_base64 requires content_type to be set",
+    (value) => !value?.image_base64 || Boolean(value?.content_type),
+  )
   .noUnknown();
 
 const parseApiKey = (authorization: string | null) => {
@@ -861,6 +943,112 @@ const tools = {
     return content({ app_metadata: data.update_app_metadata_by_pk });
   },
 
+  upload_app_image: async (input, ctx) => {
+    const args = await parseInput(uploadAppImageSchema, input);
+    const app = await requireApp(ctx.client, ctx.teamId, args.app_id);
+    const metadata = app.app_metadata[0];
+    if (!metadata) {
+      throw new McpError("Editable app metadata not found.", -32004);
+    }
+    if (metadata.verification_status !== "unverified") {
+      throw new McpError("Only unverified app metadata can be edited.", -32004);
+    }
+
+    // Resolve the image bytes + content type from either source.
+    let body: Buffer;
+    let contentType: "image/png" | "image/jpeg";
+
+    if (args.source_url) {
+      const fetchResponse = await fetch(args.source_url);
+      if (!fetchResponse.ok) {
+        throw new McpError(
+          `Failed to fetch source_url: ${fetchResponse.status} ${fetchResponse.statusText}`,
+          -32602,
+        );
+      }
+      const headerType = fetchResponse.headers.get("content-type") ?? "";
+      const inferred = headerType.includes("png")
+        ? "image/png"
+        : headerType.includes("jpeg") || headerType.includes("jpg")
+          ? "image/jpeg"
+          : null;
+      if (!inferred && !args.content_type) {
+        throw new McpError(
+          `source_url did not return a PNG/JPEG image (Content-Type: ${headerType || "unknown"}). Pass content_type to override.`,
+          -32602,
+        );
+      }
+      contentType =
+        inferred ?? (args.content_type === "png" ? "image/png" : "image/jpeg");
+      body = Buffer.from(await fetchResponse.arrayBuffer());
+    } else {
+      try {
+        body = Buffer.from(args.image_base64!, "base64");
+      } catch {
+        throw new McpError("Invalid base64 image data.", -32602);
+      }
+      contentType = args.content_type === "png" ? "image/png" : "image/jpeg";
+    }
+
+    let uploadResult: Awaited<ReturnType<typeof uploadAppImage>>;
+    try {
+      uploadResult = await uploadAppImage({
+        appId: args.app_id,
+        imageType: args.image_type as McpAppImageType,
+        body,
+        contentType,
+        locale: args.locale,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      // Size / empty errors thrown by the helper are caller-fixable.
+      if (
+        message.includes("empty") ||
+        message.includes("maximum") ||
+        message.includes("bytes")
+      ) {
+        throw new McpError(message, -32602);
+      }
+      logger.error("Failed to upload MCP app image", {
+        error,
+        app_id: args.app_id,
+        team_id: ctx.teamId,
+        image_type: args.image_type,
+      });
+      throw new McpError("Failed to upload image to storage.", -32603);
+    }
+
+    const { fileName, objectKey, mapping, sizeBytes } = uploadResult;
+    let set: Record<string, unknown>;
+    if ("arrayIndex" in mapping) {
+      const current = (metadata.showcase_img_urls ?? []) as string[];
+      const next = [...current];
+      while (next.length < mapping.arrayIndex + 1) next.push("");
+      next[mapping.arrayIndex] = fileName;
+      set = { showcase_img_urls: next };
+    } else {
+      set = { [mapping.field]: fileName };
+    }
+
+    const data = await getMcpUpdateAppMetadataSdk(
+      ctx.client,
+    ).McpUpdateAppMetadata({
+      app_metadata_id: metadata.id,
+      set,
+    });
+
+    return content({
+      app_id: args.app_id,
+      image_type: args.image_type,
+      field: mapping.field,
+      file_name: fileName,
+      s3_key: objectKey,
+      size_bytes: sizeBytes,
+      content_type: contentType,
+      app_metadata: data.update_app_metadata_by_pk,
+    });
+  },
+
   submit_app_for_review: async (input, ctx) => {
     const args = await parseInput(submitAppSchema, input);
     const app = await requireApp(ctx.client, ctx.teamId, args.app_id);
@@ -982,6 +1170,7 @@ const parseToolName = (value: unknown): ToolName => {
     case "rotate_world_id_signing_key":
     case "create_world_id_action":
     case "configure_mini_app":
+    case "upload_app_image":
     case "submit_app_for_review":
       return value;
     default:
@@ -1013,6 +1202,8 @@ const executeTool = async (
       return tools.create_world_id_action(input, ctx);
     case "configure_mini_app":
       return tools.configure_mini_app(input, ctx);
+    case "upload_app_image":
+      return tools.upload_app_image(input, ctx);
     case "submit_app_for_review":
       return tools.submit_app_for_review(input, ctx);
   }

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -25,8 +25,10 @@ import {
   decodeImageBase64,
   fetchImageFromUrl,
   ImageInputError,
+  tryDeleteAppImage,
   uploadAppImage,
 } from "@/api/helpers/app-image-storage";
+import { checkRateLimit } from "@/api/helpers/rate-limit";
 import { CategoryNameIterable } from "@/lib/categories";
 import { logger } from "@/lib/logger";
 import { mainAppStoreFormReviewSubmitSchema } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/FormSchema/form-schema";
@@ -54,6 +56,7 @@ type JsonRpcRequest = {
 
 type McpAuthContext = {
   teamId: string;
+  apiKeyId: string;
 };
 
 type ToolContext = McpAuthContext & {
@@ -502,7 +505,7 @@ const authenticate = async (req: NextRequest): Promise<McpAuthContext> => {
     throw new McpError("API key is not valid.", -32001);
   }
 
-  return { teamId: apiKey.team_id };
+  return { teamId: apiKey.team_id, apiKeyId: apiKey.id };
 };
 
 const parseInput = async <T>(schema: yup.Schema<T>, value: unknown) => {
@@ -987,6 +990,24 @@ const tools = {
       throw new McpError("Only unverified app metadata can be edited.", -32004);
     }
 
+    // Per-API-key upload throttle. Caps cost from a single key looping the
+    // tool: 60 uploads/min and 500/day. Falls open if Redis is unavailable.
+    const limit = await checkRateLimit({
+      scope: "mcp_upload_app_image",
+      key: ctx.apiKeyId,
+      windows: [
+        { label: "minute", limit: 60, periodSeconds: 60 },
+        { label: "day", limit: 500, periodSeconds: 86_400 },
+      ],
+    });
+    if (!limit.ok) {
+      throw new McpError(
+        `Rate limit exceeded for upload_app_image (${limit.window.limit}/${limit.window.label}). Retry in ${limit.resetIn}s.`,
+        -32029,
+        { retry_after_seconds: limit.resetIn, window: limit.window.label },
+      );
+    }
+
     // Resolve the image bytes + content type from either source. The helpers
     // perform SSRF-safe fetching (https only, no redirects, public addrs),
     // size-cap streaming, and authoritative magic-number detection so we
@@ -1055,14 +1076,38 @@ const tools = {
       set = { [mapping.field]: fileName };
     }
 
-    const data = await getMcpUpdateAppMetadataSdk(
-      ctx.client,
-    ).McpUpdateAppMetadata({
-      app_metadata_id: metadata.id,
-      set,
-    });
+    // S3 upload already succeeded above. If the metadata patch fails we'd
+    // leave bytes in S3 that aren't referenced, so best-effort delete the
+    // freshly-uploaded object before surfacing the error. Retries are
+    // idempotent (deterministic key, same bytes), so the caller can safely
+    // re-run.
+    let data;
+    try {
+      data = await getMcpUpdateAppMetadataSdk(ctx.client).McpUpdateAppMetadata({
+        app_metadata_id: metadata.id,
+        set,
+      });
+    } catch (error) {
+      await tryDeleteAppImage(objectKey);
+      logger.error(
+        "MCP app image uploaded to S3 but metadata patch failed; cleaned up.",
+        {
+          error,
+          app_id: args.app_id,
+          team_id: ctx.teamId,
+          image_type: args.image_type,
+          object_key: objectKey,
+        },
+      );
+      throw new McpError(
+        "Image was uploaded but the metadata update failed. The S3 object was rolled back; retry the same call.",
+        -32603,
+        { committed: false, file_name: fileName },
+      );
+    }
 
     return content({
+      committed: true,
       app_id: args.app_id,
       image_type: args.image_type,
       field: mapping.field,

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -40,6 +40,7 @@ import { LocalisationData } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Config
 import {
   encodeDescription,
   getSupportType,
+  parseDescription,
 } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/utils";
 import {
   getLocalisationFormValues,
@@ -995,18 +996,23 @@ const tools = {
     // app_metadata.description is a JSON-encoded string with shape
     // { description_overview, description_how_it_works, description_connect }.
     // Accept the sub-fields directly so the agent doesn't need to construct
-    // the JSON. Explicit `description` (legacy / advanced) wins if both are
-    // provided.
+    // the JSON. configure_mini_app behaves like a patch endpoint elsewhere
+    // (omitted fields preserve existing values) so we mirror that here:
+    // missing sub-fields fall back to whatever's already stored, NOT to "".
+    // Explicit `description` (legacy / advanced) wins if both are provided.
     if (
       description === undefined &&
       (description_overview !== undefined ||
         description_how_it_works !== undefined ||
         description_connect !== undefined)
     ) {
+      const existing = parseDescription(
+        ((metadata as { description?: string | null }).description ?? "") || "",
+      );
       advanced.description = encodeDescription(
-        description_overview ?? "",
-        description_how_it_works ?? "",
-        description_connect ?? "",
+        description_overview ?? existing.description_overview,
+        description_how_it_works ?? existing.description_how_it_works,
+        description_connect ?? existing.description_connect,
       );
     } else if (description !== undefined) {
       advanced.description = description;

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -28,7 +28,10 @@ import { CategoryNameIterable } from "@/lib/categories";
 import { logger } from "@/lib/logger";
 import { mainAppStoreFormReviewSubmitSchema } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/FormSchema/form-schema";
 import { LocalisationData } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/types/AppStoreFormTypes";
-import { getSupportType } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/utils";
+import {
+  encodeDescription,
+  getSupportType,
+} from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/utils";
 import {
   getLocalisationFormValues,
   transformMailtoToRawEmail,
@@ -185,7 +188,18 @@ const toolDefinitions = [
         category: { type: "string" },
         app_website_url: { type: "string" },
         support_link: { type: "string" },
-        description: { type: "string" },
+        description: {
+          type: "string",
+          description:
+            "Stored verbatim. Prefer description_overview for the human-readable text shown in the app store; the server will JSON-encode it for you.",
+        },
+        description_overview: {
+          type: "string",
+          description:
+            "App store overview shown to users. Required for review submission. Server JSON-encodes this (with description_how_it_works / description_connect) into app_metadata.description.",
+        },
+        description_how_it_works: { type: "string" },
+        description_connect: { type: "string" },
         logo_img_url: { type: "string" },
         hero_image_url: { type: "string" },
         meta_tag_image_url: { type: "string" },
@@ -370,6 +384,9 @@ const configureMiniAppSchema = yup
     app_website_url: yup.string().url().optional(),
     support_link: yup.string().optional(),
     description: yup.string().optional(),
+    description_overview: yup.string().optional(),
+    description_how_it_works: yup.string().optional(),
+    description_connect: yup.string().optional(),
     logo_img_url: yup.string().optional(),
     hero_image_url: yup.string().optional(),
     meta_tag_image_url: yup.string().optional(),
@@ -893,6 +910,10 @@ const tools = {
       associated_domains,
       max_notifications_per_day,
       app_mode,
+      description,
+      description_overview,
+      description_how_it_works,
+      description_connect,
       ...rest
     } = args;
 
@@ -925,6 +946,26 @@ const tools = {
       advanced.max_notifications_per_day = unlimited
         ? 0
         : max_notifications_per_day;
+    }
+
+    // app_metadata.description is a JSON-encoded string with shape
+    // { description_overview, description_how_it_works, description_connect }.
+    // Accept the sub-fields directly so the agent doesn't need to construct
+    // the JSON. Explicit `description` (legacy / advanced) wins if both are
+    // provided.
+    if (
+      description === undefined &&
+      (description_overview !== undefined ||
+        description_how_it_works !== undefined ||
+        description_connect !== undefined)
+    ) {
+      advanced.description = encodeDescription(
+        description_overview ?? "",
+        description_how_it_works ?? "",
+        description_connect ?? "",
+      );
+    } else if (description !== undefined) {
+      advanced.description = description;
     }
 
     const set = Object.fromEntries(

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -22,6 +22,9 @@ import { getSdk as getUpdateStagingStatusSdk } from "@/api/v4/rp-status/[rp_id]/
 import {
   MCP_APP_IMAGE_MAP,
   type McpAppImageType,
+  decodeImageBase64,
+  fetchImageFromUrl,
+  ImageInputError,
   uploadAppImage,
 } from "@/api/helpers/app-image-storage";
 import { CategoryNameIterable } from "@/lib/categories";
@@ -261,17 +264,12 @@ const toolDefinitions = [
         source_url: {
           type: "string",
           description:
-            "Public HTTPS URL the server will fetch. Use this OR image_base64.",
+            "Public HTTPS URL the server fetches. Must resolve to a public address (loopback/private/link-local rejected). Redirects are not followed. Use this OR image_base64.",
         },
         image_base64: {
           type: "string",
-          description: "Base64-encoded PNG/JPEG bytes. Use this OR source_url.",
-        },
-        content_type: {
-          type: "string",
-          enum: ["png", "jpeg"],
           description:
-            "Required when using image_base64. Optional with source_url (inferred from response Content-Type).",
+            "Base64-encoded PNG/JPEG bytes. Use this OR source_url. The server detects the format from magic bytes; no separate content_type input is needed.",
         },
         locale: {
           type: "string",
@@ -447,7 +445,6 @@ const uploadAppImageSchema = yup
       .matches(/^https:\/\//, "source_url must use https://")
       .optional(),
     image_base64: yup.string().optional(),
-    content_type: yup.string().oneOf(["png", "jpeg"]).optional(),
     locale: yup.string().optional(),
   })
   .test(
@@ -458,11 +455,6 @@ const uploadAppImageSchema = yup
       const hasBase64 = Boolean(value?.image_base64);
       return hasUrl !== hasBase64;
     },
-  )
-  .test(
-    "base64-needs-content-type",
-    "image_base64 requires content_type to be set",
-    (value) => !value?.image_base64 || Boolean(value?.content_type),
   )
   .noUnknown();
 
@@ -995,40 +987,32 @@ const tools = {
       throw new McpError("Only unverified app metadata can be edited.", -32004);
     }
 
-    // Resolve the image bytes + content type from either source.
+    // Resolve the image bytes + content type from either source. The helpers
+    // perform SSRF-safe fetching (https only, no redirects, public addrs),
+    // size-cap streaming, and authoritative magic-number detection so we
+    // never trust the caller-provided content_type. ImageInputError is the
+    // caller-fixable signal we map to JSON-RPC -32602.
     let body: Buffer;
     let contentType: "image/png" | "image/jpeg";
 
-    if (args.source_url) {
-      const fetchResponse = await fetch(args.source_url);
-      if (!fetchResponse.ok) {
-        throw new McpError(
-          `Failed to fetch source_url: ${fetchResponse.status} ${fetchResponse.statusText}`,
-          -32602,
-        );
+    try {
+      const resolved = args.source_url
+        ? await fetchImageFromUrl(args.source_url)
+        : decodeImageBase64(args.image_base64!);
+      body = resolved.body;
+      contentType = resolved.contentType;
+    } catch (error) {
+      if (error instanceof ImageInputError) {
+        throw new McpError(error.message, -32602);
       }
-      const headerType = fetchResponse.headers.get("content-type") ?? "";
-      const inferred = headerType.includes("png")
-        ? "image/png"
-        : headerType.includes("jpeg") || headerType.includes("jpg")
-          ? "image/jpeg"
-          : null;
-      if (!inferred && !args.content_type) {
-        throw new McpError(
-          `source_url did not return a PNG/JPEG image (Content-Type: ${headerType || "unknown"}). Pass content_type to override.`,
-          -32602,
-        );
-      }
-      contentType =
-        inferred ?? (args.content_type === "png" ? "image/png" : "image/jpeg");
-      body = Buffer.from(await fetchResponse.arrayBuffer());
-    } else {
-      try {
-        body = Buffer.from(args.image_base64!, "base64");
-      } catch {
-        throw new McpError("Invalid base64 image data.", -32602);
-      }
-      contentType = args.content_type === "png" ? "image/png" : "image/jpeg";
+      logger.error("Failed to resolve MCP app image bytes", {
+        error,
+        app_id: args.app_id,
+        team_id: ctx.teamId,
+        image_type: args.image_type,
+        source: args.source_url ? "url" : "base64",
+      });
+      throw new McpError("Failed to read image bytes.", -32603);
     }
 
     let uploadResult: Awaited<ReturnType<typeof uploadAppImage>>;

--- a/web/api/mcp/skill.ts
+++ b/web/api/mcp/skill.ts
@@ -31,12 +31,21 @@ This MCP authenticates with a developer-portal team API key and exposes 11 tools
 ### A. Build an external (non-mini) World ID app end-to-end
 
 \`\`\`
-1. create_app                  { name, app_mode: "external", build: "production", verification: "cloud" }
-2. configure_world_id          { app_id, generate_signing_key: true }      ← capture private_key, it's one-time
-3. create_world_id_action      { app_id, action: "verify-account" }
-4. upload_app_image            { app_id, image_type: "logo", source_url } ← required before submit
-5. configure_mini_app          { app_id, app_website_url, support_link, supported_countries, supported_languages: ["en"] }
-6. submit_app_for_review       { app_id, confirm_submission: true }
+1. create_app             { name, app_mode: "external", build: "production", verification: "cloud" }
+2. configure_world_id     { app_id, generate_signing_key: true }      ← capture private_key, it's one-time
+3. create_world_id_action { app_id, action: "verify-account" }
+4. upload_app_image       { app_id, image_type: "logo",       source_url }   ← required: logo_img_url
+5. upload_app_image       { app_id, image_type: "showcase_1", source_url }   ← required: ≥1 showcase per locale
+6. configure_mini_app     {
+                            app_id,
+                            app_website_url:     "https://your-app.example",
+                            description_overview: "What the app does, in one paragraph.",
+                            supported_countries: ["us"],
+                            supported_languages: ["en"],
+                            is_android_only:     false,
+                            is_for_humans_only:  false,
+                          }
+7. submit_app_for_review  { app_id, confirm_submission: true }
 \`\`\`
 
 After step 2, store the returned \`private_key\` in the developer's app environment as \`WORLD_ID_PRIVATE_KEY\` (or whatever their app expects). The portal does not retain it.
@@ -44,17 +53,35 @@ After step 2, store the returned \`private_key\` in the developer's app environm
 ### B. Build a Mini App with full Advanced settings
 
 \`\`\`
-1. create_app                  { name, app_mode: "mini-app" }
-2. configure_world_id          { app_id, generate_signing_key: true }      ← only if the mini app verifies proofs itself
-3. upload_app_image            { app_id, image_type: "logo",         source_url }
-4. upload_app_image            { app_id, image_type: "content_card", source_url }   ← required for Mini Apps
-5. upload_app_image            { app_id, image_type: "showcase_1",   source_url }   ← optional but recommended
-6. configure_mini_app          { app_id, ...store metadata, ...advanced config }
-7. submit_app_for_review       { app_id, confirm_submission: true }
+1. create_app             { name, app_mode: "mini-app" }
+2. configure_world_id     { app_id, generate_signing_key: true }      ← only if the mini app verifies proofs itself
+3. upload_app_image       { app_id, image_type: "logo",         source_url }   ← required
+4. upload_app_image       { app_id, image_type: "content_card", source_url }   ← required for Mini Apps
+5. upload_app_image       { app_id, image_type: "showcase_1",   source_url }   ← required: ≥1 showcase per locale
+6. configure_mini_app     {
+                            app_id,
+                            short_name:           "MyApp",
+                            category:             "Other",
+                            world_app_description: "One-line tag line",
+                            description_overview:  "What the mini app does, in one paragraph.",
+                            app_website_url:      "https://your-app.example",
+                            support_link:         "mailto:support@your-app.example",  // or "https://your-app.example/support"
+                            supported_countries:  ["us"],
+                            supported_languages:  ["en"],
+                            is_android_only:      false,
+                            is_for_humans_only:   false,
+                            // optional Advanced fields:
+                            contracts:            ["0x..."],
+                            permit2_tokens:       ["0x..."],
+                            max_notifications_per_day: 2,
+                          }
+7. submit_app_for_review  { app_id, confirm_submission: true }
 \`\`\`
 
-\`configure_mini_app\` accepts both store metadata (logo, screenshots, descriptions, supported countries/languages, ...) **and** Advanced/Permissions config in a single call:
+\`configure_mini_app\` accepts store metadata, Advanced/Permissions config, and the App Store description in a single call:
 
+- \`description_overview: string\` — required for review; the human-readable overview shown to users in the app store. Pass it as a plain string here; the server JSON-encodes it (with \`description_how_it_works\` and \`description_connect\`) into the underlying \`app_metadata.description\` column for you. Don't pre-construct the JSON yourself.
+- \`description_how_it_works\`, \`description_connect\` — optional companion sections (also stored inside the encoded description JSON).
 - \`contracts: string[]\` — Worldchain contract addresses the mini app calls
 - \`permit2_tokens: string[]\` — token addresses approved for Permit2 signing
 - \`whitelisted_addresses: string[]\` — wallets allowed to interact (pass \`[]\` to disable)
@@ -105,7 +132,10 @@ get_world_id_registration_status { app_id }  ← on-chain registry sync
 
 - **Managed mode is dashboard-only.** \`configure_world_id\` and rotation only work in self-managed mode. If the user wants the platform to handle on-chain registration, point them at the dashboard.
 - **Private keys are returned once.** If the user loses the value from \`configure_world_id\` / \`rotate_world_id_signing_key\`, they must rotate again. The portal does not store private keys.
-- **Submission preconditions are strict.** \`submit_app_for_review\` runs the same Yup completeness check as the dashboard; missing \`logo_img_url\`, \`app_website_url\`, English locale, etc. will return a \`-32602\` with the exact validation errors. Fix and retry. For Mini Apps, \`content_card_image_url\` is also required.
+- **Submission preconditions are strict.** \`submit_app_for_review\` runs the same Yup completeness check as the dashboard. The full required set:
+  - **Always required**: \`name\`, \`logo_img_url\`, \`app_website_url\`, \`is_android_only\`, \`is_for_humans_only\`, \`supported_countries\` (≥1), \`supported_languages\` (must include \`"en"\`), \`description_overview\` (encoded into the description JSON), and at least one entry in \`showcase_img_urls\` for the English locale.
+  - **Mini-app additional**: \`short_name\`, \`category\`, \`world_app_description\` (the tag line), \`content_card_image_url\`, and either \`support_link\` (HTTPS URL) or \`support_link\` set to a \`mailto:\` URL.
+  - On failure the server returns a \`-32602\` with the exact field path; surface that to the user verbatim.
 - **Use \`upload_app_image\`, not \`configure_mini_app\`, for image fields.** Image fields store filenames (\`logo_img.png\`), not full URLs — the dashboard reconstructs the CDN URL at view time. \`upload_app_image\` handles the S3 upload and stores the right filename automatically; passing a stray URL through \`configure_mini_app.logo_img_url\` will break the image.
 - **Staging apps cannot be submitted for review.** \`create_app\` with \`build: "staging"\` is for sandbox use; switch to \`build: "production"\` (a different app) for store submission.
 - **\`is_developer_allow_listing\` is optional on submit.** If you omit it, the existing value on \`app_metadata\` is preserved — the MCP will not silently un-list a previously listed app.

--- a/web/api/mcp/skill.ts
+++ b/web/api/mcp/skill.ts
@@ -17,7 +17,7 @@ This MCP authenticates with a developer-portal team API key and exposes 11 tools
 | \`get_team_context\`                 | List the team's apps + status                                                                                 | (none)                                                                                                                                                             |
 | \`get_app_config\`                   | Snapshot of an app: World ID config, store metadata, mini-app settings                                        | \`app_id\`                                                                                                                                                           |
 | \`create_app\`                       | Create a new app                                                                                              | \`name\`; optional \`app_mode\` (\`external\` \\| \`mini-app\`), \`build\` (\`production\` \\| \`staging\`), \`verification\` (\`cloud\` \\| \`on-chain\`), \`category\`, \`integration_url\` |
-| \`configure_world_id\`               | Create the World ID 4.0 RP and (optionally) generate a signing key. **Self-managed only.**                    | \`app_id\`; optional \`signer_private_key\`, \`generate_signing_key\`                                                                                                    |
+| \`configure_world_id\`               | Create a managed World ID 4.0 RP for the app: KMS manager key, on-chain registration, signer wallet           | \`app_id\`; optional \`signer_private_key\` (else the server generates one and returns it once)                                                                        |
 | \`get_world_id_signing_key\`         | Read the signer address for an app. Private key is never returned here.                                       | \`app_id\`; optional \`rotate_if_unavailable\`                                                                                                                         |
 | \`rotate_world_id_signing_key\`      | Generate a new World ID signing key. Returns the private key once.                                            | \`app_id\`; optional \`signer_private_key\`                                                                                                                            |
 | \`get_world_id_registration_status\` | Sync the on-chain registry status for an RP                                                                   | \`app_id\`                                                                                                                                                           |
@@ -125,7 +125,7 @@ Image bytes flow through your context as base64 — fine for typical app icons (
 1. rotate_world_id_signing_key { app_id }
 \`\`\`
 
-Returns a fresh \`private_key\` once. Updates the on-portal \`signer_address\`. **Only works for self-managed RPs.** If the registration is platform-managed, the call fails and the user has to rotate from the dashboard UI (it requires an on-chain signer-update transaction the API key path can't perform).
+Returns a fresh \`private_key\` once. Submits the on-chain \`updateRp\` transaction (primary registry, plus best-effort staging on production deployments) and updates \`app_metadata.signer_address\`. The status flips to \`pending\` until the on-chain TX confirms; poll \`status_endpoint\` to watch the transition back to \`registered\`. Self-managed RPs (e.g. legacy registrations not created via MCP) return \`-32004\` with \`data.reason: "self_managed_mode"\` — those have to be rotated by the developer themselves.
 
 ### E. Read-only inspection
 
@@ -138,7 +138,8 @@ get_world_id_registration_status { app_id }  ← on-chain registry sync
 
 ## Pitfalls and constraints
 
-- **Managed mode is dashboard-only.** \`configure_world_id\` and rotation only work in self-managed mode. If the user wants the platform to handle on-chain registration, point them at the dashboard.
+- **\`configure_world_id\` is asynchronous.** The on-chain registration is submitted to the bundler and returns immediately with \`status: "pending"\` and an \`operation_hash\`. Watch \`status_endpoint\` until it returns \`production_status: "registered"\` before relying on the RP for verifications.
+- **\`configure_world_id\` requires the team to be enabled for World ID 4.0.** A team without the feature flag gets \`-32004\` with \`data.reason: "feature_not_enabled"\`. Surface that to the user and point them at the dashboard for enrollment.
 - **Private keys are returned once.** If the user loses the value from \`configure_world_id\` / \`rotate_world_id_signing_key\`, they must rotate again. The portal does not store private keys.
 - **Submission preconditions are strict.** \`submit_app_for_review\` runs the same Yup completeness check as the dashboard. The full required set:
   - **Always required**: \`name\`, \`logo_img_url\`, \`app_website_url\`, \`is_android_only\`, \`is_for_humans_only\`, \`supported_countries\` (≥1), \`supported_languages\` (must include \`"en"\`), \`description_overview\` (encoded into the description JSON), and at least one entry in \`showcase_img_urls\` for the English locale.

--- a/web/api/mcp/skill.ts
+++ b/web/api/mcp/skill.ts
@@ -8,22 +8,23 @@
 
 export const SKILL_INSTRUCTIONS = `# World ID developer portal MCP
 
-This MCP authenticates with a developer-portal team API key and exposes 10 tools for the full app lifecycle. Always use \`get_team_context\` first if the user hasn't given you an \`app_id\` — it returns the team and any existing apps so you can pick or confirm.
+This MCP authenticates with a developer-portal team API key and exposes 11 tools for the full app lifecycle. Always use \`get_team_context\` first if the user hasn't given you an \`app_id\` — it returns the team and any existing apps so you can pick or confirm.
 
 ## Tool reference
 
-| Tool                               | Purpose                                                                                    | Key inputs                                                                                                                                                         |
-| ---------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| \`get_team_context\`                 | List the team's apps + status                                                              | (none)                                                                                                                                                             |
-| \`get_app_config\`                   | Snapshot of an app: World ID config, store metadata, mini-app settings                     | \`app_id\`                                                                                                                                                           |
-| \`create_app\`                       | Create a new app                                                                           | \`name\`; optional \`app_mode\` (\`external\` \\| \`mini-app\`), \`build\` (\`production\` \\| \`staging\`), \`verification\` (\`cloud\` \\| \`on-chain\`), \`category\`, \`integration_url\` |
-| \`configure_world_id\`               | Create the World ID 4.0 RP and (optionally) generate a signing key. **Self-managed only.** | \`app_id\`; optional \`signer_private_key\`, \`generate_signing_key\`                                                                                                    |
-| \`get_world_id_signing_key\`         | Read the signer address for an app. Private key is never returned here.                    | \`app_id\`; optional \`rotate_if_unavailable\`                                                                                                                         |
-| \`rotate_world_id_signing_key\`      | Generate a new World ID signing key. Returns the private key once.                         | \`app_id\`; optional \`signer_private_key\`                                                                                                                            |
-| \`get_world_id_registration_status\` | Sync the on-chain registry status for an RP                                                | \`app_id\`                                                                                                                                                           |
-| \`create_world_id_action\`           | Create / update a v4 action (the thing you \`verify\` against)                               | \`app_id\`, \`action\`; optional \`description\`, \`environment\`                                                                                                          |
-| \`configure_mini_app\`               | Update mini-app store metadata + Advanced/Permissions config                               | \`app_id\`; many optional fields, see below                                                                                                                          |
-| \`submit_app_for_review\`            | Submit an unverified app for review. Requires \`confirm_submission: true\`.                  | \`app_id\`, \`confirm_submission\`; optional \`changelog\`, \`is_developer_allow_listing\`                                                                                 |
+| Tool                               | Purpose                                                                                                       | Key inputs                                                                                                                                                         |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| \`get_team_context\`                 | List the team's apps + status                                                                                 | (none)                                                                                                                                                             |
+| \`get_app_config\`                   | Snapshot of an app: World ID config, store metadata, mini-app settings                                        | \`app_id\`                                                                                                                                                           |
+| \`create_app\`                       | Create a new app                                                                                              | \`name\`; optional \`app_mode\` (\`external\` \\| \`mini-app\`), \`build\` (\`production\` \\| \`staging\`), \`verification\` (\`cloud\` \\| \`on-chain\`), \`category\`, \`integration_url\` |
+| \`configure_world_id\`               | Create the World ID 4.0 RP and (optionally) generate a signing key. **Self-managed only.**                    | \`app_id\`; optional \`signer_private_key\`, \`generate_signing_key\`                                                                                                    |
+| \`get_world_id_signing_key\`         | Read the signer address for an app. Private key is never returned here.                                       | \`app_id\`; optional \`rotate_if_unavailable\`                                                                                                                         |
+| \`rotate_world_id_signing_key\`      | Generate a new World ID signing key. Returns the private key once.                                            | \`app_id\`; optional \`signer_private_key\`                                                                                                                            |
+| \`get_world_id_registration_status\` | Sync the on-chain registry status for an RP                                                                   | \`app_id\`                                                                                                                                                           |
+| \`create_world_id_action\`           | Create / update a v4 action (the thing you \`verify\` against)                                                  | \`app_id\`, \`action\`; optional \`description\`, \`environment\`                                                                                                          |
+| \`configure_mini_app\`               | Update mini-app store metadata + Advanced/Permissions config                                                  | \`app_id\`; many optional fields, see below                                                                                                                          |
+| \`upload_app_image\`                 | Upload an app image (logo, hero, content_card, meta_tag, showcase_1/2/3) and patch the matching \`*_url\` field | \`app_id\`, \`image_type\`, one of \`source_url\` / \`image_base64\` (+ \`content_type\` for base64). PNG/JPEG ≤500KB.                                                       |
+| \`submit_app_for_review\`            | Submit an unverified app for review. Requires \`confirm_submission: true\`.                                     | \`app_id\`, \`confirm_submission\`; optional \`changelog\`, \`is_developer_allow_listing\`                                                                                 |
 
 ## Canonical flows
 
@@ -33,7 +34,9 @@ This MCP authenticates with a developer-portal team API key and exposes 10 tools
 1. create_app                  { name, app_mode: "external", build: "production", verification: "cloud" }
 2. configure_world_id          { app_id, generate_signing_key: true }      ← capture private_key, it's one-time
 3. create_world_id_action      { app_id, action: "verify-account" }
-4. submit_app_for_review       { app_id, confirm_submission: true }
+4. upload_app_image            { app_id, image_type: "logo", source_url } ← required before submit
+5. configure_mini_app          { app_id, app_website_url, support_link, supported_countries, supported_languages: ["en"] }
+6. submit_app_for_review       { app_id, confirm_submission: true }
 \`\`\`
 
 After step 2, store the returned \`private_key\` in the developer's app environment as \`WORLD_ID_PRIVATE_KEY\` (or whatever their app expects). The portal does not retain it.
@@ -43,8 +46,11 @@ After step 2, store the returned \`private_key\` in the developer's app environm
 \`\`\`
 1. create_app                  { name, app_mode: "mini-app" }
 2. configure_world_id          { app_id, generate_signing_key: true }      ← only if the mini app verifies proofs itself
-3. configure_mini_app          { app_id, ...store metadata, ...advanced config }
-4. submit_app_for_review       { app_id, confirm_submission: true }
+3. upload_app_image            { app_id, image_type: "logo",         source_url }
+4. upload_app_image            { app_id, image_type: "content_card", source_url }   ← required for Mini Apps
+5. upload_app_image            { app_id, image_type: "showcase_1",   source_url }   ← optional but recommended
+6. configure_mini_app          { app_id, ...store metadata, ...advanced config }
+7. submit_app_for_review       { app_id, confirm_submission: true }
 \`\`\`
 
 \`configure_mini_app\` accepts both store metadata (logo, screenshots, descriptions, supported countries/languages, ...) **and** Advanced/Permissions config in a single call:
@@ -58,7 +64,27 @@ After step 2, store the returned \`private_key\` in the developer's app environm
 
 All address arrays are validated as \`0x\` + 40 hex chars; URLs as \`https://...\`; reject any element with an embedded comma.
 
-### C. Rotate a leaked signing key
+### C. Upload images (logo / hero / content_card / meta_tag / showcase_N)
+
+\`upload_app_image\` accepts the bytes in two ways:
+
+- **\`source_url\`** — public HTTPS URL the server fetches (best for URLs the user already gave you, or staging asset CDNs)
+- **\`image_base64\`** — base64-encoded bytes (use for local files)
+
+When the user gives you a **local file path**, base64-encode it client-side via Bash and pass through:
+
+\`\`\`
+# in Bash:
+base64 -i ./logo.png
+# pipe / capture the output, then call upload_app_image:
+upload_app_image { app_id, image_type: "logo", image_base64: "<that string>", content_type: "png" }
+\`\`\`
+
+The server validates ≤500KB PNG/JPEG either way, uploads to S3, and patches \`app_metadata.{logo_img_url|hero_image_url|content_card_image_url|meta_tag_image_url|showcase_img_urls[N]}\` in one call. No follow-up \`configure_mini_app\` is needed for images.
+
+Image bytes flow through your context as base64 — fine for typical app icons (<100KB), wasteful for very large screenshots. Prefer \`source_url\` whenever the image is already on the web.
+
+### D. Rotate a leaked signing key
 
 \`\`\`
 1. rotate_world_id_signing_key { app_id }
@@ -66,7 +92,7 @@ All address arrays are validated as \`0x\` + 40 hex chars; URLs as \`https://...
 
 Returns a fresh \`private_key\` once. Updates the on-portal \`signer_address\`. **Only works for self-managed RPs.** If the registration is platform-managed, the call fails and the user has to rotate from the dashboard UI (it requires an on-chain signer-update transaction the API key path can't perform).
 
-### D. Read-only inspection
+### E. Read-only inspection
 
 \`\`\`
 get_team_context                    ← what apps exist, their status
@@ -79,7 +105,8 @@ get_world_id_registration_status { app_id }  ← on-chain registry sync
 
 - **Managed mode is dashboard-only.** \`configure_world_id\` and rotation only work in self-managed mode. If the user wants the platform to handle on-chain registration, point them at the dashboard.
 - **Private keys are returned once.** If the user loses the value from \`configure_world_id\` / \`rotate_world_id_signing_key\`, they must rotate again. The portal does not store private keys.
-- **Submission preconditions are strict.** \`submit_app_for_review\` runs the same Yup completeness check as the dashboard; missing \`logo_img_url\`, \`app_website_url\`, English locale, etc. will return a \`-32602\` with the exact validation errors. Fix and retry.
+- **Submission preconditions are strict.** \`submit_app_for_review\` runs the same Yup completeness check as the dashboard; missing \`logo_img_url\`, \`app_website_url\`, English locale, etc. will return a \`-32602\` with the exact validation errors. Fix and retry. For Mini Apps, \`content_card_image_url\` is also required.
+- **Use \`upload_app_image\`, not \`configure_mini_app\`, for image fields.** Image fields store filenames (\`logo_img.png\`), not full URLs — the dashboard reconstructs the CDN URL at view time. \`upload_app_image\` handles the S3 upload and stores the right filename automatically; passing a stray URL through \`configure_mini_app.logo_img_url\` will break the image.
 - **Staging apps cannot be submitted for review.** \`create_app\` with \`build: "staging"\` is for sandbox use; switch to \`build: "production"\` (a different app) for store submission.
 - **\`is_developer_allow_listing\` is optional on submit.** If you omit it, the existing value on \`app_metadata\` is preserved — the MCP will not silently un-list a previously listed app.
 - **Don't re-run \`configure_world_id\` on an already-configured app.** It returns the existing registration without rotating. Use \`rotate_world_id_signing_key\` if the user actually wants a new key.

--- a/web/api/mcp/skill.ts
+++ b/web/api/mcp/skill.ts
@@ -111,7 +111,11 @@ You don't need to specify the format — the server inspects the magic bytes and
 
 \`source_url\` is fetched server-side over HTTPS only, must resolve to a public address (loopback / private / link-local rejected), and **redirects are not followed** — if the user gives you a URL that redirects, resolve the final URL client-side first.
 
-The server uploads the bytes to S3 and patches \`app_metadata.{logo_img_url|hero_image_url|content_card_image_url|meta_tag_image_url|showcase_img_urls[N]}\` in one call. No follow-up \`configure_mini_app\` is needed for images.
+The server uploads the bytes to S3 and patches \`app_metadata.{logo_img_url|hero_image_url|content_card_image_url|meta_tag_image_url|showcase_img_urls[N]}\` in one call. No follow-up \`configure_mini_app\` is needed for images. Successful responses include \`committed: true\`.
+
+If the metadata patch fails after the S3 upload (rare — typically a transient Hasura error), the server best-effort deletes the S3 object and returns \`-32603\` with \`data: { committed: false }\`. Retries are idempotent, so just call the same tool again.
+
+\`upload_app_image\` is rate-limited per API key: **60 uploads/minute, 500/day**. Hitting the cap returns \`-32029\` with \`data.retry_after_seconds\`.
 
 Image bytes flow through your context as base64 — fine for typical app icons (<100KB), wasteful for very large screenshots. Prefer \`source_url\` whenever the image is already on the web.
 

--- a/web/api/mcp/skill.ts
+++ b/web/api/mcp/skill.ts
@@ -23,7 +23,7 @@ This MCP authenticates with a developer-portal team API key and exposes 11 tools
 | \`get_world_id_registration_status\` | Sync the on-chain registry status for an RP                                                                   | \`app_id\`                                                                                                                                                           |
 | \`create_world_id_action\`           | Create / update a v4 action (the thing you \`verify\` against)                                                  | \`app_id\`, \`action\`; optional \`description\`, \`environment\`                                                                                                          |
 | \`configure_mini_app\`               | Update mini-app store metadata + Advanced/Permissions config                                                  | \`app_id\`; many optional fields, see below                                                                                                                          |
-| \`upload_app_image\`                 | Upload an app image (logo, hero, content_card, meta_tag, showcase_1/2/3) and patch the matching \`*_url\` field | \`app_id\`, \`image_type\`, one of \`source_url\` / \`image_base64\` (+ \`content_type\` for base64). PNG/JPEG ≤500KB.                                                       |
+| \`upload_app_image\`                 | Upload an app image (logo, hero, content_card, meta_tag, showcase_1/2/3) and patch the matching \`*_url\` field | \`app_id\`, \`image_type\`, one of \`source_url\` (https only, public addr, no redirects) / \`image_base64\`. Format detected from magic bytes. PNG/JPEG ≤500KB.           |
 | \`submit_app_for_review\`            | Submit an unverified app for review. Requires \`confirm_submission: true\`.                                     | \`app_id\`, \`confirm_submission\`; optional \`changelog\`, \`is_developer_allow_listing\`                                                                                 |
 
 ## Canonical flows
@@ -104,10 +104,14 @@ When the user gives you a **local file path**, base64-encode it client-side via 
 # in Bash:
 base64 -i ./logo.png
 # pipe / capture the output, then call upload_app_image:
-upload_app_image { app_id, image_type: "logo", image_base64: "<that string>", content_type: "png" }
+upload_app_image { app_id, image_type: "logo", image_base64: "<that string>" }
 \`\`\`
 
-The server validates ≤500KB PNG/JPEG either way, uploads to S3, and patches \`app_metadata.{logo_img_url|hero_image_url|content_card_image_url|meta_tag_image_url|showcase_img_urls[N]}\` in one call. No follow-up \`configure_mini_app\` is needed for images.
+You don't need to specify the format — the server inspects the magic bytes and stores the file as PNG or JPEG accordingly. Anything that isn't a real PNG/JPEG (or anything >500KB) is rejected with \`-32602\`.
+
+\`source_url\` is fetched server-side over HTTPS only, must resolve to a public address (loopback / private / link-local rejected), and **redirects are not followed** — if the user gives you a URL that redirects, resolve the final URL client-side first.
+
+The server uploads the bytes to S3 and patches \`app_metadata.{logo_img_url|hero_image_url|content_card_image_url|meta_tag_image_url|showcase_img_urls[N]}\` in one call. No follow-up \`configure_mini_app\` is needed for images.
 
 Image bytes flow through your context as base64 — fine for typical app icons (<100KB), wasteful for very large screenshots. Prefer \`source_url\` whenever the image is already on the web.
 

--- a/web/tests/api/helpers/rate-limit.test.ts
+++ b/web/tests/api/helpers/rate-limit.test.ts
@@ -1,0 +1,129 @@
+import { checkRateLimit } from "@/api/helpers/rate-limit";
+
+jest.mock(
+  "@/lib/logger",
+  () => ({
+    logger: {
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    },
+  }),
+  { virtual: true },
+);
+
+const redis = global.RedisClient as {
+  flushall: () => Promise<unknown>;
+  set: (key: string, value: string) => Promise<unknown>;
+  ttl: (key: string) => Promise<number>;
+  get: (key: string) => Promise<string | null>;
+};
+
+beforeEach(async () => {
+  await redis.flushall();
+});
+
+describe("checkRateLimit — atomic INCR + EXPIRE", () => {
+  it("admits the first call and sets a TTL on the counter", async () => {
+    const decision = await checkRateLimit({
+      scope: "test",
+      key: "k1",
+      windows: [{ label: "minute", limit: 5, periodSeconds: 60 }],
+    });
+    expect(decision).toEqual({ ok: true });
+    const ttl = await redis.ttl("ratelimit:test:minute:k1");
+    // Some Redis variants report ttl as 60 immediately; ioredis-mock can
+    // sometimes report -1 right after EXPIRE in older releases, so accept
+    // any value that's clearly within the configured window.
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(60);
+  });
+
+  it("blocks the call that crosses the limit", async () => {
+    const window = { label: "minute", limit: 3, periodSeconds: 60 };
+    for (let i = 0; i < 3; i++) {
+      const ok = await checkRateLimit({
+        scope: "test",
+        key: "k2",
+        windows: [window],
+      });
+      expect(ok.ok).toBe(true);
+    }
+    const blocked = await checkRateLimit({
+      scope: "test",
+      key: "k2",
+      windows: [window],
+    });
+    expect(blocked.ok).toBe(false);
+    if (blocked.ok === false) {
+      expect(blocked.window.label).toBe("minute");
+      expect(blocked.resetIn).toBeGreaterThan(0);
+      expect(blocked.resetIn).toBeLessThanOrEqual(60);
+    }
+  });
+
+  it("self-heals a stuck counter that has no TTL", async () => {
+    // Simulate a key left over from before INCR/EXPIRE became atomic:
+    // counter is well past the limit and has no expiry, so without
+    // self-heal the bucket would lock the API key forever.
+    const fullKey = "ratelimit:test:minute:stuck";
+    await redis.set(fullKey, "200");
+    expect(await redis.ttl(fullKey)).toBe(-1);
+
+    const decision = await checkRateLimit({
+      scope: "test",
+      key: "stuck",
+      windows: [{ label: "minute", limit: 5, periodSeconds: 60 }],
+    });
+
+    expect(decision.ok).toBe(false);
+    if (decision.ok === false) {
+      // Resetting in 1s would be misleading and lets the bucket loop
+      // forever; the self-heal must surface a real window-length retry.
+      expect(decision.resetIn).toBeGreaterThan(1);
+      expect(decision.resetIn).toBeLessThanOrEqual(60);
+    }
+    // Counter now has a real TTL — it'll actually expire.
+    const newTtl = await redis.ttl(fullKey);
+    expect(newTtl).toBeGreaterThan(0);
+    expect(newTtl).toBeLessThanOrEqual(60);
+  });
+
+  it("falls open when Redis is unavailable", async () => {
+    const original = global.RedisClient;
+    (global as { RedisClient?: unknown }).RedisClient = undefined;
+    try {
+      const decision = await checkRateLimit({
+        scope: "test",
+        key: "k3",
+        windows: [{ label: "minute", limit: 1, periodSeconds: 60 }],
+      });
+      expect(decision).toEqual({ ok: true });
+    } finally {
+      (global as { RedisClient?: unknown }).RedisClient = original;
+    }
+  });
+
+  it("falls open when the Redis call throws", async () => {
+    const original = global.RedisClient;
+    const failingRedis = {
+      eval: () => {
+        throw new Error("simulated Redis outage");
+      },
+      ttl: () => Promise.resolve(-2),
+      expire: () => Promise.resolve(0),
+    };
+    (global as { RedisClient?: unknown }).RedisClient = failingRedis;
+    try {
+      const decision = await checkRateLimit({
+        scope: "test",
+        key: "k4",
+        windows: [{ label: "minute", limit: 1, periodSeconds: 60 }],
+      });
+      expect(decision).toEqual({ ok: true });
+    } finally {
+      (global as { RedisClient?: unknown }).RedisClient = original;
+    }
+  });
+});

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -47,8 +47,65 @@ jest.mock("../../api/helpers/rp-registration-flows", () => ({
     submitManagedSignerRotationMock(...args),
 }));
 
-const fetchMock = jest.fn();
-global.fetch = fetchMock as unknown as typeof fetch;
+const httpsRequestMock = jest.fn();
+jest.mock("node:https", () => ({
+  request: (...args: unknown[]) => httpsRequestMock(...args),
+}));
+
+// Build a fake IncomingMessage + ClientRequest pair that drives the
+// streaming reader in fetchImageFromUrl. Used by tests that simulate a
+// source_url response.
+type HttpsResponseShape = {
+  statusCode: number;
+  statusMessage?: string;
+  headers?: Record<string, string>;
+  body?: Buffer;
+};
+const mockHttpsResponse = (response: HttpsResponseShape) => {
+  httpsRequestMock.mockImplementationOnce(
+    (
+      _options: unknown,
+      callback: (
+        res: NodeJS.EventEmitter & {
+          statusCode: number;
+          statusMessage?: string;
+          headers: Record<string, string>;
+          resume: () => void;
+          destroy: () => void;
+        },
+      ) => void,
+    ) => {
+      const listeners: Record<string, ((arg?: unknown) => void)[]> = {};
+      const res = {
+        statusCode: response.statusCode,
+        statusMessage: response.statusMessage ?? "",
+        headers: response.headers ?? {},
+        on: (event: string, handler: (arg?: unknown) => void) => {
+          (listeners[event] ??= []).push(handler);
+          return res;
+        },
+        resume: () => {},
+        destroy: () => {},
+      };
+      // Simulate streaming on next tick so the caller's listeners attach
+      // first.
+      process.nextTick(() => {
+        callback(res as never);
+        process.nextTick(() => {
+          if (response.body && response.body.length > 0) {
+            for (const fn of listeners.data ?? []) fn(response.body);
+          }
+          for (const fn of listeners.end ?? []) fn();
+        });
+      });
+      return {
+        on: () => {},
+        end: () => {},
+        destroy: () => {},
+      };
+    },
+  );
+};
 
 const mockLoggerInfo = logger.info as jest.Mock;
 const mockGetRpFromContract = getRpFromContract as jest.Mock;
@@ -160,7 +217,7 @@ beforeEach(async () => {
   process.env.ASSETS_S3_REGION = "us-east-1";
   process.env.ASSETS_S3_BUCKET_NAME = "test-bucket";
   s3SendMock.mockResolvedValue({});
-  fetchMock.mockReset();
+  httpsRequestMock.mockReset();
   dnsLookupMock.mockReset();
   // Default: source_url hostnames resolve to a single public address. The
   // helper calls `lookup(host, { all: true })`, which returns an array; we
@@ -748,12 +805,11 @@ describe("/api/mcp", () => {
     const pngBytes = Buffer.from([
       0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
     ]);
-    fetchMock.mockResolvedValue(
-      new Response(pngBytes, {
-        status: 200,
-        headers: { "Content-Type": "image/png" },
-      }),
-    );
+    mockHttpsResponse({
+      statusCode: 200,
+      headers: { "content-type": "image/png" },
+      body: pngBytes,
+    });
 
     const res = await POST(
       callTool("upload_app_image", {
@@ -790,7 +846,7 @@ describe("/api/mcp", () => {
     const payload = JSON.parse((await res.json()).result.content[0].text);
     expect(payload.file_name).toBe("content_card_image.jpg");
     expect(payload.content_type).toBe("image/jpeg");
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(httpsRequestMock).not.toHaveBeenCalled();
 
     const updateCall = requestMock.mock.calls.find(
       ([query]) => getOperationName(query) === "McpUpdateAppMetadata",
@@ -833,12 +889,11 @@ describe("/api/mcp", () => {
     const pngBytes = Buffer.from([
       0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
     ]);
-    fetchMock.mockResolvedValue(
-      new Response(pngBytes, {
-        status: 200,
-        headers: { "Content-Type": "image/png" },
-      }),
-    );
+    mockHttpsResponse({
+      statusCode: 200,
+      headers: { "content-type": "image/png" },
+      body: pngBytes,
+    });
 
     const res = await POST(
       callTool("upload_app_image", {
@@ -888,7 +943,7 @@ describe("/api/mcp", () => {
     const body = await res.json();
     expect(body.error.code).toBe(-32602);
     expect(body.error.message).toMatch(/private\/internal/);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(httpsRequestMock).not.toHaveBeenCalled();
     expect(s3SendMock).not.toHaveBeenCalled();
   });
 
@@ -913,7 +968,7 @@ describe("/api/mcp", () => {
       const body = await res.json();
       expect(body.error.code).toBe(-32602);
       expect(body.error.message).toMatch(/private\/internal/);
-      expect(fetchMock).not.toHaveBeenCalled();
+      expect(httpsRequestMock).not.toHaveBeenCalled();
     },
   );
 
@@ -935,19 +990,18 @@ describe("/api/mcp", () => {
     const body = await res.json();
     expect(body.error.code).toBe(-32602);
     expect(body.error.message).toMatch(/private\/internal/);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(httpsRequestMock).not.toHaveBeenCalled();
   });
 
   it("rejects source_url with Content-Length above the 500KB cap before reading body", async () => {
-    fetchMock.mockResolvedValue(
-      new Response(Buffer.from([0x89, 0x50, 0x4e, 0x47]), {
-        status: 200,
-        headers: {
-          "Content-Type": "image/png",
-          "Content-Length": String(600 * 1024),
-        },
-      }),
-    );
+    mockHttpsResponse({
+      statusCode: 200,
+      headers: {
+        "content-type": "image/png",
+        "content-length": String(600 * 1024),
+      },
+      body: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+    });
 
     const res = await POST(
       callTool("upload_app_image", {
@@ -964,17 +1018,60 @@ describe("/api/mcp", () => {
     expect(s3SendMock).not.toHaveBeenCalled();
   });
 
+  it("pins the connection to the validated IP — fetch never re-resolves the hostname", async () => {
+    dnsLookupMock.mockResolvedValue([{ address: "203.0.113.55", family: 4 }]);
+    mockHttpsResponse({
+      statusCode: 200,
+      headers: { "content-type": "image/png" },
+      body: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    });
+
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "logo",
+        source_url: "https://cdn.example.com/logo.png",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(httpsRequestMock).toHaveBeenCalledTimes(1);
+    const [requestOptions] = httpsRequestMock.mock.calls[0];
+    expect(requestOptions.host).toBe("cdn.example.com");
+    // The custom lookup we wired in must always return the validated IP,
+    // regardless of what hostname the connect path asks for. This forces
+    // any fresh resolution by the underlying HTTP stack to be ignored.
+    const lookupCb = jest.fn();
+    requestOptions.lookup("attacker-controlled.example", {}, lookupCb);
+    expect(lookupCb).toHaveBeenCalledWith(null, "203.0.113.55", 4);
+  });
+
   it("rate-limits upload_app_image at 60/minute per API key", async () => {
     const pngBytes = Buffer.from([
       0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
     ]);
-    fetchMock.mockImplementation(
-      async () =>
-        new Response(pngBytes, {
-          status: 200,
-          headers: { "Content-Type": "image/png" },
-        }),
-    );
+    httpsRequestMock.mockImplementation((_options, callback) => {
+      const listeners: Record<string, ((arg?: unknown) => void)[]> = {};
+      const res = {
+        statusCode: 200,
+        statusMessage: "OK",
+        headers: { "content-type": "image/png" },
+        on: (event: string, handler: (arg?: unknown) => void) => {
+          (listeners[event] ??= []).push(handler);
+          return res;
+        },
+        resume: () => {},
+        destroy: () => {},
+      };
+      process.nextTick(() => {
+        callback(res);
+        process.nextTick(() => {
+          for (const fn of listeners.data ?? []) fn(pngBytes);
+          for (const fn of listeners.end ?? []) fn();
+        });
+      });
+      return { on: () => {}, end: () => {}, destroy: () => {} };
+    });
 
     const callOnce = () =>
       POST(
@@ -1004,12 +1101,11 @@ describe("/api/mcp", () => {
     const pngBytes = Buffer.from([
       0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
     ]);
-    fetchMock.mockResolvedValue(
-      new Response(pngBytes, {
-        status: 200,
-        headers: { "Content-Type": "image/png" },
-      }),
-    );
+    mockHttpsResponse({
+      statusCode: 200,
+      headers: { "content-type": "image/png" },
+      body: pngBytes,
+    });
 
     const baseImpl = requestMock.getMockImplementation()!;
     requestMock.mockImplementation(async (query: unknown, variables: any) => {

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -513,24 +513,6 @@ describe("/api/mcp", () => {
     );
   });
 
-  it("accepts the legacy generate_signing_key field for backwards compatibility", async () => {
-    currentAppContextResponse = {
-      app: [{ ...appContextResponse.app[0], rp_registration: [] }],
-    };
-
-    const res = await POST(
-      callTool("configure_world_id", {
-        app_id: appId,
-        generate_signing_key: true,
-      }),
-    );
-
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.error).toBeUndefined();
-    expect(submitManagedRpRegistrationMock).toHaveBeenCalledTimes(1);
-  });
-
   it("surfaces feature_not_enabled from the registration helper as -32004", async () => {
     currentAppContextResponse = {
       app: [{ ...appContextResponse.app[0], rp_registration: [] }],

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -60,6 +60,7 @@ const appContextResponse = {
           app_mode: "mini-app",
           verification_status: "unverified",
           is_developer_allow_listing: false,
+          showcase_img_urls: [] as string[],
         },
       ],
       rp_registration: [
@@ -629,6 +630,46 @@ describe("/api/mcp", () => {
       ).toBe(false);
     },
   );
+
+  it("encodes description_overview / how_it_works / connect into a JSON description", async () => {
+    const res = await POST(
+      callTool("configure_mini_app", {
+        app_id: appId,
+        description_overview: "Cool app",
+        description_how_it_works: "It works like this",
+        description_connect: "Connect on X",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const updateCall = requestMock.mock.calls.find(
+      ([query]) => getOperationName(query) === "McpUpdateAppMetadata",
+    );
+    const set = updateCall?.[1].set ?? {};
+    expect(JSON.parse(set.description)).toEqual({
+      description_overview: "Cool app",
+      description_how_it_works: "It works like this",
+      description_connect: "Connect on X",
+    });
+  });
+
+  it("prefers explicit description over the encoded sub-fields", async () => {
+    const res = await POST(
+      callTool("configure_mini_app", {
+        app_id: appId,
+        description: '{"description_overview":"raw"}',
+        description_overview: "Cool app",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const updateCall = requestMock.mock.calls.find(
+      ([query]) => getOperationName(query) === "McpUpdateAppMetadata",
+    );
+    expect(updateCall?.[1].set.description).toBe(
+      '{"description_overview":"raw"}',
+    );
+  });
 
   it("uploads a logo image from a source_url and patches logo_img_url", async () => {
     const pngBytes = Buffer.from([

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -513,6 +513,24 @@ describe("/api/mcp", () => {
     );
   });
 
+  it("accepts the legacy generate_signing_key field for backwards compatibility", async () => {
+    currentAppContextResponse = {
+      app: [{ ...appContextResponse.app[0], rp_registration: [] }],
+    };
+
+    const res = await POST(
+      callTool("configure_world_id", {
+        app_id: appId,
+        generate_signing_key: true,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error).toBeUndefined();
+    expect(submitManagedRpRegistrationMock).toHaveBeenCalledTimes(1);
+  });
+
   it("surfaces feature_not_enabled from the registration helper as -32004", async () => {
     currentAppContextResponse = {
       app: [{ ...appContextResponse.app[0], rp_registration: [] }],
@@ -1172,6 +1190,34 @@ describe("/api/mcp", () => {
     );
     // First call: PutObject. Second call: DeleteObject (best-effort cleanup).
     expect(s3SendMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores legacy locale input and uploads to the default-locale path so default-locale fields are never corrupted", async () => {
+    // locale used to scope the S3 key prefix while the DB write still
+    // patched the base app_metadata row, which would leave the
+    // default-locale logo_img_url pointing at a path that has no asset.
+    // Locale was removed from the input schema; Yup's stripUnknown
+    // silently drops it, and the upload lands at the base path that the
+    // (single) DB field actually references.
+    const pngBytes = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "logo",
+        image_base64: pngBytes.toString("base64"),
+        locale: "es",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const payload = JSON.parse((await res.json()).result.content[0].text);
+    expect(payload.s3_key).toBe(`unverified/${appId}/logo_img.png`);
+    const updateCall = requestMock.mock.calls.find(
+      ([query]) => getOperationName(query) === "McpUpdateAppMetadata",
+    );
+    expect(updateCall?.[1].set).toEqual({ logo_img_url: "logo_img.png" });
   });
 
   it("rejects when neither source_url nor image_base64 is provided", async () => {

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -6,6 +6,7 @@ import { NextRequest } from "next/server";
 import { getRpFromContract } from "../../api/helpers/temporal-rpc";
 
 const requestMock = jest.fn();
+const s3SendMock = jest.fn();
 
 jest.mock("../../api/helpers/graphql", () => ({
   getAPIServiceGraphqlClient: jest.fn(async () => ({ request: requestMock })),
@@ -23,6 +24,14 @@ jest.mock("../../lib/logger", () => ({
 jest.mock("../../api/helpers/temporal-rpc", () => ({
   getRpFromContract: jest.fn(),
 }));
+
+jest.mock("@aws-sdk/client-s3", () => ({
+  S3Client: jest.fn().mockImplementation(() => ({ send: s3SendMock })),
+  PutObjectCommand: jest.fn().mockImplementation((args) => ({ ...args })),
+}));
+
+const fetchMock = jest.fn();
+global.fetch = fetchMock as unknown as typeof fetch;
 
 const mockLoggerInfo = logger.info as jest.Mock;
 const mockGetRpFromContract = getRpFromContract as jest.Mock;
@@ -127,6 +136,10 @@ beforeEach(() => {
   process.env.RP_REGISTRY_CONTRACT_ADDRESS =
     "0x0000000000000000000000000000000000000048";
   delete process.env.RP_REGISTRY_STAGING_CONTRACT_ADDRESS;
+  process.env.ASSETS_S3_REGION = "us-east-1";
+  process.env.ASSETS_S3_BUCKET_NAME = "test-bucket";
+  s3SendMock.mockResolvedValue({});
+  fetchMock.mockReset();
   currentAppContextResponse = appContextResponse;
   mockGetRpFromContract.mockResolvedValue({
     initialized: true,
@@ -616,6 +629,131 @@ describe("/api/mcp", () => {
       ).toBe(false);
     },
   );
+
+  it("uploads a logo image from a source_url and patches logo_img_url", async () => {
+    const pngBytes = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    fetchMock.mockResolvedValue(
+      new Response(pngBytes, {
+        status: 200,
+        headers: { "Content-Type": "image/png" },
+      }),
+    );
+
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "logo",
+        source_url: "https://cdn.example.com/logo.png",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const payload = JSON.parse((await res.json()).result.content[0].text);
+    expect(payload.file_name).toBe("logo_img.png");
+    expect(payload.s3_key).toBe(`unverified/${appId}/logo_img.png`);
+    expect(s3SendMock).toHaveBeenCalledTimes(1);
+
+    const updateCall = requestMock.mock.calls.find(
+      ([query]) => getOperationName(query) === "McpUpdateAppMetadata",
+    );
+    expect(updateCall?.[1].set).toEqual({ logo_img_url: "logo_img.png" });
+  });
+
+  it("uploads a base64 image and respects content_type", async () => {
+    const jpegBase64 = Buffer.from([0xff, 0xd8, 0xff, 0xd9]).toString("base64");
+
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "content_card",
+        image_base64: jpegBase64,
+        content_type: "jpeg",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const payload = JSON.parse((await res.json()).result.content[0].text);
+    expect(payload.file_name).toBe("content_card_image.jpg");
+    expect(payload.content_type).toBe("image/jpeg");
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const updateCall = requestMock.mock.calls.find(
+      ([query]) => getOperationName(query) === "McpUpdateAppMetadata",
+    );
+    expect(updateCall?.[1].set).toEqual({
+      content_card_image_url: "content_card_image.jpg",
+    });
+  });
+
+  it("places showcase_2 in the second slot of showcase_img_urls", async () => {
+    currentAppContextResponse = {
+      app: [
+        {
+          ...appContextResponse.app[0],
+          app_metadata: [
+            {
+              ...appContextResponse.app[0].app_metadata[0],
+              showcase_img_urls: ["showcase_img_1.png"],
+            },
+          ],
+        },
+      ],
+    };
+    fetchMock.mockResolvedValue(
+      new Response(Buffer.from("png"), {
+        status: 200,
+        headers: { "Content-Type": "image/png" },
+      }),
+    );
+
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "showcase_2",
+        source_url: "https://cdn.example.com/showcase2.png",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const updateCall = requestMock.mock.calls.find(
+      ([query]) => getOperationName(query) === "McpUpdateAppMetadata",
+    );
+    expect(updateCall?.[1].set).toEqual({
+      showcase_img_urls: ["showcase_img_1.png", "showcase_img_2.png"],
+    });
+  });
+
+  it("rejects images that exceed the 500KB cap", async () => {
+    const huge = Buffer.alloc(501 * 1024, 0).toString("base64");
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "logo",
+        image_base64: huge,
+        content_type: "png",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32602);
+    expect(s3SendMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects when neither source_url nor image_base64 is provided", async () => {
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "logo",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32602);
+  });
 
   it("rejects Mini App metadata updates after review submission", async () => {
     currentAppContextResponse = {

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -38,6 +38,15 @@ jest.mock("node:dns/promises", () => ({
   lookup: (...args: unknown[]) => dnsLookupMock(...args),
 }));
 
+const submitManagedRpRegistrationMock = jest.fn();
+const submitManagedSignerRotationMock = jest.fn();
+jest.mock("../../api/helpers/rp-registration-flows", () => ({
+  submitManagedRpRegistration: (...args: unknown[]) =>
+    submitManagedRpRegistrationMock(...args),
+  submitManagedSignerRotation: (...args: unknown[]) =>
+    submitManagedSignerRotationMock(...args),
+}));
+
 const fetchMock = jest.fn();
 global.fetch = fetchMock as unknown as typeof fetch;
 
@@ -156,6 +165,32 @@ beforeEach(async () => {
   // Default: source_url hostnames resolve to a public address. Specific tests
   // override this to simulate private / loopback responses.
   dnsLookupMock.mockResolvedValue({ address: "203.0.113.10", family: 4 });
+  submitManagedRpRegistrationMock.mockReset();
+  submitManagedSignerRotationMock.mockReset();
+  // Default: managed flows succeed. Specific tests override to assert
+  // failure paths (already_registered, self_managed_mode, etc.).
+  submitManagedRpRegistrationMock.mockImplementation(
+    async ({ appId, signerAddress }) => ({
+      ok: true,
+      rpIdString: generateRpIdString(appId),
+      managerAddress: "0x1111111111111111111111111111111111111111",
+      signerAddress,
+      operationHash: "0xop_hash_register",
+      status: "pending",
+      stagingOperationHash: null,
+      stagingStatus: null,
+    }),
+  );
+  submitManagedSignerRotationMock.mockImplementation(
+    async ({ appId, newSignerAddress }) => ({
+      ok: true,
+      rpIdString: generateRpIdString(appId),
+      newSignerAddress,
+      oldSignerAddress: "0x0000000000000000000000000000000000000001",
+      operationHash: "0xop_hash_rotate",
+      status: "pending",
+    }),
+  );
   currentAppContextResponse = appContextResponse;
   mockGetRpFromContract.mockResolvedValue({
     initialized: true,
@@ -391,27 +426,53 @@ describe("/api/mcp", () => {
     );
   });
 
-  it("configures World ID and returns a one-time signing key", async () => {
+  it("configures World ID via the managed flow and returns a one-time signing key", async () => {
     currentAppContextResponse = {
       app: [{ ...appContextResponse.app[0], rp_registration: [] }],
     };
 
-    const res = await POST(
-      callTool("configure_world_id", {
-        app_id: appId,
-        generate_signing_key: true,
-      }),
-    );
+    const res = await POST(callTool("configure_world_id", { app_id: appId }));
 
     expect(res.status).toBe(200);
     const body = await res.json();
     const payload = JSON.parse(body.result.content[0].text);
-    expect(payload.rp_registration.rp_id).toBe(rpId);
+    expect(payload.rp_id).toBe(rpId);
+    expect(payload.manager_address).toBe(
+      "0x1111111111111111111111111111111111111111",
+    );
+    expect(payload.operation_hash).toBe("0xop_hash_register");
+    expect(payload.status).toBe("pending");
     expect(payload.signing_key.private_key).toMatch(/^0x/);
     expect(payload.signing_key.signer_address).toMatch(/^0x/);
+    expect(submitManagedRpRegistrationMock).toHaveBeenCalledTimes(1);
+    expect(submitManagedRpRegistrationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId,
+        teamId,
+        signerAddress: payload.signing_key.signer_address,
+      }),
+    );
   });
 
-  it("rotates the signing key when one is missing and rotate_if_unavailable is set", async () => {
+  it("surfaces feature_not_enabled from the registration helper as -32004", async () => {
+    currentAppContextResponse = {
+      app: [{ ...appContextResponse.app[0], rp_registration: [] }],
+    };
+    submitManagedRpRegistrationMock.mockResolvedValueOnce({
+      ok: false,
+      code: "feature_not_enabled",
+      detail: "World ID 4.0 is not enabled for this team.",
+    });
+
+    const res = await POST(callTool("configure_world_id", { app_id: appId }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32004);
+    expect(body.error.data.reason).toBe("feature_not_enabled");
+  });
+
+  it("rotates the signing key via the managed flow when one is missing and rotate_if_unavailable is set", async () => {
     const baseRegistration = appContextResponse.app[0].rp_registration[0];
     const { signer_address: _signerAddress, ...registrationWithoutSigner } =
       baseRegistration;
@@ -436,9 +497,11 @@ describe("/api/mcp", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     const payload = JSON.parse(body.result.content[0].text);
-    expect(payload.rp_registration.rp_id).toBe(rpId);
+    expect(payload.rp_id).toBe(rpId);
+    expect(payload.operation_hash).toBe("0xop_hash_rotate");
     expect(payload.signing_key.private_key).toMatch(/^0x/);
     expect(payload.signing_key.signer_address).toMatch(/^0x/);
+    expect(submitManagedSignerRotationMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not rotate when a signer is already configured", async () => {
@@ -515,20 +578,13 @@ describe("/api/mcp", () => {
     expect(body.error.message).toMatch(/signer_private_key/);
   });
 
-  it("refuses to rotate signing keys for managed RPs", async () => {
-    currentAppContextResponse = {
-      app: [
-        {
-          ...appContextResponse.app[0],
-          rp_registration: [
-            {
-              ...appContextResponse.app[0].rp_registration[0],
-              mode: "managed",
-            },
-          ],
-        },
-      ],
-    };
+  it("surfaces a self_managed_mode rotation failure as -32004", async () => {
+    submitManagedSignerRotationMock.mockResolvedValueOnce({
+      ok: false,
+      code: "self_managed_mode",
+      detail:
+        "RP is in self-managed mode. You must handle signer key rotation yourself.",
+    });
 
     const res = await POST(
       callTool("rotate_world_id_signing_key", { app_id: appId }),
@@ -536,7 +592,8 @@ describe("/api/mcp", () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error.message).toMatch(/developer portal UI/);
+    expect(body.error.code).toBe(-32004);
+    expect(body.error.data.reason).toBe("self_managed_mode");
   });
 
   it("updates Mini App metadata through an app-owned context", async () => {

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -30,6 +30,11 @@ jest.mock("@aws-sdk/client-s3", () => ({
   PutObjectCommand: jest.fn().mockImplementation((args) => ({ ...args })),
 }));
 
+const dnsLookupMock = jest.fn();
+jest.mock("node:dns/promises", () => ({
+  lookup: (...args: unknown[]) => dnsLookupMock(...args),
+}));
+
 const fetchMock = jest.fn();
 global.fetch = fetchMock as unknown as typeof fetch;
 
@@ -141,6 +146,10 @@ beforeEach(() => {
   process.env.ASSETS_S3_BUCKET_NAME = "test-bucket";
   s3SendMock.mockResolvedValue({});
   fetchMock.mockReset();
+  dnsLookupMock.mockReset();
+  // Default: source_url hostnames resolve to a public address. Specific tests
+  // override this to simulate private / loopback responses.
+  dnsLookupMock.mockResolvedValue({ address: "203.0.113.10", family: 4 });
   currentAppContextResponse = appContextResponse;
   mockGetRpFromContract.mockResolvedValue({
     initialized: true,
@@ -702,7 +711,7 @@ describe("/api/mcp", () => {
     expect(updateCall?.[1].set).toEqual({ logo_img_url: "logo_img.png" });
   });
 
-  it("uploads a base64 image and respects content_type", async () => {
+  it("uploads a base64 image and detects format from magic bytes", async () => {
     const jpegBase64 = Buffer.from([0xff, 0xd8, 0xff, 0xd9]).toString("base64");
 
     const res = await POST(
@@ -710,7 +719,6 @@ describe("/api/mcp", () => {
         app_id: appId,
         image_type: "content_card",
         image_base64: jpegBase64,
-        content_type: "jpeg",
       }),
     );
 
@@ -728,6 +736,22 @@ describe("/api/mcp", () => {
     });
   });
 
+  it("rejects base64 bytes that aren't a valid PNG/JPEG", async () => {
+    const notAnImage = Buffer.from("hello world").toString("base64");
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "logo",
+        image_base64: notAnImage,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32602);
+    expect(s3SendMock).not.toHaveBeenCalled();
+  });
+
   it("places showcase_2 in the second slot of showcase_img_urls", async () => {
     currentAppContextResponse = {
       app: [
@@ -742,8 +766,11 @@ describe("/api/mcp", () => {
         },
       ],
     };
+    const pngBytes = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
     fetchMock.mockResolvedValue(
-      new Response(Buffer.from("png"), {
+      new Response(pngBytes, {
         status: 200,
         headers: { "Content-Type": "image/png" },
       }),
@@ -773,13 +800,57 @@ describe("/api/mcp", () => {
         app_id: appId,
         image_type: "logo",
         image_base64: huge,
-        content_type: "png",
       }),
     );
 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.error.code).toBe(-32602);
+    expect(s3SendMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects source_url that resolves to a private address", async () => {
+    dnsLookupMock.mockResolvedValue({ address: "127.0.0.1", family: 4 });
+
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "logo",
+        source_url: "https://internal.example.com/logo.png",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32602);
+    expect(body.error.message).toMatch(/private\/internal/);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(s3SendMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects source_url with Content-Length above the 500KB cap before reading body", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(Buffer.from([0x89, 0x50, 0x4e, 0x47]), {
+        status: 200,
+        headers: {
+          "Content-Type": "image/png",
+          "Content-Length": String(600 * 1024),
+        },
+      }),
+    );
+
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "logo",
+        source_url: "https://cdn.example.com/big.png",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32602);
+    expect(body.error.message).toMatch(/Content-Length/);
     expect(s3SendMock).not.toHaveBeenCalled();
   });
 

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -102,6 +102,7 @@ const mockHttpsResponse = (response: HttpsResponseShape) => {
         on: () => {},
         end: () => {},
         destroy: () => {},
+        setTimeout: () => {},
       };
     },
   );
@@ -134,6 +135,7 @@ const appContextResponse = {
           app_mode: "mini-app",
           verification_status: "unverified",
           is_developer_allow_listing: false,
+          logo_img_url: "" as string,
           showcase_img_urls: [] as string[],
           description: "" as string | null,
         },
@@ -1108,7 +1110,12 @@ describe("/api/mcp", () => {
           for (const fn of listeners.end ?? []) fn();
         });
       });
-      return { on: () => {}, end: () => {}, destroy: () => {} };
+      return {
+        on: () => {},
+        end: () => {},
+        destroy: () => {},
+        setTimeout: () => {},
+      };
     });
 
     const callOnce = () =>
@@ -1172,6 +1179,101 @@ describe("/api/mcp", () => {
     );
     // First call: PutObject. Second call: DeleteObject (best-effort cleanup).
     expect(s3SendMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips the S3 rollback delete when the metadata field already references the same filename", async () => {
+    // The deterministic object key (e.g. logo_img.png) means a replace-
+    // upload PUT overwrites the existing asset before the metadata patch
+    // runs. If the patch then fails AND the field already pointed at this
+    // exact filename, deleting the object would leave a dangling reference
+    // to a now-missing asset. The cleanup must be suppressed in that case.
+    currentAppContextResponse = {
+      app: [
+        {
+          ...appContextResponse.app[0],
+          app_metadata: [
+            {
+              ...appContextResponse.app[0].app_metadata[0],
+              logo_img_url: "logo_img.png",
+            },
+          ],
+        },
+      ],
+    };
+
+    const pngBytes = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    mockHttpsResponse({
+      statusCode: 200,
+      headers: { "content-type": "image/png" },
+      body: pngBytes,
+    });
+
+    const baseImpl = requestMock.getMockImplementation()!;
+    requestMock.mockImplementation(async (query: unknown, variables: any) => {
+      if (getOperationName(query) === "McpUpdateAppMetadata") {
+        throw new Error("simulated Hasura outage");
+      }
+      return baseImpl(query, variables);
+    });
+
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "logo",
+        source_url: "https://cdn.example.com/logo.png",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32603);
+    expect(body.error.data).toEqual(
+      expect.objectContaining({
+        committed: false,
+        file_name: "logo_img.png",
+      }),
+    );
+    expect(body.error.message).toMatch(/existing reference was preserved/i);
+    // PutObject only — DeleteObject was suppressed because the existing
+    // metadata reference matched the deterministic filename, so deleting
+    // would have orphaned the still-referenced field.
+    expect(s3SendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("times out a stalled source_url fetch", async () => {
+    // Simulate a host that accepts the TCP connection but never sends a
+    // response. The fetch wrapper must abort and surface a -32602 instead
+    // of pinning the worker until the platform-level request timeout.
+    httpsRequestMock.mockImplementationOnce(() => ({
+      on: () => {},
+      end: () => {},
+      destroy: () => {},
+      setTimeout: () => {},
+    }));
+
+    jest.useFakeTimers({ doNotFake: ["nextTick", "setImmediate"] });
+
+    const promise = POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "logo",
+        source_url: "https://cdn.example.com/logo.png",
+      }),
+    );
+
+    // Walk past the 10s total-fetch timeout. The helper destroys the
+    // request and rejects with an ImageInputError, which the tool handler
+    // maps to JSON-RPC -32602.
+    await jest.advanceTimersByTimeAsync(11_000);
+    jest.useRealTimers();
+
+    const res = await promise;
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32602);
+    expect(body.error.message).toMatch(/exceeded\s+\d+ms|idle/i);
   });
 
   it("ignores legacy locale input and uploads to the default-locale path so default-locale fields are never corrupted", async () => {

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -28,6 +28,9 @@ jest.mock("../../api/helpers/temporal-rpc", () => ({
 jest.mock("@aws-sdk/client-s3", () => ({
   S3Client: jest.fn().mockImplementation(() => ({ send: s3SendMock })),
   PutObjectCommand: jest.fn().mockImplementation((args) => ({ ...args })),
+  DeleteObjectCommand: jest
+    .fn()
+    .mockImplementation((args) => ({ delete: args })),
 }));
 
 const dnsLookupMock = jest.fn();
@@ -137,8 +140,11 @@ const callTool = (name: string, args: Record<string, unknown>) =>
     params: { name, arguments: args },
   });
 
-beforeEach(() => {
+beforeEach(async () => {
   jest.clearAllMocks();
+  // Reset the in-memory rate-limit counters between tests so one suite's
+  // upload bursts don't bleed into the next one.
+  await (global.RedisClient as { flushall: () => Promise<unknown> }).flushall();
   process.env.RP_REGISTRY_CONTRACT_ADDRESS =
     "0x0000000000000000000000000000000000000048";
   delete process.env.RP_REGISTRY_STAGING_CONTRACT_ADDRESS;
@@ -852,6 +858,82 @@ describe("/api/mcp", () => {
     expect(body.error.code).toBe(-32602);
     expect(body.error.message).toMatch(/Content-Length/);
     expect(s3SendMock).not.toHaveBeenCalled();
+  });
+
+  it("rate-limits upload_app_image at 60/minute per API key", async () => {
+    const pngBytes = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(pngBytes, {
+          status: 200,
+          headers: { "Content-Type": "image/png" },
+        }),
+    );
+
+    const callOnce = () =>
+      POST(
+        callTool("upload_app_image", {
+          app_id: appId,
+          image_type: "logo",
+          source_url: "https://cdn.example.com/logo.png",
+        }),
+      );
+
+    // 60 calls inside the same minute window pass.
+    for (let i = 0; i < 60; i++) {
+      const res = await callOnce();
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.error).toBeUndefined();
+    }
+
+    const blocked = await callOnce();
+    expect(blocked.status).toBe(200);
+    const blockedBody = await blocked.json();
+    expect(blockedBody.error.code).toBe(-32029);
+    expect(blockedBody.error.data.retry_after_seconds).toBeGreaterThan(0);
+  });
+
+  it("rolls back the S3 object when the metadata patch fails", async () => {
+    const pngBytes = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    fetchMock.mockResolvedValue(
+      new Response(pngBytes, {
+        status: 200,
+        headers: { "Content-Type": "image/png" },
+      }),
+    );
+
+    const baseImpl = requestMock.getMockImplementation()!;
+    requestMock.mockImplementation(async (query: unknown, variables: any) => {
+      if (getOperationName(query) === "McpUpdateAppMetadata") {
+        throw new Error("simulated Hasura outage");
+      }
+      return baseImpl(query, variables);
+    });
+
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "logo",
+        source_url: "https://cdn.example.com/logo.png",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32603);
+    expect(body.error.data).toEqual(
+      expect.objectContaining({
+        committed: false,
+        file_name: "logo_img.png",
+      }),
+    );
+    // First call: PutObject. Second call: DeleteObject (best-effort cleanup).
+    expect(s3SendMock).toHaveBeenCalledTimes(2);
   });
 
   it("rejects when neither source_url nor image_base64 is provided", async () => {

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -135,6 +135,7 @@ const appContextResponse = {
           verification_status: "unverified",
           is_developer_allow_listing: false,
           showcase_img_urls: [] as string[],
+          description: "" as string | null,
         },
       ],
       rp_registration: [
@@ -799,6 +800,43 @@ describe("/api/mcp", () => {
     expect(updateCall?.[1].set.description).toBe(
       '{"description_overview":"raw"}',
     );
+  });
+
+  it("preserves untouched description sub-fields when patching just description_overview", async () => {
+    currentAppContextResponse = {
+      app: [
+        {
+          ...appContextResponse.app[0],
+          app_metadata: [
+            {
+              ...appContextResponse.app[0].app_metadata[0],
+              description: JSON.stringify({
+                description_overview: "OLD overview",
+                description_how_it_works: "PRESERVE this",
+                description_connect: "PRESERVE this too",
+              }),
+            },
+          ],
+        },
+      ],
+    };
+
+    const res = await POST(
+      callTool("configure_mini_app", {
+        app_id: appId,
+        description_overview: "NEW overview",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const updateCall = requestMock.mock.calls.find(
+      ([query]) => getOperationName(query) === "McpUpdateAppMetadata",
+    );
+    expect(JSON.parse(updateCall?.[1].set.description)).toEqual({
+      description_overview: "NEW overview",
+      description_how_it_works: "PRESERVE this",
+      description_connect: "PRESERVE this too",
+    });
   });
 
   it("uploads a logo image from a source_url and patches logo_img_url", async () => {

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -1273,7 +1273,73 @@ describe("/api/mcp", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.error.code).toBe(-32602);
-    expect(body.error.message).toMatch(/exceeded\s+\d+ms|idle/i);
+    expect(body.error.message).toMatch(/did not respond within \d+ms/i);
+  });
+
+  it("falls through to the next validated DNS answer when the first connect fails", async () => {
+    // Dual-stack hostname: AAAA returned first, A second. Egress can't
+    // reach the IPv6 address (e.g. IPv4-only network) so the first
+    // connect errors before any response. The fetch must move on to the
+    // validated A record instead of failing the tool call.
+    const pngBytes = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    dnsLookupMock.mockResolvedValue([
+      { address: "2001:db8::1", family: 6 },
+      { address: "203.0.113.55", family: 4 },
+    ]);
+
+    // First call: simulate ENETUNREACH via 'error' event before any
+    // response handler runs. This must surface as a ConnectError so the
+    // outer loop falls through.
+    httpsRequestMock.mockImplementationOnce(() => {
+      const errorListeners: Array<(err: Error) => void> = [];
+      return {
+        on: (event: string, handler: (err: Error) => void) => {
+          if (event === "error") errorListeners.push(handler);
+        },
+        end: () => {
+          process.nextTick(() => {
+            for (const fn of errorListeners) {
+              fn(
+                Object.assign(new Error("connect ENETUNREACH 2001:db8::1"), {
+                  code: "ENETUNREACH",
+                }),
+              );
+            }
+          });
+        },
+        destroy: () => {},
+        setTimeout: () => {},
+      };
+    });
+
+    // Second call: succeeds.
+    mockHttpsResponse({
+      statusCode: 200,
+      headers: { "content-type": "image/png" },
+      body: pngBytes,
+    });
+
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "logo",
+        source_url: "https://cdn.example.com/logo.png",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error).toBeUndefined();
+    expect(httpsRequestMock).toHaveBeenCalledTimes(2);
+    // First attempt pinned the AAAA address; second pinned the A record.
+    const cb1 = jest.fn();
+    httpsRequestMock.mock.calls[0][0].lookup("any", {}, cb1);
+    expect(cb1).toHaveBeenCalledWith(null, "2001:db8::1", 6);
+    const cb2 = jest.fn();
+    httpsRequestMock.mock.calls[1][0].lookup("any", {}, cb2);
+    expect(cb2).toHaveBeenCalledWith(null, "203.0.113.55", 4);
   });
 
   it("ignores legacy locale input and uploads to the default-locale path so default-locale fields are never corrupted", async () => {

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -162,9 +162,10 @@ beforeEach(async () => {
   s3SendMock.mockResolvedValue({});
   fetchMock.mockReset();
   dnsLookupMock.mockReset();
-  // Default: source_url hostnames resolve to a public address. Specific tests
-  // override this to simulate private / loopback responses.
-  dnsLookupMock.mockResolvedValue({ address: "203.0.113.10", family: 4 });
+  // Default: source_url hostnames resolve to a single public address. The
+  // helper calls `lookup(host, { all: true })`, which returns an array; we
+  // adapt here so existing call sites stay simple.
+  dnsLookupMock.mockResolvedValue([{ address: "203.0.113.10", family: 4 }]);
   submitManagedRpRegistrationMock.mockReset();
   submitManagedSignerRotationMock.mockReset();
   // Default: managed flows succeed. Specific tests override to assert
@@ -873,7 +874,7 @@ describe("/api/mcp", () => {
   });
 
   it("rejects source_url that resolves to a private address", async () => {
-    dnsLookupMock.mockResolvedValue({ address: "127.0.0.1", family: 4 });
+    dnsLookupMock.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
 
     const res = await POST(
       callTool("upload_app_image", {
@@ -889,6 +890,52 @@ describe("/api/mcp", () => {
     expect(body.error.message).toMatch(/private\/internal/);
     expect(fetchMock).not.toHaveBeenCalled();
     expect(s3SendMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["dotted IPv4-mapped IPv6 loopback", "::ffff:127.0.0.1"],
+    ["hex IPv4-mapped IPv6 loopback", "::ffff:7f00:1"],
+    ["hex IPv4-mapped IPv6 RFC1918", "::ffff:0a00:1"],
+  ])(
+    "rejects source_url whose DNS records include %s",
+    async (_name, mappedAddress) => {
+      dnsLookupMock.mockResolvedValue([{ address: mappedAddress, family: 6 }]);
+
+      const res = await POST(
+        callTool("upload_app_image", {
+          app_id: appId,
+          image_type: "logo",
+          source_url: "https://example.com/logo.png",
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.error.code).toBe(-32602);
+      expect(body.error.message).toMatch(/private\/internal/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects source_url where any of the resolved A/AAAA records is private", async () => {
+    dnsLookupMock.mockResolvedValue([
+      { address: "203.0.113.10", family: 4 },
+      { address: "127.0.0.1", family: 4 },
+    ]);
+
+    const res = await POST(
+      callTool("upload_app_image", {
+        app_id: appId,
+        image_type: "logo",
+        source_url: "https://mixed.example.com/logo.png",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32602);
+    expect(body.error.message).toMatch(/private\/internal/);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("rejects source_url with Content-Length above the 500KB cap before reading body", async () => {


### PR DESCRIPTION
## Summary

Closes the last manual step in the MCP agent flow: image uploads. Previously an agent could create the app, configure World ID, set non-image metadata, and call submit — but submission was blocked on `logo_img_url` (and on Mini Apps, `content_card_image_url`) being empty, forcing the user back to the dashboard UI to upload images.

This PR adds a new MCP tool, `upload_app_image`, that the agent can call directly:

- **`source_url`**: server fetches a public HTTPS URL, validates ≤500KB PNG/JPEG, uploads to S3, and patches the matching `app_metadata.{logo|hero|content_card|meta_tag}_img_url` field — or merges into `showcase_img_urls[N]` for `showcase_1/2/3`. Single MCP call.
- **`image_base64` + `content_type`**: same flow but the bytes come in via base64. The user gives Claude Code a local path, Claude Code runs `base64 -i ./logo.png` via Bash, passes the output through. Single MCP call.

For ops parity with the dashboard, the S3 client setup, object-key conventions, basename map, and 500KB cap are now in a shared helper (`web/api/helpers/app-image-storage.ts`). The existing `/api/hasura/upload-image` Hasura action route is refactored to import `generateAppImagePresignedPost` from the same helper — so both paths use a single source of truth.

Object keys mirror the dashboard exactly:
```
unverified/{app_id}[/{locale}]/{basename}.{ext}
```

`SKILL.md` (and the inlined `skill.ts` returned via `initialize.instructions`) now document:
- Updated end-to-end flows (external + Mini App) including image-upload steps
- A new "Upload images" section with the local-file recipe (`base64 -i`)
- A pitfall: use `upload_app_image`, not `configure_mini_app`, for `*_img_url` fields (those store filenames, not full URLs — the dashboard reconstructs the CDN URL at view time)

## Why no presigned-PUT escape hatch yet

Base64 over JSON-RPC is slightly wasteful for huge images (a 400KB PNG → ~560KB of base64 in the agent context). For typical app icons (<100KB) this isn't a real cost. If it becomes one, we can add a presigned-PUT mode using the same helper as a follow-up — no caller-facing change to the existing tool.

## Test plan

- [x] `cd web && npx tsc --noEmit` clean
- [x] `cd web && npx jest tests/api --runInBand` — 313/313 (added 5 new MCP cases for source_url, base64, showcase merge, oversized rejection, missing-source rejection)
- [x] `cd web && pnpm format:check` clean
- [ ] After merge: re-run the staging runbook scenarios from `docs/runbooks/mcp-staging-test.md` end-to-end through MCP only. Both external app and Mini App should reach `awaiting_review` without any UI interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)