### PR TITLE
fix: guard getIsUserAllowedToInsertApp against invalid teamId

### DIFF
--- a/web/lib/permissions/index.ts
+++ b/web/lib/permissions/index.ts
@@ -25,6 +25,10 @@ const getIsIdValid = async (id: string) => {
 };
 
 export const getIsUserAllowedToInsertApp = async (teamId: string) => {
+  if (!(await getIsIdValid(teamId))) {
+    return false;
+  }
+
   const session = await getSession();
   if (!session) {
     return false;


### PR DESCRIPTION
> **DRAFT** — this changes an authorization helper. Per triage policy, auth/security-touching changes are opened as drafts for human review even when confidence is high. The only behavioral concern to confirm: returning `false` (permission denied) for an invalid/empty `teamId` is the desired outcome (it matches every sibling helper in this file).

## Datadog issue
[expecting a value for non-nullable variable: "teamId"](https://app.datadoghq.com/error-tracking/issue/e8ef415c-5ff5-11f1-bc4c-da7ad0900002) — `Error`, 54 occurrences / 7d (18 / 3d), first_seen 2026-06-04.

## Root cause (with evidence)
`getIsUserAllowedToInsertApp(teamId)` in `web/lib/permissions/index.ts` was the **only** permission helper in the module that did not validate its id argument before issuing its GraphQL query. Every sibling (`getIsUserAllowedToReadApp`, `...UpdateApp`, `...DeleteApp`, `...UpdateTeam`, etc.) begins with a `getIsIdValid(...)` guard.

When `teamId` is `undefined`/empty, it is forwarded to the `GetIsUserPermittedToInsertApp($userId: String!, $teamId: String!)` query as a `String!` non-nullable variable. Hasura rejects it with:

```
expecting a value for non-nullable variable: "teamId" (code: validation-failed)
```

which throws and is logged as a production error. The Datadog sample confirms `userId` is present while `teamId` is missing. Log-onset analysis shows this is a genuine recent onset (1 in wk of 05‑25 → 19 in wk of 06‑01 → 7 so far in 06‑08), not a deploy re-fingerprint.

## Fix
Add the same `getIsIdValid(teamId)` guard the sibling helpers use, short-circuiting to `false` (permission denied) before the GraphQL call:

```ts
if (!(await getIsIdValid(teamId))) {
  return false;
}
```

Minimal, scoped, no logic change beyond the early return.

## Confidence: 85%
Mirrors an established, identical pattern already used by every other helper in the same file; low blast radius. Held below auto-merge / opened as draft only because it is an authz helper and warrants a human eyeball on the deny-on-invalid semantics.

## Test plan
- `npx tsc --noEmit` — passes
- `prettier --check` on the file — passes
- Manual: calling the insert-app permission check with an undefined/empty `teamId` now returns `false` without issuing the GraphQL query; valid `teamId` path is unchanged.
- No handler test added (would require heavy auth0 + GraphQL SDK mocks, against repo testing conventions).

---
_Generated by [Claude Code](https://claude.ai/code/session_0154cjkfZjbBkeM5vJq6NwMS)_