### PR TITLE
fix: honour options.all in pinned image-fetcher DNS lookup

### DIFF
--- a/web/api/helpers/app-image-storage.ts
+++ b/web/api/helpers/app-image-storage.ts
@@ -390,11 +390,25 @@ const httpsRequestPinned = ({
     port: url.port ? Number(url.port) : 443,
     path: `${url.pathname}${url.search}`,
     headers: { Host: url.host, "User-Agent": "world-developer-portal-mcp" },
-    lookup: (_hostname, _options, callback) => {
+    lookup: (_hostname, lookupOptions, callback) => {
       // Ignore the hostname argument — we always return the pinned IP.
-      // Cast trick: dns.lookup callback takes either (err, addresses)
-      // or (err, address, family) depending on options.all. The
-      // https.request connect path uses the single-result form.
+      // dns.lookup's callback contract differs by options.all:
+      //   - options.all === true → (err, addresses[]) where each
+      //     entry is { address, family }
+      //   - otherwise            → (err, address, family)
+      // Node's lookupAndConnectMultiple (used by the default
+      // autoSelectFamily connect path on Node 18+) calls lookup with
+      // { all: true } and treats a string address as an object,
+      // triggering `Invalid IP address: undefined`. Honour both shapes.
+      if (lookupOptions && (lookupOptions as { all?: boolean }).all === true) {
+        (
+          callback as (
+            err: NodeJS.ErrnoException | null,
+            addresses: Array<{ address: string; family: number }>,
+          ) => void
+        )(null, [{ address: pinnedAddress, family: pinnedFamily }]);
+        return;
+      }
       (
         callback as (
           err: NodeJS.ErrnoException | null,


### PR DESCRIPTION
## Summary

- Fixes the custom `lookup` shim in `httpsRequestPinned` (in `web/api/helpers/app-image-storage.ts`) to honour both `dns.lookup` callback contracts: the legacy `(err, address, family)` form and the `{ all: true }` form that returns `{ address, family }[]`.
- Closes ~48/wk Datadog noise from [`e9448594`](https://app.datadoghq.com/error-tracking/issue/e9448594-44d5-11f1-8a87-da7ad0900002): `TypeError [ERR_INVALID_IP_ADDRESS]: Invalid IP address: undefined`.

## Why

On Node 18+ with `autoSelectFamily` enabled (default), the connect path runs through `lookupAndConnectMultiple`, which calls `lookup` with `{ all: true }`. The previous shim only emitted the single-result form, so the caller indexed into a string expecting `.address` and got `undefined`. The TCP connection failed before any socket opened — explaining the high failure rate against benign hosts like `httpbin.org` in production traces.

## SSRF guards unchanged

The fix only changes callback dispatch shape inside the pinned lookup. The pinned IP handed back in the new array branch is the same value already validated by `assertSafeImageUrl` upstream (`isPrivateIp` against the full set of v4/v6 private/reserved/metadata CIDRs, including IPv4-mapped-IPv6 normalisation). DNS-rebinding protection still holds because the hostname argument remains ignored and TCP connects to the pre-validated IP. No guard branch (scheme allowlist, embedded-cred rejection, per-record fail-whole-URL, redirect rejection, streaming size cap, timeouts) was touched.

Context: see the SSRF audit at `web/api/mcp/SSRF_AUDIT.md` (in #4's audit worktree) for the full assessment of the pinned fetcher.

## Test plan

- [ ] Locally, fetch a benign external image via `upload_app_image` and confirm the connection succeeds (currently fails with the `Invalid IP address` TypeError)
- [ ] Confirm a URL pointing at a private CIDR (e.g. `https://169.254.169.254/...`) is still rejected before the lookup shim is reached
- [ ] After merge, watch Datadog issue [`e9448594`](https://app.datadoghq.com/error-tracking/issue/e9448594-44d5-11f1-8a87-da7ad0900002) — expect firing rate to fall to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)