### PR TITLE
fix: bump dd-trace to 5.84.0 to silence middleware bubble-error noise

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -27,7 +27,15 @@ RUN npm install -g corepack@0.31.0 && corepack --version
 # ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING). Pin to the same version declared in
 # the project's packageManager field.
 # TODO: Can be further optimized to remove next peer dependency
-RUN corepack enable pnpm && corepack prepare pnpm@9.15.4 --activate && pnpm i next-logger@5.0.0 pino@9.2.0 dd-trace@5.12.0
+# dd-trace must be >=5.27.0 so its Next.js instrumentation detects
+# middlewareInvoke via the request meta symbol introduced in Next.js 14.2.7
+# (DataDog/dd-trace-js#4916). Earlier versions only checked the legacy
+# `x-middleware-invoke` header, so the internal bubble Error thrown by
+# `handleCatchallMiddlewareRequest` (next-server.js) was captured as a span
+# error on every middleware-matched request, generating tens of thousands of
+# noisy "untyped Error" events in Datadog Error Tracking despite HTTP 200
+# responses. Keep this in sync with the `dd-trace` version in package.json.
+RUN corepack enable pnpm && corepack prepare pnpm@9.15.4 --activate && pnpm i next-logger@5.0.0 pino@9.2.0 dd-trace@5.84.0
 
 # Rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
## Summary

- Bumps `dd-trace` from `5.12.0` to `5.84.0` in the `server_deps` stage of `web/Dockerfile` to align with `package.json`.
- Closes the dominant source of error-tracking noise in the developer-portal: ~44k untyped "Error" events per week from [Datadog issue `32ea19aa`](https://app.datadoghq.com/error-tracking/issue/32ea19aa-d8c8-11ef-89f6-da7ad0900002), despite the underlying HTTP responses being 200.

## Why

The Dockerfile pinned `dd-trace@5.12.0` while `package.json` declared `5.84.0`. The Dockerfile install wins in the production image.

`dd-trace` before `5.27.0` detects Next.js middleware invocations via the legacy `x-middleware-invoke` header. Next.js `14.2.7+` replaced that with an internal request-meta symbol, so the old tracer no longer recognises middleware and treats the internal "bubble Error" thrown by `handleCatchallMiddlewareRequest` (`next-server.js`) as a real span error.

Upstream fix: [DataDog/dd-trace-js#4916](https://github.com/DataDog/dd-trace-js/pull/4916), shipped in `v5.27.0`. We jump straight to `5.84.0` to match `package.json`.

## Test plan

- [ ] Build the production image and confirm it starts without dd-trace init errors
- [ ] Deploy to staging
- [ ] Watch [Datadog issue `32ea19aa`](https://app.datadoghq.com/error-tracking/issue/32ea19aa-d8c8-11ef-89f6-da7ad0900002) — expect firing rate to collapse from ~44k/wk to near zero
- [ ] Confirm middleware spans still get traced (search APM for `service:developer-portal operation_name:next.middleware`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)