### PR TITLE
fix: allow max_verifications=0 for unlimited verifications

### DIFF
--- a/web/api/v2/create-action/index.ts
+++ b/web/api/v2/create-action/index.ts
@@ -23,7 +23,7 @@ const createActionBodySchema = yup
     max_verifications: yup
       .number()
       .integer()
-      .min(1)
+      .min(0)
       .max(2147483647)
       .optional()
       .default(1),

--- a/web/tests/api/v2/create-action.test.ts
+++ b/web/tests/api/v2/create-action.test.ts
@@ -115,6 +115,35 @@ describe("/api/v2/create-action [success cases]", () => {
     });
   });
 
+  it("accepts max_verifications=0 for unlimited verifications", async () => {
+    const mockReq = createMockRequest({
+      url: getUrl(validAppId),
+      api_key: validApiKey,
+      body: { ...validBody, max_verifications: 0 },
+    });
+
+    const ctx = { params: { app_id: validAppId } };
+    VerifyFetchAPIKey.mockResolvedValue(validApiKeyResponse);
+
+    const actionResult = {
+      id: "action_123",
+      action: validBody.action,
+      name: validBody.name,
+      description: validBody.description,
+      max_verifications: 0,
+    };
+
+    CreateDynamicAction.mockResolvedValue({
+      insert_action_one: actionResult,
+    });
+
+    const res = await POST(mockReq, ctx);
+    expect(res.status).toBe(200);
+    expect(CreateDynamicAction).toHaveBeenCalledWith(
+      expect.objectContaining({ max_verifications: 0 }),
+    );
+  });
+
   it("can create a new action with full set of body params", async () => {
     const mockReq = createMockRequest({
       url: getUrl(validAppId),


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

The `POST /api/v2/create-action` endpoint enforced `min(1)` on `max_verifications`, but the DB trigger (`check_nullifier_uses_limit`) treats `0` as unlimited. The `min(1)` was added incidentally in #1550 alongside the `.integer()` fix for float inputs — there was no business rationale for it, and it left API consumers with no way to request an unlimited action without going through the portal UI. Relaxing the lower bound to `0` so the API matches DB semantics; negative values are still rejected.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.