### PR TITLE
fix: return 400 instead of 500 for invalid JSON request bodies

### DIFF
--- a/web/api/helpers/parse-request-body.ts
+++ b/web/api/helpers/parse-request-body.ts
@@ -1,0 +1,33 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import { errorValidation, ErrorResponseBody } from "./errors";
+
+type ParseRequestBodyResult<T> =
+  | { isValid: true; body: T; error?: never }
+  | { isValid: false; body?: never; error: NextResponse<ErrorResponseBody> };
+
+/**
+ * Parses the JSON body of a request and returns a 400 response if it is missing
+ * or malformed, instead of letting `req.json()` throw and surface as a 500.
+ */
+export const parseRequestBody = async <T = unknown>(
+  req: NextRequest,
+  options?: { app_id?: string },
+): Promise<ParseRequestBodyResult<T>> => {
+  try {
+    const body = (await req.json()) as T;
+    return { isValid: true, body };
+  } catch {
+    return {
+      isValid: false,
+      error: errorValidation(
+        "invalid_json",
+        "Request body must be valid JSON.",
+        null,
+        req,
+        options?.app_id,
+      ),
+    };
+  }
+};

--- a/web/api/v1/debugger/index.ts
+++ b/web/api/v1/debugger/index.ts
@@ -1,4 +1,5 @@
 import { errorResponse } from "@/api/helpers/errors";
+import { parseRequestBody } from "@/api/helpers/parse-request-body";
 import { corsHandler } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { verifyProof } from "@/api/helpers/verify";
