### PR TITLE
fix: display configuration images at their natural aspect ratio

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ContentCardImageUpload/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ContentCardImageUpload/index.tsx
@@ -1,15 +1,16 @@
 import { Button } from "@/components/Button";
 import { Dialog } from "@/components/Dialog";
 import { DialogOverlay } from "@/components/DialogOverlay";
-import { DialogPanel } from "@/components/DialogPanel";
+import { CloseIcon } from "@/components/Icons/CloseIcon";
 import { TrashIcon } from "@/components/Icons/TrashIcon";
 import { WorldIcon } from "@/components/Icons/WorldIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { getCDNImageUrl } from "@/lib/utils";
+import { Dialog as HeadlessDialog, Transition } from "@headlessui/react";
 import clsx from "clsx";
 import { useAtom } from "jotai";
 import Image from "next/image";
-import { ChangeEvent, useMemo, useRef, useState } from "react";
+import { ChangeEvent, Fragment, useMemo, useRef, useState } from "react";
 import { toast } from "react-toastify";
 import { FetchAppMetadataDocument } from "../../graphql/client/fetch-app-metadata.generated";
 import { ImageValidationError, useImage } from "../../hook/use-image";
@@ -292,20 +293,36 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
 
       <Dialog open={!!lightboxUrl} onClose={() => setLightboxUrl(null)}>
         <DialogOverlay />
-        <DialogPanel
-          showCloseIcon
-          onClose={() => setLightboxUrl(null)}
-          className="md:max-w-[90vw]"
+        <Transition.Child
+          enter="transition duration-200 ease"
+          enterFrom="opacity-0 scale-95"
+          enterTo="opacity-100 scale-100"
+          leave="transition duration-150 ease"
+          leaveFrom="opacity-100 scale-100"
+          leaveTo="opacity-0 scale-95"
+          as={Fragment}
         >
-          {lightboxUrl && (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={lightboxUrl}
-              alt="Full resolution preview"
-              className="max-h-[80vh] max-w-full object-contain"
-            />
-          )}
-        </DialogPanel>
+          <div className="fixed inset-0 flex items-center justify-center p-4">
+            <HeadlessDialog.Panel className="relative">
+              {lightboxUrl && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={lightboxUrl}
+                  alt="Full resolution preview"
+                  className="block max-h-[90vh] max-w-[90vw] rounded-2xl object-contain shadow-2xl"
+                />
+              )}
+              <button
+                type="button"
+                onClick={() => setLightboxUrl(null)}
+                className="absolute right-3 top-3 flex size-9 items-center justify-center rounded-full bg-white/95 text-grey-700 shadow-md transition-colors hover:bg-white"
+                aria-label="Close"
+              >
+                <CloseIcon className="size-4" />
+              </button>
+            </HeadlessDialog.Panel>
+          </div>
+        </Transition.Child>
       </Dialog>
     </div>
   );

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ContentCardImageUpload/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ContentCardImageUpload/index.tsx
@@ -7,7 +7,6 @@ import clsx from "clsx";
 import { useAtom } from "jotai";
 import Image from "next/image";
 import { ChangeEvent, useMemo, useRef, useState } from "react";
-import Skeleton from "react-loading-skeleton";
 import { toast } from "react-toastify";
 import { FetchAppMetadataDocument } from "../../graphql/client/fetch-app-metadata.generated";
 import { ImageValidationError, useImage } from "../../hook/use-image";
@@ -134,11 +133,18 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
     return getCDNImageUrl(appId, contentCardImageFile);
   }, [appId, contentCardImageFile, viewMode]);
 
