### PR TITLE
chore: log remaining expected 4xx guards at warn, not error

### DIFF
--- a/web/api/hasura/create-new-draft/index.ts
+++ b/web/api/hasura/create-new-draft/index.ts
@@ -97,6 +97,7 @@ export const POST = async (req: NextRequest) => {
       code: "app_not_found",
       app_id,
       team_id,
+      logLevel: "warn",
     });
   }
 
@@ -109,6 +110,7 @@ export const POST = async (req: NextRequest) => {
       code: "verified_app_metadata_not_found",
       app_id,
       team_id,
+      logLevel: "warn",
     });
   }
 

--- a/web/api/hasura/invite-team-members/index.ts
+++ b/web/api/hasura/invite-team-members/index.ts
@@ -62,6 +62,7 @@ export const POST = async (req: NextRequest) => {
       req,
       detail: "userId must be set.",
       code: "required",
+      logLevel: "warn",
     });
   }
 
@@ -122,6 +123,7 @@ export const POST = async (req: NextRequest) => {
       detail: "Insufficient Permissions",
       code: "insufficient_permissions",
       team_id,
+      logLevel: "warn",
     });
   }
 

--- a/web/api/hasura/reset-api-key/index.ts
+++ b/web/api/hasura/reset-api-key/index.ts
@@ -41,6 +41,7 @@ export const POST = async (req: NextRequest) => {
       req,
       detail: "userId must be set.",
       code: "required",
+      logLevel: "warn",
     });
   }
 
@@ -78,6 +79,7 @@ export const POST = async (req: NextRequest) => {
       detail: "User does not have sufficient permissions.",
       code: "no_permission",
       team_id,
+      logLevel: "warn",
     });
   }
 

--- a/web/api/hasura/reset-client-secret/index.ts
+++ b/web/api/hasura/reset-client-secret/index.ts
@@ -40,6 +40,7 @@ export const POST = async (req: NextRequest) => {
       req,
       detail: "userId must be set.",
       code: "required",
+      logLevel: "warn",
     });
   }
 
@@ -80,6 +81,7 @@ export const POST = async (req: NextRequest) => {
       code: "insufficient_permissions",
       team_id,
       app_id,
+      logLevel: "warn",
     });
   }
 


### PR DESCRIPTION
## Summary
Downgrades expected client 4xx rejections (validation / permission / not-found) from `error` to `warn` in four Hasura action handlers, so they stop being reported to Datadog Error Tracking as defects. HTTP status codes and response bodies are unchanged — only log severity.

Handlers (none covered by other open PRs):
- **create-new-draft** — "App not found", "Verified app metadata not found"
- **invite-team-members** — "userId must be set", "Insufficient Permissions"
- **reset-api-key** — "userId must be set", "User does not have sufficient permissions"
- **reset-client-secret** — "userId must be set", "Insufficient Permissions"

## Context
Part of a 3-day Error Tracking cleanup. Complements the per-theme PRs already open: #1926 (RP action handlers), #1927 (upload-image), #1925 (v4 proof). Genuine server faults are deliberately left at `error` — e.g. "Failed to reset the client secret" (fires only after auth passes, on a 0-row DB update).

Note: `create-new-draft/index.ts` is also touched by #1929 (empty-array crash guard) on a different line; the two merge cleanly.

## Verification
- `npx tsc --noEmit`: clean
- `pnpm format:check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)