### PR TITLE
fix(login): guard against undefined hasura claim on login page

### DIFF
--- a/web/scenes/Onboarding/Login/page/index.tsx
+++ b/web/scenes/Onboarding/Login/page/index.tsx
@@ -24,7 +24,7 @@ export const LoginPage = async () => {
 
     try {
       const data = await getFetchMembershipsSdk(client).FetchMemberships({
-        userId: user?.hasura.id,
+        userId: user?.hasura?.id,
       });
 
       membership = data.membership;


### PR DESCRIPTION
## Summary
Fixes a production `TypeError: Cannot read properties of undefined (reading 'id')` on the login page that throws before any redirect and can block login.

## Root cause
`user?.hasura.id` — the optional chain stops at `user` but not `.hasura`. When a session exists but the JWT has no Hasura claims yet (first login / callback race), `user.hasura` is `undefined` and `.id` throws.

## Fix
`user?.hasura.id` -> `user?.hasura?.id`, matching every other call site. The resulting `undefined` flows into the existing try/catch which redirects to logout — no error-handling change.

## Verification
- `npx tsc --noEmit`: clean
- `pnpm format:check`: clean

Found via a 3-day Datadog Error Tracking review. Datadog issue: https://app.datadoghq.com/error-tracking/issue/f75e55c8-0fdf-11f0-b4db-da7ad0900002

🤖 Generated with [Claude Code](https://claude.com/claude-code)