### PR TITLE
fix: validate max_verifications bound on /api/v2/create-action

### DIFF
--- a/web/api/v2/create-action/index.ts
+++ b/web/api/v2/create-action/index.ts
@@ -20,7 +20,13 @@ const createActionBodySchema = yup
     action: yup.string().strict().required(),
     name: yup.string().optional().default(""),
     description: yup.string().optional().default(""),
-    max_verifications: yup.number().integer().min(1).optional().default(1),
+    max_verifications: yup
+      .number()
+      .integer()
+      .min(1)
+      .max(2147483647)
+      .optional()
+      .default(1),
   })
   .noUnknown();
 
@@ -176,6 +182,23 @@ export const POST = async (
         code: "constraint-violation",
         detail: "Action already exists.",
         attribute: "action",
+        req,
+        app_id,
+      });
+    }
+
+    if (e.response.errors[0].extensions.code === "parse-failed") {
+      const extensionsPath = e.response.errors[0].extensions.path;
+      const attribute =
+        typeof extensionsPath === "string"
+          ? extensionsPath.split(".").pop()
+          : undefined;
+
+      return errorResponse({
+        statusCode: 400,
+        code: "validation_error",
+        detail: "One or more fields could not be parsed.",
+        attribute,
         req,
         app_id,
       });

--- a/web/tests/api/v2/create-action.test.ts
+++ b/web/tests/api/v2/create-action.test.ts
@@ -258,5 +258,51 @@ describe("/api/v2/create-action [error cases]", () => {
     const res = await POST(mockReq, ctx);
     expect(res.status).toBe(400);
   });
+
+  it("returns 400 if max_verifications exceeds int32 max", async () => {
+    const mockReq = createMockRequest({
+      url: getUrl(validAppId),
+      api_key: validApiKey,
+      body: { ...validBody, max_verifications: 2147483648 },
+    });
+
+    const ctx = { params: { app_id: validAppId } };
+    VerifyFetchAPIKey.mockResolvedValue(validApiKeyResponse);
+
+    const res = await POST(mockReq, ctx);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.attribute).toBe("max_verifications");
+  });
+
+  it("returns 400 when Hasura responds with parse-failed", async () => {
+    const mockReq = createMockRequest({
+      url: getUrl(validAppId),
+      api_key: validApiKey,
+      body: validBody,
+    });
+
+    const ctx = { params: { app_id: validAppId } };
+    VerifyFetchAPIKey.mockResolvedValue(validApiKeyResponse);
+
+    CreateDynamicAction.mockRejectedValue({
+      response: {
+        errors: [
+          {
+            extensions: {
+              code: "parse-failed",
+              path: "$.selectionSet.insert_action_one.args.object.max_verifications",
+            },
+          },
+        ],
+      },
+    });
+
+    const res = await POST(mockReq, ctx);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("validation_error");
+    expect(body.attribute).toBe("max_verifications");
+  });
 });
 // #endregion


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

`POST /api/v2/create-action/[app_id]` was returning 500 ("Action can't be created.") when callers sent `max_verifications` values larger than the underlying Postgres `integer` column / Hasura `Int!` bound (~14 occurrences in the last 30 days, [example trace](https://app.datadoghq.com/apm/trace/69fb09ca000000000456f943d2287399)). The yup schema enforced `min(1)` but no upper bound, so oversized values passed validation and hit Hasura, which rejected them with a `parse-failed` GraphQL error that the catch block didn't recognize.

This PR caps `max_verifications` at int32 max in the yup schema so malformed values are rejected with a 400 at validation time, and adds a `parse-failed` branch in the catch that maps any future Hasura parse failures to a 400 `validation_error` (with the offending field name) instead of a generic 500.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.