+  const aspectRatioStyle = { aspectRatio: "345 / 240" };
+
   if (
     viewMode === "unverified" &&
     unverifiedImages?.content_card_image_url === "loading"
   ) {
-    return <Skeleton className="h-[200px] w-full rounded-xl" />;
+    return (
+      <div
+        className="w-full animate-pulse rounded-xl bg-grey-100"
+        style={aspectRatioStyle}
+      />
+    );
   }
 
   return (
@@ -155,35 +161,48 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
       {/* Verified: full-width image */}
       {viewMode === "verified" &&
         (verifiedImageError ? (
-          <div className="flex h-[200px] w-full items-center justify-center rounded-xl bg-blue-100">
+          <div
+            className="flex w-full items-center justify-center rounded-xl bg-blue-100"
+            style={aspectRatioStyle}
+          >
             <WorldIcon className="size-10 text-blue-500" />
           </div>
         ) : (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={verifiedImageURL}
-            alt="content card image"
-            className="h-[200px] w-full rounded-xl object-cover drop-shadow-sm"
-            onError={() => setVerifiedImageError(true)}
-          />
+          <div
+            className="w-full overflow-hidden rounded-xl"
+            style={aspectRatioStyle}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={verifiedImageURL}
+              alt="content card image"
+              className="size-full rounded-xl object-contain drop-shadow-sm"
+              onError={() => setVerifiedImageError(true)}
+            />
+          </div>
         ))}
 
       {/* Unverified: uploading loader */}
       {viewMode === "unverified" && isUploading && (
-        <ImageLoader name="content_card_image" className="h-[200px] w-full" />
+        <div className="w-full" style={aspectRatioStyle}>
+          <ImageLoader name="content_card_image" className="size-full" />
+        </div>
       )}
 
       {/* Unverified: uploaded image or drop zone */}
       {viewMode === "unverified" &&
         !isUploading &&
         (unverifiedImages?.content_card_image_url ? (
-          <div className="relative overflow-hidden rounded-xl">
+          <div
+            className="relative w-full overflow-hidden rounded-xl"
+            style={aspectRatioStyle}
+          >
             <Image
               alt="content card image"
               src={unverifiedImages?.content_card_image_url}
-              className="h-[200px] w-full rounded-xl object-cover"
-              width={1200}
-              height={600}
+              className="size-full rounded-xl object-contain"
+              width={345}
+              height={240}
             />
             <Button
               type="button"

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ContentCardImageUpload/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ContentCardImageUpload/index.tsx
@@ -1,4 +1,7 @@
 import { Button } from "@/components/Button";
+import { Dialog } from "@/components/Dialog";
+import { DialogOverlay } from "@/components/DialogOverlay";
+import { DialogPanel } from "@/components/DialogPanel";
 import { TrashIcon } from "@/components/Icons/TrashIcon";
 import { WorldIcon } from "@/components/Icons/WorldIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
@@ -13,6 +16,12 @@ import { ImageValidationError, useImage } from "../../hook/use-image";
 import ImageLoader from "../ImageForm/ImageLoader";
 import { unverifiedImageAtom, viewModeAtom } from "../../layout/ImagesProvider";
 import { useUpdateContentCardImageMutation } from "./graphql/client/update-content-card-image.generated";
+
+const PREVIEW_HEIGHT_PX = 200;
+const previewStyle = {
+  height: `${PREVIEW_HEIGHT_PX}px`,
+  width: `${(PREVIEW_HEIGHT_PX * 345) / 240}px`,
+};
 
 type ContentCardImageUploadProps = {
   appId: string;
@@ -36,6 +45,7 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
   const [isSecondUpload, setIsSecondUpload] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [disabled] = useState(false);
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
   const [viewMode] = useAtom(viewModeAtom);
   const [unverifiedImages, setUnverifiedImages] = useAtom(unverifiedImageAtom);
   const [updateContentCardImageMutation, { loading }] =
@@ -133,16 +143,14 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
     return getCDNImageUrl(appId, contentCardImageFile);
   }, [appId, contentCardImageFile, viewMode]);
 
-  const aspectRatioStyle = { aspectRatio: "345 / 240" };
-
   if (
     viewMode === "unverified" &&
     unverifiedImages?.content_card_image_url === "loading"
   ) {
     return (
       <div
-        className="w-full animate-pulse rounded-xl bg-grey-100"
-        style={aspectRatioStyle}
+        className="animate-pulse rounded-xl bg-grey-100"
+        style={previewStyle}
       />
     );
   }
@@ -158,33 +166,37 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
         style={{ display: "none" }}
       />
 
-      {/* Verified: full-width image */}
+      {/* Verified: thumbnail */}
       {viewMode === "verified" &&
         (verifiedImageError ? (
           <div
-            className="flex w-full items-center justify-center rounded-xl bg-blue-100"
-            style={aspectRatioStyle}
+            className="flex items-center justify-center rounded-xl bg-blue-100"
+            style={previewStyle}
           >
             <WorldIcon className="size-10 text-blue-500" />
           </div>
         ) : (
-          <div
-            className="w-full overflow-hidden rounded-xl"
-            style={aspectRatioStyle}
-          >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={verifiedImageURL}
-              alt="content card image"
-              className="size-full rounded-xl object-contain drop-shadow-sm"
-              onError={() => setVerifiedImageError(true)}
-            />
+          <div className="overflow-hidden rounded-xl" style={previewStyle}>
+            <button
+              type="button"
+              onClick={() => setLightboxUrl(verifiedImageURL)}
+              className="block size-full cursor-zoom-in"
+              aria-label="View full resolution"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={verifiedImageURL}
+                alt="content card image"
+                className="size-full rounded-xl object-contain drop-shadow-sm"
+                onError={() => setVerifiedImageError(true)}
+              />
+            </button>
           </div>
         ))}
 
       {/* Unverified: uploading loader */}
       {viewMode === "unverified" && isUploading && (
-        <div className="w-full" style={aspectRatioStyle}>
+        <div style={previewStyle}>
           <ImageLoader name="content_card_image" className="size-full" />
         </div>
       )}
@@ -194,16 +206,25 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
         !isUploading &&
         (unverifiedImages?.content_card_image_url ? (
           <div
-            className="relative w-full overflow-hidden rounded-xl"
-            style={aspectRatioStyle}
+            className="relative overflow-hidden rounded-xl"
+            style={previewStyle}
           >
-            <Image
-              alt="content card image"
-              src={unverifiedImages?.content_card_image_url}
-              className="size-full rounded-xl object-contain"
-              width={345}
-              height={240}
-            />
+            <button
+              type="button"
+              onClick={() =>
+                setLightboxUrl(unverifiedImages?.content_card_image_url ?? null)
+              }
+              className="block size-full cursor-zoom-in"
+              aria-label="View full resolution"
+            >
+              <Image
+                alt="content card image"
+                src={unverifiedImages?.content_card_image_url}
+                className="size-full rounded-xl object-contain"
+                width={345}
+                height={240}
+              />
+            </button>
             <Button
               type="button"
               onClick={removeImage}
@@ -268,6 +289,24 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
             </div>
           </label>
         ))}
+
+      <Dialog open={!!lightboxUrl} onClose={() => setLightboxUrl(null)}>
+        <DialogOverlay />
+        <DialogPanel
+          showCloseIcon
+          onClose={() => setLightboxUrl(null)}
+          className="md:max-w-[90vw]"
+        >
+          {lightboxUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={lightboxUrl}
+              alt="Full resolution preview"
+              className="max-h-[80vh] max-w-full object-contain"
+            />
+          )}
+        </DialogPanel>
+      </Dialog>
     </div>
   );
 };

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
@@ -190,6 +190,10 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
 
   const canUploadMore = value.length < maxImages;
 
