### PR TITLE
chore: log on-chain proof-verification reverts at warn, not error

### DIFF
--- a/web/api/helpers/temporal-rpc.ts
+++ b/web/api/helpers/temporal-rpc.ts
@@ -209,14 +209,19 @@ function parseVerifierRevertReason(error: unknown): {
  */
 function isVerifierRevert(error: unknown): boolean {
   const ethersError = error as EthersCallException;
+  const knownRevertNames = Object.keys(VERIFIER_ERROR_MAP);
+  // Only downgrade reverts we recognize as expected invalid-proof outcomes.
+  // Built-in Error(string)/Panic(uint256) reverts and unmapped custom errors
+  // stay at error so new contract/verifier failures remain visible in Error
+  // Tracking.
   if (ethersError?.revert?.name) {
-    return true;
+    return knownRevertNames.includes(ethersError.revert.name);
   }
   const message =
     ethersError?.shortMessage ||
     ethersError?.message ||
     (error instanceof Error ? error.message : String(error));
-  return Object.keys(VERIFIER_ERROR_MAP).some((name) => message.includes(name));
+  return knownRevertNames.some((name) => message.includes(name));
 }
 
 // =============================================================================

--- a/web/api/helpers/temporal-rpc.ts
+++ b/web/api/helpers/temporal-rpc.ts
@@ -200,6 +200,25 @@ function parseVerifierRevertReason(error: unknown): {
   };
 }
 
+/**
+ * Distinguishes an expected on-chain Verifier revert (an invalid or expired
+ * proof — a client/business outcome the caller handles) from an unexpected
+ * failure (RPC/network/infra fault). Reverts are surfaced to the caller as a
+ * structured failure and are not server faults, so callers can log them at
+ * warn instead of error to keep them out of Error Tracking.
+ */
+function isVerifierRevert(error: unknown): boolean {
+  const ethersError = error as EthersCallException;
+  if (ethersError?.revert?.name) {
+    return true;
+  }
+  const message =
+    ethersError?.shortMessage ||
+    ethersError?.message ||
+    (error instanceof Error ? error.message : String(error));
+  return Object.keys(VERIFIER_ERROR_MAP).some((name) => message.includes(name));
+}
+
 // =============================================================================
 // UserOperation Submission
 // =============================================================================
@@ -373,7 +392,8 @@ export async function verifyProofOnChain(
     });
     return { success: true };
   } catch (error) {
-    logger.error("Proof verification failed", {
+    const logLevel = isVerifierRevert(error) ? "warn" : "error";
+    logger[logLevel]("Proof verification failed", {
       error: error instanceof Error ? error.message : String(error),
       rpId: params.rpId.toString(),
     });
@@ -428,7 +448,8 @@ export async function verifySessionProofOnChain(
     });
     return { success: true };
   } catch (error) {
-    logger.error("Session proof verification failed", {
+    const logLevel = isVerifierRevert(error) ? "warn" : "error";
+    logger[logLevel]("Session proof verification failed", {
       error: error instanceof Error ? error.message : String(error),
       rpId: params.rpId.toString(),
       sessionId: params.sessionId.toString(),


### PR DESCRIPTION
**Opened as a DRAFT** because this touches the World ID proof-verification (security) path. Control flow and returned results are unchanged — only the log severity of an *expected* invalid-proof outcome changes — but flagging it for a human review per triage policy.

### Datadog issue
[Proof verification failed](https://app.datadoghq.com/error-tracking/issue/2b74df22-5f75-11f1-a738-da7ad0900002) — `service:developer-portal env:production`, ~20 occurrences in the last 3 days. NOTE: Datadog reports `first_seen 2026-06-03`, but `aggregate_spans` on `@error.message` over 6 weeks shows it present continuously since at least 2026-05-17 — this is a **long-standing issue re-fingerprinted on a recent deploy, not a regression**.

### Root cause (evidence)
`verifyProofOnChain` / `verifySessionProofOnChain` (`web/api/helpers/temporal-rpc.ts`) call the on-chain Verifier contract. The contract **reverts when a submitted proof is invalid or expired** — an expected client/business outcome. The function catches that revert, maps it via `parseVerifierRevertReason`, and returns a structured `{ success: false, error }` that callers turn into a 400. But the catch logged it with `logger.error("Proof verification failed", ...)`, so every invalid proof was tagged onto the APM span (`web/lib/logger.ts:139-145`) and fingerprinted into Error Tracking.

### Fix
Add an `isVerifierRevert()` helper (reusing the same revert-detection logic as `parseVerifierRevertReason`: structured `revert.name` or a message matching a known `VERIFIER_ERROR_MAP` key). Log at `warn` when the failure is a recognized contract revert; **keep `error` for genuine RPC/network/infra faults** so real verifier outages stay visible. Applied to both verifier entry points for consistency.

### Confidence: 72%
The revert-vs-infra split is principled and reuses existing logic, and invalid proofs are clearly the dominant cause here. Slightly lower because the catch is a broad `catch (error)` and a previously-unseen ethers error shape could in theory be misclassified as a revert (it would fall through to `error` since it wouldn't match a known revert name — the conservative direction).

### Test plan
- `npx tsc --noEmit` ✅ (passes)
- `pnpm format:check` ✅ (passes)
- No new tests added (would require heavy ethers `Contract` mocking, against repo testing conventions). `isVerifierRevert` mirrors the already-tested-in-prod `parseVerifierRevertReason` detection.
- Post-deploy: confirm invalid-proof events appear as `warn` and that a forced RPC failure still logs at `error`.

https://claude.ai/code/session_01EPGwLdouXUrPRDBz8Zmn11

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPGwLdouXUrPRDBz8Zmn11)_