### PR TITLE
chore: stop fingerprinting invalid-JSON bad-client input in v2/verify

### DIFF
--- a/web/api/v2/verify/index.ts
+++ b/web/api/v2/verify/index.ts
@@ -76,8 +76,14 @@ export async function POST(
   try {
     body = JSON.parse(rawBody);
   } catch (error) {
+    // Serialize to message/name only (drop the stack) so this expected
+    // bad-client input is not fingerprinted into Datadog Error Tracking,
+    // mirroring the serializedError pattern in errorFormAction.
     logger.warn("Invalid JSON in request body", {
-      error,
+      error:
+        error instanceof Error
+          ? { message: error.message, name: error.name }
+          : error,
       app_id,
       body: rawBody,
     });


### PR DESCRIPTION
## Datadog issue
[Unexpected token 'e', "email=test@gmail.com" is not valid JSON](https://app.datadoghq.com/error-tracking/issue/a6b4e802-61dd-11f1-9e58-da7ad0900002) — `SyntaxError` in `/api/v2/verify/[app_id]/route.js`, 36 occurrences / 7d (all in the last 3d), first_seen 2026-06-06. (Same class as the sibling issue [`Unexpected token 'r', "returnTo=/"...`](https://app.datadoghq.com/error-tracking/issue/8591155c-dcbd-11ef-aa6e-da7ad0900002).)

## Root cause (with evidence)
`POST /api/v2/verify/[app_id]` reads the raw body and wraps `JSON.parse` in a try/catch — it **already** returns a `400` and logs at `warn` level (not error). But the catch attaches the raw `SyntaxError` object:

```ts
logger.warn("Invalid JSON in request body", { error, app_id, body: rawBody });
```

Because that `error` carries a stack, Datadog Error Tracking fingerprints it into an *error* issue even though the log severity is `warn`. The samples (`email=test@gmail.com`, `returnTo=/...`) are bots/scanners POSTing **form-encoded** bodies to a JSON endpoint — expected bad input, not a fault. The handler's behavior is already correct; only the observability is noisy.

## Fix
Serialize the caught error to `{ message, name }` (dropping the stack) before logging, so the `warn` log is preserved but Error Tracking no longer treats it as an error. This mirrors the `serializedError = { message, name }` pattern already used by `errorFormAction` in `web/api/helpers/errors.ts`. No control-flow/logic change — still a 400 with the same body.

## Confidence: 78%
The fix matches an existing in-repo pattern and is logging-only (zero behavioral risk). Held below 100% because suppression in Error Tracking depends on Datadog's pipeline keying on the stack attribute; if the org's pipeline also fingerprints on `@error.message` alone, the issue volume may shrink rather than disappear. Either way the handler stays correct and the log remains for debugging.

## Test plan
- `npx tsc --noEmit` — passes
- `prettier --check` on the file — passes
- Manual: POST a non-JSON body (e.g. `email=test@gmail.com`) to `/api/v2/verify/<app_id>` → still returns `400 invalid_request`; a `warn` log is emitted with `error.message`/`error.name` but no stack, so no new Error Tracking issue.
- No handler test added (would require heavy GraphQL SDK + verify-helper mocks, against repo testing conventions); the catch branch is unchanged in behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_0154cjkfZjbBkeM5vJq6NwMS)_