### PR TITLE
fix: reload on stale Server Action errors via global-error boundary

### DIFF
--- a/web/app/global-error.tsx
+++ b/web/app/global-error.tsx
@@ -47,20 +47,28 @@ const shouldAutoReload = () => {
     }
     return Date.now() - lastAt > RELOAD_COOLDOWN_MS;
   } catch {
-    // sessionStorage can throw in private modes / disabled storage. If we
-    // can't read it we err on the side of reloading once.
-    return true;
+    // sessionStorage is unavailable (private mode / disabled storage).
+    // Without a persisted marker we can't enforce the cooldown across
+    // the reload, so a recurring stale-action error would trigger a
+    // reload on every render. Refuse to auto-reload — the manual
+    // fallback UI handles it.
+    return false;
   }
 };
 
-const markReload = () => {
+// Persist the reload marker. Returns true only if the write succeeded;
+// callers MUST NOT trigger window.location.reload() unless this returns
+// true, otherwise a recurring error after the reload becomes a tight
+// loop with no enforceable cooldown.
+const markReload = (): boolean => {
   if (typeof window === "undefined") {
-    return;
+    return false;
   }
   try {
     window.sessionStorage.setItem(RELOAD_KEY, Date.now().toString());
+    return true;
   } catch {
-    // ignore — best effort
+    return false;
   }
 };
 
@@ -78,7 +86,12 @@ export default function GlobalError({
     if (!willReload) {
       return;
     }
-    markReload();
+    if (!markReload()) {
+      // Cooldown marker couldn't be persisted; reloading without it
+      // risks a tight loop if the error recurs. Skip the reload and
+      // let the user retry manually via the fallback UI.
+      return;
+    }
     window.location.reload();
   }, [willReload]);
 

--- a/web/app/global-error.tsx
+++ b/web/app/global-error.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Window (ms) within which we will not auto-reload again after we just did.
+// Guards against tight reload loops if the stale-bundle issue somehow persists
+// after a reload (e.g. CDN caching).
+const RELOAD_COOLDOWN_MS = 30_000;
+const RELOAD_KEY = "sa_reload_at";
+
+// Match the Next.js stale-Server-Action error class. After a deploy the
+// client bundle still references an action id the server no longer knows
+// about, which surfaces as one of these messages:
+//
+//   - "Failed to find Server Action ..."
+//   - "Cannot read properties of undefined (reading 'workers')"
+//     (thrown inside next/dist/server/app-render after the action lookup
+//     fails)
+//   - "Failed to parse body as FormData"
+//     (undici can't decode the action request body after the boundary
+//     mismatch)
+//
+// See: https://nextjs.org/docs/messages/failed-to-find-server-action
+const isStaleServerActionError = (error: Error & { digest?: string }) => {
+  const message = error?.message ?? "";
+  return (
+    message.includes("Failed to find Server Action") ||
+    message.includes(
+      "Cannot read properties of undefined (reading 'workers')",
+    ) ||
+    message.includes("Failed to parse body as FormData")
+  );
+};
+
+const shouldAutoReload = () => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    const last = window.sessionStorage.getItem(RELOAD_KEY);
+    if (!last) {
+      return true;
+    }
+    const lastAt = Number.parseInt(last, 10);
+    if (!Number.isFinite(lastAt)) {
+      return true;
+    }
+    return Date.now() - lastAt > RELOAD_COOLDOWN_MS;
+  } catch {
+    // sessionStorage can throw in private modes / disabled storage. If we
+    // can't read it we err on the side of reloading once.
+    return true;
+  }
+};
+
+const markReload = () => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    window.sessionStorage.setItem(RELOAD_KEY, Date.now().toString());
+  } catch {
+    // ignore — best effort
+  }
+};
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const staleAction = isStaleServerActionError(error);
+  const willReload = staleAction && shouldAutoReload();
+
+  useEffect(() => {
+    if (!willReload) {
+      return;
+    }
+    markReload();
+    window.location.reload();
+  }, [willReload]);
+
+  return (
+    <html lang="en">
+      <body>
+        {willReload ? (
+          <div
+            role="status"
+            aria-live="polite"
+            style={{
+              display: "flex",
+              minHeight: "100vh",
+              alignItems: "center",
+              justifyContent: "center",
+              fontFamily:
+                "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+              color: "#0c0e10",
+            }}
+          >
+            Reloading…
+          </div>
+        ) : (
+          <div
+            style={{
+              display: "flex",
+              minHeight: "100vh",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "16px",
+              padding: "24px",
+              fontFamily:
+                "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+              color: "#0c0e10",
+              textAlign: "center",
+            }}
+          >
+            <h1 style={{ fontSize: "20px", fontWeight: 600 }}>
+              Something went wrong
+            </h1>
+            <p style={{ color: "#657080", maxWidth: "420px" }}>
+              An unexpected error occurred. Please try again.
+            </p>
+            <button
+              type="button"
+              onClick={() => reset()}
+              style={{
+                padding: "8px 16px",
+                borderRadius: "8px",
+                border: "1px solid #d6d9dd",
+                background: "#ffffff",
+                color: "#0c0e10",
+                cursor: "pointer",
+              }}
+            >
+              Try again
+            </button>
+          </div>
+        )}
+      </body>
+    </html>
+  );
+}

