### PR TITLE
fix: validate Content-Type before parsing v1/graphql request body

### DIFF
--- a/web/api/v1/graphql/index.ts
+++ b/web/api/v1/graphql/index.ts
@@ -17,8 +17,10 @@ export async function POST(req: NextRequest) {
 
   // Reject non-JSON request bodies up front so a form-encoded or otherwise
   // malformed payload does not surface as an unhandled SyntaxError from
-  // `req.json()`.
-  const contentType = req.headers.get("content-type");
+  // `req.json()`. Media-type tokens are case-insensitive per RFC 9110, so
+  // normalise before matching to keep mixed-case clients working
+  // (e.g. `Application/JSON; charset=UTF-8`).
+  const contentType = req.headers.get("content-type")?.toLowerCase();
   if (!contentType?.includes("application/json")) {
     return errorValidation(
       "invalid_content_type",

--- a/web/api/v1/graphql/index.ts
+++ b/web/api/v1/graphql/index.ts
@@ -1,4 +1,4 @@
-import { errorUnauthenticated } from "@/api/helpers/errors";
+import { errorUnauthenticated, errorValidation } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { generateAPIKeyJWT, generateUserJWT } from "@/api/helpers/jwts";
 import { parseRequestBody } from "@/api/helpers/parse-request-body";
@@ -12,6 +12,19 @@ export async function POST(req: NextRequest) {
   if (!process.env.NEXT_PUBLIC_GRAPHQL_API_URL) {
     throw new Error(
       "Improperly configured. `NEXT_PUBLIC_GRAPHQL_API_URL` env var must be set.",
+    );
+  }
+
+  // Reject non-JSON request bodies up front so a form-encoded or otherwise
+  // malformed payload does not surface as an unhandled SyntaxError from
+  // `req.json()`.
+  const contentType = req.headers.get("content-type");
+  if (!contentType?.includes("application/json")) {
+    return errorValidation(
+      "invalid_content_type",
+      "Content-Type must be application/json.",
+      "content-type",
+      req,
     );
   }
 


### PR DESCRIPTION
## Summary

- Returns a 400 (`code: \"invalid_content_type\"`) on `POST /api/v1/graphql` when the request `Content-Type` is not `application/json`, instead of letting `req.json()` throw a `SyntaxError`.
- Closes ~30/wk Datadog noise from regression [`8591155c`](https://app.datadoghq.com/error-tracking/issue/8591155c-dcbd-11ef-aa6e-da7ad0900002).

## Why

The route called `req.json()` unconditionally at the very top of the handler. Form-encoded bot traffic (bodies like `returnTo=/...`, `debug=brow...`) surfaced as unhandled `SyntaxError`s in production. The previous mitigation (`parseRequestBody` helper introduced in `113216d0`) sits further down the call path and didn't cover this entry point.

The legitimate GraphQL flow (POST with `Content-Type: application/json` carrying `query`/`variables`/`operationName`) is unaffected — `parseRequestBody` still runs. `.includes(\"application/json\")` accepts suffixes like `; charset=utf-8`.

## Test plan

- [ ] `curl -X POST -d 'returnTo=/' https://dev-developer.worldcoin.org/api/v1/graphql` → expect 400 with `code: \"invalid_content_type\"`
- [ ] `curl -X POST -H 'Content-Type: application/json' -d '{\"query\":\"{__typename}\"}' …/api/v1/graphql` → expect normal GraphQL response
- [ ] After merge, watch Datadog issue [`8591155c`](https://app.datadoghq.com/error-tracking/issue/8591155c-dcbd-11ef-aa6e-da7ad0900002) — expect firing rate to fall to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)