### PR TITLE
fix: avoid uniqueness violation in /api/create-team for existing users

### DIFF
--- a/web/api/create-team/graphql/get-user-by-auth0id.generated.ts
+++ b/web/api/create-team/graphql/get-user-by-auth0id.generated.ts
@@ -1,0 +1,62 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type GetUserByAuth0IdQueryVariables = Types.Exact<{
+  auth0Id: Types.Scalars["String"]["input"];
+}>;
+
+export type GetUserByAuth0IdQuery = {
+  __typename?: "query_root";
+  user: Array<{ __typename?: "user"; id: string; posthog_id?: string | null }>;
+};
+
+export const GetUserByAuth0IdDocument = gql`
+  query GetUserByAuth0Id($auth0Id: String!) {
+    user(where: { auth0Id: { _eq: $auth0Id } }, limit: 1) {
+      id
+      posthog_id
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    GetUserByAuth0Id(
+      variables: GetUserByAuth0IdQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetUserByAuth0IdQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetUserByAuth0IdQuery>(
+            GetUserByAuth0IdDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "GetUserByAuth0Id",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/create-team/graphql/get-user-by-auth0id.graphql
+++ b/web/api/create-team/graphql/get-user-by-auth0id.graphql
@@ -1,0 +1,6 @@
+query GetUserByAuth0Id($auth0Id: String!) {
+  user(where: { auth0Id: { _eq: $auth0Id } }, limit: 1) {
+    id
+    posthog_id
+  }
+}

--- a/web/api/create-team/index.ts
+++ b/web/api/create-team/index.ts
@@ -29,6 +29,11 @@ import {
   getSdk as getInsertUserSdk,
 } from "./graphql/insert-user.generated";
 
+import {
+  GetUserByAuth0IdQuery,
+  getSdk as getGetUserByAuth0IdSdk,
+} from "./graphql/get-user-by-auth0id.generated";
+
 import { teamNameSchema } from "@/lib/schema";
 import { captureEvent } from "@/services/posthogClient";
 import {
@@ -88,10 +93,41 @@ export const POST = withApiAuthRequired(async (req: NextRequest) => {
 
   const { team_name, hasUser } = parsedParams;
 
+  const client = await getAPIServiceGraphqlClient();
+
+  // The `hasUser` flag in the body is derived from the session, which can be
+  // stale (e.g. session.user.hasura missing or out of date). Trust Hasura
+  // instead by looking up the user by auth0Id. Otherwise we hit a uniqueness
+  // violation on InsertUser when the user already exists.
+  let existingUser: GetUserByAuth0IdQuery["user"][number] | null = null;
+  try {
+    const { user: foundUsers } = await getGetUserByAuth0IdSdk(
+      client,
+    ).GetUserByAuth0Id({
+      auth0Id: auth0User.sub,
+    });
+
+    existingUser = foundUsers[0] ?? null;
+  } catch (error) {
+    logger.error("Error while looking up user on create team:", {
+      error,
+      graphqlResponse: (error as { response?: unknown })?.response,
+    });
+
+    return errorResponse({
+      statusCode: 500,
+      code: "server_error",
+      detail: "Failed to create team",
+      req,
+    });
+  }
+
+  const effectiveHasUser = hasUser || Boolean(existingUser);
+
   // ANCHOR: Sending acceptance
   let ironCladUserId: string | null = null;
 
-  if (!hasUser) {
+  if (!effectiveHasUser) {
     const ironcladActivityApi = new IroncladActivityApi();
     ironCladUserId = crypto.randomUUID();
 
@@ -132,8 +168,6 @@ export const POST = withApiAuthRequired(async (req: NextRequest) => {
     }
   }
 
-  const client = await getAPIServiceGraphqlClient();
-
   // ANCHOR: Insert team
   let insertedTeam: InsertTeamMutation["insert_team_one"] | null = null;
 
@@ -144,7 +178,10 @@ export const POST = withApiAuthRequired(async (req: NextRequest) => {
 
     insertedTeam = insert_team_one;
   } catch (error) {
-    logger.error("Error while inserting team on create team:", { error });
+    logger.error("Error while inserting team on create team:", {
+      error,
+      graphqlResponse: (error as { response?: unknown })?.response,
+    });
 
     return errorResponse({
       statusCode: 500,
@@ -164,7 +201,7 @@ export const POST = withApiAuthRequired(async (req: NextRequest) => {
 
   let insertedUser: InsertUserMutation["insert_user_one"] | null = null;
 
-  if (!hasUser) {
+  if (!effectiveHasUser) {
     try {
       const { insert_user_one } = await getInsertUserSdk(client).InsertUser({
         user_data: {
@@ -192,7 +229,10 @@ export const POST = withApiAuthRequired(async (req: NextRequest) => {
         },
       });
     } catch (error) {
-      logger.error("Error while inserting user on create team:", { error });
+      logger.error("Error while inserting user on create team:", {
+        error,
+        graphqlResponse: (error as { response?: unknown })?.response,
+      });
 
       return errorResponse({
         statusCode: 500,
@@ -209,7 +249,9 @@ export const POST = withApiAuthRequired(async (req: NextRequest) => {
     | null = null;
 
   try {
-    const user_id = hasUser ? hasuraUserId : insertedUser?.id;
+    const user_id = effectiveHasUser
+      ? hasuraUserId ?? existingUser?.id
+      : insertedUser?.id;
 
     if (!insertedTeam?.id) {
       throw new Error("Team id is null");
@@ -229,7 +271,10 @@ export const POST = withApiAuthRequired(async (req: NextRequest) => {
 
     insertedMembership = insert_membership_one;
   } catch (error) {
-    logger.error("Error while inserting membership on create team:", { error });
+    logger.error("Error while inserting membership on create team:", {
+      error,
+      graphqlResponse: (error as { response?: unknown })?.response,
+    });
 
     return errorResponse({
       statusCode: 500,
@@ -251,7 +296,7 @@ export const POST = withApiAuthRequired(async (req: NextRequest) => {
 
   const user = insertedMembership.user;
 
-  const returnTo = urls[hasUser ? "teams" : "app"]({
+  const returnTo = urls[effectiveHasUser ? "teams" : "app"]({
     team_id: insertedMembership.team_id,
   });
 

--- a/web/api/login-callback/index.ts
+++ b/web/api/login-callback/index.ts
@@ -86,6 +86,7 @@ export const loginCallback = withApiAuthRequired(async (req: NextRequest) => {
     } catch (error) {
       logger.error(`Error while fetching user for FetchUserByNullifierSdk.`, {
         error,
+        graphqlResponse: (error as { response?: unknown })?.response,
       });
 
       return NextResponse.redirect(
@@ -128,6 +129,7 @@ export const loginCallback = withApiAuthRequired(async (req: NextRequest) => {
     } catch (error) {
       logger.error("Error while fetching user for FetchUserByAuth0IdSdk.", {
         error,
+        graphqlResponse: (error as { response?: unknown })?.response,
       });
 
       return NextResponse.redirect(
@@ -140,6 +142,19 @@ export const loginCallback = withApiAuthRequired(async (req: NextRequest) => {
   const invite_id = req.nextUrl.searchParams.get("invite_id") as string;
 
   if (!user) {
+    // No matching Hasura user. The user is being routed to onboarding
+    // (create-team or join-callback). Log this so we can correlate when
+    // /api/create-team subsequently fails on a uniqueness violation.
+    logger.warn("login-callback: no Hasura user found, routing to onboarding", {
+      auth0Sub: auth0User.sub,
+      hasInvite: Boolean(invite_id),
+      authMethod: isEmailUser(auth0User)
+        ? "email"
+        : isPasswordUser(auth0User)
+          ? "password"
+          : "world_id",
+    });
+
     return NextResponse.redirect(
       new URL(
         invite_id ? urls.joinCallback({ invite_id }) : urls.createTeam(),


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Investigated a recurring 500 on `POST /api/create-team` ([DD trace](https://app.datadoghq.com/apm/trace/69f9ba470000000041bc855291516d82)) — Hasura returns a uniqueness violation on `InsertUser` because the handler trusts a body-supplied `hasUser` flag derived from `session.user.hasura`, which can be stale and cause the insert to collide with an existing record's `auth0Id`/`email` (24 occurrences in the last 30 days).

The handler now performs a defensive `GetUserByAuth0Id` lookup at the top: if Hasura already has the user, `effectiveHasUser` becomes true and we skip Ironclad acceptance, the `InsertUser` mutation, and the `signup_success` PostHog event, reusing the existing user's id for the membership. All GraphQL `logger.error` calls in `create-team` and `login-callback` now also pass `graphqlResponse: error?.response` (only the fingerprint was previously persisted, so the constraint name was lost), and `login-callback` warns when no Hasura user is found so we can correlate future occurrences.

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.