### PR TITLE
fix(apollo): clean up Apollo Client 3.14 deprecation noise

### DIFF
--- a/web/components/LoggedUserNav/index.tsx
+++ b/web/components/LoggedUserNav/index.tsx
@@ -74,8 +74,6 @@ export const LoggedUserNav = () => {
     skip: !teamId,
   });
 
-  // Apollo Client 3.14 deprecated `useQuery({ onCompleted })`; sync into
-  // the affiliate-config atom via derived state on `data` instead.
   const fetchedTeam = teamRes.data;
   useEffect(() => {
     if (!fetchedTeam) return;

--- a/web/components/LoggedUserNav/index.tsx
+++ b/web/components/LoggedUserNav/index.tsx
@@ -72,15 +72,20 @@ export const LoggedUserNav = () => {
           id: teamId,
         },
     skip: !teamId,
-    onCompleted: (data) => {
-      console.log("fetched team", data);
-      setAffiliateConfig((prev) => ({
-        ...prev,
-        isFetched: true,
-        teamVerifiedAppsCount: data.team?.verified_apps.aggregate?.count || 0,
-      }));
-    },
   });
+
+  // Apollo Client 3.14 deprecated `useQuery({ onCompleted })`; sync into
+  // the affiliate-config atom via derived state on `data` instead.
+  const fetchedTeam = teamRes.data;
+  useEffect(() => {
+    if (!fetchedTeam) return;
+    setAffiliateConfig((prev) => ({
+      ...prev,
+      isFetched: true,
+      teamVerifiedAppsCount:
+        fetchedTeam.team?.verified_apps.aggregate?.count || 0,
+    }));
+  }, [fetchedTeam, setAffiliateConfig]);
 
   const isAffiliateEnabled = useMemo(
     () => isAffiliateEnabledForTeam(affiliateConfig, teamId, auth0User),

--- a/web/lib/use-refetch-queries.ts
+++ b/web/lib/use-refetch-queries.ts
@@ -12,23 +12,6 @@ export const useRefetchQueries = <Variables extends Record<string, unknown>>(
   );
 
   const refetch = useCallback(async () => {
-    // Refetch matching observables only when the consumer invokes `refetch()`.
-    //
-    // The previous implementation called `client.refetchQueries({ include })`
-    // inside a `useMemo` at hook-setup time. That had two side effects:
-    //   1. Apollo emits "Unknown query named X" (3.14 code 43) when no
-    //      active observable matches the document at that moment — common
-    //      because the consumer that subscribes to the query may not have
-    //      mounted yet when the hook owner mounts.
-    //   2. `refetchQueries` itself triggers an immediate refetch on matching
-    //      observables, so on every mount we silently re-fetched data —
-    //      then on the user's action we fetched again. Two fetches per
-    //      logical refetch.
-    //
-    // Calling it lazily here, with `onQueryUpdated` filtering by variables
-    // (Apollo's idiomatic selector), preserves the original "refetch only
-    // queries whose variables match" intent without the mount-time refetch
-    // or the misleading warning.
     const { results } = client.refetchQueries({
       include: [queryDocument],
       onQueryUpdated(observableQuery) {

--- a/web/lib/use-refetch-queries.ts
+++ b/web/lib/use-refetch-queries.ts
@@ -6,29 +6,39 @@ export const useRefetchQueries = <Variables extends Record<string, unknown>>(
   variables?: Variables,
 ) => {
   const client = useApolloClient();
-  const variablesInternal = useMemo(() => variables || {}, [variables]);
-  const { queries } = useMemo(
-    () =>
-      client.refetchQueries({
-        include: [queryDocument],
-      }),
-    [client, queryDocument],
+  const variablesKey = useMemo(
+    () => JSON.stringify(variables || {}),
+    [variables],
   );
 
-  const queriesToRefetch = useMemo(
-    () =>
-      queries.filter(
-        (q) =>
-          JSON.stringify(q.options.variables) ===
-          JSON.stringify(variablesInternal),
-      ),
-    [queries, variablesInternal],
-  );
-
-  // may mask successful refetches if any fail
   const refetch = useCallback(async () => {
-    return await Promise.all(queriesToRefetch.map((q) => q.refetch()));
-  }, [queriesToRefetch]);
+    // Refetch matching observables only when the consumer invokes `refetch()`.
+    //
+    // The previous implementation called `client.refetchQueries({ include })`
+    // inside a `useMemo` at hook-setup time. That had two side effects:
+    //   1. Apollo emits "Unknown query named X" (3.14 code 43) when no
+    //      active observable matches the document at that moment — common
+    //      because the consumer that subscribes to the query may not have
+    //      mounted yet when the hook owner mounts.
+    //   2. `refetchQueries` itself triggers an immediate refetch on matching
+    //      observables, so on every mount we silently re-fetched data —
+    //      then on the user's action we fetched again. Two fetches per
+    //      logical refetch.
+    //
+    // Calling it lazily here, with `onQueryUpdated` filtering by variables
+    // (Apollo's idiomatic selector), preserves the original "refetch only
+    // queries whose variables match" intent without the mount-time refetch
+    // or the misleading warning.
+    const { results } = client.refetchQueries({
+      include: [queryDocument],
+      onQueryUpdated(observableQuery) {
+        return (
+          JSON.stringify(observableQuery.options.variables) === variablesKey
+        );
+      },
+    });
+    return await Promise.all(results);
+  }, [client, queryDocument, variablesKey]);
 
   return { refetch };
 };

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/layout/ImagesProvider/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/layout/ImagesProvider/index.tsx
@@ -45,8 +45,6 @@ export const ImagesProvider = (props: {
     },
   });
 
-  // Apollo Client 3.14 deprecated `useQuery({ onCompleted })`; sync into
-  // the unverified-images atom via derived state on `data` instead.
   useEffect(() => {
     if (!data) return;
     setUnverifiedImages({

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/layout/ImagesProvider/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/layout/ImagesProvider/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { atom, useSetAtom } from "jotai";
-import { Fragment, ReactNode } from "react";
+import { Fragment, ReactNode, useEffect } from "react";
 import { useFetchImagesQuery } from "../../graphql/client/fetch-images.generated";
 
 type Images = {
@@ -37,23 +37,26 @@ export const ImagesProvider = (props: {
   const { appId, teamId, locale } = props;
   const setUnverifiedImages = useSetAtom(unverifiedImageAtom);
 
-  const {} = useFetchImagesQuery({
+  const { data } = useFetchImagesQuery({
     variables: {
       id: appId ?? "",
       team_id: teamId ?? "",
       locale: locale,
     },
-
-    onCompleted: (data) => {
-      setUnverifiedImages({
-        logo_img_url: data?.unverified_images?.logo_img_url ?? "",
-        showcase_image_urls: data?.unverified_images?.showcase_img_urls,
-        meta_tag_image_url: data?.unverified_images?.meta_tag_image_url ?? "",
-        content_card_image_url:
-          data?.unverified_images?.content_card_image_url ?? "",
-      });
-    },
   });
+
+  // Apollo Client 3.14 deprecated `useQuery({ onCompleted })`; sync into
+  // the unverified-images atom via derived state on `data` instead.
+  useEffect(() => {
+    if (!data) return;
+    setUnverifiedImages({
+      logo_img_url: data?.unverified_images?.logo_img_url ?? "",
+      showcase_image_urls: data?.unverified_images?.showcase_img_urls,
+      meta_tag_image_url: data?.unverified_images?.meta_tag_image_url ?? "",
+      content_card_image_url:
+        data?.unverified_images?.content_card_image_url ?? "",
+    });
+  }, [data, setUnverifiedImages]);
 
   return <Fragment>{props.children}</Fragment>;
 };


### PR DESCRIPTION
## Summary

Apollo Client 3.14 (bumped in [#1920](https://github.com/worldcoin/developer-portal/pull/1920)) emits two warnings repeatedly on the staging dashboard. This PR addresses both.

### 1. `useQuery({ onCompleted })` — warning code 103

Each render of an affected component re-emits the warning. Migrate the two `useQuery` sites that drove external state from the callback to a `useEffect` keyed on `data` (Apollo's recommended pattern):

- `web/components/LoggedUserNav/index.tsx` — `useFetchTeamQuery` populated `affiliateEnabledAtom` from `onCompleted`. Also dropped the leftover `console.log("fetched team", data)` that was surfacing as Datadog noise.
- `web/scenes/.../Configuration/layout/ImagesProvider/index.tsx` — `useFetchImagesQuery` hydrated `unverifiedImageAtom`.

The three `useMutation({ onCompleted })` and the one `useLazyQuery`-execute `onCompleted` in the codebase aren't affected by this deprecation and are left alone.

### 2. `client.refetchQueries({ include })` for an inactive query — warning code 43

`web/lib/use-refetch-queries.ts` was calling `client.refetchQueries({ include: [queryDocument] })` inside a `useMemo` at hook-setup time. Two side effects:

- Apollo 3.14 logs warning code 43 (`"Unknown query named X requested in refetchQueries options.include array"`) when no active observable matches the document at the moment of the call. The consumer that subscribes to the query often mounts *after* the hook owner, so the warning fires on most route loads — visible on staging as repeated `["FetchAppMetadata"]` and `["FetchLocalisations"]` entries.
- `client.refetchQueries({ include })` itself triggers an immediate refetch on matching observables. So mounting any component that uses this hook silently re-fetched data, and then the user's later `refetch()` triggered a *second* fetch via `q.refetch()`.

Move the call into the `refetch` callback so it only runs when the consumer actually invokes it, and use Apollo's `onQueryUpdated` for the variables filtering. External API of the hook is unchanged.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (only the pre-existing `<a>` warning on `LoggedUserNav` remains)
- [x] `pnpm build` succeeds
- [ ] After deploy: no `go.apollo.dev/c/err#…useQuery…onCompleted` (code 103) entries
- [ ] After deploy: no `go.apollo.dev/c/err#…43…[FetchAppMetadata]` / `[FetchLocalisations]` (code 43) entries
- [ ] Verify after a form save the previously-double refetch now fires exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)