### PR TITLE
fix: raise minikit transaction fetch timeout + retry, pass through upstream status

### DIFF
--- a/web/api/v2/minikit/transaction/[transaction_id]/index.ts
+++ b/web/api/v2/minikit/transaction/[transaction_id]/index.ts
@@ -5,7 +5,7 @@ import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { logger } from "@/lib/logger";
 import { appIdSchema } from "@/lib/schema";
 import { TransactionTypes } from "@/lib/types";
-import { fetchWithTimeout } from "@/lib/utils";
+import { fetchWithRetry } from "@/lib/utils";
 import { NextRequest, NextResponse } from "next/server";
 import * as yup from "yup";
 
@@ -64,7 +64,7 @@ export const GET = async (
 
   let res: Response;
   try {
-    res = await fetchWithTimeout(
+    res = await fetchWithRetry(
       url,
       {
         method: "GET",
@@ -73,10 +73,18 @@ export const GET = async (
           "Content-Type": "application/json",
         },
       },
-      5000, // fetch timeout in ms
+      2, // max retries: one extra attempt to ride out a transient timeout/transport blip
+      500, // initial retry delay in ms
+      10000, // fetch timeout in ms (upstream p90 sits just under the old 5s cap)
+      false, // do not throw: return the last response so genuine upstream statuses pass through
       signedFetch,
     );
   } catch (error) {
+    logger.error("Transaction fetch to backend failed", {
+      error,
+      req,
+      app_id: appId,
+    });
     return corsHandler(
       errorResponse({
         statusCode: 500,

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -473,8 +473,13 @@ export const fetchWithRetry = async (
         return lastResponse;
       }
       lastError = new Error(`HTTP status ${lastResponse.status}`);
-      // 4xx responses are definitive — surface them immediately instead of retrying.
-      if (lastResponse.status < 500) {
+      // Retry transient statuses only: 5xx, plus 408 (timeout) and 429 (rate limit).
+      // Other 4xx are definitive client errors — surface them immediately.
+      const isRetryableStatus =
+        lastResponse.status >= 500 ||
+        lastResponse.status === 408 ||
+        lastResponse.status === 429;
+      if (!isRetryableStatus) {
         break;
       }
     } catch (error) {

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -473,6 +473,10 @@ export const fetchWithRetry = async (
         return lastResponse;
       }
       lastError = new Error(`HTTP status ${lastResponse.status}`);
+      // 4xx responses are definitive — surface them immediately instead of retrying.
+      if (lastResponse.status < 500) {
+        break;
+      }
     } catch (error) {
       lastError = error as Error;
       lastResponse = null;


### PR DESCRIPTION
## Summary
- `GET /api/v2/minikit/transaction/[transaction_id]` hard-capped its upstream fetch at **5s** and returned a generic **500** on abort.
- Datadog shows the transactions backend (`app-backend-main`, `/prod/internal/v1/transactions/miniapp-actions`) responds with **P90/P99 just above 5s**, so the `AbortController` was killing valid-but-slow requests at the 5.0s cliff — **155 "Transaction fetch to backend failed" 500s in 3 days**, span durations tightly clustered at ~5.00s.

## Fix
Switch `fetchWithTimeout` → `fetchWithRetry` (the helper already used for this same backend in `send-notification`):
- Timeout **5s → 10s** per attempt
- **One retry** (500ms backoff) to ride out transient timeouts
- `throwOnError=false` so genuine upstream 4xx/5xx pass through the existing `if (!res.ok)` branch with their real code/message instead of being masked as 500
- Added `logger.error` in the now-rare `catch`

## Caveat
Root driver is upstream latency in `app-backend-main`. If its P90 climbs past 10s, that's a backend/infra issue for the transactions team (flagged, out of scope here).

## Test plan
- [ ] tsc + format (done locally, clean)
- [ ] Watch [issue 450234d6](https://app.datadoghq.com/error-tracking/issue/450234d6-01c3-11f1-8594-da7ad0900002) — expect the ~5.0s-timeout 500s to drop sharply
- [ ] Confirm genuine upstream 404/400 now surface to callers with real status (no longer hidden behind 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)