+  const aspectRatioStyle = {
+    aspectRatio: `${imageConstraints.width} / ${imageConstraints.height}`,
+  };
+
   const resolvedImageUrls = useMemo(() => {
     if (isAppVerified) {
       return value.map((url: string) =>
@@ -280,14 +284,15 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
             return (
               <div
                 key={imagePath}
-                className="relative overflow-hidden rounded-xl"
+                className="relative w-full overflow-hidden rounded-xl"
+                style={aspectRatioStyle}
               >
                 <ImageDisplay
                   src={resolvedUrl}
                   type="original"
                   width={imageConstraints.width}
                   height={imageConstraints.height}
-                  className="h-[200px] w-full rounded-xl object-cover"
+                  className="size-full rounded-xl object-contain"
                 />
                 <Button
                   type="button"
@@ -301,17 +306,22 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
             );
           })}
           {isUploading && (
-            <ImageLoader
-              name={imageTypeNamer(value.length)}
-              className="h-[200px]"
-            />
+            <div className="w-full" style={aspectRatioStyle}>
+              <ImageLoader
+                name={imageTypeNamer(value.length)}
+                className="size-full"
+              />
+            </div>
           )}
         </>
       )}
 
       {/* maxImages === 1: skeleton */}
       {value.length > 0 && maxImages === 1 && isImagesLoading && (
-        <Skeleton height={200} className="rounded-xl" />
+        <div
+          className="w-full animate-pulse rounded-xl bg-grey-100"
+          style={aspectRatioStyle}
+        />
       )}
 
       {/* ── maxImages > 1: 2-column grid — images + drop zone inline ── */}
