### PR TITLE
fix: hide World ID 4.0 migration banner for non-admins

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/WorldId40MigrationBanner/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/WorldId40MigrationBanner/index.tsx
@@ -15,27 +15,31 @@ interface WorldId40MigrationBannerProps {
   teamId: string;
   appId: string;
   hasRpRegistration: boolean;
+  canRegisterRp: boolean;
 }
 
 export const WorldId40MigrationBanner = ({
   teamId,
   appId,
   hasRpRegistration,
+  canRegisterRp,
 }: WorldId40MigrationBannerProps) => {
   const worldId40Config = useAtomValue(worldId40Atom);
   const isEnabled = isWorldId40Enabled(worldId40Config, teamId);
   const searchParams = useSearchParams();
   const autoOpen = searchParams.get("enableWorldId4") === "true";
-  const [dialogOpen, setDialogOpen] = useState(autoOpen);
+  const [dialogOpen, setDialogOpen] = useState(autoOpen && canRegisterRp);
 
   useEffect(() => {
-    if (autoOpen) setDialogOpen(true);
-  }, [autoOpen]);
+    if (autoOpen && canRegisterRp) setDialogOpen(true);
+  }, [autoOpen, canRegisterRp]);
 
   // Don't show banner if:
   // - World ID 4.0 is not enabled for this team, OR
-  // - App already has RP registration
-  if (!isEnabled || hasRpRegistration) {
+  // - App already has RP registration, OR
+  // - User lacks ADMIN/OWNER role (register_rp Hasura action would
+  //   reject with `unauthorized` and surface a generic toast).
+  if (!isEnabled || hasRpRegistration || !canRegisterRp) {
     return null;
   }
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/index.tsx
@@ -1,5 +1,8 @@
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { SizingWrapper } from "@/components/SizingWrapper";
+import { Role_Enum } from "@/graphql/graphql";
+import { Auth0SessionUser } from "@/lib/types";
+import { getSession } from "@auth0/nextjs-auth0";
 import { BanMessageDialog } from "../../common/BanMessageDialog";
 import { getSdk as getAppEnvSdk } from "../layout/graphql/server/fetch-app-env.generated";
 import { BanStatusSection } from "./BanStatusSection";
@@ -27,12 +30,20 @@ export const AppIdPage = async (props: {
   const hasRpRegistration =
     (appEnvData.app[0]?.rp_registration?.length ?? 0) > 0;
 
+  const session = await getSession();
+  const user = session?.user as Auth0SessionUser["user"] | undefined;
+  const role = user?.hasura?.memberships?.find(
+    (m) => m.team?.id === teamId,
+  )?.role;
+  const canRegisterRp = role === Role_Enum.Owner || role === Role_Enum.Admin;
+
   return (
     <SizingWrapper className="flex flex-col gap-y-8 py-4">
       <WorldId40MigrationBanner
         teamId={teamId}
         appId={appId}
         hasRpRegistration={hasRpRegistration}
+        canRegisterRp={canRegisterRp}
       />
 
       <div className="grid gap-y-3">


### PR DESCRIPTION
## Summary
- The migration banner rendered for any team member, but the `register_rp` Hasura action requires ADMIN/OWNER and rejects others with `unauthorized`. The dialog dead-ended on a generic *"Failed to register Relying Party"* toast.
- Resolve the user's role server-side in `AppIdPage` and pass `canRegisterRp` to the banner. The banner now bails when the user lacks ADMIN/OWNER, and the `?enableWorldId4=true` auto-open is gated the same way.
- Defense-in-depth on the client: the Hasura permission check is unchanged.

## Context
Surfaced when a developer for `app_1f7f2c379f20307a414f6cf8b544ec8a` got the toast 8 times in a row migrating to World ID 4.0. Datadog showed all 8 attempts hitting the `unauthorized` branch in `register-rp/index.ts` because the user isn't ADMIN/OWNER on `team_1104b6c15c85336b5453d02836274f36`.

## Test plan
- [ ] As ADMIN/OWNER on a team without RP registration: banner renders, "Get started" opens dialog (regression check)
- [ ] As MEMBER on the same team: banner does not render
- [ ] As MEMBER hitting `/teams/.../apps/...?enableWorldId4=true`: dialog does not auto-open
- [ ] Already-registered app: banner does not render (regression check)
- [ ] World ID 4.0 feature flag off: banner does not render (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)