### PR TITLE
fix(mcp): return HTTP 400 for malformed JSON request bodies

### DIFF
--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -1648,6 +1648,7 @@ export const POST = async (req: NextRequest) => {
     return jsonRpcError(
       null,
       new McpError("Invalid JSON-RPC request body.", -32700),
+      400,
     );
   }
 

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -1993,7 +1993,7 @@ describe("/api/mcp", () => {
 
     const res = await POST(req);
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.jsonrpc).toBe("2.0");
     expect(body.error.code).toBe(-32700);


### PR DESCRIPTION
## Summary
The `/api/mcp` POST handler already caught JSON parse errors, but `jsonRpcError` defaulted to HTTP 200, so malformed bodies returned `200` with a JSON-RPC `-32700` error instead of a proper `400`. (The original `SyntaxError` in Error Tracking was bucketed from an older deploy before the catch existed.)

## Fix
Pass `400` as the status in the parse-error branch; update the existing test to assert `400`.

## Verification
- `npx tsc --noEmit`: clean
- `pnpm format:check`: clean
- `npx jest tests/api/mcp.test.ts`: 58/58 pass

Found via a 3-day Datadog Error Tracking review. Datadog issue: https://app.datadoghq.com/error-tracking/issue/ae43a97a-5cd1-11f1-bc1c-da7ad0900002

🤖 Generated with [Claude Code](https://claude.com/claude-code)