### PR TITLE
test(e2e): add CI retries and make app teardown idempotent

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -10,6 +10,7 @@ const config: PlaywrightTestConfig = {
   globalSetup: require.resolve("tests/e2e/global-setup"),
   globalTeardown: require.resolve("tests/e2e/global-teardown"),
   workers: 1,
+  retries: process.env.CI ? 2 : 0,
   use: {
     baseURL: process.env.NEXT_PUBLIC_APP_URL,
     browserName: "chromium",

--- a/web/tests/e2e/helpers/hasura/app/delete-apps-for-user.ts
+++ b/web/tests/e2e/helpers/hasura/app/delete-apps-for-user.ts
@@ -20,7 +20,7 @@ export const deleteAppsForTeam = async (teamId: string): Promise<void> => {
     affected_rows = response.delete_app?.affected_rows;
   } catch {}
 
-  if (!affected_rows) {
+  if (affected_rows == null) {
     throw new Error(
       `Failed to delete apps for team (${teamId}) from Hasura:\n${JSON.stringify(response, null, 2)}`,
     );

--- a/web/tests/e2e/specs/action.spec.ts
+++ b/web/tests/e2e/specs/action.spec.ts
@@ -6,11 +6,11 @@ test.describe("Action", () => {
   const appName = "World Test!";
   let appId: string;
 
-  test.beforeAll(async () => {
+  test.beforeEach(async () => {
     appId = await createApp(appName);
   });
 
-  test.afterAll(async () => {
+  test.afterEach(async () => {
     await deleteAppsForTeam(constants.teamId);
   });
 

--- a/web/tests/e2e/specs/app.spec.ts
+++ b/web/tests/e2e/specs/app.spec.ts
@@ -3,7 +3,7 @@ import { deleteAppsForTeam } from "@e2e/helpers/hasura/app";
 import { qase } from "playwright-qase-reporter";
 
 test.describe("App", () => {
-  test.afterAll(async () => {
+  test.afterEach(async () => {
     await deleteAppsForTeam(constants.teamId);
   });
 


### PR DESCRIPTION
## Summary
Reduces flakiness in the **End-to-end Tests** CI job. Over a 3-day window, trivial unrelated PRs repeatedly failed *only* the e2e job and went green on a plain rerun — a classic flaky suite.

Two targeted fixes:

1. **CI retries** (`playwright.config.ts`): `retries: process.env.CI ? 2 : 0`. The suite had no retries, so one transient blip failed the whole PR. The most common flake — `app.spec.ts › Create an App` timing out waiting for the `/configuration` title — is dev-server first-compile slowness; on a retry the route is already compiled, so retries clear it cleanly.
2. **Idempotent teardown** (`tests/e2e/helpers/hasura/app/delete-apps-for-user.ts`): the `afterAll` cleanup threw when `affected_rows` was `0` — i.e. it treated deleting *zero* apps as a failure. That is the `action.spec.ts › Create an Action` "Failed to delete apps for team" error. It now only throws when the mutation returns no result (`affected_rows == null`), treating 0 as a valid no-op.

## Deliberately not included
The bigger lever — running e2e against a production build instead of `pnpm dev` — is left out on purpose: under Next 15 a prod build may turn the current Auth0 `getSession()` sync-`cookies()` warnings into hard failures, so it should be trialed separately (ideally alongside the planned Auth0 v4 upgrade).

## Verification
- `npx tsc --noEmit`: clean
- `pnpm format:check`: clean
- This PR's own e2e run exercises the new retry path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)