### PR TITLE
chore: log upload-image "App not found" rejections at warn, not error

### DIFF
--- a/web/api/hasura/upload-image/index.ts
+++ b/web/api/hasura/upload-image/index.ts
@@ -100,6 +100,7 @@ export const POST = async (req: NextRequest) => {
           code: "not_found",
           app_id,
           team_id,
+          logLevel: "warn",
         });
       }
 
@@ -110,6 +111,7 @@ export const POST = async (req: NextRequest) => {
           code: "not_found",
           app_id,
           team_id,
+          logLevel: "warn",
         });
       }
     } else {
@@ -139,6 +141,7 @@ export const POST = async (req: NextRequest) => {
           code: "not_found",
           app_id,
           team_id,
+          logLevel: "warn",
         });
       }
 
@@ -149,6 +152,7 @@ export const POST = async (req: NextRequest) => {
           code: "not_found",
           app_id,
           team_id,
+          logLevel: "warn",
         });
       }
     }


### PR DESCRIPTION
## Summary
- Adds `logLevel: "warn"` to all four "App not found." rejections in `web/api/hasura/upload-image/index.ts` (lines 99/109/138/148).
- Stops ~68/3d legitimate rejections ([issue 21877ad2](https://app.datadoghq.com/error-tracking/issue/21877ad2-5aa3-11f1-a61f-da7ad0900002)) from polluting Error Tracking.

## Why this is noise, not a bug (and not something we introduced)
- **Not new:** the issue's `first_seen: 2026-05-28` is a Datadog **fingerprint reset** caused by the 05-27/28 deploy cluster changing the minified chunk (`6477.js`) — not the real onset. The error ran at *higher* volume the prior month (week of 05-21: **52**; 05-28 itself: only 6). 68/3d is below the prior steady-state.
- **No recent change touched the lookup:** the gating queries `CheckAppInTeam` / `CheckUserInApp` are unchanged since PR #1874. Of the 9 PRs merged that window, none touch this path (#1917 changed an unrelated SSRF DNS shim; #1918's retry is query-only and can't turn a found app into not-found).
- The guard legitimately fires for: wrong/foreign team, soft-deleted app, non-admin user, or an app with no `unverified` metadata (e.g. already-verified).

`errorHasuraQuery` defaulted `logLevel` to `"error"`; downgrading to `"warn"` matches the sibling action `get-unverified-images/index.ts:102` which already does this for the identical check. HTTP 400 + `code: not_found` response shape unchanged, so existing tests stay valid.

## Test plan
- [ ] tsc + format + `jest tests/api/hasura/upload-image/index.test.ts` (done locally, 4/4 pass)
- [ ] Watch [issue 21877ad2](https://app.datadoghq.com/error-tracking/issue/21877ad2-5aa3-11f1-a61f-da7ad0900002) — expect it to leave Error Tracking (continues as warn logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)