### PR TITLE
fix: disable notifications for external apps

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -22,8 +22,11 @@ WORKDIR /app
 # Install working version of corepack
 RUN npm install -g corepack@0.31.0 && corepack --version
 
+# This stage has no project package.json, so corepack would otherwise fall back
+# to the latest pnpm (incompatible with the Node 20 base). Pin to the same
+# version declared in the project's packageManager field.
 # TODO: Can be further optimized to remove next peer dependency
-RUN corepack enable pnpm && pnpm i next-logger@5.0.0 pino@9.2.0 dd-trace@5.12.0
+RUN corepack enable pnpm && corepack prepare pnpm@9.15.4 --activate && pnpm i next-logger@5.0.0 pino@9.2.0 dd-trace@5.12.0
 
 # Rebuild the source code only when needed
 FROM base AS builder

--- a/web/api/v2/minikit/send-notification/graphql/fetch-metadata.generated.ts
+++ b/web/api/v2/minikit/send-notification/graphql/fetch-metadata.generated.ts
@@ -14,6 +14,8 @@ export type GetAppMetadataQuery = {
     __typename?: "app_metadata";
     name: string;
     app_id: string;
+    app_mode: string;
+    category: string;
     is_reviewer_app_store_approved: boolean;
     is_allowed_unlimited_notifications?: boolean | null;
     max_notifications_per_day?: number | null;
@@ -29,6 +31,8 @@ export const GetAppMetadataDocument = gql`
     ) {
       name
       app_id
+      app_mode
+      category
       is_reviewer_app_store_approved
       is_allowed_unlimited_notifications
       max_notifications_per_day

--- a/web/api/v2/minikit/send-notification/graphql/fetch-metadata.graphql
+++ b/web/api/v2/minikit/send-notification/graphql/fetch-metadata.graphql
@@ -4,6 +4,8 @@ query GetAppMetadata($app_id: String!) {
   ) {
     name
     app_id
+    app_mode
+    category
     is_reviewer_app_store_approved
     is_allowed_unlimited_notifications
     max_notifications_per_day

--- a/web/api/v2/minikit/send-notification/index.ts
+++ b/web/api/v2/minikit/send-notification/index.ts
@@ -292,6 +292,21 @@ export const POST = async (req: NextRequest) => {
   const appMetadata = app_metadata?.[0];
   const teamId = appMetadata.app.team.id;
 
+  if (
+    verifiedOrDefaultApp.app_mode === "external" ||
+    verifiedOrDefaultApp.category?.toLowerCase() === "external"
+  ) {
+    return errorResponse({
+      statusCode: 400,
+      code: "external_app_not_allowed",
+      detail: "Notifications are not available for external apps",
+      attribute: "app",
+      req,
+      app_id,
+      team_id: teamId,
+    });
+  }
+
   // If app is not verified we allow max 40 notifications per 4 hours
   if (verifiedOrDefaultApp?.verification_status !== "verified") {
     const key = `app_notifications_${app_id}`;

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Notifications/graphql/client/fetch-notification-app-metadata.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Notifications/graphql/client/fetch-notification-app-metadata.generated.ts
@@ -17,11 +17,15 @@ export type FetchNotificationAppMetadataQuery = {
       __typename?: "app_metadata";
       id: string;
       verification_status: string;
+      app_mode: string;
+      category: string;
     }>;
     verified_app_metadata: Array<{
       __typename?: "app_metadata";
       id: string;
       verified_at?: string | null;
+      app_mode: string;
+      category: string;
     }>;
   }>;
 };
@@ -33,12 +37,16 @@ export const FetchNotificationAppMetadataDocument = gql`
       app_metadata(where: { verification_status: { _neq: "verified" } }) {
         id
         verification_status
+        app_mode
+        category
       }
       verified_app_metadata: app_metadata(
         where: { verification_status: { _eq: "verified" } }
       ) {
         id
         verified_at
+        app_mode
+        category
       }
     }
   }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Notifications/graphql/client/fetch-notification-app-metadata.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Notifications/graphql/client/fetch-notification-app-metadata.graphql