@@ -42,10 +43,14 @@ const schema = yup
 const corsMethods = ["POST", "OPTIONS"];
 
 export async function POST(req: NextRequest) {
-  const body = await req.json();
+  const parseResult = await parseRequestBody(req);
+  if (!parseResult.isValid) {
+    return corsHandler(parseResult.error, corsMethods);
+  }
+
   const { isValid, parsedParams, handleError } = await validateRequestSchema({
     schema,
-    value: body,
+    value: parseResult.body,
   });
 
   if (!isValid) {

--- a/web/api/v1/graphql/index.ts
+++ b/web/api/v1/graphql/index.ts
@@ -1,6 +1,7 @@
 import { errorUnauthenticated } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { generateAPIKeyJWT, generateUserJWT } from "@/api/helpers/jwts";
+import { parseRequestBody } from "@/api/helpers/parse-request-body";
 import { verifyHashedSecret } from "@/api/helpers/utils";
 import { getSession } from "@auth0/nextjs-auth0";
 import dayjs from "dayjs";
@@ -58,20 +59,11 @@ export async function POST(req: NextRequest) {
     headers.append("authorization", `Bearer ${authorization}`);
   }
 
-  let body;
-  try {
-    body = await req.json();
-  } catch (error) {
-    console.error("Error parsing request body:", error);
-    return NextResponse.json(
-      {
-        code: "unsupported_media_type",
-        detail: "The body request does not look like a valid JSON payload.",
-        attribute: null,
-      },
-      { status: 415 },
-    );
+  const parseResult = await parseRequestBody(req);
+  if (!parseResult.isValid) {
+    return parseResult.error;
   }
+  const body = parseResult.body;
 
   let res = NextResponse.json({ success: true });
   if (!headers.get("authorization")) {

--- a/web/api/v1/oidc/authorize/index.ts
+++ b/web/api/v1/oidc/authorize/index.ts
@@ -10,6 +10,7 @@ import {
   fetchOIDCApp,
   generateOIDCCode,
 } from "@/api/helpers/oidc";
+import { parseRequestBody } from "@/api/helpers/parse-request-body";
 import { corsHandler } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { encodeNullifierForStorage, verifyProof } from "@/api/helpers/verify";
@@ -88,11 +89,15 @@ export async function POST(req: NextRequest) {
 
   let app_id: string | undefined;
 
+  const parseResult = await parseRequestBody(req);
+  if (!parseResult.isValid) {
+    return corsHandler(parseResult.error, corsMethods);
+  }
+
   try {
-    const body = await req.json();
     const { isValid, parsedParams, handleError } = await validateRequestSchema({
       schema,
-      value: body,
+      value: parseResult.body,
     });
 
     if (!isValid) {

--- a/web/api/v1/oidc/validate/index.ts
+++ b/web/api/v1/oidc/validate/index.ts
@@ -1,5 +1,6 @@
 import { errorResponse } from "@/api/helpers/errors";
 import { fetchOIDCApp } from "@/api/helpers/oidc";
+import { parseRequestBody } from "@/api/helpers/parse-request-body";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { validateUrl } from "@/lib/utils";
 import { NextRequest, NextResponse } from "next/server";
@@ -16,10 +17,14 @@ const schema = yup
  * Prevalidates app_id & redirect_uri is valid for Sign in with World ID for early user feedback
  */
 export async function POST(req: NextRequest) {
-  const body = await req.json();
+  const parseResult = await parseRequestBody(req);
+  if (!parseResult.isValid) {
+    return parseResult.error;
+  }
+
   const { isValid, parsedParams, handleError } = await validateRequestSchema({
     schema,
-    value: body,
+    value: parseResult.body,
   });
 
   if (!isValid) {

--- a/web/api/v1/precheck/[app_id]/index.ts
+++ b/web/api/v1/precheck/[app_id]/index.ts
@@ -1,5 +1,6 @@
 import { errorResponse } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { parseRequestBody } from "@/api/helpers/parse-request-body";
 import { RpRegistrationStatus } from "@/api/helpers/rp-utils";
 import { corsHandler } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
@@ -64,17 +65,22 @@ export async function POST(
   req: NextRequest,
   { params: routeParams }: { params: { app_id: string } },
 ) {
-  const body = await req.json();
+  const app_id = routeParams.app_id;
+
+  const parseResult = await parseRequestBody(req, { app_id });
+  if (!parseResult.isValid) {
+    return corsHandler(parseResult.error, corsMethods);
+  }
+
   const { isValid, parsedParams, handleError } = await validateRequestSchema({
     schema,
-    value: body,
+    value: parseResult.body,
   });
 
   if (!isValid) {
     return corsHandler(handleError(req), corsMethods);
   }
 
-  const app_id = routeParams.app_id;
   const action = parsedParams.action ?? "";
   const nullifier_hash = parsedParams.nullifier_hash;
 

--- a/web/tests/api/helpers/parse-request-body.test.ts
+++ b/web/tests/api/helpers/parse-request-body.test.ts
@@ -1,0 +1,76 @@
+import { parseRequestBody } from "@/api/helpers/parse-request-body";
+import { NextRequest } from "next/server";
+
+jest.mock(
+  "@/lib/logger",
+  () => ({
+    logger: {
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    },
+  }),
+  { virtual: true },
+);
+
+const buildRequest = (body: BodyInit | null) =>
+  new NextRequest("http://localhost/api/test", {
+    method: "POST",
+    body,
+  });
+
+describe("parseRequestBody", () => {
+  it("returns the parsed body for valid JSON", async () => {
+    const req = buildRequest(JSON.stringify({ foo: "bar", n: 1 }));
+
+    const result = await parseRequestBody<{ foo: string; n: number }>(req);
+
+    expect(result.isValid).toBe(true);
+    if (result.isValid) {
+      expect(result.body).toEqual({ foo: "bar", n: 1 });
+    }
+  });
+
+  it("returns a 400 invalid_json response for an empty body", async () => {
+    const req = buildRequest(null);
+
+    const result = await parseRequestBody(req);
+
+    expect(result.isValid).toBe(false);
+    if (!result.isValid) {
+      expect(result.error.status).toBe(400);
+      const json = await result.error.json();
+      expect(json).toMatchObject({
+        code: "invalid_json",
+        detail: "Request body must be valid JSON.",
+        attribute: null,
+      });
+    }
+  });
+
+  it("returns a 400 invalid_json response for malformed JSON", async () => {
+    const req = buildRequest("{ not: valid json");
+
+    const result = await parseRequestBody(req);
+
+    expect(result.isValid).toBe(false);
+    if (!result.isValid) {
+      expect(result.error.status).toBe(400);
+      const json = await result.error.json();
+      expect(json.code).toBe("invalid_json");
+    }
+  });
+
+  it("includes app_id in the error response when provided", async () => {
+    const req = buildRequest("");
+
+    const result = await parseRequestBody(req, { app_id: "app_abc" });
+
+    expect(result.isValid).toBe(false);
+    if (!result.isValid) {
+      const json = await result.error.json();
+      expect(json.app_id).toBe("app_abc");
+    }
+  });
+});


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Several v1 API routes called `await req.json()` unguarded, so requests with empty or malformed bodies threw `SyntaxError: Unexpected end of JSON input` and surfaced as a 500. This pattern accounted for ~889 production errors over the last 7 days (e.g. trace [`69fa5a94…`](https://app.datadoghq.com/apm/trace/69fa5a94000000005b2f4c240650432c) on `/api/v1/precheck/[app_id]`).

Added a `parseRequestBody` helper that wraps `req.json()` and returns a 400 `invalid_json` response on failure (via the existing `errorValidation`, so it logs at `warn` rather than `error`). Migrated all five v1 routes that read JSON bodies — `precheck/[app_id]`, `debugger`, `oidc/validate`, `oidc/authorize`, and `graphql`. Note: `graphql` previously returned 415 `unsupported_media_type` for the same case; it now returns 400 `invalid_json` for consistency (only the dev-portal frontend calls this endpoint).

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.