@@ -325,14 +335,15 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
             return (
               <div
                 key={imagePath}
-                className="relative overflow-hidden rounded-xl"
+                className="relative w-full overflow-hidden rounded-xl"
+                style={aspectRatioStyle}
               >
                 <ImageDisplay
                   src={resolvedUrl}
                   type="original"
                   width={imageConstraints.width}
                   height={imageConstraints.height}
-                  className="h-[200px] w-full rounded-xl object-cover"
+                  className="size-full rounded-xl object-contain"
                 />
                 <Button
                   type="button"
@@ -348,25 +359,29 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
 
           {/* uploading loader occupies next grid slot */}
           {isUploading && (
-            <ImageLoader
-              name={imageTypeNamer(value.length)}
-              className="h-[200px]"
-            />
+            <div className="w-full" style={aspectRatioStyle}>
+              <ImageLoader
+                name={imageTypeNamer(value.length)}
+                className="size-full"
+              />
+            </div>
           )}
 
           {/* drop zone occupies next grid slot */}
           {canUploadMore && !isUploading && (
-            <ImageDropZone
-              width={imageConstraints.width}
-              height={imageConstraints.height}
-              disabled={disabled || !canUploadMore}
-              uploadImage={uploadImage}
-              imageType={imageTypeNamer(value.length)}
-              error={error}
-              className="h-[200px] !rounded-xl"
-            >
-              {dropZoneChildren}
-            </ImageDropZone>
+            <div className="w-full" style={aspectRatioStyle}>
+              <ImageDropZone
+                width={imageConstraints.width}
+                height={imageConstraints.height}
+                disabled={disabled || !canUploadMore}
+                uploadImage={uploadImage}
+                imageType={imageTypeNamer(value.length)}
+                error={error}
+                className="h-full !rounded-xl"
+              >
+                {dropZoneChildren}
+              </ImageDropZone>
+            </div>
           )}
         </div>
       )}