@@ -4,12 +4,16 @@ query FetchNotificationAppMetadata($id: String!) {
     app_metadata(where: { verification_status: { _neq: "verified" } }) {
       id
       verification_status
+      app_mode
+      category
     }
     verified_app_metadata: app_metadata(
       where: { verification_status: { _eq: "verified" } }
     ) {
       id
       verified_at
+      app_mode
+      category
     }
   }
 }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Notifications/page.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Notifications/page.tsx
@@ -39,6 +39,15 @@ export const NotificationsPage = () => {
     (appData?.app_metadata.length ?? 0) > 0 &&
     (appData?.verified_app_metadata.length ?? 0) > 0;
 
+  const isExternalApp = [
+    appData?.verified_app_metadata[0],
+    appData?.app_metadata[0],
+  ].some(
+    (meta) =>
+      meta?.app_mode === "external" ||
+      meta?.category?.toLowerCase() === "external",
+  );
+
   const {
     register,
     handleSubmit,
@@ -197,6 +206,29 @@ export const NotificationsPage = () => {
     walletAddressesValue
       ?.split(",")
       .filter((address) => address.trim().length > 0).length ?? 0;
+
+  if (isExternalApp) {
+    return (
+      <div className="my-8 grid max-w-[1180px] gap-y-10">
+        <div className="md:hidden">
+          <MiniAppSubTabs />
+        </div>
+
+        <div className="grid grid-cols-auto/1fr items-start gap-x-3 rounded-[10px] bg-grey-50 p-4 sm:p-5">
+          <NotificationBellIcon className="size-8" aria-hidden="true" />
+
+          <div className="min-w-0 font-world text-[13px] leading-[120%] text-grey-900">
+            <Typography as="p" className="font-world text-[13px] font-semibold">
+              Notifications unavailable
+            </Typography>
+            <Typography as="p" className="font-world text-[13px] font-medium">
+              Notifications aren't available for external apps.
+            </Typography>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="my-8 grid max-w-[1180px] gap-y-10">

--- a/web/tests/api/v2/send-notification.test.ts
+++ b/web/tests/api/v2/send-notification.test.ts
@@ -358,6 +358,51 @@ describe("/api/v2/minikit/send-notification [error cases]", () => {
     expect((await res.json()).detail).toBe("API key is inactive.");
   });
 
+  it.each([
+    {
+      label: "app_mode is external",
+      app_mode: "external",
+      category: "Social",
+    },
+    {
+      label: "category is External",
+      app_mode: "mini-app",
+      category: "External",
+    },
+  ])("returns 400 when $label", async ({ app_mode, category }) => {
+    const mockReq = createMockRequest({
+      url: "http://localhost:3000/api/v2/minikit/send-notification",
+      api_key: validApiKey,
+    });
+
+    GetAppMetadata.mockResolvedValue({
+      app_metadata: [
+        {
+          name: "Example App",
+          app_id: "app_staging_9cdd0a714aec9ed17dca660bc9ffe72a",
+          app_mode,
+          category,
+          is_reviewer_app_store_approved: true,
+          is_allowed_unlimited_notifications: true,
+          max_notifications_per_day: 10,
+          verification_status: "verified",
+          app: { team: { id: testTeamId } },
+        },
+      ],
+    });
+
+    mockSignedFetcher.mockClear();
+
+    const res = await POST(mockReq);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("external_app_not_allowed");
+    expect(body.detail).toBe(
+      "Notifications are not available for external apps",
+    );
+    expect(mockSignedFetcher).not.toHaveBeenCalled();
+  });
+
   it("returns 400 if not allowed to send notifications", async () => {
     const mockReq = createMockRequest({
       url: "http://localhost:3000/api/v2/minikit/send-notification",


### PR DESCRIPTION
## PR Type

- [x] Bug Fix

## Description

External apps were producing repeated "App Directory Metadata call failed" / "Invalid category" 404s because app-backend's send-notification flow fetches app metadata from `/api/v2/public/app/[app_id]`, which 404s when the app's category is "external" and `show_external` isn't passed. Rather than punching a hole through that endpoint, this PR blocks the feature for external apps at the developer portal: `/api/v2/minikit/send-notification` now returns a clear \`external_app_not_allowed\` 400 (checking both \`app_mode === "external"\` and \`category === "External"\`, matching the existing filter pattern in the apps list endpoint), and the Notifications UI page renders an "unavailable" notice instead of the form. New unit tests cover both rejection paths.

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have added necessary unit tests.