### PR TITLE
fix(csp): allow PostHog assets host for lazy-loaded scripts

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -50,6 +50,9 @@ const generateCsp = () => {
         ...(isDev ? ["'unsafe-eval'"] : []),
         "https://cookie-cdn.cookiepro.com",
         "https://app.posthog.com",
+        // PostHog lazy-loads extension scripts (web-vitals, etc.) from the
+        // assets host matching its US api_host (us.i.posthog.com).
+        "https://us-assets.i.posthog.com",
       ],
     },
     {
@@ -83,6 +86,7 @@ const generateCsp = () => {
         "https://worldcoin.pactsafe.io",
         "https://bridge.worldcoin.org",
         "https://us.i.posthog.com",
+        "https://us-assets.i.posthog.com",
         ...(s3BucketUrl ? [s3BucketUrl] : []),
         ...(appUrl ? [appUrl] : []),
         ...(altAppUrl ? [altAppUrl] : []),


### PR DESCRIPTION
## Summary

PostHog is configured with `api_host: https://us.i.posthog.com` (`web/scenes/Root/providers/providers.tsx`). It lazy-loads its extension scripts — `web-vitals.js`, surveys, etc. — from the matching **assets** host `us-assets.i.posthog.com`, which was never in the CSP. `script-src` only allowed `app.posthog.com` (the `ui_host`), so the browser blocks the load:

```
Loading the script 'https://us-assets.i.posthog.com/static/web-vitals.js?v=1.166.1'
violates the following Content Security Policy directive:
"script-src 'self' 'nonce-…' 'wasm-unsafe-eval' https://cookie-cdn.cookiepro.com https://app.posthog.com".
The action has been blocked.
```

Add `https://us-assets.i.posthog.com` to:
- `script-src` — the injected `<script>` tag for `web-vitals.js`
- `connect-src` — PostHog also fetches these via XHR (the violation stack shows `XMLHttpRequest.send`)

This matches [PostHog's documented CSP requirements](https://posthog.com/docs/advanced/content-security-policy) for US-hosted projects.

## Not a migration regression

The PostHog CSP hosts were last touched in **Feb 2024** (`6e24afd1`) — this gap predates and is unrelated to the Next.js 15 upgrade. `web-vitals.js` would have been blocked on Next 14 too; it surfaced now during close post-deploy monitoring.

## Alternative

If web-vitals capture isn't actually wanted (the config already sets `autocapture: false` and `disable_session_recording: true`, suggesting a minimal footprint), the alternative is to disable it at the source with `capture_performance: false` in `posthog.init` rather than widening CSP. I went with allowing the host since the US `api_host` is explicitly configured and the documented PostHog setup expects the assets host to be allowlisted — happy to switch to the `capture_performance: false` approach if preferred.

## Test plan

- [x] `pnpm typecheck` clean
- [ ] After deploy: no `us-assets.i.posthog.com … violates … Content Security Policy` errors in the browser console; PostHog web-vitals loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)