### PR TITLE
fix: stop PostHog flush failures from polluting service error rate

### DIFF
--- a/web/services/posthogClient.ts
+++ b/web/services/posthogClient.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger";
 import { PostHog } from "posthog-node";
 
 interface CaptureEventParams {
@@ -21,21 +22,48 @@ function initializePostHog(): PostHog | null {
 // Initialize PostHog only if it hasn't been initialized yet
 let posthogClient: PostHog | null = null;
 
+/**
+ * Send a PostHog event from server code.
+ *
+ * Telemetry is best-effort: PostHog upstream failures (TLS resets, socket
+ * hang-ups against app.posthog.com, etc.) must never propagate into the
+ * caller's response path or count toward the developer-portal's error rate.
+ * We catch and log at `warn`, then resolve.
+ */
 export async function captureEvent({
   event,
   distinctId,
   properties,
 }: CaptureEventParams): Promise<void> {
-  if (!posthogClient) {
-    posthogClient = initializePostHog();
-  }
-  if (posthogClient) {
+  try {
+    if (!posthogClient) {
+      posthogClient = initializePostHog();
+    }
+    if (!posthogClient) {
+      return;
+    }
     posthogClient.capture({
       distinctId,
       event,
       properties: { ...properties, $geoip_disable: true },
     });
-    posthogClient.flush();
+    // flush() returns a Promise in posthog-node v4; without an attached
+    // handler an upstream socket error becomes an unhandled rejection that
+    // dd-trace's http instrumentation reports as a service error.
+    const flushed = posthogClient.flush();
+    if (flushed && typeof flushed.catch === "function") {
+      flushed.catch((error) => {
+        logger.warn("PostHog flush failed", {
+          event,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }
+  } catch (error) {
+    logger.warn("PostHog captureEvent failed", {
+      event,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

- Wraps `captureEvent` in `try/catch` and attaches a `.catch()` to the `posthog-node` `flush()` promise so telemetry transport failures log at `warn` instead of becoming Datadog span errors.
- Targets the dominant share of \"socket hang up\" / \"fetch failed\" noise routed at `app.posthog.com:443/decide` (208/wk in issue [`2b66a2fc`](https://app.datadoghq.com/error-tracking/issue/2b66a2fc-dda5-11ef-b97e-da7ad0900002), 35/wk in issue [`71f93256`](https://app.datadoghq.com/error-tracking/issue/71f93256-d8d3-11ef-a029-da7ad0900002)).

## Why

`posthog-node` v4's `flush()` returns a promise. Without an attached handler, an upstream socket reset becomes an unhandled rejection that `dd-trace`'s HTTP instrumentation reports as a service-level error. Telemetry is best-effort and PostHog upstream flakiness shouldn't count against the developer-portal's error rate. Triage write-up: `.context/outbound-http-triage.md`.

Behavior:
- Successful events still go through unchanged.
- Failures (init returns null, capture throws, flush rejects) log a `warn` with the event name and resolve. The caller's response path is never affected.

Out of scope (flagged as follow-ups in the write-up):
- Adding retry-on-transport-error to the shared `graphql-request` `GraphQLClient` (the 35/wk `fetch failed` against Hasura)
- Investigating the ECS task IAM-role credential endpoint regression at `169.254.170.2` (63/wk regressed twin)

## Test plan

- [ ] Locally throw from `captureEvent` (mock `posthog.capture` to reject) and confirm the caller's response is unaffected
- [ ] Confirm a normal capture still flushes (check PostHog ingest for the event)
- [ ] After merge, watch Datadog issue [`2b66a2fc`](https://app.datadoghq.com/error-tracking/issue/2b66a2fc-dda5-11ef-b97e-da7ad0900002) for the firing rate to drop significantly (PostHog component will fall to zero; Hasura/ECS components remain until separate PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)