### PR TITLE
fix: parse opaque session ids for verification

### DIFF
--- a/web/api/v4/verify/session-proof/verify-util.ts
+++ b/web/api/v4/verify/session-proof/verify-util.ts
@@ -1,6 +1,7 @@
 import { logger } from "../../../../lib/logger";
 import { verifySessionProofOnChain } from "../../../helpers/temporal-rpc";
 import { SessionProofRequest } from "../request-schema";
+import { getSessionCommitment } from "@worldcoin/idkit-server";
 
 export interface SessionResult {
   identifier: string;
@@ -9,6 +10,14 @@ export interface SessionResult {
   nullifier?: string;
   code?: string;
   detail?: string;
+}
+
+export function getVerifierSessionId(sessionId: string): bigint {
+  if (sessionId.startsWith("session_")) {
+    return getSessionCommitment(sessionId);
+  }
+
+  return BigInt(sessionId);
 }
 
 export async function processSessionProof(
@@ -29,7 +38,7 @@ export async function processSessionProof(
             credentialGenesisIssuedAtMin: BigInt(
               item.credential_genesis_issued_at_min || "0",
             ),
-            sessionId: BigInt(sessionProofRequest.session_id),
+            sessionId: getVerifierSessionId(sessionProofRequest.session_id),
             sessionNullifier: [
               BigInt(item.session_nullifier[0]),
               BigInt(item.session_nullifier[1]),

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "@sendgrid/mail": "^8.1.3",
     "@worldcoin/idkit": "^4.0.9",
+    "@worldcoin/idkit-server": "^1.1.1",
     "auth0": "^4.10.0",
     "aws-sigv4-fetch": "^4.0.1",
     "cbor-x": "1.6.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@worldcoin/idkit':
         specifier: ^4.0.9
         version: 4.0.9(react-dom@18.2.0(react@18.3.1))(react@18.3.1)
+      '@worldcoin/idkit-server':
+        specifier: ^1.1.1
+        version: 1.1.1
       auth0:
         specifier: ^4.10.0
         version: 4.10.0
@@ -2875,6 +2878,10 @@ packages:
 
   '@worldcoin/idkit-server@1.0.0':
     resolution: {integrity: sha512-ZCyXJFexxLjPtG7lxTntf6oiwF0pzoUIsVFIAAgFyXav5KmUnVlrvVoeGrgpiDFRznH2B4/Iv5xv+SkEHxOdXQ==}
+    engines: {node: '>=18'}
+
+  '@worldcoin/idkit-server@1.1.1':
+    resolution: {integrity: sha512-iO4Kd3QBLzJak3BPz5eIzRjW0kT8Px5c3LbNzvCKMnczLvVSKoWqdvGiJlkK8Dp29KstNI62iv4ak0z8nzui/Q==}
     engines: {node: '>=18'}
 
   '@worldcoin/idkit@4.0.9':
@@ -10808,6 +10815,11 @@ snapshots:
       '@worldcoin/idkit-server': 1.0.0
 
   '@worldcoin/idkit-server@1.0.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@noble/secp256k1': 2.3.0
+
+  '@worldcoin/idkit-server@1.1.1':
     dependencies:
       '@noble/hashes': 1.8.0
       '@noble/secp256k1': 2.3.0

--- a/web/tests/api/v4/session-proof.test.ts
+++ b/web/tests/api/v4/session-proof.test.ts
@@ -1,0 +1,25 @@
+jest.mock("@worldcoin/idkit-server", () => ({
+  getSessionCommitment: (sessionId: string) => {
+    if (!/^session_[0-9a-fA-F]{128}$/.test(sessionId)) {
+      throw new Error("Invalid session ID");
+    }
+
+    return BigInt(`0x${sessionId.slice(8, 72)}`);
+  },
+}));
+
+import { getVerifierSessionId } from "@/api/v4/verify/session-proof/verify-util";
+
+describe("v4 session proof verification", () => {
+  it("extracts the verifier commitment from opaque SDK session ids", () => {
+    const commitment = "0".repeat(63) + "1";
+    const oprfSeed = "ab".repeat(32);
+
+    expect(getVerifierSessionId(`session_${commitment}${oprfSeed}`)).toBe(1n);
+  });
+
+  it("preserves existing numeric session id inputs", () => {
+    expect(getVerifierSessionId("123")).toBe(123n);
+    expect(getVerifierSessionId("0x7b")).toBe(123n);
+  });
+});


### PR DESCRIPTION
This PR added parsing for `session_id` that we didn't had before, this is not a breaking change as sessions haven't released yet.