### PR TITLE
fix: intercept stale/bot Server-Action POSTs in middleware to stop /_not-found 500s

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -2,7 +2,7 @@ import {
   getSession,
   withMiddlewareAuthRequired,
 } from "@auth0/nextjs-auth0/edge";
-import { NextRequest, NextResponse } from "next/server";
+import { NextFetchEvent, NextRequest, NextResponse } from "next/server";
 import { Role_Enum } from "./graphql/graphql";
 import { Auth0SessionUser } from "./lib/types";
 import { urls } from "./lib/urls";
@@ -116,6 +116,99 @@ const generateCsp = () => {
   return { csp: cspString, nonce };
 };
 
+// Next.js routes any POST to an unmatched path to the internal
+// `/_not-found/page`. When that POST *looks like* a Server Action — it carries
+// a `next-action` header, or a `multipart/form-data` body — the app router runs
+// the Server Action machinery against the not-found page and throws while
+// decoding the body. This surfaces as a server-side HTTP 500 with either
+// "Failed to find Server Action." or "Failed to parse body as FormData.".
+// (A bare `application/x-www-form-urlencoded` POST without `next-action` is NOT
+// affected: Next bails out of the action handler and serves a clean 404, so we
+// deliberately leave those alone.)
+//
+// In production these 500s are exclusively bot/scanner traffic: file-upload
+// exploit probes (`/wp-admin/admin-ajax.php`, `/.../upload.php`, etc.) that
+// POST multipart bodies to paths that do not exist. ~1.2k throw a 500 each
+// week and inflate the service error rate, with zero real users behind them.
+//
+// We intercept those requests in middleware — before the app router invokes
+// the Server Action handler — and return a clean response instead of letting
+// Next throw.
+//
+// Safety: every genuine Server Action in this app is invoked via the Next.js
+// client fetch path (react-hook-form `handleSubmit` -> `await action(...)`),
+// which ALWAYS sends both the `next-action` and `next-router-state-tree`
+// headers (see next/dist/.../server-action-reducer). There are no
+// progressively-enhanced `<form action={...}>` (no-JS / MPA) Server Actions.
+// So the presence of `next-router-state-tree` reliably marks a real action
+// from a live page, and we exempt it. We only short-circuit possible-action
+// POSTs that lack that header — i.e. requests that could never be a real
+// action and would otherwise land on the not-found page and 500.
+const NEXT_ACTION_HEADER = "next-action";
+const NEXT_ROUTER_STATE_TREE_HEADER = "next-router-state-tree";
+
+// True for POSTs that Next would feed into the Server Action handler against
+// the not-found page and that throw (500) when the body can't be decoded:
+// a `next-action` header, or a `multipart/form-data` body.
+const isThrowingServerActionPost = (request: NextRequest): boolean => {
+  if (request.method !== "POST") {
+    return false;
+  }
+  if (request.headers.has(NEXT_ACTION_HEADER)) {
+    return true;
+  }
+  const contentType = request.headers.get("content-type") ?? "";
+  return contentType.startsWith("multipart/form-data");
+};
+
+// Returns a short-circuit response for a stale/bot Server-Action POST that
+// would otherwise throw a 500 on the not-found page, or `null` to let the
+// request proceed untouched.
+const handleStaleServerActionPost = (
+  request: NextRequest,
+): NextResponse | null => {
+  if (!isThrowingServerActionPost(request)) {
+    return null;
+  }
+  // A live page's Server Action fetch always carries the router state tree.
+  // Its presence means this is (or could be) a real action — never touch it.
+  if (request.headers.has(NEXT_ROUTER_STATE_TREE_HEADER)) {
+    return null;
+  }
+  // No router state tree => not a real action from a live page. This is the
+  // stale-deployment / scanner shape. Respond with a clean 409 carrying a
+  // header the client (web/app/global-error.tsx) can act on, instead of
+  // letting Next render the not-found page for a POST and throw a 500.
+  return NextResponse.json(
+    {
+      error: "stale_or_unrecognized_server_action",
+      description:
+        "This request targets a Server Action that does not exist on the current deployment, or a route that was not found.",
+    },
+    {
+      status: 409,
+      headers: {
+        "x-stale-deployment": "1",
+        "cache-control": "no-store",
+      },
+    },
+  );
+};
+
+// Mirrors the `matcher` route subset that actually requires the Auth0 session
+// + CSP handling. The matcher below is intentionally broad so the stale-action
+// interceptor can see bot traffic on arbitrary paths, but auth/CSP must remain
+// scoped to these app pages exactly as before.
+const authProtectedMatchers = [
+  /^\/teams(\/|$)/,
+  /^\/create-team$/,
+  /^\/profile(\/|$)/,
+  /^\/join-callback$/,
+];
+
+const isAuthProtectedPath = (pathname: string): boolean =>
+  authProtectedMatchers.some((pattern) => pattern.test(pathname));
+
 const checkRouteRolesRestrictions = async (request: NextRequest) => {
   const session = await getSession();
   const user = session?.user as Auth0SessionUser["user"];
@@ -151,7 +244,9 @@ const checkRouteRolesRestrictions = async (request: NextRequest) => {
   return false;
 };
 
-export default withMiddlewareAuthRequired({
+// Auth0 session + role/CSP enforcement for the protected app pages. Unchanged
+// behaviour — only invoked for `authProtectedMatchers` paths (see dispatcher).
+const authMiddleware = withMiddlewareAuthRequired({
   middleware: async function middleware(request: NextRequest) {
     try {
       const redirect = await checkRouteRolesRestrictions(request);
@@ -181,11 +276,33 @@ export default withMiddlewareAuthRequired({
     }),
 });
 
+export default async function middleware(
+  request: NextRequest,
+  event: NextFetchEvent,
+) {
+  // 1. Short-circuit stale/bot Server-Action POSTs to unmatched routes before
+  //    the app router can run the action handler and throw a 500.
+  const staleActionResponse = handleStaleServerActionPost(request);
+  if (staleActionResponse) {
+    return staleActionResponse;
+  }
+
+  // 2. Enforce auth/CSP for the protected app pages, exactly as before.
+  if (isAuthProtectedPath(request.nextUrl.pathname)) {
+    return authMiddleware(request, event);
+  }
+
+  // 3. Everything else passes through untouched (equivalent to middleware not
+  //    running for this request).
+  return NextResponse.next();
+}
+
 export const config = {
+  // Run on all paths so the stale-action interceptor can catch bot/scanner
+  // POSTs to arbitrary unmatched routes. Static assets, image optimizer and
+  // Next internals are excluded — they are never Server Action targets and we
+  // must not add overhead there. Auth/CSP stay scoped via `isAuthProtectedPath`.
   matcher: [
-    "/teams/:path*",
-    "/create-team",
-    "/profile/:path*",
-    "/join-callback",
+    "/((?!_next/static|_next/image|_next/data|favicon.ico|sitemap.xml|robots.txt).*)",
   ],
 };

--- a/web/tests/unit/middleware.test.ts
+++ b/web/tests/unit/middleware.test.ts
@@ -157,10 +157,7 @@ describe("middleware [pass-through behaviour]", () => {
   });
 
   it("delegates a GET on a protected path to the auth middleware", async () => {
-    await middleware(
-      makeRequest("/teams/team_123", { method: "GET" }),
-      EVENT,
-    );
+    await middleware(makeRequest("/teams/team_123", { method: "GET" }), EVENT);
 
     expect(authMiddlewareSpy).toHaveBeenCalledTimes(1);
   });

--- a/web/tests/unit/middleware.test.ts
+++ b/web/tests/unit/middleware.test.ts
@@ -1,0 +1,174 @@
+import { NextRequest } from "next/server";
+
+// #region Mocks
+// Mock the Auth0 edge module at the I/O boundary so the middleware module can
+// be imported in a node test env and so `withMiddlewareAuthRequired` becomes a
+// transparent passthrough we can assert against. We only care about the
+// dispatcher + stale-action interceptor logic here, not the real auth flow.
+//
+// The factory creates the spy lazily on first call (the middleware module
+// invokes `withMiddlewareAuthRequired()` at import time), and stores it on the
+// mocked module so tests can read it back via `getAuthMiddlewareSpy()`.
+jest.mock("@auth0/nextjs-auth0/edge", () => {
+  const spy = jest.fn(async () => undefined);
+  return {
+    withMiddlewareAuthRequired: () => spy,
+    getSession: jest.fn().mockResolvedValue(null),
+    __authMiddlewareSpy: spy,
+  };
+});
+// #endregion
+
+// Import after mocks are registered.
+import middleware from "../../middleware";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const authMiddlewareSpy: jest.Mock = (
+  require("@auth0/nextjs-auth0/edge") as { __authMiddlewareSpy: jest.Mock }
+).__authMiddlewareSpy;
+
+// #region Test Data
+const EVENT = {} as any;
+
+const makeRequest = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string> },
+) =>
+  new NextRequest(new URL(url, "https://developer.worldcoin.org").toString(), {
+    method: init?.method ?? "GET",
+    headers: init?.headers,
+  });
+
+const MULTIPART = "multipart/form-data; boundary=----x";
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// #region stale / bot Server-Action POSTs that would otherwise 500
+describe("middleware [stale/bot Server-Action POSTs]", () => {
+  it("short-circuits a multipart POST to an unmatched path with a clean 409", async () => {
+    const res = await middleware(
+      makeRequest("/wp-admin/admin-ajax.php", {
+        method: "POST",
+        headers: { "content-type": MULTIPART },
+      }),
+      EVENT,
+    );
+
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(409);
+    expect(res!.headers.get("x-stale-deployment")).toBe("1");
+    expect(res!.headers.get("cache-control")).toBe("no-store");
+    // Must not have invoked the auth machinery for a bot path.
+    expect(authMiddlewareSpy).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits a POST carrying a next-action header to an unmatched path", async () => {
+    const res = await middleware(
+      makeRequest("/index.php", {
+        method: "POST",
+        headers: { "next-action": "abc123", "content-type": "text/plain" },
+      }),
+      EVENT,
+    );
+
+    expect(res!.status).toBe(409);
+    expect(res!.headers.get("x-stale-deployment")).toBe("1");
+  });
+
+  it("short-circuits even when the path starts with a real prefix (e.g. /api/...) but is a multipart bot probe", async () => {
+    const res = await middleware(
+      makeRequest("/api/files/extract-text", {
+        method: "POST",
+        headers: { "content-type": MULTIPART },
+      }),
+      EVENT,
+    );
+
+    expect(res!.status).toBe(409);
+    expect(authMiddlewareSpy).not.toHaveBeenCalled();
+  });
+});
+// #endregion
+
+// #region real Server Actions must NOT be intercepted
+describe("middleware [real Server Actions are not intercepted]", () => {
+  it("passes through a real fetch Server Action POST (has next-router-state-tree) on a protected page", async () => {
+    await middleware(
+      makeRequest("/teams/team_123/apps/app_456/configuration", {
+        method: "POST",
+        headers: {
+          "next-action": "realActionId",
+          "next-router-state-tree": "%5B%22%22%2C...%5D",
+          "content-type": "text/plain;charset=UTF-8",
+        },
+      }),
+      EVENT,
+    );
+
+    // Not short-circuited (interceptor returns a 409 only for stale/bot POSTs);
+    // instead the protected-path branch delegates to the auth middleware.
+    expect(authMiddlewareSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes through a multipart POST that carries next-router-state-tree (defensive exemption)", async () => {
+    await middleware(
+      makeRequest("/teams/team_123/apps/app_456/configuration", {
+        method: "POST",
+        headers: {
+          "content-type": MULTIPART,
+          "next-router-state-tree": "%5B%22%22%5D",
+        },
+      }),
+      EVENT,
+    );
+
+    // The router-state-tree header exempts it from interception; it reaches the
+    // protected-path auth branch instead of getting a 409.
+    expect(authMiddlewareSpy).toHaveBeenCalledTimes(1);
+  });
+});
+// #endregion
+
+// #region requests that should flow through untouched
+describe("middleware [pass-through behaviour]", () => {
+  it("does not intercept a GET to an unmatched path (genuine 404 page for browsers)", async () => {
+    const res = await middleware(
+      makeRequest("/some/random/path", { method: "GET" }),
+      EVENT,
+    );
+
+    expect(res?.headers.get("x-stale-deployment")).toBeNull();
+    expect(authMiddlewareSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not intercept a bare urlencoded POST (Next serves a clean 404, not a 500)", async () => {
+    const res = await middleware(
+      makeRequest("/user/register", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+      EVENT,
+    );
+
+    expect(res?.headers.get("x-stale-deployment")).toBeNull();
+    expect(authMiddlewareSpy).not.toHaveBeenCalled();
+  });
+
+  it("delegates a GET on a protected path to the auth middleware", async () => {
+    await middleware(
+      makeRequest("/teams/team_123", { method: "GET" }),
+      EVENT,
+    );
+
+    expect(authMiddlewareSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run auth for a GET on a public path", async () => {
+    await middleware(makeRequest("/login", { method: "GET" }), EVENT);
+
+    expect(authMiddlewareSpy).not.toHaveBeenCalled();
+  });
+});
+// #endregion


### PR DESCRIPTION
## Summary
Stops the ~1.2k/week HTTP **500s** on Next.js's internal `/_not-found/page` (issues [07359352](https://app.datadoghq.com/error-tracking/issue/07359352-1acb-11f1-b6aa-da7ad0900002), [355d359a](https://app.datadoghq.com/error-tracking/issue/355d359a-d8ab-11ef-910b-da7ad0900002)). A POST to an unmatched path that *looks like* a Server Action (a `next-action` header, or a `multipart/form-data` body) makes Next 15 run the action handler against the not-found page and **throw** while decoding the body → 500.

`web/middleware.ts` now intercepts these **before** the app router runs the handler and returns a clean **409 + `x-stale-deployment: 1`** instead.

## ⚠️ Two corrections to the original triage (please note)
1. **The app is on Next.js 15.5.18, not 14.2.35** (the Next 15 / React 19 upgrade is in prod). The fix is validated against 15.5.18.
2. **These 500s are 100% bot/scanner exploit probes, not real users on stale bundles.** All 142 distinct `POST /_not-found/page` @500 paths are file-upload CVE probes (`/wp-admin/admin-ajax.php`, `/.../upload.php`, `FileUploader.ashx`, Gotenberg `/forms/...`). In Next 15 a genuine stale-bundle action already returns a clean 404 (`x-nextjs-action-not-found`), never a 500 — so this is a **different population** from what PR #1913's client reload addresses. #1913 is not regressed.

## Safety analysis
- **Interception predicate is narrow:** `POST` AND (`next-action` header OR `multipart/form-data` body) AND **no `next-router-state-tree` header**.
- Every genuine Server Action in this app (33 of them) is invoked via the Next client fetch path (`react-hook-form` `handleSubmit` → `await action(...)`), which **always** sends `next-router-state-tree` → exempted. There are **no** progressively-enhanced `<form action={...}>` (no-JS) actions.
- **No API route parses multipart** (verified: zero `request.formData()` in `web/api`), so the interceptor cannot 409 a legitimate direct upload. The Bun `/api/v2/verify` integrator sends JSON → untouched. GET 404s (browsers) → untouched (predicate requires POST).

## ⚠️ Behavioral change worth a careful look: broadened matcher
The `config.matcher` is widened from 4 path prefixes (`/teams`, `/create-team`, `/profile`, `/join-callback`) to **all non-asset paths**, so the interceptor can see bot POSTs on arbitrary routes. **Auth/CSP behavior is unchanged** — `withMiddlewareAuthRequired` now runs only for the original paths via `isAuthProtectedPath`; everything else falls through with `NextResponse.next()`. But middleware now executes on every request (incl. `/api/*`), where before it didn't. The per-request work for non-protected paths is header-only + `next()` (cheap, no body read), but please **soak on staging and watch p50/p95 latency** before/after.

## Tests
`web/tests/unit/middleware.test.ts` — 9 branch tests: multipart→409, next-action→409, multipart on `/api/*`→409, real action (router-state-tree) exempt, multipart+router-state-tree exempt, GET unmatched untouched, bare urlencoded untouched, GET protected→auth, GET public→no auth.

## Test plan
- [ ] `npx jest tests/unit tests/api` (done locally: 450/450 + new suite 9/9) and `npx next build` (compiles clean)
- [ ] **Staging soak**: confirm real Server Actions on `/teams/*` etc. still work (submit forms), image upload still works, login/auth redirects unchanged
- [ ] Watch p50/p95 latency across the matcher change
- [ ] After deploy, watch `resource_name:"POST /_not-found/page" @http.status_code:500` → expect ~0; bots now get a 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)