### PR TITLE
fix: use rp id as integrity token audience

### DIFF
--- a/web/api/v4/verify/integrity-bundle.ts
+++ b/web/api/v4/verify/integrity-bundle.ts
@@ -28,8 +28,6 @@ const JWKS_FETCH_TIMEOUT_MS = 4_000;
 const DEFAULT_INTEGRITY_JWKS_URL =
   "https://attestation.worldcoin.org/.well-known/jwks.json";
 const DEFAULT_INTEGRITY_ISSUER = "attestation.worldcoin.org";
-// Temporary fixed audience for internal testing only.
-const DEFAULT_INTEGRITY_AUDIENCE = "developer.worldcoin.org";
 
 export const INTEGRITY_VERIFICATION_ERROR_CODE =
   "integrity_verification_failed";
@@ -108,11 +106,6 @@ const getIntegrityExpectedIssuer = () =>
   process.env.INTEGRITY_BUNDLE_EXPECTED_ISSUER ??
   process.env.INTEGRITY_TOKEN_EXPECTED_ISSUER ??
   DEFAULT_INTEGRITY_ISSUER;
-
-const getIntegrityExpectedAudience = () =>
-  process.env.INTEGRITY_BUNDLE_EXPECTED_AUDIENCE ??
-  process.env.INTEGRITY_TOKEN_EXPECTED_AUDIENCE ??
-  DEFAULT_INTEGRITY_AUDIENCE;
 
 export function normalizeIntegrityBundle(
   integrityBundle: IntegrityBundle,
@@ -429,12 +422,16 @@ function extractDevicePublicKey(payload: IntegrityTokenClaims) {
   return publicKey;
 }
 
-async function verifyJwtWithJwk(params: { integrityJwt: string; jwk: JWK }) {
+async function verifyJwtWithJwk(params: {
+  integrityJwt: string;
+  jwk: JWK;
+  rpId: string;
+}) {
   const publicKey = await importJWK(params.jwk, "ES256");
   const { payload } = await jwtVerify(params.integrityJwt, publicKey, {
     algorithms: ["ES256"],
     issuer: getIntegrityExpectedIssuer(),
-    audience: getIntegrityExpectedAudience(),
+    audience: params.rpId,
     requiredClaims: ["cnf", "exp", "platform", "pass"],
   });
 
@@ -476,6 +473,7 @@ async function verifyIntegrityToken(params: {
     payload = await verifyJwtWithJwk({
       integrityJwt: params.integrityJwt,
       jwk: keyResult.jwk,
+      rpId: params.rpId,
     });
   } catch (error) {
     if (!keyResult.fromCache || !shouldRefreshJwksAfterJwtFailure(error)) {
@@ -495,6 +493,7 @@ async function verifyIntegrityToken(params: {
       payload = await verifyJwtWithJwk({
         integrityJwt: params.integrityJwt,
         jwk: keyResult.jwk,
+        rpId: params.rpId,
       });
     } catch (retryError) {
       throw new IntegrityBundleError(

--- a/web/tests/api/v4/integrity-bundle.test.ts
+++ b/web/tests/api/v4/integrity-bundle.test.ts
@@ -22,7 +22,6 @@ const RP_ID = "rp_test_123";
 const AG_KID = "ag-test-key";
 const JWKS_URL = "https://attestation.example/.well-known/jwks.json";
 const ISSUER = "attestation.worldcoin.org";
-const EXPECTED_AUDIENCE = "developer.worldcoin.org";
 
 type DeviceKey = {
   privateKey: Uint8Array;
@@ -78,7 +77,7 @@ function createDeviceKey(): DeviceKey {
 
 async function createIntegrityJwt(params: {
   agPrivateKey: KeyObject;
-  audience?: string;
+  rpId: string;
   devicePublicJwk: JWK;
   expirationTime?: number | string | Date;
   pass?: boolean;
@@ -93,7 +92,7 @@ async function createIntegrityJwt(params: {
   })
     .setProtectedHeader({ alg: "ES256", kid: AG_KID })
     .setIssuer(ISSUER)
-    .setAudience(params.audience ?? EXPECTED_AUDIENCE)
+    .setAudience(params.rpId)
     .setIssuedAt()
     .setExpirationTime(params.expirationTime ?? "5m")
     .sign(params.agPrivateKey);
@@ -101,7 +100,7 @@ async function createIntegrityJwt(params: {
 
 async function createBundle(params?: {
   agKey?: AgKey;
-  audience?: string;
+  rpId?: string;
   jwtExpirationTime?: number | string | Date;
   jwtPlatform?: "android" | "ios";
   pass?: boolean;
@@ -120,7 +119,7 @@ async function createBundle(params?: {
 
   const integrityJwt = await createIntegrityJwt({
     agPrivateKey: agKey.privateKey,
-    audience: params?.audience,
+    rpId: params?.rpId ?? RP_ID,
     devicePublicJwk: deviceKey.publicJwk,
     expirationTime: params?.jwtExpirationTime,
     pass: params?.pass,
@@ -182,7 +181,6 @@ describe("integrity bundle verification", () => {
     jest.clearAllMocks();
     process.env.INTEGRITY_BUNDLE_JWKS_URL = JWKS_URL;
     process.env.INTEGRITY_BUNDLE_EXPECTED_ISSUER = ISSUER;
-    process.env.INTEGRITY_BUNDLE_EXPECTED_AUDIENCE = EXPECTED_AUDIENCE;
     await (global.RedisClient as any)?.flushall?.();
   });
 
@@ -190,7 +188,6 @@ describe("integrity bundle verification", () => {
     jest.restoreAllMocks();
     delete process.env.INTEGRITY_BUNDLE_JWKS_URL;
     delete process.env.INTEGRITY_BUNDLE_EXPECTED_ISSUER;
-    delete process.env.INTEGRITY_BUNDLE_EXPECTED_AUDIENCE;
   });
 
   it("normalizes a structured integrity bundle", () => {
@@ -397,7 +394,7 @@ describe("integrity bundle verification", () => {
 
   it("logs and rejects integrity tokens with an unexpected audience", async () => {
     const { agPublicJwk, integrityBundle, nonce } = await createBundle({
-      audience: "unexpected-audience",
+      rpId: "unexpected-audience",
     });
     jest.spyOn(global, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ keys: [agPublicJwk] }), {


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Remove the hardcoded `developer.worldcoin.org` audience constant and instead validate the JWT `aud` claim against the `rpId` of the verifying relying party. This ensures each RP's integrity token is only accepted for that specific RP rather than for a shared fixed audience.

- Removed `DEFAULT_INTEGRITY_AUDIENCE` constant and `getIntegrityExpectedAudience()` helper
- `verifyJwtWithJwk` now accepts `rpId` and passes it as the expected JWT audience
- Updated tests to use `rpId` instead of the `INTEGRITY_BUNDLE_EXPECTED_AUDIENCE` env var

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.