### PR TITLE
chore: log "App not found." hasura rejections at warn, not error

### DIFF
--- a/web/api/hasura/get-image/index.ts
+++ b/web/api/hasura/get-image/index.ts
@@ -96,6 +96,7 @@ export const POST = async (req: NextRequest) => {
         code: "not_found",
         team_id,
         app_id,
+        logLevel: "warn",
       });
     }
 

--- a/web/api/hasura/register-rp/index.ts
+++ b/web/api/hasura/register-rp/index.ts
@@ -115,6 +115,7 @@ export const POST = async (req: NextRequest) => {
       detail: "App not found.",
       code: "app_not_found",
       app_id,
+      logLevel: "warn",
     });
   }
   const appInfo = app[0];

--- a/web/api/hasura/verify-app/index.ts
+++ b/web/api/hasura/verify-app/index.ts
@@ -96,6 +96,7 @@ export const POST = async (req: NextRequest) => {
       req,
       detail: "App not found.",
       code: "not_found",
+      logLevel: "warn",
     });
   }
 


### PR DESCRIPTION
## Datadog issue
["App not found."](https://app.datadoghq.com/error-tracking/issue/21877ad2-5aa3-11f1-a61f-da7ad0900002) — `Error`, BACKEND, 65 occurrences / 7d, first_seen 2026-05-28 (the Next 15.5 upgrade deploy — a re-fingerprint of a long-standing pattern, **not** a new regression).

## Root cause (with evidence)
Several Hasura action handlers return `errorHasuraQuery({ detail: "App not found.", ... })` at the **default** `error` log level. These are legitimate business rejections, not faults:
- `get-image` — caller is not an Admin/Owner of the owning team (`userTeam.length === 0`)
- `register-rp` — the app id does not resolve to an app
- `verify-app` — reviewer targets an app that has no metadata row

`errorHasuraQuery` logs at `logger[logLevel]`, defaulting to `error`, so each rejection is fingerprinted into Error Tracking. Onset analysis over 8 weeks shows a flat, long-standing volume (139 → 1778 → 1763 / wk) consistent with steady background rejection traffic rather than a code defect.

The sibling **`upload-image`** handler already returns this identical `"App not found."` rejection with `logLevel: "warn"` — so warn is the established, intended severity for this case.

## Fix
Add `logLevel: "warn"` to the three remaining `"App not found."` `errorHasuraQuery` calls, matching `upload-image`. No control-flow or response change — same 400 body and `code`; only the log severity (and therefore Error Tracking visibility) changes.

## Confidence: 88%
Mirrors an existing in-repo precedent for the exact same message/handler family; logging-only, no logic touched. The `errorHasuraQuery` `logLevel` parameter is purpose-built for exactly this.

## Test plan
- `npx tsc --noEmit` — passes
- `prettier --check` on all three files — passes
- Manual: trigger each rejection (request an image for a team you're not in; register-rp with an unknown app id; verify-app for an app with no metadata) → response is unchanged (`400`, `not_found`/`app_not_found`); the log line is now `warn` and no longer surfaces in Error Tracking.
- No handler test added (these handlers need heavy GraphQL SDK + S3/auth mocks; behavior is unchanged so existing branch coverage is unaffected — per repo testing conventions).

---
_Generated by [Claude Code](https://claude.ai/code/session_0154cjkfZjbBkeM5vJq6NwMS)_