### PR TITLE
chore: log rotate-signer-key authz rejection at warn, not error

### DIFF
--- a/web/api/hasura/rotate-signer-key/index.ts
+++ b/web/api/hasura/rotate-signer-key/index.ts
@@ -115,6 +115,7 @@ export const POST = async (req: NextRequest) => {
       detail: "User does not have permission to rotate signer key.",
       code: "unauthorized",
       app_id,
+      logLevel: "warn",
     });
   }
 


### PR DESCRIPTION
**Opened as a DRAFT** because this change is in an authorization code path. It is a **log-level-only** change — no auth logic is modified — but flagging it for a human per triage policy.

### Datadog issue
[User does not have permission to rotate signer key.](https://app.datadoghq.com/error-tracking/issue/64f41df0-5ab9-11f1-91dd-da7ad0900002) — `service:developer-portal env:production`, 12 occurrences in the last 7 days, long-standing.

### Root cause (evidence)
`POST /api/hasura/rotate-signer-key` (`web/api/hasura/rotate-signer-key/index.ts:113`) rejects callers who are not members of the app's owning team via `errorHasuraQuery` at the **default `error`** log level:

```ts
if (!team || team.length === 0) {
  return errorHasuraQuery({
    req,
    detail: "User does not have permission to rotate signer key.",
    code: "unauthorized",
    app_id,
  }); // logLevel defaults to "error"
}
```

This is a legitimate authorization rejection (the user simply lacks permission), not a server fault, yet `logger.error` causes the active APM span to be tagged with an error (`web/lib/logger.ts:139-145`), which fingerprints it into Error Tracking.

### Fix
Add `logLevel: "warn"`, mirroring the sibling "RP registration not found" rejection a few lines above (line 97-103) in the same handler, which already does this. Logic unchanged.

### Confidence: 90%
Trivial, well-established pattern already used in the same file; the only reason it isn't higher is that it touches an authz handler (hence draft).

### Test plan
- `npx tsc --noEmit` ✅ (passes)
- `pnpm format:check` ✅ (passes)
- No behavior change to assert; the rejection response and status are identical, only log severity differs. Verify in Datadog after deploy that the issue stops accruing new error-tracked events.

https://claude.ai/code/session_01EPGwLdouXUrPRDBz8Zmn11

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPGwLdouXUrPRDBz8Zmn11)_