### PR TITLE
fix: show created api key

### DIFF
--- a/web/components/InitialSteps/index.tsx
+++ b/web/components/InitialSteps/index.tsx
@@ -15,12 +15,15 @@ export enum StepEnum {
 export const InitialSteps = (props: {
   title: string;
   description: string;
-  steps: ReactNode[];
+  steps?: ReactNode[];
+  children?: ReactNode;
+  className?: string;
 }) => {
   return (
     <div
       className={clsx(
         "grid w-full max-w-[480px] items-center justify-items-center gap-y-6 ",
+        props.className,
       )}
     >
       <div className="relative min-h-[60px] max-w-full">
@@ -39,13 +42,17 @@ export const InitialSteps = (props: {
         </Typography>
       </div>
 
-      <div
-        className={clsx(
-          "mt-4 max-w-[320px] rounded-2xl border border-grey-200 shadow-button md:max-w-full",
-        )}
-      >
-        {props.steps.map((step) => step)}
-      </div>
+      {props.children}
+
+      {props.steps && (
+        <div
+          className={clsx(
+            "mt-4 max-w-[320px] rounded-2xl border border-grey-200 shadow-button md:max-w-full",
+          )}
+        >
+          {props.steps.map((step) => step)}
+        </div>
+      )}
     </div>
   );
 };

--- a/web/scenes/Portal/Teams/TeamId/Apps/page/AppsPageClient.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/page/AppsPageClient.tsx
@@ -3,5 +3,5 @@
 import { ClientPage } from "./ClientPage";
 
 export const AppsPageClient = (props: { teamId: string }) => {
-  return <ClientPage />;
+  return <ClientPage teamId={props.teamId} />;
 };

--- a/web/scenes/Portal/Teams/TeamId/Apps/page/ClientPage/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/page/ClientPage/index.tsx
@@ -1,52 +1,191 @@
 "use client";
 
+import { Button } from "@/components/Button";
+import { ArrowRightIcon } from "@/components/Icons/ArrowRightIcon";
+import { CodeIcon } from "@/components/Icons/CodeIcon";
+import { LockIcon } from "@/components/Icons/LockIcon";
 import { InitialSteps } from "@/components/InitialSteps";
-import { IconFrame } from "@/components/InitialSteps/IconFrame";
-import { Step } from "@/components/InitialSteps/Step";
 import { SizingWrapper } from "@/components/SizingWrapper";
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { createAppDialogOpenedAtom } from "@/scenes/Portal/layout/Header";
-import clsx from "clsx";
 import { useAtom } from "jotai";
 import { Fragment } from "react";
 
-export const ClientPage = () => {
+const pathButtonClassName =
+  "flex h-10 w-full items-center justify-center gap-2 rounded-12 border px-4 font-gta text-sm font-medium leading-none shadow-button transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-150 md:h-11";
+
+const PathStep = (props: {
+  index: number;
+  title: string;
+  description: string;
+  disabled?: boolean;
+  variant: "manual" | "agents";
+}) => {
+  const isAgents = props.variant === "agents";
+
+  return (
+    <div
+      className={
+        props.disabled
+          ? "flex min-h-14 items-center gap-3 rounded-12 bg-grey-50 p-3 opacity-60"
+          : isAgents
+            ? "flex min-h-14 items-center gap-3 rounded-12 border border-blue-150/50 bg-grey-0 p-3 shadow-button"
+            : "flex min-h-14 items-center gap-3 rounded-12 bg-grey-50 p-3"
+      }
+    >
+      <div
+        className={
+          props.disabled
+            ? "flex size-6 shrink-0 items-center justify-center rounded-full bg-grey-200 text-xs font-medium text-grey-500"
+            : isAgents
+              ? "flex size-6 shrink-0 items-center justify-center rounded-full bg-blue-500 text-xs font-medium text-grey-0"
+              : "flex size-6 shrink-0 items-center justify-center rounded-full bg-grey-900 text-xs font-medium text-grey-0"
+        }
+      >
+        {props.index}
+      </div>
+
+      <div className="grid min-w-0 gap-0.5">
+        <Typography variant={TYPOGRAPHY.M4} className="truncate text-grey-900">
+          {props.title}
+        </Typography>
+
+        <Typography variant={TYPOGRAPHY.R5} className="text-grey-500">
+          {props.description}
+        </Typography>
+      </div>
+    </div>
+  );
+};
+
+export const ClientPage = (props: { teamId: string }) => {
   const [_, setCreateAppDialogOpen] = useAtom(createAppDialogOpenedAtom);
 
   return (
     <Fragment>
-      <SizingWrapper gridClassName="grow flex justify-center items-center pb-10">
+      <SizingWrapper
+        className="px-4 sm:px-6 md:px-0"
+        gridClassName="grow flex justify-center items-center pb-10"
+      >
         <InitialSteps
+          className="max-w-[720px]"
           title="Build your first project"
           description="Welcome to World ID! Let's get started by creating your first app."
-          steps={[
-            <Step
-              key={`apps-tutorial-step-1`}
-              type="button"
-              onClick={() => setCreateAppDialogOpen(true)}
-              icon={
-                <IconFrame className="bg-blue-500 text-grey-0">1</IconFrame>
-              }
-              title="Create an app"
-              description="Begin by creating your app"
-              buttonText="Start"
-              testId="create-an-app"
-            />,
+        >
+          <div className="mt-2 grid w-full items-stretch gap-4 md:mt-4 md:grid-cols-2">
+            <section className="grid h-full grid-rows-[auto_auto_1fr_auto] gap-4 rounded-2xl border border-grey-200 bg-grey-0 p-5 shadow-lg md:gap-5 md:p-6">
+              <div className="flex items-center gap-3">
+                <div className="flex size-8 items-center justify-center rounded-8 bg-blue-50 text-blue-500">
+                  <LockIcon className="size-4" />
+                </div>
 
-            <Step
-              key={`apps-tutorial-step-2`}
-              href="?createAction=true"
-              icon={
-                <IconFrame className={clsx("bg-grey-100 text-grey-500")}>
-                  2
-                </IconFrame>
-              }
-              title="Create action"
-              description="Allow user to verify as a unique human"
-              buttonText="Create"
-              disabled
-            />,
-          ]}
-        />
+                <Typography
+                  variant={TYPOGRAPHY.M5}
+                  className="uppercase tracking-[0.04em] text-grey-500"
+                >
+                  Build manually
+                </Typography>
+              </div>
+
+              <div className="grid gap-1">
+                <Typography variant={TYPOGRAPHY.H7} className="text-grey-900">
+                  Build in the dashboard
+                </Typography>
+
+                <Typography variant={TYPOGRAPHY.R4} className="text-grey-500">
+                  Configure your app and actions through the developer portal
+                  interface.
+                </Typography>
+              </div>
+
+              <div className="grid content-start gap-2">
+                <PathStep
+                  variant="manual"
+                  index={1}
+                  title="Create an app"
+                  description="Begin by creating your app"
+                />
+                <PathStep
+                  variant="manual"
+                  index={2}
+                  title="Create action"
+                  description="Verify users as unique humans"
+                  disabled
+                />
+              </div>
+
+              <Button
+                type="button"
+                onClick={() => setCreateAppDialogOpen(true)}
+                className={`${pathButtonClassName} border-grey-900 bg-grey-900 bg-gradient-to-b from-white/15 to-transparent text-grey-0 hover:bg-grey-700 hover:from-white/20`}
+                data-testid="button-create-an-app"
+              >
+                Start
+              </Button>
+            </section>
+
+            <section className="relative grid h-full grid-rows-[auto_auto_1fr_auto] gap-4 rounded-2xl border border-blue-150 bg-gradient-to-b from-blue-50 to-additional-purple-100 p-5 shadow-lg md:gap-5 md:p-6">
+              <div className="absolute right-4 top-4 rounded-full border border-blue-150 bg-grey-0 px-2 py-1 text-[10px] font-medium tracking-[0.02em] text-blue-500">
+                NEW
+              </div>
+
+              <div className="flex items-center gap-3 pr-12">
+                <div className="flex size-8 items-center justify-center rounded-8 bg-grey-0 text-blue-500 shadow-button">
+                  <CodeIcon className="size-4" />
+                </div>
+
+                <Typography
+                  variant={TYPOGRAPHY.M5}
+                  className="uppercase tracking-[0.04em] text-blue-500"
+                >
+                  Build with agents
+                </Typography>
+              </div>
+
+              <div className="grid gap-1">
+                <Typography variant={TYPOGRAPHY.H7} className="text-grey-900">
+                  Set up MCP
+                </Typography>
+
+                <Typography variant={TYPOGRAPHY.R4} className="text-grey-500">
+                  Connect Claude, Cursor, or any MCP client to build and manage
+                  your app via natural language.
+                </Typography>
+              </div>
+
+              <div className="grid content-start gap-2">
+                <PathStep
+                  variant="agents"
+                  index={1}
+                  title="Generate an API key"
+                  description="Create credentials for MCP access"
+                />
+                <PathStep
+                  variant="agents"
+                  index={2}
+                  title="Connect your agent"
+                  description="Paste setup into your MCP client"
+                />
+              </div>
+
+              <Button
+                href={`/teams/${props.teamId}/api-keys`}
+                className={`${pathButtonClassName} border-blue-500 bg-blue-500 text-grey-0 hover:border-blue-500 hover:bg-[#3f37c9]`}
+              >
+                Create API key
+                <ArrowRightIcon className="size-4" />
+              </Button>
+            </section>
+          </div>
+
+          <Typography
+            variant={TYPOGRAPHY.R5}
+            className="max-w-[720px] text-center text-grey-400"
+          >
+            Both paths use the same World ID. You can switch between them
+            anytime.
+          </Typography>
+        </InitialSteps>
       </SizingWrapper>
     </Fragment>
   );

--- a/web/scenes/Portal/Teams/TeamId/Apps/page/ClientPage/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/page/ClientPage/index.tsx
@@ -148,7 +148,7 @@ export const ClientPage = (props: { teamId: string }) => {
                 </Typography>
 
                 <Typography variant={TYPOGRAPHY.R4} className="text-grey-500">
-                  Connect Claude, Cursor, or any MCP client to build and manage
+                  Connect Codex, Claude, or any MCP client to build and manage
                   your app via natural language.
                 </Typography>
               </div>

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
@@ -1,40 +1,373 @@
 "use client";
 
-import { CopyButton } from "@/components/CopyButton";
-import { Input } from "@/components/Input";
+import { CopyCheckIcon } from "@/components/Icons/CopyCheckIcon";
+import { CopyIcon } from "@/components/Icons/CopyIcon";
+import { ExternalLinkIcon } from "@/components/Icons/ExternalLinkIcon";
+import { LockIcon } from "@/components/Icons/LockIcon";
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import clsx from "clsx";
+import { useMemo, useState } from "react";
+import { toast } from "react-toastify";
+
+const MCP_SERVER_NAME = "worldcoin-developer-portal";
+const MCP_ENDPOINT = "https://developer.world.org/api/mcp";
+const MCP_API_KEY_ENV_VAR = "WORLD_DEVELOPER_API_KEY";
+
+type ProviderId =
+  | "codex"
+  | "claude"
+  | "cursor"
+  | "windsurf"
+  | "chatgpt"
+  | "zed";
+
+type Provider = {
+  id: ProviderId;
+  name: string;
+  setupLabel: string;
+};
+
+type ProviderSnippet = {
+  command: string;
+  rawConfig: string;
+};
+
+const shellQuote = (value: string) => `'${value.replace(/'/g, "'\\''")}'`;
+const envReference = (name: string) => `\${${name}}`;
+const tomlString = (value: string) => JSON.stringify(value);
 
 export const getClaudeMcpCommand = (apiKey: string) =>
-  `claude mcp add --transport http --scope project worldcoin-developer-portal https://developer.world.org/api/mcp --header "Authorization: Bearer ${apiKey}"`;
+  `claude mcp add --transport http --scope project ${MCP_SERVER_NAME} ${MCP_ENDPOINT} --header "Authorization: Bearer ${apiKey}"`;
+
+export const getCodexMcpCommand = (apiKey: string) =>
+  `codex mcp add ${MCP_SERVER_NAME} --env ${MCP_API_KEY_ENV_VAR}=${shellQuote(apiKey)} -- npx -y mcp-remote ${MCP_ENDPOINT} --transport http-only --header 'Authorization:Bearer ${envReference(MCP_API_KEY_ENV_VAR)}'`;
+
+const getClaudeJsonConfig = (apiKey: string) =>
+  JSON.stringify(
+    {
+      mcpServers: {
+        [MCP_SERVER_NAME]: {
+          type: "http",
+          url: MCP_ENDPOINT,
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+const getCursorJsonConfig = (apiKey: string) =>
+  JSON.stringify(
+    {
+      mcpServers: {
+        [MCP_SERVER_NAME]: {
+          url: MCP_ENDPOINT,
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+const getWindsurfJsonConfig = (apiKey: string) =>
+  JSON.stringify(
+    {
+      mcpServers: {
+        [MCP_SERVER_NAME]: {
+          serverUrl: MCP_ENDPOINT,
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+const getChatGptConnectorConfig = (apiKey: string) =>
+  [
+    `Name: World Developer Portal`,
+    `URL: ${MCP_ENDPOINT}`,
+    `Authorization: Bearer ${apiKey}`,
+  ].join("\n");
+
+const getZedJsonConfig = (apiKey: string) =>
+  JSON.stringify(
+    {
+      context_servers: {
+        [MCP_SERVER_NAME]: {
+          url: MCP_ENDPOINT,
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+const getProviderSnippets = (
+  apiKey: string,
+): Record<ProviderId, ProviderSnippet> => {
+  const claudeJsonConfig = getClaudeJsonConfig(apiKey);
+  const cursorJsonConfig = getCursorJsonConfig(apiKey);
+  const windsurfJsonConfig = getWindsurfJsonConfig(apiKey);
+  const chatGptConnectorConfig = getChatGptConnectorConfig(apiKey);
+  const zedJsonConfig = getZedJsonConfig(apiKey);
+
+  return {
+    codex: {
+      command: getCodexMcpCommand(apiKey),
+      rawConfig: [
+        `[mcp_servers.${MCP_SERVER_NAME}]`,
+        `command = "npx"`,
+        `args = ["-y", "mcp-remote", ${tomlString(MCP_ENDPOINT)}, "--transport", "http-only", "--header", ${tomlString(`Authorization:Bearer ${envReference(MCP_API_KEY_ENV_VAR)}`)}]`,
+        "",
+        `[mcp_servers.${MCP_SERVER_NAME}.env]`,
+        `${MCP_API_KEY_ENV_VAR} = ${tomlString(apiKey)}`,
+      ].join("\n"),
+    },
+    claude: {
+      command: getClaudeMcpCommand(apiKey),
+      rawConfig: claudeJsonConfig,
+    },
+    cursor: {
+      command: cursorJsonConfig,
+      rawConfig: cursorJsonConfig,
+    },
+    windsurf: {
+      command: windsurfJsonConfig,
+      rawConfig: windsurfJsonConfig,
+    },
+    chatgpt: {
+      command: chatGptConnectorConfig,
+      rawConfig: chatGptConnectorConfig,
+    },
+    zed: {
+      command: zedJsonConfig,
+      rawConfig: zedJsonConfig,
+    },
+  };
+};
+
+const PROVIDERS: Provider[] = [
+  {
+    id: "codex",
+    name: "Codex",
+    setupLabel: "Run in your terminal",
+  },
+  {
+    id: "claude",
+    name: "Claude",
+    setupLabel: "Run in your terminal",
+  },
+  {
+    id: "cursor",
+    name: "Cursor",
+    setupLabel: "Paste into .cursor/mcp.json",
+  },
+  {
+    id: "windsurf",
+    name: "Windsurf",
+    setupLabel: "Paste into MCP config",
+  },
+  {
+    id: "chatgpt",
+    name: "ChatGPT",
+    setupLabel: "Use as connector config",
+  },
+  {
+    id: "zed",
+    name: "Zed",
+    setupLabel: "Paste into settings.json",
+  },
+];
+
+const CopyControl = (props: {
+  fieldName: string;
+  fieldValue: string;
+  variant: "pill" | "icon";
+}) => {
+  const { fieldName, fieldValue, variant } = props;
+  const [isCopied, setIsCopied] = useState(false);
+
+  const copyToClipboard = () => {
+    setIsCopied(true);
+    navigator.clipboard.writeText(fieldValue);
+    toast.success(`${fieldName} copied to clipboard`);
+
+    setTimeout(() => {
+      setIsCopied(false);
+    }, 4000);
+  };
+
+  const Icon = isCopied ? CopyCheckIcon : CopyIcon;
+
+  return (
+    <button
+      type="button"
+      className={clsx(
+        "flex shrink-0 items-center justify-center text-blue-500 transition-colors hover:text-grey-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-150",
+        {
+          "h-9 gap-1.5 rounded-12 border border-grey-200 bg-grey-0 px-3 text-sm font-medium shadow-button":
+            variant === "pill",
+          "size-8 rounded-12": variant === "icon",
+        },
+      )}
+      onClick={copyToClipboard}
+    >
+      <Icon className="size-4" />
+      {variant === "pill" && <span>{isCopied ? "Copied" : "Copy"}</span>}
+    </button>
+  );
+};
+
+const SnippetText = (props: { value: string; isRawConfig: boolean }) => {
+  const { value, isRawConfig } = props;
+
+  if (isRawConfig) {
+    return (
+      <pre className="min-w-0 overflow-x-auto whitespace-pre font-ibm text-xs leading-5 text-grey-900">
+        <code>{value}</code>
+      </pre>
+    );
+  }
+
+  const firstSpace = value.indexOf(" ");
+  const firstEquals = value.indexOf("=");
+  const splitAt =
+    firstSpace === -1
+      ? firstEquals
+      : firstEquals === -1
+        ? firstSpace
+        : Math.min(firstSpace, firstEquals);
+  const firstToken = splitAt === -1 ? value : value.slice(0, splitAt);
+  const rest = splitAt === -1 ? "" : value.slice(splitAt);
+
+  return (
+    <pre className="min-w-0 overflow-x-auto whitespace-pre font-ibm text-xs leading-5 text-grey-900 md:text-sm">
+      <code>
+        <span className="text-blue-500">{firstToken}</span>
+        {rest}
+      </code>
+    </pre>
+  );
+};
 
 export const ApiKeySecretFields = (props: { apiKey: string }) => {
   const { apiKey } = props;
-  const claudeMcpCommand = getClaudeMcpCommand(apiKey);
+  const [selectedProvider, setSelectedProvider] = useState<ProviderId>("codex");
+  const [showRawConfig, setShowRawConfig] = useState(false);
+  const snippets = useMemo(() => getProviderSnippets(apiKey), [apiKey]);
+  const provider = PROVIDERS.find((item) => item.id === selectedProvider)!;
+  const snippet = snippets[selectedProvider];
+  const snippetValue = showRawConfig ? snippet.rawConfig : snippet.command;
 
   return (
-    <>
-      <Input
-        label="API key"
-        value={apiKey}
-        readOnly
-        disabled
-        className="h-16"
-        helperText="Save this API key. You won't be able to see it again."
-        addOnRight={<CopyButton fieldName="API Key" fieldValue={apiKey} />}
-      />
+    <div className="grid w-full gap-y-5">
+      <section className="grid gap-y-2">
+        <div className="flex items-center justify-between gap-4 px-1">
+          <Typography
+            variant={TYPOGRAPHY.M4}
+            className="uppercase text-grey-400"
+          >
+            API key
+          </Typography>
 
-      <Input
-        label="Claude MCP"
-        value={claudeMcpCommand}
-        readOnly
-        disabled
-        className="h-16"
-        addOnRight={
-          <CopyButton
-            fieldName="Claude MCP command"
-            fieldValue={claudeMcpCommand}
-          />
-        }
-      />
-    </>
+          <Typography
+            variant={TYPOGRAPHY.M4}
+            className="flex items-center gap-1 text-grey-400"
+          >
+            <LockIcon className="size-4" />
+            Shown once
+          </Typography>
+        </div>
+
+        <div className="grid min-h-12 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-12 border border-blue-150 bg-blue-50 p-1.5 pl-3">
+          <code
+            className="truncate font-ibm text-sm text-grey-900"
+            title={apiKey}
+          >
+            {apiKey}
+          </code>
+
+          <CopyControl fieldName="API Key" fieldValue={apiKey} variant="pill" />
+        </div>
+      </section>
+
+      <section className="grid gap-y-2">
+        <div className="flex items-center justify-between gap-4 px-1">
+          <Typography
+            variant={TYPOGRAPHY.M4}
+            className="uppercase text-grey-400"
+          >
+            Connect to
+          </Typography>
+
+          <button
+            type="button"
+            className="flex items-center gap-1 text-sm font-medium text-blue-500 transition-colors hover:text-grey-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-150"
+            onClick={() => setShowRawConfig((value) => !value)}
+          >
+            {showRawConfig ? "Command" : "Raw config"}
+            {!showRawConfig && <ExternalLinkIcon />}
+          </button>
+        </div>
+
+        <div className="flex flex-wrap gap-1.5">
+          {PROVIDERS.map((item) => {
+            const isSelected = item.id === selectedProvider;
+
+            return (
+              <button
+                key={item.id}
+                type="button"
+                className={clsx(
+                  "flex h-9 items-center rounded-full border px-3 text-grey-500 transition-colors hover:border-blue-150 hover:bg-blue-50 hover:text-grey-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-150",
+                  {
+                    "border-blue-150 bg-blue-50 text-grey-900": isSelected,
+                    "border-transparent bg-grey-0": !isSelected,
+                  },
+                )}
+                aria-pressed={isSelected}
+                onClick={() => {
+                  setSelectedProvider(item.id);
+                  setShowRawConfig(false);
+                }}
+              >
+                <Typography variant={TYPOGRAPHY.M5}>{item.name}</Typography>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="grid gap-y-2 rounded-12 border border-grey-200 bg-grey-50 p-3">
+          <Typography
+            variant={TYPOGRAPHY.M4}
+            className="flex items-center gap-2 text-grey-400"
+          >
+            <span className="font-ibm">&gt;_</span>
+            {showRawConfig ? "Raw config" : provider.setupLabel}
+          </Typography>
+
+          <div className="grid min-h-12 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-12 bg-grey-0 px-3 py-2 shadow-button">
+            <SnippetText value={snippetValue} isRawConfig={showRawConfig} />
+            <CopyControl
+              fieldName={`${provider.name} ${showRawConfig ? "config" : "setup"}`}
+              fieldValue={snippetValue}
+              variant="icon"
+            />
+          </div>
+        </div>
+      </section>
+    </div>
   );
 };

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { CopyButton } from "@/components/CopyButton";
+import { Input } from "@/components/Input";
+
+export const getClaudeMcpCommand = (apiKey: string) =>
+  `claude mcp add --transport http --scope project worldcoin-developer-portal https://developer.world.org/api/mcp --header "Authorization: Bearer ${apiKey}"`;
+
+export const ApiKeySecretFields = (props: { apiKey: string }) => {
+  const { apiKey } = props;
+  const claudeMcpCommand = getClaudeMcpCommand(apiKey);
+
+  return (
+    <>
+      <Input
+        label="API key"
+        value={apiKey}
+        readOnly
+        disabled
+        className="h-16"
+        helperText="Save this API key. You won't be able to see it again."
+        addOnRight={<CopyButton fieldName="API Key" fieldValue={apiKey} />}
+      />
+
+      <Input
+        label="Claude MCP"
+        value={claudeMcpCommand}
+        readOnly
+        disabled
+        className="h-16"
+        addOnRight={
+          <CopyButton
+            fieldName="Claude MCP command"
+            fieldValue={claudeMcpCommand}
+          />
+        }
+      />
+    </>
+  );
+};

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
@@ -37,7 +37,7 @@ const envReference = (name: string) => `\${${name}}`;
 const tomlString = (value: string) => JSON.stringify(value);
 
 export const getClaudeMcpCommand = (apiKey: string) =>
-  `claude mcp add --transport http --scope project ${MCP_SERVER_NAME} ${MCP_ENDPOINT} --header "Authorization: Bearer ${apiKey}"`;
+  `claude mcp add --transport http --scope project --header "Authorization: Bearer ${apiKey}" ${MCP_SERVER_NAME} ${MCP_ENDPOINT}`;
 
 export const getCodexMcpCommand = (apiKey: string) =>
   `codex mcp add ${MCP_SERVER_NAME} --env ${MCP_API_KEY_ENV_VAR}=${shellQuote(apiKey)} -- npx -y mcp-remote ${MCP_ENDPOINT} --transport http-only --header 'Authorization:Bearer ${envReference(MCP_API_KEY_ENV_VAR)}'`;

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
@@ -36,6 +36,14 @@ const shellQuote = (value: string) => `'${value.replace(/'/g, "'\\''")}'`;
 const envReference = (name: string) => `\${${name}}`;
 const tomlString = (value: string) => JSON.stringify(value);
 
+const getApiKeyPreview = (apiKey: string) => {
+  if (apiKey.length <= 34) {
+    return apiKey;
+  }
+
+  return `${apiKey.slice(0, 18)}...${apiKey.slice(-12)}`;
+};
+
 export const getClaudeMcpCommand = (apiKey: string) =>
   `claude mcp add --transport http --scope project --header "Authorization: Bearer ${apiKey}" ${MCP_SERVER_NAME} ${MCP_ENDPOINT}`;
 
@@ -264,6 +272,7 @@ const SnippetText = (props: { value: string; isRawConfig: boolean }) => {
 
 export const ApiKeySecretFields = (props: { apiKey: string }) => {
   const { apiKey } = props;
+  const apiKeyPreview = getApiKeyPreview(apiKey);
   const [selectedProvider, setSelectedProvider] = useState<ProviderId>("codex");
   const [showRawConfig, setShowRawConfig] = useState(false);
   const snippets = useMemo(() => getProviderSnippets(apiKey), [apiKey]);
@@ -292,11 +301,8 @@ export const ApiKeySecretFields = (props: { apiKey: string }) => {
         </div>
 
         <div className="grid min-h-12 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-12 border border-blue-150 bg-blue-50 p-1.5 pl-3">
-          <code
-            className="truncate font-ibm text-sm text-grey-900"
-            title={apiKey}
-          >
-            {apiKey}
+          <code className="min-w-0 break-all font-ibm text-sm text-grey-900">
+            {apiKeyPreview}
           </code>
 
           <CopyControl fieldName="API Key" fieldValue={apiKey} variant="pill" />

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretModal/index.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { CircleIconContainer } from "@/components/CircleIconContainer";
+import { DecoratedButton } from "@/components/DecoratedButton";
+import { Dialog } from "@/components/Dialog";
+import { DialogOverlay } from "@/components/DialogOverlay";
+import { DialogPanel } from "@/components/DialogPanel";
+import { KeyIcon } from "@/components/Icons/KeyIcon";
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { ApiKeySecretFields } from "../ApiKeySecretFields";
+
+export const ApiKeySecretModal = (props: {
+  apiKey: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  description: string;
+}) => {
+  const { apiKey, isOpen, onClose, title, description } = props;
+
+  return (
+    <Dialog open={isOpen} onClose={onClose}>
+      <DialogOverlay />
+
+      <DialogPanel className="md:max-w-[36rem]">
+        <div className="grid grid-cols-1 justify-items-center gap-y-10">
+          <CircleIconContainer variant={"info"}>
+            <KeyIcon className="text-blue-500" />
+          </CircleIconContainer>
+
+          <div className="grid w-full justify-items-center gap-y-4">
+            <Typography variant={TYPOGRAPHY.H6} className="text-grey-900">
+              {title}
+            </Typography>
+
+            <Typography variant={TYPOGRAPHY.R3} className="text-grey-500">
+              {description}
+            </Typography>
+          </div>
+
+          {apiKey && (
+            <div className="grid w-full gap-y-10">
+              <ApiKeySecretFields apiKey={apiKey} />
+
+              <DecoratedButton type="button" onClick={onClose}>
+                Done
+              </DecoratedButton>
+            </div>
+          )}
+        </div>
+      </DialogPanel>
+    </Dialog>
+  );
+};

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretModal/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { CircleIconContainer } from "@/components/CircleIconContainer";
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { Dialog } from "@/components/Dialog";
 import { DialogOverlay } from "@/components/DialogOverlay";
@@ -22,27 +21,34 @@ export const ApiKeySecretModal = (props: {
     <Dialog open={isOpen} onClose={onClose}>
       <DialogOverlay />
 
-      <DialogPanel className="md:max-w-[36rem]">
-        <div className="grid grid-cols-1 justify-items-center gap-y-10">
-          <CircleIconContainer variant={"info"}>
-            <KeyIcon className="text-blue-500" />
-          </CircleIconContainer>
+      <DialogPanel className="max-h-[calc(100dvh-2rem)] overflow-y-auto rounded-20 p-5 sm:p-6 md:w-[34rem] md:max-w-[calc(100vw-2rem)]">
+        <div className="grid grid-cols-1 justify-items-center gap-y-5">
+          <div className="flex size-12 items-center justify-center rounded-full border border-blue-150 bg-blue-50 text-blue-500">
+            <KeyIcon className="size-5" />
+          </div>
 
-          <div className="grid w-full justify-items-center gap-y-4">
-            <Typography variant={TYPOGRAPHY.H6} className="text-grey-900">
+          <div className="grid w-full justify-items-center gap-y-2 text-center">
+            <Typography variant={TYPOGRAPHY.H5} className="text-grey-900">
               {title}
             </Typography>
 
-            <Typography variant={TYPOGRAPHY.R3} className="text-grey-500">
+            <Typography
+              variant={TYPOGRAPHY.R3}
+              className="max-w-[24rem] text-grey-500"
+            >
               {description}
             </Typography>
           </div>
 
           {apiKey && (
-            <div className="grid w-full gap-y-10">
+            <div className="grid w-full gap-y-5">
               <ApiKeySecretFields apiKey={apiKey} />
 
-              <DecoratedButton type="button" onClick={onClose}>
+              <DecoratedButton
+                type="button"
+                className="min-h-11"
+                onClick={onClose}
+              >
                 Done
               </DecoratedButton>
             </div>

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
@@ -16,6 +16,7 @@ import clsx from "clsx";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "react-toastify";
 import { ApiKeySecretModal } from "../../ApiKeySecretModal";
+import { FetchKeysDocument } from "../../graphql/client/fetch-keys.generated";
 import { Status } from "./Status";
 import { useResetApiKeyMutation } from "./graphql/client/reset-api-key.generated";
 
@@ -54,6 +55,7 @@ export const ApiKeyRow = (props: {
             id: apiKeyId,
             team_id: teamId,
           },
+          refetchQueries: [FetchKeysDocument],
         });
 
         if (result instanceof Error || Boolean(result?.errors)) {

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
@@ -93,7 +93,7 @@ export const ApiKeyRow = (props: {
         apiKey={resetKey}
         isOpen={Boolean(resetKey)}
         onClose={() => setResetKey(null)}
-        title="API key reset"
+        title="API Key"
         description="Your new API key is ready. Save it now because you won't be able to see it again."
       />
 

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
@@ -5,7 +5,6 @@ import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { formatDistanceToNowStrict } from "date-fns";
 import { FetchKeysQuery } from "../../graphql/client/fetch-keys.generated";
 
-import { CopyButton } from "@/components/CopyButton";
 import { EditIcon } from "@/components/Icons/EditIcon";
 import { KeyIcon } from "@/components/Icons/KeyIcon";
 import { TrashIcon } from "@/components/Icons/TrashIcon";
@@ -16,6 +15,7 @@ import { useUser } from "@auth0/nextjs-auth0/client";
 import clsx from "clsx";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "react-toastify";
+import { ApiKeySecretModal } from "../../ApiKeySecretModal";
 import { Status } from "./Status";
 import { useResetApiKeyMutation } from "./graphql/client/reset-api-key.generated";
 
@@ -27,7 +27,7 @@ export const ApiKeyRow = (props: {
   openDeleteKeyModal: (key: FetchKeysQuery["api_key"][0]) => void;
 }) => {
   const { apiKey, index, teamId, openViewDetails, openDeleteKeyModal } = props;
-  const [secretKey, setSecretKey] = useState<string | null>(null);
+  const [resetKey, setResetKey] = useState<string | null>(null);
   const timeAgo = formatDistanceToNowStrict(new Date(apiKey.created_at), {
     addSuffix: true,
   });
@@ -66,7 +66,7 @@ export const ApiKeyRow = (props: {
           throw new Error("No API key returned");
         }
 
-        setSecretKey(result.data?.reset_api_key?.api_key);
+        setResetKey(result.data.reset_api_key.api_key);
       } catch (error) {
         let errorText = "Error occurred while resetting API key.";
 
@@ -88,131 +88,126 @@ export const ApiKeyRow = (props: {
   );
 
   return (
-    <div
-      className={clsx(
-        "max-md:grid max-md:grid-cols-[max-content_auto_auto_max-content] max-md:items-center max-md:gap-x-3 max-md:gap-y-1 max-md:rounded-2xl max-md:border max-md:border-grey-100 max-md:px-5 max-md:py-4 md:table-row",
-      )}
-    >
-      <div
-        key={`api_key_${index}_1`}
-        className="group max-md:col-start-2 max-md:col-end-3 max-md:row-start-1 max-md:row-end-2 md:table-cell md:border-b md:border-grey-200 md:py-4 md:pl-2 md:pr-4"
-      >
-        <div className="grid">
-          <Typography
-            variant={TYPOGRAPHY.R3}
-            as="div"
-            className="truncate md:!leading-6"
-          >
-            {apiKey.name}
-          </Typography>
-        </div>
-      </div>
+    <>
+      <ApiKeySecretModal
+        apiKey={resetKey}
+        isOpen={Boolean(resetKey)}
+        onClose={() => setResetKey(null)}
+        title="API key reset"
+        description="Your new API key is ready. Save it now because you won't be able to see it again."
+      />
 
       <div
-        className="group max-md:col-start-3 max-md:col-end-4 max-md:row-start-1 max-md:row-end-3 max-md:text-end md:table-cell md:border-b md:border-grey-200 md:pr-4"
-        key={`api_key${index}_2`}
+        className={clsx(
+          "max-md:grid max-md:grid-cols-[max-content_auto_auto_max-content] max-md:items-center max-md:gap-x-3 max-md:gap-y-1 max-md:rounded-2xl max-md:border max-md:border-grey-100 max-md:px-5 max-md:py-4 md:table-row",
+        )}
       >
-        <div className="inline-grid grid-cols-1fr/auto gap-x-2 max-md:pl-8">
-          <Typography
-            variant={TYPOGRAPHY.R4}
-            as="div"
-            className="truncate md:!leading-6"
-          >
-            {secretKey
-              ? "api_" + btoa(apiKey.id).substring(0, 20) + "......"
-              : "Reset to view"}
-          </Typography>
-
-          <CopyButton
-            className={clsx(
-              "cursor-default !p-0 opacity-0 transition-opacity duration-300",
-              {
-                "cursor-pointer sm:opacity-0 sm:group-hover:opacity-100":
-                  secretKey,
-              },
-            )}
-            disabled={!secretKey}
-            fieldValue={secretKey ?? ""}
-            fieldName="API Key"
-          />
-        </div>
-      </div>
-
-      <div
-        key={`api_key_${index}_3`}
-        className="text-grey-500 max-md:col-start-2 max-md:col-end-3 max-md:row-start-2 max-md:row-end-3 max-md:table-cell md:table-cell md:border-b md:border-grey-200 md:pr-4"
-      >
-        <div className="grid">
-          <Typography
-            variant={TYPOGRAPHY.R4}
-            as="div"
-            className="max-md:truncate md:whitespace-nowrap md:!leading-6"
-          >
-            {timeAgo}
-          </Typography>
-        </div>
-      </div>
-
-      <div
-        key={`api_key_${index}_4`}
-        className="text-grey-500 max-md:col-start-1 max-md:col-end-2 max-md:row-start-1 max-md:row-end-3 max-md:table-cell md:table-cell md:border-b md:border-grey-200 md:pr-4 md:align-middle"
-      >
-        <Typography variant={TYPOGRAPHY.R4}>
-          <Status isActive={apiKey.is_active} />
-        </Typography>
-      </div>
-
-      <div className="max-md:col-start-4 max-md:col-end-5 max-md:row-start-1 max-md:row-end-3 max-md:pl-2 md:table-cell md:border-b md:border-grey-200 md:pl-4 md:pr-2 md:align-middle">
         <div
-          key={`api_key_${index}_5`}
-          className={clsx("flex w-full justify-end", {
-            hidden: !isEnoughPermissions,
-          })}
+          key={`api_key_${index}_1`}
+          className="group max-md:col-start-2 max-md:col-end-3 max-md:row-start-1 max-md:row-end-2 md:table-cell md:border-b md:border-grey-200 md:py-4 md:pl-2 md:pr-4"
         >
-          <Dropdown>
-            <Dropdown.Button>
-              <MoreVerticalIcon />
-            </Dropdown.Button>
+          <div className="grid">
+            <Typography
+              variant={TYPOGRAPHY.R3}
+              as="div"
+              className="truncate md:!leading-6"
+            >
+              {apiKey.name}
+            </Typography>
+          </div>
+        </div>
 
-            <Dropdown.List align="end" heading={apiKey.name} hideBackButton>
-              <Dropdown.ListItem asChild>
-                <button onClick={() => openViewDetails(apiKey)}>
-                  <Dropdown.ListItemIcon asChild>
-                    <EditIcon />
-                  </Dropdown.ListItemIcon>
+        <div
+          className="group max-md:col-start-3 max-md:col-end-4 max-md:row-start-1 max-md:row-end-3 max-md:text-end md:table-cell md:border-b md:border-grey-200 md:pr-4"
+          key={`api_key${index}_2`}
+        >
+          <div className="inline-grid max-md:pl-8">
+            <Typography
+              variant={TYPOGRAPHY.R4}
+              as="div"
+              className="truncate md:!leading-6"
+            >
+              Reset to view
+            </Typography>
+          </div>
+        </div>
 
-                  <Dropdown.ListItemText>Edit Key</Dropdown.ListItemText>
-                </button>
-              </Dropdown.ListItem>
+        <div
+          key={`api_key_${index}_3`}
+          className="text-grey-500 max-md:col-start-2 max-md:col-end-3 max-md:row-start-2 max-md:row-end-3 max-md:table-cell md:table-cell md:border-b md:border-grey-200 md:pr-4"
+        >
+          <div className="grid">
+            <Typography
+              variant={TYPOGRAPHY.R4}
+              as="div"
+              className="max-md:truncate md:whitespace-nowrap md:!leading-6"
+            >
+              {timeAgo}
+            </Typography>
+          </div>
+        </div>
 
-              <Dropdown.ListItem asChild>
-                <button onClick={() => resetAPIKey(apiKey.id)}>
-                  <Dropdown.ListItemIcon asChild>
-                    <KeyIcon />
-                  </Dropdown.ListItemIcon>
+        <div
+          key={`api_key_${index}_4`}
+          className="text-grey-500 max-md:col-start-1 max-md:col-end-2 max-md:row-start-1 max-md:row-end-3 max-md:table-cell md:table-cell md:border-b md:border-grey-200 md:pr-4 md:align-middle"
+        >
+          <Typography variant={TYPOGRAPHY.R4}>
+            <Status isActive={apiKey.is_active} />
+          </Typography>
+        </div>
 
-                  <Dropdown.ListItemText>Reset key</Dropdown.ListItemText>
-                </button>
-              </Dropdown.ListItem>
+        <div className="max-md:col-start-4 max-md:col-end-5 max-md:row-start-1 max-md:row-end-3 max-md:pl-2 md:table-cell md:border-b md:border-grey-200 md:pl-4 md:pr-2 md:align-middle">
+          <div
+            key={`api_key_${index}_5`}
+            className={clsx("flex w-full justify-end", {
+              hidden: !isEnoughPermissions,
+            })}
+          >
+            <Dropdown>
+              <Dropdown.Button>
+                <MoreVerticalIcon />
+              </Dropdown.Button>
 
-              <Dropdown.ListItem asChild>
-                <button onClick={() => openDeleteKeyModal(apiKey)}>
-                  <Dropdown.ListItemIcon
-                    className="text-system-error-600"
-                    asChild
-                  >
-                    <TrashIcon />
-                  </Dropdown.ListItemIcon>
+              <Dropdown.List align="end" heading={apiKey.name} hideBackButton>
+                <Dropdown.ListItem asChild>
+                  <button onClick={() => openViewDetails(apiKey)}>
+                    <Dropdown.ListItemIcon asChild>
+                      <EditIcon />
+                    </Dropdown.ListItemIcon>
 
-                  <Dropdown.ListItemText className="text-system-error-600">
-                    Remove key
-                  </Dropdown.ListItemText>
-                </button>
-              </Dropdown.ListItem>
-            </Dropdown.List>
-          </Dropdown>
+                    <Dropdown.ListItemText>Edit Key</Dropdown.ListItemText>
+                  </button>
+                </Dropdown.ListItem>
+
+                <Dropdown.ListItem asChild>
+                  <button onClick={() => resetAPIKey(apiKey.id)}>
+                    <Dropdown.ListItemIcon asChild>
+                      <KeyIcon />
+                    </Dropdown.ListItemIcon>
+
+                    <Dropdown.ListItemText>Reset key</Dropdown.ListItemText>
+                  </button>
+                </Dropdown.ListItem>
+
+                <Dropdown.ListItem asChild>
+                  <button onClick={() => openDeleteKeyModal(apiKey)}>
+                    <Dropdown.ListItemIcon
+                      className="text-system-error-600"
+                      asChild
+                    >
+                      <TrashIcon />
+                    </Dropdown.ListItemIcon>
+
+                    <Dropdown.ListItemText className="text-system-error-600">
+                      Remove key
+                    </Dropdown.ListItemText>
+                  </button>
+                </Dropdown.ListItem>
+              </Dropdown.List>
+            </Dropdown>
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/CreateKeyModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/CreateKeyModal/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { CircleIconContainer } from "@/components/CircleIconContainer";
+import { CopyButton } from "@/components/CopyButton";
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { Dialog } from "@/components/Dialog";
 import { DialogOverlay } from "@/components/DialogOverlay";
@@ -8,9 +9,11 @@ import { KeyIcon } from "@/components/Icons/KeyIcon";
 import { Input } from "@/components/Input";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import * as yup from "yup";
+import { useResetApiKeyMutation } from "../ApiKeyTable/ApiKeyRow/graphql/client/reset-api-key.generated";
 import { FetchKeysDocument } from "../graphql/client/fetch-keys.generated";
 import { useInsertKeyMutation } from "./graphql/client/create-key.generated";
 
@@ -28,10 +31,20 @@ type CreateKeyModal = {
 };
 
 export type CreateKeyFormValues = yup.Asserts<typeof schema>;
+export type CreatedAPIKey = {
+  id: string;
+  apiKey: string;
+};
+
+const getClaudeMcpCommand = (apiKey: string) =>
+  `claude mcp add --transport http --scope project worldcoin-developer-portal https://developer.world.org/api/mcp --header "Authorization: Bearer ${apiKey}"`;
 
 export const CreateKeyModal = (props: CreateKeyModal) => {
   const { teamId, isOpen, setIsOpen } = props;
+  const [createdKey, setCreatedKey] = useState<CreatedAPIKey | null>(null);
   const [insertKeyMutation, { loading: creatingKey }] = useInsertKeyMutation();
+  const [resetApiKeyMutation, { loading: revealingKey }] =
+    useResetApiKeyMutation();
 
   const {
     register,
@@ -42,8 +55,14 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
     resolver: yupResolver(schema),
   });
 
+  const close = () => {
+    reset();
+    setCreatedKey(null);
+    setIsOpen(false);
+  };
+
   const submit = async (values: CreateKeyFormValues) => {
-    if (creatingKey) return;
+    if (creatingKey || revealingKey) return;
 
     try {
       const result = await insertKeyMutation({
@@ -51,18 +70,44 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
           name: values.name,
           teamId,
         },
-        refetchQueries: [FetchKeysDocument],
       });
-      if (result instanceof Error) {
+      if (result instanceof Error || Boolean(result?.errors)) {
         throw result;
       }
+
+      const createdApiKey = result.data?.insert_api_key_one;
+      if (!createdApiKey?.id) {
+        throw new Error("No API key created");
+      }
+
+      const resetResult = await resetApiKeyMutation({
+        variables: {
+          id: createdApiKey.id,
+          team_id: teamId,
+        },
+        refetchQueries: [FetchKeysDocument],
+      });
+      if (resetResult instanceof Error || Boolean(resetResult?.errors)) {
+        throw resetResult;
+      }
+
+      const apiKey = resetResult.data?.reset_api_key?.api_key;
+      if (!apiKey) {
+        throw new Error("No API key returned");
+      }
+
+      const revealedApiKey = {
+        id: createdApiKey.id,
+        apiKey,
+      };
+
+      setCreatedKey(revealedApiKey);
       toast.success(
         <span>
           New API key <b>{values.name}</b> was created
         </span>,
       );
       reset();
-      setIsOpen(false);
     } catch (error) {
       console.error("Failed to create API key: ", error);
 
@@ -70,8 +115,12 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
     }
   };
 
+  const claudeMcpCommand = createdKey
+    ? getClaudeMcpCommand(createdKey.apiKey)
+    : "";
+
   return (
-    <Dialog open={isOpen} onClose={() => setIsOpen(false)}>
+    <Dialog open={isOpen} onClose={close}>
       <DialogOverlay />
 
       <DialogPanel className="md:max-w-[36rem]">
@@ -91,37 +140,75 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
             </Typography>
           </div>
 
-          <form
-            className="grid w-full gap-y-10"
-            onSubmit={handleSubmit(submit)}
-          >
-            <Input
-              register={register("name")}
-              label="Key name"
-              required
-              errors={errors.name}
-              placeholder="Staging_key"
-            />
+          {createdKey ? (
+            <div className="grid w-full gap-y-10">
+              <Input
+                label="API key"
+                value={createdKey.apiKey}
+                readOnly
+                disabled
+                className="h-16"
+                helperText="Save this API key. You won't be able to see it again."
+                addOnRight={
+                  <CopyButton
+                    fieldName="API Key"
+                    fieldValue={createdKey.apiKey}
+                  />
+                }
+              />
 
-            <div className="grid w-full gap-x-4 gap-y-2 md:grid-cols-2">
-              <DecoratedButton
-                className="order-2 md:order-1"
-                type="button"
-                variant="secondary"
-                onClick={() => setIsOpen(false)}
-              >
-                Cancel
-              </DecoratedButton>
+              <Input
+                label="Claude MCP"
+                value={claudeMcpCommand}
+                readOnly
+                disabled
+                className="h-16"
+                addOnRight={
+                  <CopyButton
+                    fieldName="Claude MCP command"
+                    fieldValue={claudeMcpCommand}
+                  />
+                }
+              />
 
-              <DecoratedButton
-                type="submit"
-                disabled={!teamId}
-                className="order-1 whitespace-nowrap"
-              >
-                Create new key
+              <DecoratedButton type="button" onClick={close}>
+                Done
               </DecoratedButton>
             </div>
-          </form>
+          ) : (
+            <form
+              className="grid w-full gap-y-10"
+              onSubmit={handleSubmit(submit)}
+            >
+              <Input
+                register={register("name")}
+                label="Key name"
+                required
+                errors={errors.name}
+                placeholder="Staging_key"
+              />
+
+              <div className="grid w-full gap-x-4 gap-y-2 md:grid-cols-2">
+                <DecoratedButton
+                  className="order-2 md:order-1"
+                  type="button"
+                  variant="secondary"
+                  onClick={close}
+                >
+                  Cancel
+                </DecoratedButton>
+
+                <DecoratedButton
+                  type="submit"
+                  disabled={!teamId || creatingKey || revealingKey}
+                  loading={creatingKey || revealingKey}
+                  className="order-1 whitespace-nowrap"
+                >
+                  Create new key
+                </DecoratedButton>
+              </div>
+            </form>
+          )}
         </div>
       </DialogPanel>
     </Dialog>

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/CreateKeyModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/CreateKeyModal/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { CircleIconContainer } from "@/components/CircleIconContainer";
-import { CopyButton } from "@/components/CopyButton";
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { Dialog } from "@/components/Dialog";
 import { DialogOverlay } from "@/components/DialogOverlay";
@@ -14,6 +13,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import * as yup from "yup";
 import { useResetApiKeyMutation } from "../ApiKeyTable/ApiKeyRow/graphql/client/reset-api-key.generated";
+import { ApiKeySecretFields } from "../ApiKeySecretFields";
 import { FetchKeysDocument } from "../graphql/client/fetch-keys.generated";
 import { useInsertKeyMutation } from "./graphql/client/create-key.generated";
 
@@ -31,17 +31,9 @@ type CreateKeyModal = {
 };
 
 export type CreateKeyFormValues = yup.Asserts<typeof schema>;
-export type CreatedAPIKey = {
-  id: string;
-  apiKey: string;
-};
-
-const getClaudeMcpCommand = (apiKey: string) =>
-  `claude mcp add --transport http --scope project worldcoin-developer-portal https://developer.world.org/api/mcp --header "Authorization: Bearer ${apiKey}"`;
-
 export const CreateKeyModal = (props: CreateKeyModal) => {
   const { teamId, isOpen, setIsOpen } = props;
-  const [createdKey, setCreatedKey] = useState<CreatedAPIKey | null>(null);
+  const [createdKey, setCreatedKey] = useState<string | null>(null);
   const [insertKeyMutation, { loading: creatingKey }] = useInsertKeyMutation();
   const [resetApiKeyMutation, { loading: revealingKey }] =
     useResetApiKeyMutation();
@@ -96,12 +88,7 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
         throw new Error("No API key returned");
       }
 
-      const revealedApiKey = {
-        id: createdApiKey.id,
-        apiKey,
-      };
-
-      setCreatedKey(revealedApiKey);
+      setCreatedKey(apiKey);
       toast.success(
         <span>
           New API key <b>{values.name}</b> was created
@@ -114,10 +101,6 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
       toast.error("Error occurred while creating API key.");
     }
   };
-
-  const claudeMcpCommand = createdKey
-    ? getClaudeMcpCommand(createdKey.apiKey)
-    : "";
 
   return (
     <Dialog open={isOpen} onClose={close}>
@@ -142,34 +125,7 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
 
           {createdKey ? (
             <div className="grid w-full gap-y-10">
-              <Input
-                label="API key"
-                value={createdKey.apiKey}
-                readOnly
-                disabled
-                className="h-16"
-                helperText="Save this API key. You won't be able to see it again."
-                addOnRight={
-                  <CopyButton
-                    fieldName="API Key"
-                    fieldValue={createdKey.apiKey}
-                  />
-                }
-              />
-
-              <Input
-                label="Claude MCP"
-                value={claudeMcpCommand}
-                readOnly
-                disabled
-                className="h-16"
-                addOnRight={
-                  <CopyButton
-                    fieldName="Claude MCP command"
-                    fieldValue={claudeMcpCommand}
-                  />
-                }
-              />
+              <ApiKeySecretFields apiKey={createdKey} />
 
               <DecoratedButton type="button" onClick={close}>
                 Done

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/CreateKeyModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/CreateKeyModal/index.tsx
@@ -8,12 +8,12 @@ import { KeyIcon } from "@/components/Icons/KeyIcon";
 import { Input } from "@/components/Input";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import * as yup from "yup";
-import { useResetApiKeyMutation } from "../ApiKeyTable/ApiKeyRow/graphql/client/reset-api-key.generated";
 import { ApiKeySecretFields } from "../ApiKeySecretFields";
+import { useResetApiKeyMutation } from "../ApiKeyTable/ApiKeyRow/graphql/client/reset-api-key.generated";
 import { FetchKeysDocument } from "../graphql/client/fetch-keys.generated";
 import { useInsertKeyMutation } from "./graphql/client/create-key.generated";
 
@@ -34,6 +34,8 @@ export type CreateKeyFormValues = yup.Asserts<typeof schema>;
 export const CreateKeyModal = (props: CreateKeyModal) => {
   const { teamId, isOpen, setIsOpen } = props;
   const [createdKey, setCreatedKey] = useState<string | null>(null);
+  const isOpenRef = useRef(isOpen);
+  const requestIdRef = useRef(0);
   const [insertKeyMutation, { loading: creatingKey }] = useInsertKeyMutation();
   const [resetApiKeyMutation, { loading: revealingKey }] =
     useResetApiKeyMutation();
@@ -47,7 +49,12 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
     resolver: yupResolver(schema),
   });
 
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
   const close = () => {
+    requestIdRef.current += 1;
     reset();
     setCreatedKey(null);
     setIsOpen(false);
@@ -55,6 +62,8 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
 
   const submit = async (values: CreateKeyFormValues) => {
     if (creatingKey || revealingKey) return;
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
 
     try {
       const result = await insertKeyMutation({
@@ -89,6 +98,10 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
         throw new Error("No API key returned");
       }
 
+      if (!isOpenRef.current || requestIdRef.current !== requestId) {
+        return;
+      }
+
       setCreatedKey(apiKey);
       toast.success(
         <span>
@@ -98,6 +111,10 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
       reset();
     } catch (error) {
       console.error("Failed to create API key: ", error);
+
+      if (!isOpenRef.current || requestIdRef.current !== requestId) {
+        return;
+      }
 
       toast.error("Error occurred while creating API key.");
     }
@@ -150,7 +167,7 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
             >
               {createdKey
                 ? "Your new key is ready. Save it now because you won't be able to see it again."
-                : "Create a secure API key to seamlessly connect with your World ID App."}
+                : "Create a secure API key to seamlessly connect with your App."}
             </Typography>
           </div>
 
@@ -176,7 +193,7 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
                 label="Key name"
                 required
                 errors={errors.name}
-                placeholder="Staging_key"
+                placeholder="api_key_123"
               />
 
               <div className="grid w-full gap-x-4 gap-y-2 md:grid-cols-2">

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/CreateKeyModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/CreateKeyModal/index.tsx
@@ -62,6 +62,7 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
           name: values.name,
           teamId,
         },
+        refetchQueries: [FetchKeysDocument],
       });
       if (result instanceof Error || Boolean(result?.errors)) {
         throw result;
@@ -106,28 +107,62 @@ export const CreateKeyModal = (props: CreateKeyModal) => {
     <Dialog open={isOpen} onClose={close}>
       <DialogOverlay />
 
-      <DialogPanel className="md:max-w-[36rem]">
-        <div className="grid grid-cols-1 justify-items-center gap-y-10">
-          <CircleIconContainer variant={"info"}>
-            <KeyIcon className="text-blue-500" />
-          </CircleIconContainer>
+      <DialogPanel
+        className={
+          createdKey
+            ? "max-h-[calc(100dvh-2rem)] overflow-y-auto rounded-20 p-5 sm:p-6 md:w-[34rem] md:max-w-[calc(100vw-2rem)]"
+            : "md:max-w-[36rem]"
+        }
+      >
+        <div
+          className={
+            createdKey
+              ? "grid grid-cols-1 justify-items-center gap-y-5"
+              : "grid grid-cols-1 justify-items-center gap-y-10"
+          }
+        >
+          {createdKey ? (
+            <div className="flex size-12 items-center justify-center rounded-full border border-blue-150 bg-blue-50 text-blue-500">
+              <KeyIcon className="size-5" />
+            </div>
+          ) : (
+            <CircleIconContainer variant={"info"}>
+              <KeyIcon className="text-blue-500" />
+            </CircleIconContainer>
+          )}
 
-          <div className="grid w-full justify-items-center gap-y-4">
+          <div
+            className={
+              createdKey
+                ? "grid w-full justify-items-center gap-y-2 text-center"
+                : "grid w-full justify-items-center gap-y-4 text-center"
+            }
+          >
             <Typography variant={TYPOGRAPHY.H6} className="text-grey-900">
-              Create a new API key
+              {createdKey ? "API key created" : "Create a new API key"}
             </Typography>
 
-            <Typography variant={TYPOGRAPHY.R3} className="text-grey-500">
-              Create a secure API key to seamlessly connect with your World ID
-              App.
+            <Typography
+              variant={createdKey ? TYPOGRAPHY.R4 : TYPOGRAPHY.R3}
+              className={
+                createdKey ? "max-w-[24rem] text-grey-500" : "text-grey-500"
+              }
+            >
+              {createdKey
+                ? "Your new key is ready. Save it now because you won't be able to see it again."
+                : "Create a secure API key to seamlessly connect with your World ID App."}
             </Typography>
           </div>
 
           {createdKey ? (
-            <div className="grid w-full gap-y-10">
+            <div className="grid w-full gap-y-5">
               <ApiKeySecretFields apiKey={createdKey} />
 
-              <DecoratedButton type="button" onClick={close}>
+              <DecoratedButton
+                type="button"
+                className="min-h-11"
+                onClick={close}
+              >
                 Done
               </DecoratedButton>
             </div>

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/index.tsx
@@ -47,7 +47,10 @@ export const TeamApiKeysPage = (props: TeamApiKeysPageProps) => {
                 className="text-center text-grey-500"
               >
                 Create a secure API key to seamlessly <br />
-                manage your team&apos;s World ID apps
+                manage your team&apos;s apps.
+                <br />
+                <br />
+                Also used for MCP authorization
               </Typography>
             </div>
 


### PR DESCRIPTION
This PR ...
- keeps the create API key modal open after creation and shows the generated key
- adds a copyable Claude MCP command field using the generated key
- refetches the API key list after revealing the key


https://github.com/user-attachments/assets/acb8df34-f405-4209-b094-ca4d4e5edbb8

