### PR TITLE
chore: log app-info Hasura client-input rejections at warn, not error

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/server/submit.ts
@@ -86,9 +86,13 @@ export async function validateAndSubmitServerSide(
     };
   } catch (error) {
     // Hasura rejects malformed client input (e.g. an invalid integration_url
-    // that fails the DB's URL/format check) with a GraphQL "data-exception" /
-    // "constraint-violation" / "validation-failed". These are bad-client input,
-    // not server faults.
+    // that fails the DB's URL/format check) with a GraphQL "data-exception" or
+    // "constraint-violation". These are bad-client input, not server faults.
+    // "validation-failed" is deliberately excluded: the UpdateAppInfo document
+    // is generated and the inputs are plain strings, so that code can only mean
+    // the GraphQL operation no longer validates against Hasura (schema /
+    // generated-query drift) — a deployment fault that must stay in Error
+    // Tracking.
     const hasuraCode = (
       error as {
         response?: { errors?: { extensions?: { code?: unknown } }[] };
@@ -97,9 +101,7 @@ export async function validateAndSubmitServerSide(
 
     if (
       typeof hasuraCode === "string" &&
-      ["data-exception", "constraint-violation", "validation-failed"].includes(
-        hasuraCode,
-      )
+      ["data-exception", "constraint-violation"].includes(hasuraCode)
     ) {
       // Log at warn and DO NOT attach the raw Error. The logger tags the active
       // APM span with an error whenever an Error instance is attached (any log

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/server/submit.ts
@@ -85,6 +85,42 @@ export async function validateAndSubmitServerSide(
       message: "App information updated successfully",
     };
   } catch (error) {
+    // Hasura rejects malformed client input (e.g. an invalid integration_url
+    // that fails the DB's URL/format check) with a GraphQL "data-exception" /
+    // "constraint-violation" / "validation-failed". These are bad-client input,
+    // not server faults.
+    const hasuraCode = (
+      error as {
+        response?: { errors?: { extensions?: { code?: unknown } }[] };
+      }
+    )?.response?.errors?.[0]?.extensions?.code;
+
+    if (
+      typeof hasuraCode === "string" &&
+      ["data-exception", "constraint-violation", "validation-failed"].includes(
+        hasuraCode,
+      )
+    ) {
+      // Log at warn and DO NOT attach the raw Error. The logger tags the active
+      // APM span with an error whenever an Error instance is attached (any log
+      // level) or whenever the level is "error" — and that span tag is what
+      // feeds Datadog Error Tracking. Passing the details as plain strings keeps
+      // a useful warn log without fingerprinting an expected validation
+      // rejection, mirroring the errorHasuraQuery warn calls elsewhere.
+      return errorFormAction({
+        message: "An error occurred while updating the app information",
+        additionalInfo: {
+          app_metadata_id,
+          input,
+          hasuraCode,
+          hasuraMessage: error instanceof Error ? error.message : String(error),
+        },
+        team_id: teamId,
+        app_id: app_id ?? undefined,
+        logLevel: "warn",
+      });
+    }
+
     return errorFormAction({
       message: "An error occurred while updating the app information",
       error: error as Error,


### PR DESCRIPTION
### Datadog issue
[Invalid URL format. URLs must use HTTPS protocol.](https://app.datadoghq.com/error-tracking/issue/e633e5b6-6622-11f1-a2aa-da7ad0900002) — `service:developer-portal env:production`, ~18 occurrences in the last 3 days and growing (first_seen 2026-06-12).

### Root cause (evidence)
The "update app info" server action (`web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/server/submit.ts`) forwards `name` / `integration_url` / `app_website_url` to Hasura via the `UpdateAppInfo` mutation. A user submitted `integration_url: "https://app.hachidefi."` — it passes the client form schema (`new URL()` accepts a trailing-dot host) but fails Hasura's stricter DB URL check, which rejects with a GraphQL `data-exception`:

```json
{"errors":[{"message":"Invalid URL format. URLs must use HTTPS protocol.","extensions":{"code":"data-exception"}}]}
```

The generic `catch` logged this via `errorFormAction` at `error` level **with the raw `Error` attached**. Per `web/lib/logger.ts:132-146`, the logger tags the active APM span with an error **whenever an `Error` instance is attached (at any log level) _or_ whenever the level is `error`** — and that span tag is what feeds Error Tracking. So this expected bad-client input was fingerprinted as a production error.

### Fix
Detect Hasura client-input rejection codes (`data-exception` / `constraint-violation` / `validation-failed`) on the caught GraphQL error (same `error.response.errors[0].extensions.code` shape already used in `web/api/v2/create-action/index.ts:180`). For those, log at `warn` **and** without attaching the raw `Error` (details preserved as plain strings in `additionalInfo`) — both are required to keep it out of Error Tracking, given the logger behavior above. Genuine server faults still log at `error` with the full error. User-facing failure response is unchanged.

### Confidence: 80%
The error shape and code are confirmed from the Datadog payload and match an existing in-repo detection pattern; the logger mechanism is verified in source. Not higher only because the client-input code list is a curated set — an unlisted Hasura client-error code would still log at `error` (the safe/conservative direction).

### Test plan
- `npx tsc --noEmit` ✅ (passes)
- `pnpm format:check` ✅ (passes)
- No existing test for this handler; no new heavy-SDK-mock test added per repo testing conventions.
- Post-deploy: confirm a bad `integration_url` submit now produces a `warn` log (not error-tracked) while the user still sees the same failure toast.

https://claude.ai/code/session_01EPGwLdouXUrPRDBz8Zmn11

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPGwLdouXUrPRDBz8Zmn11)_