### PR TITLE
fix(mcp): use string-only enum for max_notifications_per_day

### DIFF
--- a/web/api/mcp/SKILL.md
+++ b/web/api/mcp/SKILL.md
@@ -70,7 +70,7 @@ After step 2, store the returned `private_key` in the developer's app environmen
                             // optional Advanced fields:
                             contracts:            ["0x..."],
                             permit2_tokens:       ["0x..."],
-                            max_notifications_per_day: 2,
+                            max_notifications_per_day: "2",
                           }
 7. submit_app_for_review  { app_id, confirm_submission: true }
 ```
@@ -84,7 +84,7 @@ After step 2, store the returned `private_key` in the developer's app environmen
 - `whitelisted_addresses: string[]` — wallets allowed to interact (pass `[]` to disable)
 - `associated_domains: string[]` — universal-link domains
 - `can_import_all_contacts`, `can_use_attestation` — capability toggles
-- `max_notifications_per_day`: `0 | 1 | 2 | "unlimited"` — notification cap (`"unlimited"` automatically sets `is_allowed_unlimited_notifications: true`)
+- `max_notifications_per_day`: `"0" | "1" | "2" | "unlimited"` — notification cap (string-only enum so MCP clients with strict JSON schema validators accept all values; `"unlimited"` automatically sets `is_allowed_unlimited_notifications: true`)
 
 All address arrays are validated as `0x` + 40 hex chars; URLs as `https://...`; reject any element with an embedded comma.
 

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -242,10 +242,10 @@ const toolDefinitions = [
         can_import_all_contacts: { type: "boolean" },
         can_use_attestation: { type: "boolean" },
         max_notifications_per_day: {
-          oneOf: [
-            { type: "integer", enum: [0, 1, 2] },
-            { type: "string", enum: ["unlimited"] },
-          ],
+          type: "string",
+          enum: ["0", "1", "2", "unlimited"],
+          description:
+            'How many notifications the mini app may send per day. Pass "unlimited" for no cap (automatically sets is_allowed_unlimited_notifications: true).',
         },
       },
       required: ["app_id"],
@@ -422,8 +422,8 @@ const configureMiniAppSchema = yup
     can_import_all_contacts: yup.boolean().optional(),
     can_use_attestation: yup.boolean().optional(),
     max_notifications_per_day: yup
-      .mixed<0 | 1 | 2 | "unlimited">()
-      .oneOf([0, 1, 2, "unlimited"])
+      .mixed<"0" | "1" | "2" | "unlimited">()
+      .oneOf(["0", "1", "2", "unlimited"])
       .optional(),
   })
   .noUnknown();
@@ -984,7 +984,7 @@ const tools = {
       advanced.is_allowed_unlimited_notifications = unlimited;
       advanced.max_notifications_per_day = unlimited
         ? 0
-        : max_notifications_per_day;
+        : Number(max_notifications_per_day);
     }
 
     // app_metadata.description is a JSON-encoded string with shape

--- a/web/api/mcp/skill.ts
+++ b/web/api/mcp/skill.ts
@@ -73,7 +73,7 @@ After step 2, store the returned \`private_key\` in the developer's app environm
                             // optional Advanced fields:
                             contracts:            ["0x..."],
                             permit2_tokens:       ["0x..."],
-                            max_notifications_per_day: 2,
+                            max_notifications_per_day: "2",
                           }
 7. submit_app_for_review  { app_id, confirm_submission: true }
 \`\`\`
@@ -87,7 +87,7 @@ After step 2, store the returned \`private_key\` in the developer's app environm
 - \`whitelisted_addresses: string[]\` — wallets allowed to interact (pass \`[]\` to disable)
 - \`associated_domains: string[]\` — universal-link domains
 - \`can_import_all_contacts\`, \`can_use_attestation\` — capability toggles
-- \`max_notifications_per_day\`: \`0 | 1 | 2 | "unlimited"\` — notification cap (\`"unlimited"\` automatically sets \`is_allowed_unlimited_notifications: true\`)
+- \`max_notifications_per_day\`: \`"0" | "1" | "2" | "unlimited"\` — notification cap (string-only enum so MCP clients with strict JSON schema validators accept all values; \`"unlimited"\` automatically sets \`is_allowed_unlimited_notifications: true\`)
 
 All address arrays are validated as \`0x\` + 40 hex chars; URLs as \`https://...\`; reject any element with an embedded comma.
 

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -684,7 +684,7 @@ describe("/api/mcp", () => {
         associated_domains: ["https://example.com"],
         can_import_all_contacts: true,
         can_use_attestation: true,
-        max_notifications_per_day: 2,
+        max_notifications_per_day: "2",
       }),
     );
 
@@ -704,6 +704,22 @@ describe("/api/mcp", () => {
         is_allowed_unlimited_notifications: false,
       }),
     );
+  });
+
+  it("rejects max_notifications_per_day passed as an integer (string-only enum)", async () => {
+    // Mixed integer/string oneOf in the JSON schema broke MCP client
+    // validation in staging. The input is now a string-only enum; numeric
+    // values must surface a clear -32602 instead of silently slipping
+    // through.
+    const res = await POST(
+      callTool("configure_mini_app", {
+        app_id: appId,
+        max_notifications_per_day: 2,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32602);
   });
 
   it("maps max_notifications_per_day=unlimited to the unlimited flag pair", async () => {


### PR DESCRIPTION
## Summary
- The `max_notifications_per_day` JSON schema used a `oneOf` of `{type: integer, enum: [0,1,2]}` and `{type: string, enum: ["unlimited"]}`. Strict MCP-client validators reject mixed-type `oneOf` shapes — observed in staging, where the agent could pass `"unlimited"` but every integer value (0/1/2) failed schema validation and the field was silently dropped (the app ended up with `is_allowed_unlimited_notifications: true` instead of the requested cap).
- Switched the input to a single string-only enum `"0" | "1" | "2" | "unlimited"`. Yup schema and the handler convert the string to the integer column server-side; behavior of the underlying `max_notifications_per_day` / `is_allowed_unlimited_notifications` columns is unchanged.
- `SKILL.md` and `skill.ts` updated to match. New test asserts a numeric input now surfaces as a clean `-32602` instead of slipping past validation.

## Test plan
- [x] `npx jest tests/api/mcp.test.ts` — 52/52 passing (new case for numeric rejection)
- [x] `npx tsc --noEmit` clean
- [x] `pnpm format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)