### PR TITLE
fix(create-new-draft): guard against empty app array to prevent TypeError

### DIFF
--- a/web/api/hasura/create-new-draft/index.ts
+++ b/web/api/hasura/create-new-draft/index.ts
@@ -90,7 +90,7 @@ export const POST = async (req: NextRequest) => {
     user_id: userId,
   });
 
-  if (!app) {
+  if (!app || app.length === 0) {
     return errorHasuraQuery({
       req,
       detail: "App not found",


### PR DESCRIPTION
## Summary
Fixes a production `TypeError: Cannot read properties of undefined (reading 'verified_app_metadata')` on the `create-new-draft` Hasura action (~13 hits / 3 days).

## Root cause
`FetchAppMetadata` returns `app` as an array. The guard `if (!app)` does not catch an empty array (`[]` is truthy), so when no row matches (invalid `app_id`, or the user is not on the team) `app[0]` is `undefined` and `appMetadata.verified_app_metadata` throws.

## Fix
Widen the guard to `if (!app || app.length === 0)` so the empty case returns the existing `app_not_found` error instead of crashing.

## Verification
- `npx tsc --noEmit`: clean
- `pnpm format:check`: clean

Found via a 3-day Datadog Error Tracking review. Datadog issue: https://app.datadoghq.com/error-tracking/issue/ecddedde-4977-11f1-a8b2-da7ad0900002

🤖 Generated with [Claude Code](https://claude.com/claude-code)