### PR TITLE
chore: log v4 proof per-item failures at warn, not error

### DIFF
--- a/web/api/v4/verify/session-proof/verify-util.ts
+++ b/web/api/v4/verify/session-proof/verify-util.ts
@@ -76,7 +76,13 @@ export async function processSessionProof(
         };
       } catch (e: unknown) {
         const errorMessage = e instanceof Error ? e.message : String(e);
-        logger.error("Error verifying v4 session proof", {
+        // Reaching this catch means a per-item input could not be processed
+        // (e.g. a malformed client-supplied field that fails BigInt conversion).
+        // On-chain verifier reverts are handled gracefully by
+        // verifySessionProofOnChain (returns success:false) and never throw
+        // here. This is client-driven bad input that yields a 400, so log at
+        // warn to avoid polluting the error rate.
+        logger.warn("Error verifying v4 session proof", {
           error: errorMessage,
           rpId,
           identifier: item.identifier,

--- a/web/api/v4/verify/uniqueness-proof/verify-v4.ts
+++ b/web/api/v4/verify/uniqueness-proof/verify-v4.ts
@@ -61,7 +61,13 @@ export async function processUniquenessProofV4(
         };
       } catch (e: unknown) {
         const errorMessage = e instanceof Error ? e.message : String(e);
-        logger.error("Error verifying v4 proof", {
+        // Reaching this catch means a per-item input could not be processed
+        // (e.g. a malformed client-supplied field that fails BigInt conversion).
+        // On-chain verifier reverts are handled gracefully by verifyProofOnChain
+        // (returns success:false) and never throw here. This is client-driven
+        // bad input that yields a 400, so log at warn to avoid polluting the
+        // error rate.
+        logger.warn("Error verifying v4 proof", {
           error: errorMessage,
           rpId: rpId.toString(),
           identifier: item.identifier,


### PR DESCRIPTION
## Summary
- Downgrades the per-item `catch` logs in `processUniquenessProofV4` (`verify-v4.ts`) and `processSessionProof` (`verify-util.ts`) from `logger.error` → `logger.warn`.
- Stops ~94/3d "Error verifying v4 proof" entries ([issue 1ec560e2](https://app.datadoghq.com/error-tracking/issue/1ec560e2-5c61-11f1-bfcc-da7ad0900002)) from polluting Error Tracking.

## Why this is noise, not a bug
- The Datadog "error" is just the `logger.error()` call captured by dd-trace, not a propagating exception — the request completes as a clean handled **400** (`all_verifications_failed`).
- On-chain verifier reverts are caught internally by `verifyProofOnChain` / `verifySessionProofOnChain` (return `{success:false}`) and never reach this catch. The only way in is client-supplied input that fails `BigInt()` conversion. Sample caller UA: `"ChainBricker Supabase API"` (an automated scraper).
- **Not a regression:** the "new" fingerprint `1ec560e2` (first_seen 2026-05-30) only differs because the minified logger was inlined into a different bundle chunk; an identical issue (`037d8bec`) has existed since 2026-03-19. Prod is on next@14.2.35 (`522c7b51`); no verification-logic commit landed near 05-30.

Matches the rationale of PR #1914 (legitimate rejections shouldn't trip error alerts). Status code and behavior unchanged — only log severity drops.

## Test plan
- [ ] tsc + format + `jest tests/api/v4/session-proof.test.ts` (done locally, 2/2 pass)
- [ ] Watch [issue 1ec560e2](https://app.datadoghq.com/error-tracking/issue/1ec560e2-5c61-11f1-bfcc-da7ad0900002) — expect it to stop appearing in Error Tracking (entries continue as warn logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)