### PR TITLE
fix(teams/apps): optional-chain user.hasura.memberships to prevent TypeError

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/page/index.tsx
@@ -23,10 +23,14 @@ export const AppsPage = async (props: AppPage) => {
     return redirect("/api/auth/logout");
   }
 
+  const memberships = user.hasura?.memberships ?? [];
+
   // If user tries to access another team's app, redirect to the their own.
-  if (!user.hasura.memberships.find((m) => m.team?.id === teamId)) {
-    const redirectTeamId = user.hasura.memberships[0]?.team?.id;
-    return redirect(`/teams/${redirectTeamId}/apps`);
+  if (!memberships.find((m) => m.team?.id === teamId)) {
+    const redirectTeamId = memberships[0]?.team?.id;
+    return redirect(
+      redirectTeamId ? `/teams/${redirectTeamId}/apps` : "/api/auth/logout",
+    );
   }
 
   const client = await getAPIServiceGraphqlClient();


### PR DESCRIPTION
## Summary
Fixes a production `TypeError: Cannot read properties of undefined (reading 'memberships')` that renders an error page on `/teams/[teamId]/apps`.

## Root cause
`user` is guarded, but `user.hasura` is not. When the Auth0 session user lacks the `hasura` claim, `user.hasura.memberships.find(...)` throws. Every other call site already uses `user?.hasura?.memberships?.` — this page was the only one missing it.

## Fix
Null-safe extraction `const memberships = user.hasura?.memberships ?? []`, plus a logout fallback so we never build a `/teams/undefined/apps` URL.

## Verification
- `npx tsc --noEmit`: clean
- `pnpm format:check`: clean

Found via a 3-day Datadog Error Tracking review. Datadog issue: https://app.datadoghq.com/error-tracking/issue/b88f3af6-461b-11f1-97a3-da7ad0900002

🤖 Generated with [Claude Code](https://claude.com/claude-code)