### PR TITLE
fix: block World ID 4.0 migration for staging apps

### DIFF
--- a/web/api/hasura/register-rp/graphql/get-app-info.generated.ts
+++ b/web/api/hasura/register-rp/graphql/get-app-info.generated.ts
@@ -14,6 +14,7 @@ export type GetAppInfoQuery = {
     __typename?: "app";
     id: string;
     team_id: string;
+    is_staging: boolean;
     app_metadata: Array<{ __typename?: "app_metadata"; name: string }>;
   }>;
 };
@@ -23,6 +24,7 @@ export const GetAppInfoDocument = gql`
     app(where: { id: { _eq: $app_id } }) {
       id
       team_id
+      is_staging
       app_metadata(limit: 1) {
         name
       }

--- a/web/api/hasura/register-rp/graphql/get-app-info.graphql
+++ b/web/api/hasura/register-rp/graphql/get-app-info.graphql
@@ -2,6 +2,7 @@ query GetAppInfo($app_id: String!) {
   app(where: { id: { _eq: $app_id } }) {
     id
     team_id
+    is_staging
     app_metadata(limit: 1) {
       name
     }

--- a/web/api/hasura/register-rp/index.ts
+++ b/web/api/hasura/register-rp/index.ts
@@ -52,6 +52,7 @@ const REGISTRATION_ERROR_HTTP_CODE: Record<
   string
 > = {
   feature_not_enabled: "feature_not_enabled",
+  staging_not_supported: "staging_not_supported",
   config_error: "config_error",
   already_registered: "already_registered",
   kms_error: "kms_error",
@@ -134,6 +135,15 @@ export const POST = async (req: NextRequest) => {
     });
   }
 
+  if (appInfo.is_staging) {
+    return errorHasuraQuery({
+      req,
+      detail: "Staging apps cannot be migrated to World ID 4.0.",
+      code: "staging_not_supported",
+      app_id,
+    });
+  }
+
   // World ID 4.0 rollout flag still gates BOTH modes — the managed helper
   // checks it internally, but the self_managed branch below skips the
   // helper, so we explicitly check here to match prior behavior.
@@ -186,6 +196,7 @@ export const POST = async (req: NextRequest) => {
     teamId,
     signerAddress: signer_address!,
     appName,
+    isStaging: appInfo.is_staging,
   });
 
   if (!result.ok) {

--- a/web/api/helpers/rp-registration-flows.ts
+++ b/web/api/helpers/rp-registration-flows.ts
@@ -49,6 +49,7 @@ export type ManagedRegistrationResult =
       ok: false;
       code:
         | "feature_not_enabled"
+        | "staging_not_supported"
         | "config_error"
         | "already_registered"
         | "kms_error"
@@ -70,13 +71,23 @@ export async function submitManagedRpRegistration({
   teamId,
   signerAddress,
   appName,
+  isStaging,
 }: {
   client: GraphQLClient;
   appId: string;
   teamId: string;
   signerAddress: string;
   appName: string;
+  isStaging: boolean;
 }): Promise<ManagedRegistrationResult> {
+  if (isStaging) {
+    return {
+      ok: false,
+      code: "staging_not_supported",
+      detail: "Staging apps cannot be migrated to World ID 4.0.",
+    };
+  }
+
   if (!(await isWorldId40EnabledServer(teamId))) {
     return {
       ok: false,

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -866,6 +866,7 @@ const REGISTRATION_FLOW_RPC_CODE: Record<
   number
 > = {
   feature_not_enabled: -32004,
+  staging_not_supported: -32004,
   already_registered: -32004,
   config_error: -32603,
   kms_error: -32603,
@@ -1001,6 +1002,13 @@ const tools = {
           "World ID is already configured. Use rotate_world_id_signing_key to generate a new private signing key.",
       });
     }
+    if (app.is_staging) {
+      throw new McpError(
+        "Staging apps cannot be migrated to World ID 4.0.",
+        -32004,
+        { reason: "staging_not_supported" },
+      );
+    }
 
     // Always generate a wallet — managed mode requires a real signer
     // address up front. If the caller passed a private key we honor it,
@@ -1014,6 +1022,7 @@ const tools = {
       teamId: ctx.teamId,
       signerAddress: signingKey.signer_address,
       appName,
+      isStaging: app.is_staging,
     });
 
     if (!result.ok) {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/graphql/server/fetch-app-env.generated.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/graphql/server/fetch-app-env.generated.ts
@@ -14,6 +14,7 @@ export type FetchAppEnvQuery = {
     __typename?: "app";
     id: string;
     engine: string;
+    is_staging: boolean;
     rp_registration: Array<{ __typename?: "rp_registration"; rp_id: string }>;
   }>;
   action: Array<{ __typename?: "action"; id: string }>;
@@ -24,6 +25,7 @@ export const FetchAppEnvDocument = gql`
     app(where: { id: { _eq: $id } }) {
       id
       engine
+      is_staging
       rp_registration {
         rp_id
       }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/graphql/server/fetch-app-env.graphql
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/graphql/server/fetch-app-env.graphql
@@ -2,6 +2,7 @@ query FetchAppEnv($id: String!) {
   app(where: { id: { _eq: $id } }) {
     id
     engine
+    is_staging
     rp_registration {
       rp_id
     }

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/index.tsx
@@ -22,6 +22,7 @@ export const AppIdLayout = async (props: AppIdLayoutProps) => {
   let isOnChainApp = false;
   let hasLegacyActions = false;
   let hasRpRegistration = false;
+  let isStagingApp = false;
 
   const session = await getSession();
   const user = session?.user as Auth0SessionUser["user"];
@@ -41,6 +42,7 @@ export const AppIdLayout = async (props: AppIdLayoutProps) => {
         isOnChainApp = app[0].engine === EngineType.OnChain;
         hasLegacyActions = action.length > 0;
         hasRpRegistration = app[0].rp_registration.length > 0;
+        isStagingApp = app[0].is_staging;
       } else {
         logger.warn("AppIdLayout could not resolve app from FetchAppEnv", {
           appId: params.appId,
@@ -58,7 +60,9 @@ export const AppIdLayout = async (props: AppIdLayoutProps) => {
     }
   }
 
-  const showWorldId40Nav = await isWorldId40EnabledServer(params.teamId);
+  const showWorldId40Nav =
+    (await isWorldId40EnabledServer(params.teamId)) &&
+    (!isStagingApp || hasRpRegistration);
 
   return (
     <AppIdChrome

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/WorldId40MigrationBanner/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/WorldId40MigrationBanner/index.tsx
@@ -16,6 +16,7 @@ interface WorldId40MigrationBannerProps {
   appId: string;
   hasRpRegistration: boolean;
   canRegisterRp: boolean;
+  isStaging: boolean;
 }
 
 export const WorldId40MigrationBanner = ({
@@ -23,6 +24,7 @@ export const WorldId40MigrationBanner = ({
   appId,
   hasRpRegistration,
   canRegisterRp,
+  isStaging,
 }: WorldId40MigrationBannerProps) => {
   const worldId40Config = useAtomValue(worldId40Atom);
   const isEnabled = isWorldId40Enabled(worldId40Config, teamId);
@@ -37,9 +39,10 @@ export const WorldId40MigrationBanner = ({
   // Don't show banner if:
   // - World ID 4.0 is not enabled for this team, OR
   // - App already has RP registration, OR
+  // - App is a staging app, OR
   // - User lacks ADMIN/OWNER role (register_rp Hasura action would
   //   reject with `unauthorized` and surface a generic toast).
-  if (!isEnabled || hasRpRegistration || !canRegisterRp) {
+  if (!isEnabled || hasRpRegistration || isStaging || !canRegisterRp) {
     return null;
   }
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/index.tsx
@@ -27,8 +27,8 @@ export const AppIdPage = async (props: {
 
   const client = await getAPIServiceGraphqlClient();
   const appEnvData = await getAppEnvSdk(client).FetchAppEnv({ id: appId });
-  const hasRpRegistration =
-    (appEnvData.app[0]?.rp_registration?.length ?? 0) > 0;
+  const appInfo = appEnvData.app[0];
+  const hasRpRegistration = (appInfo?.rp_registration?.length ?? 0) > 0;
 
   const session = await getSession();
   const user = session?.user as Auth0SessionUser["user"] | undefined;
@@ -44,6 +44,7 @@ export const AppIdPage = async (props: {
         appId={appId}
         hasRpRegistration={hasRpRegistration}
         canRegisterRp={canRegisterRp}
+        isStaging={Boolean(appInfo?.is_staging)}
       />
 
       <div className="grid gap-y-3">

--- a/web/tests/api/hasura/register-rp.test.ts
+++ b/web/tests/api/hasura/register-rp.test.ts
@@ -1,0 +1,129 @@
+import { POST } from "@/api/hasura/register-rp";
+import { isWorldId40EnabledServer } from "@/lib/feature-flags/world-id-4-0/server";
+import { NextRequest } from "next/server";
+
+// #region Mocks
+const requestMock = jest.fn();
+const submitManagedRpRegistrationMock = jest.fn();
+
+jest.mock("@/api/helpers/graphql", () => ({
+  getAPIServiceGraphqlClient: jest.fn(async () => ({ request: requestMock })),
+}));
+
+jest.mock("@/api/helpers/rp-registration-flows", () => ({
+  submitManagedRpRegistration: (...args: unknown[]) =>
+    submitManagedRpRegistrationMock(...args),
+}));
+
+jest.mock("@/lib/feature-flags/world-id-4-0/server", () => ({
+  isWorldId40EnabledServer: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+// #endregion
+
+// #region Test Data
+const appId = "app_staging_9cdd0a714aec9ed17dca660bc9ffe72a";
+const teamId = "team_dd2ecd36c6c45f645e8e5d9a31abdee1";
+const userId = "user_123";
+const signerAddress = "0x1111111111111111111111111111111111111111";
+
+const getOperationName = (query: unknown) => {
+  if (typeof query === "string") {
+    return query;
+  }
+
+  return (
+    (query as { definitions?: { name?: { value?: string } }[] })
+      .definitions?.[0]?.name?.value ?? ""
+  );
+};
+
+const createMockRequest = (input: Record<string, unknown>) =>
+  new NextRequest("http://localhost:3000/api/hasura/register-rp", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.INTERNAL_ENDPOINTS_SECRET}`,
+    },
+    body: JSON.stringify({
+      action: { name: "register_rp" },
+      session_variables: {
+        "x-hasura-user-id": userId,
+      },
+      input,
+    }),
+  });
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.INTERNAL_ENDPOINTS_SECRET = "internal-secret";
+  (isWorldId40EnabledServer as jest.Mock).mockResolvedValue(true);
+
+  requestMock.mockImplementation(async (query: unknown) => {
+    const operationName = getOperationName(query);
+
+    if (operationName.includes("GetAppInfo")) {
+      return {
+        app: [
+          {
+            id: appId,
+            team_id: teamId,
+            is_staging: true,
+            app_metadata: [{ name: "Staging App" }],
+          },
+        ],
+      };
+    }
+
+    if (operationName.includes("CheckUserInApp")) {
+      return { team: [{ id: teamId }] };
+    }
+
+    throw new Error(`Unexpected query: ${operationName}`);
+  });
+});
+
+// #region Staging app migration
+describe("/api/hasura/register-rp [staging app migration]", () => {
+  it("rejects managed RP registration for staging apps", async () => {
+    const res = (await POST(
+      createMockRequest({
+        app_id: appId,
+        mode: "managed",
+        signer_address: signerAddress,
+      }),
+    ))!;
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.extensions.code).toBe("staging_not_supported");
+    expect(body.message).toBe(
+      "Staging apps cannot be migrated to World ID 4.0.",
+    );
+    expect(submitManagedRpRegistrationMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects self-managed RP registration for staging apps", async () => {
+    const res = (await POST(
+      createMockRequest({
+        app_id: appId,
+        mode: "self_managed",
+        signer_address: null,
+      }),
+    ))!;
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.extensions.code).toBe("staging_not_supported");
+    expect(submitManagedRpRegistrationMock).not.toHaveBeenCalled();
+  });
+});
+// #endregion

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -566,6 +566,26 @@ describe("/api/mcp", () => {
     );
   });
 
+  it("rejects World ID migration for staging apps", async () => {
+    currentAppContextResponse = {
+      app: [
+        {
+          ...appContextResponse.app[0],
+          is_staging: true,
+          rp_registration: [],
+        },
+      ],
+    };
+
+    const res = await POST(callTool("configure_world_id", { app_id: appId }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32004);
+    expect(body.error.data.reason).toBe("staging_not_supported");
+    expect(submitManagedRpRegistrationMock).not.toHaveBeenCalled();
+  });
+
   it("surfaces feature_not_enabled from the registration helper as -32004", async () => {
     currentAppContextResponse = {
       app: [{ ...appContextResponse.app[0], rp_registration: [] }],


### PR DESCRIPTION
## Summary

Staging apps can no longer be migrated into World ID 4.0. The portal now hides the migration banner and avoids routing unregistered staging apps into the World ID 4.0 setup flow, while the Hasura action, MCP tool, and shared managed-registration helper all reject staging-app registration attempts with `staging_not_supported` before creating RP records or submitting on-chain work.

Existing staging apps that already have an RP registration can still view their World ID 4.0 state.

## Testing

- `pnpm exec jest tests/api/mcp.test.ts tests/api/hasura/register-rp.test.ts`
- `npx tsc --noEmit`
- `pnpm format:check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