@@ -375,10 +390,10 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
       {value.length > 0 && maxImages > 1 && isImagesLoading && (
         <div className="grid grid-cols-2 gap-3">
           {value.map((url, index) => (
-            <Skeleton
+            <div
               key={`${url}-${index}`}
-              height={200}
-              className="rounded-xl"
+              className="w-full animate-pulse rounded-xl bg-grey-100"
+              style={aspectRatioStyle}
             />
           ))}
         </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
@@ -1,4 +1,7 @@
 import { Button } from "@/components/Button";
+import { Dialog } from "@/components/Dialog";
+import { DialogOverlay } from "@/components/DialogOverlay";
+import { DialogPanel } from "@/components/DialogPanel";
 import { TrashIcon } from "@/components/Icons/TrashIcon";
 import { ImageDropZone } from "@/components/ImageDropZone";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
@@ -10,6 +13,8 @@ import { ImageValidationError, useImage } from "../../hook/use-image";
 import { extractImagePathWithExtensionFromActualUrl } from "../utils";
 import { ImageDisplay } from "./ImageDisplay";
 import ImageLoader from "./ImageLoader";
+
+const PREVIEW_HEIGHT_PX = 200;
 
 interface ImageConstraints {
   width: number;
@@ -71,6 +76,7 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
   } = props;
 
   const [isUploading, setIsUploading] = useState(false);
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
   const isMountedRef = useRef(true);
   const abortControllerRef = useRef<AbortController | null>(null);
   const isLocalized = locale !== "en";
@@ -190,8 +196,9 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
 
   const canUploadMore = value.length < maxImages;
 
-  const aspectRatioStyle = {
-    aspectRatio: `${imageConstraints.width} / ${imageConstraints.height}`,
+  const previewStyle = {
+    height: `${PREVIEW_HEIGHT_PX}px`,
+    width: `${(PREVIEW_HEIGHT_PX * imageConstraints.width) / imageConstraints.height}px`,
   };
 
   const resolvedImageUrls = useMemo(() => {
@@ -284,16 +291,23 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
             return (
               <div
                 key={imagePath}
-                className="relative w-full overflow-hidden rounded-xl"
-                style={aspectRatioStyle}
+                className="relative overflow-hidden rounded-xl"
+                style={previewStyle}
               >
-                <ImageDisplay
-                  src={resolvedUrl}
-                  type="original"
-                  width={imageConstraints.width}
-                  height={imageConstraints.height}
-                  className="size-full rounded-xl object-contain"
-                />
+                <button
+                  type="button"
+                  onClick={() => setLightboxUrl(resolvedUrl)}
+                  className="block size-full cursor-zoom-in"
+                  aria-label="View full resolution"
+                >
+                  <ImageDisplay
+                    src={resolvedUrl}
+                    type="original"
+                    width={imageConstraints.width}
+                    height={imageConstraints.height}
+                    className="size-full rounded-xl object-contain"
+                  />
+                </button>
                 <Button
                   type="button"
                   onClick={() => handleDelete(imagePath)}
@@ -306,7 +320,7 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
             );
           })}
           {isUploading && (
-            <div className="w-full" style={aspectRatioStyle}>
+            <div style={previewStyle}>
               <ImageLoader
                 name={imageTypeNamer(value.length)}
                 className="size-full"
@@ -319,14 +333,14 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
       {/* maxImages === 1: skeleton */}
       {value.length > 0 && maxImages === 1 && isImagesLoading && (
         <div
-          className="w-full animate-pulse rounded-xl bg-grey-100"
-          style={aspectRatioStyle}
+          className="animate-pulse rounded-xl bg-grey-100"
+          style={previewStyle}
         />
       )}
 
-      {/* ── maxImages > 1: 2-column grid — images + drop zone inline ── */}
+      {/* ── maxImages > 1: thumbnails + drop zone inline ── */}
       {value.length > 0 && maxImages > 1 && !isImagesLoading && (
-        <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-wrap gap-3">
           {value.map((url) => {
             const imagePath = extractImagePathWithExtensionFromActualUrl(url);
             const resolvedUrl =
@@ -335,16 +349,23 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
             return (
               <div
                 key={imagePath}
-                className="relative w-full overflow-hidden rounded-xl"
-                style={aspectRatioStyle}
+                className="relative overflow-hidden rounded-xl"
+                style={previewStyle}
               >
-                <ImageDisplay
-                  src={resolvedUrl}
-                  type="original"
-                  width={imageConstraints.width}
-                  height={imageConstraints.height}
-                  className="size-full rounded-xl object-contain"
-                />
+                <button
+                  type="button"
+                  onClick={() => setLightboxUrl(resolvedUrl)}
+                  className="block size-full cursor-zoom-in"
+                  aria-label="View full resolution"
+                >
+                  <ImageDisplay
+                    src={resolvedUrl}
+                    type="original"
+                    width={imageConstraints.width}
+                    height={imageConstraints.height}
+                    className="size-full rounded-xl object-contain"
+                  />
+                </button>
                 <Button
                   type="button"
                   onClick={() => handleDelete(imagePath)}
@@ -357,9 +378,9 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
             );
           })}
 
-          {/* uploading loader occupies next grid slot */}
+          {/* uploading loader occupies next slot */}
           {isUploading && (
-            <div className="w-full" style={aspectRatioStyle}>
+            <div style={previewStyle}>
               <ImageLoader
                 name={imageTypeNamer(value.length)}
                 className="size-full"
@@ -367,9 +388,9 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
             </div>
           )}
 
-          {/* drop zone occupies next grid slot */}
+          {/* drop zone occupies next slot */}
           {canUploadMore && !isUploading && (
-            <div className="w-full" style={aspectRatioStyle}>
+            <div style={previewStyle}>
               <ImageDropZone
                 width={imageConstraints.width}
                 height={imageConstraints.height}
@@ -388,16 +409,34 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
 
       {/* maxImages > 1: skeleton */}
       {value.length > 0 && maxImages > 1 && isImagesLoading && (
-        <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-wrap gap-3">
           {value.map((url, index) => (
             <div
               key={`${url}-${index}`}
-              className="w-full animate-pulse rounded-xl bg-grey-100"
-              style={aspectRatioStyle}
+              className="animate-pulse rounded-xl bg-grey-100"
+              style={previewStyle}
             />
           ))}
         </div>
       )}
+
+      <Dialog open={!!lightboxUrl} onClose={() => setLightboxUrl(null)}>
+        <DialogOverlay />
+        <DialogPanel
+          showCloseIcon
+          onClose={() => setLightboxUrl(null)}
+          className="md:max-w-[90vw]"
+        >
+          {lightboxUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={lightboxUrl}
+              alt="Full resolution preview"
+              className="max-h-[80vh] max-w-full object-contain"
+            />
+          )}
+        </DialogPanel>
+      </Dialog>
     </div>
   );
 };

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
@@ -1,12 +1,20 @@
 import { Button } from "@/components/Button";
 import { Dialog } from "@/components/Dialog";
 import { DialogOverlay } from "@/components/DialogOverlay";
-import { DialogPanel } from "@/components/DialogPanel";
+import { CloseIcon } from "@/components/Icons/CloseIcon";
 import { TrashIcon } from "@/components/Icons/TrashIcon";
 import { ImageDropZone } from "@/components/ImageDropZone";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { getCDNImageUrl } from "@/lib/utils";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Dialog as HeadlessDialog, Transition } from "@headlessui/react";
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import Skeleton from "react-loading-skeleton";
 import { toast } from "react-toastify";
 import { ImageValidationError, useImage } from "../../hook/use-image";
@@ -422,20 +430,36 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
 
       <Dialog open={!!lightboxUrl} onClose={() => setLightboxUrl(null)}>
         <DialogOverlay />
-        <DialogPanel
-          showCloseIcon
-          onClose={() => setLightboxUrl(null)}
-          className="md:max-w-[90vw]"
+        <Transition.Child
+          enter="transition duration-200 ease"
+          enterFrom="opacity-0 scale-95"
+          enterTo="opacity-100 scale-100"
+          leave="transition duration-150 ease"
+          leaveFrom="opacity-100 scale-100"
+          leaveTo="opacity-0 scale-95"
+          as={Fragment}
         >
-          {lightboxUrl && (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={lightboxUrl}
-              alt="Full resolution preview"
-              className="max-h-[80vh] max-w-full object-contain"
-            />
-          )}
-        </DialogPanel>
+          <div className="fixed inset-0 flex items-center justify-center p-4">
+            <HeadlessDialog.Panel className="relative">
+              {lightboxUrl && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={lightboxUrl}
+                  alt="Full resolution preview"
+                  className="block max-h-[90vh] max-w-[90vw] rounded-2xl object-contain shadow-2xl"
+                />
+              )}
+              <button
+                type="button"
+                onClick={() => setLightboxUrl(null)}
+                className="absolute right-3 top-3 flex size-9 items-center justify-center rounded-full bg-white/95 text-grey-700 shadow-md transition-colors hover:bg-white"
+                aria-label="Close"
+              >
+                <CloseIcon className="size-4" />
+              </button>
+            </HeadlessDialog.Panel>
+          </div>
+        </Transition.Child>
       </Dialog>
     </div>
   );


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Showcase, meta-tag, content-card, and uploaded-image previews on the app configuration page were rendered into a fixed `h-[200px] w-full` box with `object-cover`, which cropped every image whose source aspect ratio didn't match the container's runtime aspect. Containers now derive `aspectRatio` from each field's `imageConstraints` (1080×1080 / 1200×600 / 345×240), and the images use `object-contain` so they're never clipped. Also fixed the Next `Image` width/height on the content-card preview which were incorrectly set to 1200×600 (meta-tag's dimensions) instead of 345×240.

<img width="731" height="367" alt="image" src="https://github.com/user-attachments/assets/e8203508-1bc1-401a-afad-0e9703fb9037" />
<img width="1426" height="919" alt="image" src="https://github.com/user-attachments/assets/587e94ba-f7e7-4ae6-84d0-00e875bf8aa2" />
<img width="695" height="297" alt="image" src="https://github.com/user-attachments/assets/1d959ba1-fbb3-4110-b0da-3aae4c46e3fb" />
<img width="695" height="714" alt="image" src="https://github.com/user-attachments/assets/33fcffce-c24f-403a-ba20-ca41059c43d1" />


## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.