--- a/web/app/global-error.tsx
+++ b/web/app/global-error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 // Window (ms) within which we will not auto-reload again after we just did.
 // Guards against tight reload loops if the stale-bundle issue somehow persists
@@ -37,21 +37,32 @@ const shouldAutoReload = () => {
     return false;
   }
   try {
-    const last = window.sessionStorage.getItem(RELOAD_KEY);
-    if (!last) {
-      return true;
+    const storage = window.sessionStorage;
+    const last = storage.getItem(RELOAD_KEY);
+    if (last) {
+      const lastAt = Number.parseInt(last, 10);
+      if (
+        Number.isFinite(lastAt) &&
+        Date.now() - lastAt <= RELOAD_COOLDOWN_MS
+      ) {
+        return false;
+      }
     }
-    const lastAt = Number.parseInt(last, 10);
-    if (!Number.isFinite(lastAt)) {
-      return true;
-    }
-    return Date.now() - lastAt > RELOAD_COOLDOWN_MS;
+    // Probe write capability separately from the real marker so the
+    // commit doesn't happen during render (which would race with React
+    // StrictMode's double render and trip the cooldown on the second
+    // pass). If storage is read-only (Safari Lockdown, quota
+    // exhausted, restricted iframe), the probe throws and we refuse
+    // the auto-reload — the manual fallback UI handles it.
+    const probeKey = "__sa_probe__";
+    storage.setItem(probeKey, "1");
+    storage.removeItem(probeKey);
+    return true;
   } catch {
-    // sessionStorage is unavailable (private mode / disabled storage).
-    // Without a persisted marker we can't enforce the cooldown across
-    // the reload, so a recurring stale-action error would trigger a
-    // reload on every render. Refuse to auto-reload — the manual
-    // fallback UI handles it.
+    // Storage unavailable for either read or write. Without a
+    // persisted marker we can't enforce the cooldown across the
+    // reload, so a recurring stale-action error would re-fire on
+    // every render. Refuse to auto-reload.
     return false;
   }
 };
@@ -79,17 +90,21 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  // `bailed` flips us off the reload path if markReload fails between
+  // the probe in shouldAutoReload and the real write here (e.g. a
+  // microsecond race where storage filled up). Without it, the
+  // "Reloading…" UI would be rendered but never actually reload,
+  // stranding the user on the status text.
+  const [bailed, setBailed] = useState(false);
   const staleAction = isStaleServerActionError(error);
-  const willReload = staleAction && shouldAutoReload();
+  const willReload = staleAction && !bailed && shouldAutoReload();
 
   useEffect(() => {
     if (!willReload) {
       return;
     }
     if (!markReload()) {
-      // Cooldown marker couldn't be persisted; reloading without it
-      // risks a tight loop if the error recurs. Skip the reload and
-      // let the user retry manually via the fallback UI.
+      setBailed(true);
       return;
     }
     window.location.reload();


### PR DESCRIPTION
## Summary

- Adds `web/app/global-error.tsx`. The app previously had no client-side error boundary at any level.
- Detects the three known stale-bundle error variants and triggers a one-time `window.location.reload()` so clients holding an older bundle recover transparently after a deploy.
- Guards against reload loops with a 30s `sessionStorage` cooldown.

## Why

After a deploy, clients with an older JS bundle call Server Action IDs the new server no longer recognises and Next.js throws:

- `Failed to find Server Action ...` — ~3,009/wk ([`07359352`](https://app.datadoghq.com/error-tracking/issue/07359352-1acb-11f1-b6aa-da7ad0900002))
- `Failed to find Server Action ... Cannot read properties of undefined (reading 'workers')` — ~951/wk ([`ee11556a`](https://app.datadoghq.com/error-tracking/issue/ee11556a-2bb8-11f1-bf12-da7ad0900002))
- `TypeError: Failed to parse body as FormData.` — ~455/wk ([`355d359a`](https://app.datadoghq.com/error-tracking/issue/355d359a-d8ab-11ef-910b-da7ad0900002))

All three flow through the same Next.js Server Action body-parsing path. Documented behavior: https://nextjs.org/docs/messages/failed-to-find-server-action.

## Behavior

- Matches on `error.message?.includes(...)` for all three variants.
- On match: shows minimal "Reloading…" UI and calls `window.location.reload()` inside `useEffect`.
- On non-match: neutral fallback with a "Try again" button wired to Next's `reset()` — strict improvement over no boundary.
- `sessionStorage` key `sa_reload_at` stores last-reload timestamp; if a stale-action error fires again within 30s, we skip the auto-reload and show the manual fallback. Private-mode safe via `try/catch`.

## Test plan

- [ ] Locally trigger a Server Action ID change between builds and verify a stale client reloads exactly once
- [ ] Force the cooldown: throw the matching error twice within 30s, confirm the second occurrence shows the manual fallback (no infinite reload)
- [ ] Verify unrelated runtime errors still render the neutral fallback (and that "Try again" calls `reset()`)
- [ ] After merge, monitor the three Datadog issues and expect a drop in combined firing rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)