### PR TITLE
UGROWTH-1018 gate World Grow menu item on approved KYB/KYC

### DIFF
--- a/web/components/LoggedUserNav/index.tsx
+++ b/web/components/LoggedUserNav/index.tsx
@@ -209,7 +209,7 @@ export const LoggedUserNav = () => {
                 </Dropdown.ListItem>
               )}
 
-              {isWorldGrowApproved && (
+              {isAffiliateEnabled && isWorldGrowApproved && (
                 <Dropdown.ListItem asChild>
                   <Link href={`/teams/${teamId}/affiliate-program`}>
                     <Dropdown.ListItemIcon asChild>

--- a/web/components/LoggedUserNav/index.tsx
+++ b/web/components/LoggedUserNav/index.tsx
@@ -7,13 +7,14 @@ import { TeamLogo } from "@/components/LoggedUserNav/Teams/TeamLogo";
 import { useFetchTeamQuery } from "@/components/LoggedUserNav/graphql/client/fetch-team.generated";
 import { Role_Enum } from "@/graphql/graphql";
 import { DOCS_URL } from "@/lib/constants";
-import { Auth0SessionUser } from "@/lib/types";
+import { Auth0SessionUser, IdentityVerificationStatus } from "@/lib/types";
 import { checkUserPermissions } from "@/lib/utils";
 import {
   affiliateEnabledAtom,
   isAffiliateEnabledForTeam,
 } from "@/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/common/affiliate-enabled-atom";
 import { getParameter } from "@/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/common/server/getParameter";
+import { useGetAffiliateMetadata } from "@/scenes/Portal/Teams/TeamId/Team/AffiliateProgram/Overview/page/hooks/use-get-affiliate-metadata";
 import { colorAtom } from "@/scenes/Portal/layout";
 import { useMeQuery } from "@/scenes/common/me-query/client";
 import { useUser } from "@auth0/nextjs-auth0/client";
@@ -89,6 +90,14 @@ export const LoggedUserNav = () => {
     () => isAffiliateEnabledForTeam(affiliateConfig, teamId, auth0User),
     [affiliateConfig, teamId, auth0User],
   );
+
+  const { data: affiliateMetadata } = useGetAffiliateMetadata({
+    skip: !isAffiliateEnabled,
+  });
+
+  const isWorldGrowApproved =
+    affiliateMetadata?.identityVerificationStatus ===
+    IdentityVerificationStatus.SUCCESS;
 
   return (
     <div
@@ -200,7 +209,7 @@ export const LoggedUserNav = () => {
                 </Dropdown.ListItem>
               )}
 
-              {isAffiliateEnabled && (
+              {isWorldGrowApproved && (
                 <Dropdown.ListItem asChild>
                   <Link href={`/teams/${teamId}/affiliate-program`}>
                     <Dropdown.ListItemIcon asChild>


### PR DESCRIPTION
## PR Type

- [x] Regular Task

## Description

The affiliate program is being sunset — no new affiliates should be onboarded. The "World Grow (affiliate)" nav dropdown entry now only appears for teams whose affiliate identity verification status is `success` (approved KYB/KYC), instead of showing for any team with a verified app. The existing `isAffiliateEnabled` check is kept as a cheap gate to skip the metadata fetch entirely for non-affiliate teams.

## Checklist

- [x] I have self-reviewed this PR.