### PR TITLE
chore: log "RP registration not found" at warn across RP action handlers

### DIFF
--- a/web/api/hasura/rotate-signer-key/index.ts
+++ b/web/api/hasura/rotate-signer-key/index.ts
@@ -99,6 +99,7 @@ export const POST = async (req: NextRequest) => {
       detail: "RP registration not found for this app.",
       code: "rp_not_registered",
       app_id,
+      logLevel: "warn",
     });
   }
   const teamId = rp_registration[0].app.team_id;

--- a/web/api/hasura/switch-to-self-managed/index.ts
+++ b/web/api/hasura/switch-to-self-managed/index.ts
@@ -115,6 +115,7 @@ export const POST = async (req: NextRequest) => {
       detail: "RP registration not found for this app.",
       code: "rp_not_registered",
       app_id,
+      logLevel: "warn",
     });
   }
 

--- a/web/api/hasura/toggle-rp-active/index.ts
+++ b/web/api/hasura/toggle-rp-active/index.ts
@@ -96,6 +96,7 @@ export const POST = async (req: NextRequest) => {
       detail: "RP registration not found for this app.",
       code: "rp_not_registered",
       app_id,
+      logLevel: "warn",
     });
   }
 


### PR DESCRIPTION
## Summary
- Adds `logLevel: "warn"` to the `errorHasuraQuery` call at three RP-action handler guards that throw "RP registration not found for this app.":
  - `web/api/hasura/rotate-signer-key/index.ts:96`
  - `web/api/hasura/switch-to-self-managed/index.ts:112`
  - `web/api/hasura/toggle-rp-active/index.ts:93`
- Stops ~36/3d legitimate rejections ([5016f8f2](https://app.datadoghq.com/error-tracking/issue/5016f8f2-1fb9-11f1-8570-da7ad0900002), [cc67a924](https://app.datadoghq.com/error-tracking/issue/cc67a924-0745-11f1-9554-da7ad0900002)) from polluting Error Tracking.

## Why this is noise, not a bug
The guard (`if (!rp_registration || rp_registration.length === 0)`) fires only when the app has **no** RP-registration row at all — a user acting on an app that never registered an RP. The row is created by a separate `register-rp` flow, so there's no read-after-write race. All sites return HTTP **400** `rp_not_registered`, `handling: handled`, `is_crash: false`. Same class as PR #1914.

`errorHasuraQuery` defaults `logLevel` to `"error"`; these handlers omitted it, so each rejection emitted `logger.error`. Downgrading to `warn` keeps the audit log but drops it from Error Tracking. The shared `rp-registration-flows.ts` path already returns a tagged result without logging, so it needed no change.

## Follow-up (out of scope)
The co-occurring "Cannot toggle RP. Current status is 'pending'…" and "User does not have permission to toggle RP status." are the same class of legitimate 400 logged at error level — could be downgraded too in a follow-up.

## Test plan
- [ ] tsc + format (done locally, clean)
- [ ] Watch the two issues — expect them to stop appearing in Error Tracking (continue as warn logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)