### PR TITLE
fix: reuse single transaction signed-fetcher across requests

### DIFF
--- a/web/api/helpers/signed-fetch.ts
+++ b/web/api/helpers/signed-fetch.ts
@@ -1,0 +1,38 @@
+import "server-only";
+
+import { createSignedFetcher } from "aws-sigv4-fetch";
+
+/**
+ * Module-scoped, lazily-initialised SigV4 signed-fetch singleton for the
+ * `execute-api` service in `TRANSACTION_BACKEND_REGION`.
+ *
+ * `aws-sigv4-fetch` (via `@aws-sdk/credential-provider-node`) caches resolved
+ * IAM credentials on the signer instance. Constructing a new signer per
+ * request — as we used to do in every handler — defeats that cache and
+ * hammers the ECS task IAM-role credential endpoint (`169.254.170.2`),
+ * which has produced "socket hang up" regressions in production.
+ *
+ * Prefer the global set by `instrumentation.ts` so we share a single signer
+ * across all entry points; fall back to a local lazy singleton if
+ * instrumentation never ran (e.g. it bailed early on missing Redis /
+ * OpenSearch env, see the early `return console.error` paths there). Either
+ * way every caller in the process reuses one signer, so the underlying
+ * credential provider chain is built once and credentials get cached for
+ * their full TTL.
+ */
+let cachedSignedFetch: typeof fetch | undefined;
+
+export const getTransactionSignedFetch = (): typeof fetch => {
+  if (global.TransactionSignedFetcher) {
+    return global.TransactionSignedFetcher;
+  }
+
+  if (!cachedSignedFetch) {
+    cachedSignedFetch = createSignedFetcher({
+      service: "execute-api",
+      region: process.env.TRANSACTION_BACKEND_REGION,
+    });
+  }
+
+  return cachedSignedFetch;
+};

--- a/web/api/v2/minikit/send-notification/index.ts
+++ b/web/api/v2/minikit/send-notification/index.ts
@@ -1,10 +1,10 @@
 import { errorResponse } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import { verifyHashedSecret } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { logger } from "@/lib/logger";
 import { fetchWithRetry } from "@/lib/utils";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 import { createHash } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import * as yup from "yup";
@@ -383,13 +383,7 @@ export const POST = async (req: NextRequest) => {
           ...(draft_id !== undefined && { draftId: draft_id }),
         };
 
-  let signedFetch = global.TransactionSignedFetcher;
-  if (!signedFetch) {
-    signedFetch = createSignedFetcher({
-      service: "execute-api",
-      region: process.env.TRANSACTION_BACKEND_REGION,
-    });
-  }
+  const signedFetch = getTransactionSignedFetch();
 
   let res: Response;
 

--- a/web/api/v2/minikit/transaction/[transaction_id]/index.ts
+++ b/web/api/v2/minikit/transaction/[transaction_id]/index.ts
@@ -1,11 +1,11 @@
 import { errorResponse } from "@/api/helpers/errors";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import { corsHandler } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { logger } from "@/lib/logger";
 import { appIdSchema } from "@/lib/schema";
 import { TransactionTypes } from "@/lib/types";
 import { fetchWithTimeout } from "@/lib/utils";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 import { NextRequest, NextResponse } from "next/server";
 import * as yup from "yup";
 
@@ -55,13 +55,7 @@ export const GET = async (
 
   const { app_id: appId, type } = parsedParams;
 
-  let signedFetch = global.TransactionSignedFetcher;
-  if (!signedFetch) {
-    signedFetch = createSignedFetcher({
-      service: "execute-api",
-      region: process.env.TRANSACTION_BACKEND_REGION,
-    });
-  }
+  const signedFetch = getTransactionSignedFetch();
   const url =
     type === TransactionTypes.Payment
       ? `${process.env.NEXT_SERVER_INTERNAL_PAYMENTS_ENDPOINT}/miniapp?miniapp-id=${appId}&transaction-id=${transactionId}`

--- a/web/api/v2/minikit/transaction/debug/index.ts
+++ b/web/api/v2/minikit/transaction/debug/index.ts
@@ -1,10 +1,10 @@
 import { errorResponse } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import { corsHandler, verifyHashedSecret } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { logger } from "@/lib/logger";
 import { appIdSchema } from "@/lib/schema";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 import { NextRequest, NextResponse } from "next/server";
 import * as yup from "yup";
 import { getSdk as fetchApiKeySdk } from "../../graphql/fetch-api-key.generated";
@@ -105,13 +105,7 @@ export const GET = async (req: NextRequest) => {
     });
   }
 
