### PR TITLE
fix: prevent timeout in delete-expired-notification-logs cron

### DIFF
--- a/web/api/delete-expired-notification-logs/index.ts
+++ b/web/api/delete-expired-notification-logs/index.ts
@@ -1,12 +1,16 @@
 import { errorNotAllowed, errorResponse } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { protectInternalEndpoint } from "@/api/helpers/utils";
+import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
 import { getSdk as deleteExpiredNotificationLogsSdk } from "./graphql/delete-expired-notification-logs-batch.generated";
 import { getSdk as getExpiredNotificationLogIdsBatchSdk } from "./graphql/get-expired-notification-log-ids-batch.generated";
 
 const BATCH_SIZE = 100;
 const DELAY_MS = 10000;
+// Hasura cron timeout is 60s; leave headroom so we exit cleanly instead of
+// being aborted mid-batch. Remaining rows are picked up on the next run.
+const TIME_BUDGET_MS = 45000;
 
 export const POST = async (req: NextRequest) => {
   const { isAuthenticated, errorResponse: authErrorResponse } =
@@ -27,6 +31,8 @@ export const POST = async (req: NextRequest) => {
       Date.now() - 4 * 7 * 24 * 60 * 60 * 1000,
     ).toISOString();
 
+    const start = Date.now();
+    let totalDeleted = 0;
     let batchIds: string[] = [];
     do {
       const fetchResult = await getExpiredNotificationLogIdsBatchSdk(
@@ -46,13 +52,27 @@ export const POST = async (req: NextRequest) => {
       ).DeleteExpiredNotificationLogs({
         notificationLogIds: batchIds,
       });
+      totalDeleted += batchIds.length;
 
-      // Wait between batches
-      if (batchIds.length === BATCH_SIZE) {
-        await new Promise((r) => setTimeout(r, DELAY_MS));
+      if (batchIds.length < BATCH_SIZE) {
+        break;
       }
+
+      if (Date.now() - start + DELAY_MS > TIME_BUDGET_MS) {
+        logger.info(
+          "delete-expired-notification-logs: time budget reached, deferring remainder to next run",
+          { totalDeleted },
+        );
+        break;
+      }
+
+      await new Promise((r) => setTimeout(r, DELAY_MS));
     } while (batchIds.length === BATCH_SIZE);
   } catch (err) {
+    logger.error("Failed to delete expired notification logs", {
+      error: err,
+      req,
+    });
     return errorResponse({
       statusCode: 500,
       code: "server_error",


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

The `/api/delete-expired-notification-logs` cron handler has been failing recurrently (8 times in the past 24h, ongoing since Aug 2025 — Datadog issue `ccb17576-81e0-11f0-b499-da7ad0900002`). It tries to drain the entire backlog in one request with 10s sleeps between batches, but Hasura's cron trigger has a 60s `timeout_seconds`, so the connection gets aborted after ~6 batches and the next GraphQL call throws — caught and re-thrown as a generic `"Failed to delete expired notification logs"` 500 with no underlying error logged. This PR adds a `TIME_BUDGET_MS=45000` deadline check that exits the loop cleanly before Hasura times out (the next 15-minute cron tick picks up the remainder), and changes the catch block to log the underlying `err` so future failures are diagnosable instead of opaque.

Reference trace: https://app.datadoghq.com/apm/trace/69fb3b9b000000001ff2bf88ab3adcf3

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.