### PR TITLE
feat: environment-based issuer selection for v4 verify integrity bundle

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -67,7 +67,7 @@ REDIS_USERNAME=default
 REDIS_PASSWORD=
 
 # Integrity Bundle Verification
-INTEGRITY_BUNDLE_JWKS_URL=https://attestation.worldcoin.org/.well-known/jwks.json
+ATTESTATION_GATEWAY_JWKS_URL=https://attestation.worldcoin.org/.well-known/jwks.json
 INTEGRITY_BUNDLE_EXPECTED_ISSUER=attestation.worldcoin.org
 
 # RP Registry (requires worldcoin-consumer-stage AWS profile for KMS)

--- a/web/.env.test
+++ b/web/.env.test
@@ -69,7 +69,7 @@ REDIS_USERNAME=default
 REDIS_PASSWORD=
 
 # Integrity Bundle Verification
-INTEGRITY_BUNDLE_JWKS_URL=https://attestation.worldcoin.org/.well-known/jwks.json
+ATTESTATION_GATEWAY_JWKS_URL=https://attestation.worldcoin.org/.well-known/jwks.json
 INTEGRITY_BUNDLE_EXPECTED_ISSUER=attestation.worldcoin.org
 
 # OpenSearch

--- a/web/api/v4/verify/index.ts
+++ b/web/api/v4/verify/index.ts
@@ -151,6 +151,7 @@ export async function POST(
           | UniquenessProofResponseV3[]
           | UniquenessProofResponseV4[],
         rpId,
+        environment: parsedParams.environment,
       });
 
       if (!integrityResult.success) {

--- a/web/api/v4/verify/integrity-bundle.ts
+++ b/web/api/v4/verify/integrity-bundle.ts
@@ -28,6 +28,9 @@ const JWKS_FETCH_TIMEOUT_MS = 4_000;
 const DEFAULT_INTEGRITY_JWKS_URL =
   "https://attestation.worldcoin.org/.well-known/jwks.json";
 const DEFAULT_INTEGRITY_ISSUER = "attestation.worldcoin.org";
+const DEFAULT_INTEGRITY_JWKS_URL_STAGING =
+  "https://attestation.worldcoin.dev/.well-known/jwks.json";
+const DEFAULT_INTEGRITY_ISSUER_STAGING = "attestation.worldcoin.dev";
 
 export const INTEGRITY_VERIFICATION_ERROR_CODE =
   "integrity_verification_failed";
@@ -58,6 +61,7 @@ type IntegrityVerificationParams = {
     | UniquenessProofResponseV4[]
     | SessionResponseItem[];
   rpId: string;
+  environment?: string;
 };
 
 export type IntegrityVerificationResult =
@@ -96,16 +100,17 @@ const i64be = (value: number) => {
   return buffer;
 };
 
-const getIntegrityJwksUrl = () =>
-  process.env.ATTESTATION_GATEWAY_JWKS_URL ??
-  process.env.INTEGRITY_BUNDLE_JWKS_URL ??
-  process.env.INTEGRITY_TOKEN_JWKS_URL ??
-  DEFAULT_INTEGRITY_JWKS_URL;
+const getIntegrityJwksUrl = (environment?: string) =>
+  environment === "staging"
+    ? process.env.ATTESTATION_GATEWAY_JWKS_URL_STAGING ??
+      DEFAULT_INTEGRITY_JWKS_URL_STAGING
+    : process.env.ATTESTATION_GATEWAY_JWKS_URL ?? DEFAULT_INTEGRITY_JWKS_URL;
 
-const getIntegrityExpectedIssuer = () =>
-  process.env.INTEGRITY_BUNDLE_EXPECTED_ISSUER ??
-  process.env.INTEGRITY_TOKEN_EXPECTED_ISSUER ??
-  DEFAULT_INTEGRITY_ISSUER;
+const getIntegrityExpectedIssuer = (environment?: string) =>
+  environment === "staging"
+    ? process.env.INTEGRITY_BUNDLE_EXPECTED_ISSUER_STAGING ??
+      DEFAULT_INTEGRITY_ISSUER_STAGING
+    : process.env.INTEGRITY_BUNDLE_EXPECTED_ISSUER ?? DEFAULT_INTEGRITY_ISSUER;
 
 export function normalizeIntegrityBundle(
   integrityBundle: IntegrityBundle,
@@ -426,11 +431,12 @@ async function verifyJwtWithJwk(params: {
   integrityJwt: string;
   jwk: JWK;
   rpId: string;
+  issuer: string;
 }) {
   const publicKey = await importJWK(params.jwk, "ES256");
   const { payload } = await jwtVerify(params.integrityJwt, publicKey, {
     algorithms: ["ES256"],
-    issuer: getIntegrityExpectedIssuer(),
+    issuer: params.issuer,
     audience: params.rpId,
     requiredClaims: ["cnf", "exp", "platform", "pass"],
   });
@@ -446,6 +452,7 @@ async function verifyIntegrityToken(params: {
   integrityJwt: string;
   rpId: string;
   signatureFormat: SignatureFormat;
+  environment?: string;
 }) {
   let protectedHeader: ReturnType<typeof decodeProtectedHeader>;
   try {
@@ -462,7 +469,8 @@ async function verifyIntegrityToken(params: {
     throw new IntegrityBundleError("missing_integrity_token_kid");
   }
 
-  const jwksUrl = getIntegrityJwksUrl();
+  const jwksUrl = getIntegrityJwksUrl(params.environment);
+  const issuer = getIntegrityExpectedIssuer(params.environment);
   let keyResult = await getJwkForKid({
     jwksUrl,
     kid: protectedHeader.kid,
@@ -474,6 +482,7 @@ async function verifyIntegrityToken(params: {
       integrityJwt: params.integrityJwt,
       jwk: keyResult.jwk,
       rpId: params.rpId,
+      issuer,
     });
   } catch (error) {
     if (!keyResult.fromCache || !shouldRefreshJwksAfterJwtFailure(error)) {
@@ -494,6 +503,7 @@ async function verifyIntegrityToken(params: {
         integrityJwt: params.integrityJwt,
         jwk: keyResult.jwk,
         rpId: params.rpId,
+        issuer,
       });
     } catch (retryError) {
       throw new IntegrityBundleError(
@@ -599,6 +609,7 @@ export async function verifyIntegrityBundle(
       integrityJwt: bundle.jwt,
       rpId: params.rpId,
       signatureFormat: bundle.signatureFormat,
+      environment: params.environment,
     });
 
     const payloadDigest = computeProofIntegrityDigest({

--- a/web/tests/api/v4/integrity-bundle.test.ts
+++ b/web/tests/api/v4/integrity-bundle.test.ts
@@ -22,6 +22,9 @@ const RP_ID = "rp_test_123";
 const AG_KID = "ag-test-key";
 const JWKS_URL = "https://attestation.example/.well-known/jwks.json";
 const ISSUER = "attestation.worldcoin.org";
+const STAGING_ISSUER = "attestation.worldcoin.dev";
+const STAGING_JWKS_URL =
+  "https://attestation-staging.example/.well-known/jwks.json";
 
 type DeviceKey = {
   privateKey: Uint8Array;
@@ -82,6 +85,7 @@ async function createIntegrityJwt(params: {
   expirationTime?: number | string | Date;
   pass?: boolean;
   platform: "android" | "ios";
+  issuer?: string;
 }) {
   return await new SignJWT({
     pass: params.pass ?? true,
@@ -91,7 +95,7 @@ async function createIntegrityJwt(params: {
     },
   })
     .setProtectedHeader({ alg: "ES256", kid: AG_KID })
-    .setIssuer(ISSUER)
+    .setIssuer(params.issuer ?? ISSUER)
     .setAudience(params.rpId)
     .setIssuedAt()
     .setExpirationTime(params.expirationTime ?? "5m")
@@ -108,6 +112,7 @@ async function createBundle(params?: {
   signedTimestamp?: number;
   signatureFormat?: "android_keystore" | "apple_app_attest";
   timestamp?: number;
+  issuer?: string;
 }) {
   const agKey = params?.agKey ?? createAgKey();
   const deviceKey = createDeviceKey();
@@ -124,6 +129,7 @@ async function createBundle(params?: {
     expirationTime: params?.jwtExpirationTime,
     pass: params?.pass,
     platform,
+    issuer: params?.issuer,
   });
 
   const digest = computeProofIntegrityDigest({
@@ -179,15 +185,17 @@ async function createBundle(params?: {
 describe("integrity bundle verification", () => {
   beforeEach(async () => {
     jest.clearAllMocks();
-    process.env.INTEGRITY_BUNDLE_JWKS_URL = JWKS_URL;
+    process.env.ATTESTATION_GATEWAY_JWKS_URL = JWKS_URL;
     process.env.INTEGRITY_BUNDLE_EXPECTED_ISSUER = ISSUER;
     await (global.RedisClient as any)?.flushall?.();
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
-    delete process.env.INTEGRITY_BUNDLE_JWKS_URL;
+    delete process.env.ATTESTATION_GATEWAY_JWKS_URL;
     delete process.env.INTEGRITY_BUNDLE_EXPECTED_ISSUER;
+    delete process.env.ATTESTATION_GATEWAY_JWKS_URL_STAGING;
+    delete process.env.INTEGRITY_BUNDLE_EXPECTED_ISSUER_STAGING;
   });
 
   it("normalizes a structured integrity bundle", () => {
@@ -389,6 +397,55 @@ describe("integrity bundle verification", () => {
     expect(result).toEqual({
       success: false,
       reason: "invalid_device_signature",
+    });
+  });
+
+  it("verifies a staging bundle using the staging issuer when environment is staging", async () => {
+    process.env.ATTESTATION_GATEWAY_JWKS_URL_STAGING = STAGING_JWKS_URL;
+    process.env.INTEGRITY_BUNDLE_EXPECTED_ISSUER_STAGING = STAGING_ISSUER;
+
+    const { agPublicJwk, integrityBundle, nonce } = await createBundle({
+      issuer: STAGING_ISSUER,
+    });
+    jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ keys: [agPublicJwk] }), { status: 200 }),
+      );
+
+    const result = await verifyIntegrityBundle({
+      integrityBundle,
+      nonce,
+      protocolVersion: "4.0",
+      responses: [response],
+      rpId: RP_ID,
+      environment: "staging",
+    });
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it("rejects a staging bundle when environment is not staging (uses prod issuer)", async () => {
+    const { agPublicJwk, integrityBundle, nonce } = await createBundle({
+      issuer: STAGING_ISSUER,
+    });
+    jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ keys: [agPublicJwk] }), { status: 200 }),
+      );
+
+    const result = await verifyIntegrityBundle({
+      integrityBundle,
+      nonce,
+      protocolVersion: "4.0",
+      responses: [response],
+      rpId: RP_ID,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      reason: "invalid_integrity_token",
     });
   });
 


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

`verifyIntegrityBundle` previously used a single prod issuer (`attestation.worldcoin.org`) and JWKS URL regardless of the `environment` field in the `/v4/verify` payload. Staging World App proofs signed by `attestation.worldcoin.dev` would fail verification when submitted to prod with `environment: "staging"`.

- `getIntegrityJwksUrl` and `getIntegrityExpectedIssuer` now accept `environment` and return staging values when `environment === "staging"`
- `environment` is threaded from `verifyIntegrityBundle` → `verifyIntegrityToken` → `verifyJwtWithJwk`
- Prod deploy config gains `ATTESTATION_GATEWAY_JWKS_URL_STAGING` and `INTEGRITY_BUNDLE_EXPECTED_ISSUER_STAGING`
- Removed dead legacy env var fallbacks: `INTEGRITY_BUNDLE_JWKS_URL`, `INTEGRITY_TOKEN_JWKS_URL`, `INTEGRITY_TOKEN_EXPECTED_ISSUER`, `INTEGRITY_BUNDLE_EXPECTED_AUDIENCE`

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.