-  let signedFetch = global.TransactionSignedFetcher;
-  if (!signedFetch) {
-    signedFetch = createSignedFetcher({
-      service: "execute-api",
-      region: process.env.TRANSACTION_BACKEND_REGION,
-    });
-  }
+  const signedFetch = getTransactionSignedFetch();
 
   const res = await signedFetch(
     `${process.env.NEXT_SERVER_INTERNAL_PAYMENTS_ENDPOINT}/miniapp-actions/debug?miniapp-id=${appId}`,

--- a/web/api/v2/minikit/user-grant-cycle/index.ts
+++ b/web/api/v2/minikit/user-grant-cycle/index.ts
@@ -1,7 +1,7 @@
 import { verifyApiKey } from "@/api/helpers/auth/verify-api-key";
 import { errorResponse } from "@/api/helpers/errors";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 import { NextRequest, NextResponse } from "next/server";
 import * as yup from "yup";
 
@@ -44,13 +44,7 @@ export const GET = async (req: NextRequest) => {
     return apiKeyResult.errorResponse;
   }
 
-  let signedFetch = global.TransactionSignedFetcher;
-  if (!signedFetch) {
-    signedFetch = createSignedFetcher({
-      service: "execute-api",
-      region: process.env.TRANSACTION_BACKEND_REGION,
-    });
-  }
+  const signedFetch = getTransactionSignedFetch();
 
   try {
     const res = await signedFetch(

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/server/getAccumulativeTransactionData.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/server/getAccumulativeTransactionData.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { errorFormAction } from "@/api/helpers/errors";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import { getIsUserAllowedToReadApp } from "@/lib/permissions";
 import { extractIdsFromPath, getPathFromHeaders } from "@/lib/server-utils";
 import {
@@ -10,7 +11,6 @@ import {
   TransactionMetadata,
   TransactionStatus,
 } from "@/lib/types";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 
 export type GetAccumulativePaymentsDataReturnType = {
   accumulativePayments: PaymentMetadata[];
@@ -46,13 +46,7 @@ const fetchTransactionData = async (
   const path = getPathFromHeaders() || "";
   const { Teams: teamId } = extractIdsFromPath(path, ["Teams"]);
 
-  let signedFetch = global.TransactionSignedFetcher;
-  if (!signedFetch) {
-    signedFetch = createSignedFetcher({
-      service: "execute-api",
-      region: process.env.TRANSACTION_BACKEND_REGION,
-    });
-  }
+  const signedFetch = getTransactionSignedFetch();
 
   const response = await signedFetch(url, {
     method: "GET",

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/server/index.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/server/index.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { errorFormAction } from "@/api/helpers/errors";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import { extractIdsFromPath, getPathFromHeaders } from "@/lib/server-utils";
 import {
   Auth0SessionUser,
@@ -8,7 +9,6 @@ import {
   PaymentMetadata,
 } from "@/lib/types";
 import { getSession } from "@auth0/nextjs-auth0";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 
 export const getTransactionData = async (
   appId: string,
@@ -53,13 +53,7 @@ export const getTransactionData = async (
       });
     }
 
-    let signedFetch = global.TransactionSignedFetcher;
-    if (!signedFetch) {
-      signedFetch = createSignedFetcher({
-        service: "execute-api",
-        region: process.env.TRANSACTION_BACKEND_REGION,
-      });
-    }
+    const signedFetch = getTransactionSignedFetch();
 
     let url = `${process.env.NEXT_SERVER_INTERNAL_PAYMENTS_ENDPOINT}/miniapp?miniapp-id=${appId}`;
 

--- a/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/Earnings/server/getAffiliateTransactions.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/Earnings/server/getAffiliateTransactions.ts
@@ -1,12 +1,12 @@
 "use server";
 
 import { errorFormAction } from "@/api/helpers/errors";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import {
   AffiliateTransactionsRequestParams,
   AffiliateTransactionsResponse,
   FormActionResult,
 } from "@/lib/types";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 import { validateAffiliateRequest } from "../../common/server/validate-affiliate-request";
 
 export const getAffiliateTransactions = async (
@@ -23,13 +23,7 @@ export const getAffiliateTransactions = async (
 
     teamId = validation.data.teamId;
 
-    let signedFetch = global.TransactionSignedFetcher;
-    if (!signedFetch) {
-      signedFetch = createSignedFetcher({
-        service: "execute-api",
-        region: process.env.TRANSACTION_BACKEND_REGION,
-      });
-    }
+    const signedFetch = getTransactionSignedFetch();
 
     const reqParams: AffiliateTransactionsRequestParams = {
       cursor: params?.cursor,

--- a/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/Overview/page/server/getAffiliateMetadata.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/Overview/page/server/getAffiliateMetadata.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { errorFormAction } from "@/api/helpers/errors";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import { AffiliateMetadataResponse, FormActionResult } from "@/lib/types";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 import { validateAffiliateRequest } from "../../../common/server/validate-affiliate-request";
 
 export const getAffiliateMetadata = async (): Promise<FormActionResult> => {
@@ -17,13 +17,7 @@ export const getAffiliateMetadata = async (): Promise<FormActionResult> => {
 
     teamId = validation.data.teamId;
 
-    let signedFetch = global.TransactionSignedFetcher;
-    if (!signedFetch) {
-      signedFetch = createSignedFetcher({
-        service: "execute-api",
-        region: process.env.TRANSACTION_BACKEND_REGION,
-      });
-    }
+    const signedFetch = getTransactionSignedFetch();
 
     let url = `${process.env.NEXT_SERVER_APP_BACKEND_BASE_URL}/internal/v1/affiliate/metadata`;
 

--- a/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/Overview/server/executeAcceptTerms.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/Overview/server/executeAcceptTerms.ts
@@ -1,9 +1,9 @@
 "use server";
 
 import { errorFormAction } from "@/api/helpers/errors";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import { logger } from "@/lib/logger";
 import { AcceptTermsResponse, FormActionResult } from "@/lib/types";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 import { validateAffiliateRequest } from "../../common/server/validate-affiliate-request";
 
 export const executeAcceptTerms = async (): Promise<FormActionResult> => {
@@ -18,13 +18,7 @@ export const executeAcceptTerms = async (): Promise<FormActionResult> => {
 
     teamId = validation.data.teamId;
 
-    let signedFetch = global.TransactionSignedFetcher;
-    if (!signedFetch) {
-      signedFetch = createSignedFetcher({
-        service: "execute-api",
-        region: process.env.TRANSACTION_BACKEND_REGION,
-      });
-    }
+    const signedFetch = getTransactionSignedFetch();
     const url = `${process.env.NEXT_SERVER_APP_BACKEND_BASE_URL}/internal/v1/affiliate/terms/accept`;
 
     const response = await signedFetch(url, {

--- a/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/Overview/server/getIdentityVerificationLink.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/Overview/server/getIdentityVerificationLink.ts
@@ -1,13 +1,13 @@
 "use server";
 
 import { errorFormAction } from "@/api/helpers/errors";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import { logger } from "@/lib/logger";
 import {
   FormActionResult,
   GetIdentityVerificationLinkRequest,
   GetIdentityVerificationLinkResponse,
 } from "@/lib/types";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 import { validateAffiliateRequest } from "../../common/server/validate-affiliate-request";
 
 export const getIdentityVerificationLink = async ({
@@ -28,13 +28,7 @@ export const getIdentityVerificationLink = async ({
 
     teamId = validation.data.teamId;
 
-    let signedFetch = global.TransactionSignedFetcher;
-    if (!signedFetch) {
-      signedFetch = createSignedFetcher({
-        service: "execute-api",
-        region: process.env.TRANSACTION_BACKEND_REGION,
-      });
-    }
+    const signedFetch = getTransactionSignedFetch();
     const url = `${process.env.NEXT_SERVER_APP_BACKEND_BASE_URL}/internal/v1/affiliate/identity-verification/verification-link`;
     // NOTE: set kyb because app backend doesn't if it's kyc or kyb
     const requestBody = { type, redirectUri };

--- a/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/Withdraw/server/confirmWithdraw.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/Withdraw/server/confirmWithdraw.ts
@@ -1,11 +1,11 @@
 "use server";
 import { errorFormAction } from "@/api/helpers/errors";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import {
   ConfirmWithdrawRequest,
   ConfirmWithdrawResponse,
   FormActionResult,
 } from "@/lib/types";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 import { validateAffiliateRequest } from "../../common/server/validate-affiliate-request";
 
 export const confirmWithdraw = async ({
@@ -31,13 +31,7 @@ export const confirmWithdraw = async ({
       });
     }
 
-    let signedFetch = global.TransactionSignedFetcher;
-    if (!signedFetch) {
-      signedFetch = createSignedFetcher({
-        service: "execute-api",
-        region: process.env.TRANSACTION_BACKEND_REGION,
-      });
-    }
+    const signedFetch = getTransactionSignedFetch();
     const url = `${process.env.NEXT_SERVER_APP_BACKEND_BASE_URL}/internal/v1/affiliate/withdraw/confirm`;
 
     const response = await signedFetch(url, {

--- a/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/Withdraw/server/initiateWithdraw.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/Withdraw/server/initiateWithdraw.ts
@@ -1,12 +1,12 @@
 "use server";
 
 import { errorFormAction } from "@/api/helpers/errors";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import {
   FormActionResult,
   InitiateWithdrawRequest,
   InitiateWithdrawResponse,
 } from "@/lib/types";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 import { validateAffiliateRequest } from "../../common/server/validate-affiliate-request";
 
 export const initiateWithdraw = async ({
@@ -23,13 +23,7 @@ export const initiateWithdraw = async ({
 
     teamId = validation.data.teamId;
 
-    let signedFetch = global.TransactionSignedFetcher;
-    if (!signedFetch) {
-      signedFetch = createSignedFetcher({
-        service: "execute-api",
-        region: process.env.TRANSACTION_BACKEND_REGION,
-      });
-    }
+    const signedFetch = getTransactionSignedFetch();
 
     const url = `${process.env.NEXT_SERVER_APP_BACKEND_BASE_URL}/internal/v1/affiliate/withdraw/initiate`;
 

--- a/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/common/server/getAffiliateBalance.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/common/server/getAffiliateBalance.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { errorFormAction } from "@/api/helpers/errors";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import { AffiliateBalanceResponse, FormActionResult } from "@/lib/types";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 import { validateAffiliateRequest } from "./validate-affiliate-request";
 
 export const getAffiliateBalance = async (): Promise<FormActionResult> => {
@@ -17,13 +17,7 @@ export const getAffiliateBalance = async (): Promise<FormActionResult> => {
 
     teamId = validation.data.teamId;
 
-    let signedFetch = global.TransactionSignedFetcher;
-    if (!signedFetch) {
-      signedFetch = createSignedFetcher({
-        service: "execute-api",
-        region: process.env.TRANSACTION_BACKEND_REGION,
-      });
-    }
+    const signedFetch = getTransactionSignedFetch();
 
     let url = `${process.env.NEXT_SERVER_APP_BACKEND_BASE_URL}/internal/v1/affiliate/balance`;
 

--- a/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/common/server/getAffiliateOverview.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/common/server/getAffiliateOverview.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { errorFormAction } from "@/api/helpers/errors";
+import { getTransactionSignedFetch } from "@/api/helpers/signed-fetch";
 import { AffiliateOverviewResponse, FormActionResult } from "@/lib/types";
-import { createSignedFetcher } from "aws-sigv4-fetch";
 import { validateAffiliateRequest } from "./validate-affiliate-request";
 
 export const getAffiliateOverview = async ({
@@ -21,13 +21,7 @@ export const getAffiliateOverview = async ({
 
     teamId = validation.data.teamId;
 
-    let signedFetch = global.TransactionSignedFetcher;
-    if (!signedFetch) {
-      signedFetch = createSignedFetcher({
-        service: "execute-api",
-        region: process.env.TRANSACTION_BACKEND_REGION,
-      });
-    }
+    const signedFetch = getTransactionSignedFetch();
 
     let url = `${process.env.NEXT_SERVER_APP_BACKEND_BASE_URL}/internal/v1/affiliate/overview${period ? `?period=${period}` : ""}`;
 


### PR DESCRIPTION
## Summary

- Replaces 14 per-request `createSignedFetcher` instantiations with a single module-scoped singleton via a new helper `web/api/helpers/signed-fetch.ts`.
- Closes ~63/wk Datadog noise from regression [`624a97b8`](https://app.datadoghq.com/error-tracking/issue/624a97b8-d992-11ef-8f2e-da7ad0900002) (\"socket hang up\" against the ECS task IAM-role credential endpoint at `169.254.170.2`).

## Why

14 transaction / affiliate handlers and server-actions all used the same pattern: `if (!global.TransactionSignedFetcher) createSignedFetcher({...})`. That global is supposed to be set once in `instrumentation.ts`'s `register()`. In practice `register()` returns early when Redis / OpenSearch env vars are absent, so the fallback fired on most requests and **every** request rebuilt the AWS credential-provider chain — hammering `169.254.170.2`.

All 14 sites used identical config (`service: \"execute-api\"`, `region: process.env.TRANSACTION_BACKEND_REGION`), so a single module-scoped singleton is sufficient. `getTransactionSignedFetch()` prefers the instrumentation-bootstrapped global (so behaviour is unchanged when instrumentation runs) and falls back to its own cached singleton when it doesn't. Either way, exactly **one** signer per process. The underlying `@aws-sdk/credential-provider-node` cache then stays warm and the metadata endpoint is hit once per credential TTL instead of once per request.

Triage write-up that flagged this: `.context/outbound-http-triage.md` (in the #6 follow-up worktree).

## Diff shape

`+66 / -112` across 15 files. 14 call sites each lose ~6 lines of fallback boilerplate and now call `getTransactionSignedFetch()`. `instrumentation.ts` and `web/@types/global.d.ts` are unchanged — the global path is preserved.

## Conflict note

This PR and #1914 (`chore/downgrade-authz-rejection-loglevel`) both touch `web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/server/getAccumulativeTransactionData.ts` at different line ranges (this PR at the top of each function, #1914 at the `logLevel` calls). Expect a trivial rebase conflict on whichever lands second.

## Test plan

- [ ] `cd web && npx jest tests/api/v2/minikit/` — all 37 affected tests pass (verified locally; tests mock `aws-sigv4-fetch` which the helper still calls underneath)
- [ ] `cd web && npx tsc --noEmit` — clean (verified locally)
- [ ] Deploy to staging and confirm minikit transaction routes still work
- [ ] After merge, watch Datadog issue [`624a97b8`](https://app.datadoghq.com/error-tracking/issue/624a97b8-d992-11ef-8f2e-da7ad0900002) — expect firing rate to fall toward zero (cleanup also helps reduce noise on the closely-related [`2b66a2fc`](https://app.datadoghq.com/error-tracking/issue/2b66a2fc-dda5-11ef-b97e-da7ad0900002) socket-hang-up issue)
- [ ] Watch outbound `http.url:*169.254.170.2*` request volume in Datadog APM drop to a few-per-process

🤖 Generated with [Claude Code](https://claude.com/claude-code)