### PR TITLE
feat: let network app read app_mode and integration_url from DB

### DIFF
--- a/web/api/v2/public/app/[app_id]/index.ts
+++ b/web/api/v2/public/app/[app_id]/index.ts
@@ -238,7 +238,7 @@ export async function GET(
 
     formattedMetadata = {
       ...formattedMetadata,
-      app_mode: nativeAppItem.app_mode,
+      app_mode: nativeAppItem.app_mode ?? formattedMetadata.app_mode,
       integration_url:
         nativeAppItem.integration_url !== ""
           ? nativeAppItem.integration_url

--- a/web/api/v2/public/apps/index.ts
+++ b/web/api/v2/public/apps/index.ts
@@ -257,7 +257,7 @@ export const GET = async (request: NextRequest) => {
             ? nativeAppItem.integration_url
             : app.integration_url,
         app_id: nativeAppItem.app_id,
-        app_mode: nativeAppItem.app_mode,
+        app_mode: nativeAppItem.app_mode ?? app.app_mode,
         unique_users: metricsMap.get(nativeAppItem.app_id)?.unique_users ?? 0,
       };
     }
@@ -269,9 +269,12 @@ export const GET = async (request: NextRequest) => {
       const nativeAppItem = nativeAppMetadata[app.app_id];
       return {
         ...app,
-        integration_url: nativeAppItem.integration_url,
+        integration_url:
+          nativeAppItem.integration_url !== ""
+            ? nativeAppItem.integration_url
+            : app.integration_url,
         app_id: nativeAppItem.app_id,
-        app_mode: nativeAppItem.app_mode,
+        app_mode: nativeAppItem.app_mode ?? app.app_mode,
         unique_users: metricsMap.get(nativeAppItem.app_id)?.unique_users ?? 0,
       };
     }

--- a/web/lib/constants.ts
+++ b/web/lib/constants.ts
@@ -106,8 +106,7 @@ export const NativeApps: Record<string, NativeAppsMap> = {
     },
     [NativeAppToAppIdMapping.staging.network]: {
       app_id: "network",
-      integration_url: "worldapp://network",
-      app_mode: "native",
+      integration_url: "",
     },
     [NativeAppToAppIdMapping.staging.grants_native]: {
       app_id: "worldcoin",
@@ -133,8 +132,7 @@ export const NativeApps: Record<string, NativeAppsMap> = {
     },
     [NativeAppToAppIdMapping.production.network]: {
       app_id: "network",
-      integration_url: "worldapp://network",
-      app_mode: "native",
+      integration_url: "",
     },
     [NativeAppToAppIdMapping.production.contacts]: {
       app_id: "contacts",

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -263,7 +263,7 @@ export type AppStoreFormattedFields = Omit<
 type NativeApp = {
   app_id: string;
   integration_url: string;
-  app_mode: "native" | "mini-app";
+  app_mode?: "native" | "mini-app";
 };
 
 export type NativeAppsMap = {


### PR DESCRIPTION
## PR Type

- [x] Regular Task

## Description

Removes the hardcoded `app_mode: "native"` and `integration_url: "worldapp://network"` from the `NativeApps` map for the network app (staging + production) so the DB values drive those fields instead. Makes `app_mode` optional on the `NativeApp` type, and updates the three public endpoint override blocks (`/app/[app_id]`, `/apps` top_apps, `/apps` highlights) to fall back to the DB value via `??` when `app_mode` is absent. The `app_id` slug `"network"` and metrics bucketing in `NativeAppToAppIdMapping`/`NATIVE_MAPPED_APP_ID` are unchanged; all other native apps (grants, invites, contacts, TEST_APP) are unaffected.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.