### PR TITLE
chore: log unauthorized app access at warn level

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/server/getAccumulativeTransactionData.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/server/getAccumulativeTransactionData.ts
@@ -94,7 +94,7 @@ export const getAccumulativePaymentsData = async (
         message: "User is not authorized to view this app's data",
         app_id: appId,
         team_id: teamId,
-        logLevel: "error",
+        logLevel: "warn",
       });
     }
 
@@ -217,7 +217,7 @@ export const getAccumulativeTransactionsData = async (
         message: "User is not authorized to view this app's data",
         app_id: appId,
         team_id: teamId,
-        logLevel: "error",
+        logLevel: "warn",
       });
     }
 


### PR DESCRIPTION
## Summary

- Downgrades `logLevel: \"error\"` to `\"warn\"` for the two `errorFormAction` calls that fire when a user navigates to a transaction page for an app they don't own.
- Closes ~66/wk Datadog noise from issue [`be8c106c`](https://app.datadoghq.com/error-tracking/issue/be8c106c-49c4-11f1-966c-da7ad0900002).

## Why

The team-membership checks in `getAccumulativePaymentsData` and `getAccumulativeTransactionsData` (file `web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/server/getAccumulativeTransactionData.ts`) were added in #1860 as a CVE-grade fix — before that, any authenticated user could query payment data for any `appId`.

The rejections themselves are legitimate (users following stale links, support staff without team membership, crawlers hitting authenticated routes). They are not errors that warrant pages or investigation — they are the authz check doing its job. Logging them at `warn` preserves the audit trail without polluting error tracking.

The other `logLevel: \"error\"` calls in the same file (missing `NEXT_SERVER_INTERNAL_PAYMENTS_ENDPOINT` env var, generic fetch failure) are unchanged — those are real errors.

## Test plan

- [ ] After merge, watch Datadog issue [`be8c106c`](https://app.datadoghq.com/error-tracking/issue/be8c106c-49c4-11f1-966c-da7ad0900002) — expect firing rate to fall to zero (the entries will reappear as `warn`-level logs)
- [ ] Confirm `warn`-level logs are still emitted by checking Datadog Logs for the message "User is not authorized to view this app's data"
- [ ] Confirm the user-facing behavior is unchanged (still returns a `FormActionResult` rejection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)