### PR TITLE
fix: return 400 instead of 500 for invalid JSON in proof-context

### DIFF
--- a/web/api/v4/proof-context/[id]/index.ts
+++ b/web/api/v4/proof-context/[id]/index.ts
@@ -1,5 +1,6 @@
 import { errorResponse } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { parseRequestBody } from "@/api/helpers/parse-request-body";
 import {
   resolveRpRegistration,
   RpRegistrationStatus,
@@ -76,10 +77,15 @@ export async function POST(
   >
 > {
   const routeParams = await props.params;
-  const body = await req.json();
+
+  const parseResult = await parseRequestBody(req);
+  if (!parseResult.isValid) {
+    return corsHandler(parseResult.error, corsMethods);
+  }
+
   const { isValid, parsedParams, handleError } = await validateRequestSchema({
     schema,
-    value: body,
+    value: parseResult.body,
   });
 
   if (!isValid) {


### PR DESCRIPTION
## What

`POST /api/v4/proof-context/[id]` called `await req.json()` with no guard. A request with an empty or malformed body made `req.json()` throw `SyntaxError: Unexpected end of JSON input`, which surfaced as an unhandled **500**.

This adopts the existing [`parseRequestBody`](web/api/helpers/parse-request-body.ts) helper (added in #1900 for exactly this class of bug) so a bad body returns a CORS-wrapped **400 `invalid_json`** response instead. This mirrors the predecessor `/api/v1/precheck/[app_id]` endpoint, which already uses the helper — proof-context (the "precheck successor") was simply missed during that migration.

## Why

The `developer-portal - proof context endpoint availability` monitor ([Datadog 258709539](https://app.datadoghq.com/monitors/258709539)) measures success rate as `non-5xx / total`. These uncaught 500s on malformed input ate into the error budget and triggered the alert.

Datadog evidence (production, 2026-06-13 23:35:49Z, commit `a45f7b72`):

```
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    ...
    at async I (/app/.next/server/app/api/v4/proof-context/[id]/route.js:75:304)
```
Request: `POST http://developer.world.org/api/v4/proof-context/rp_7a7c4c4d289540ed` (curl, empty body) → HTTP 500.

## Testing

- `npx tsc --noEmit` — clean
- `npx prettier --check` — clean
- `npx jest tests/api/helpers/parse-request-body.test.ts` — 4/4 pass (covers empty-body and malformed-body → 400). The helper is unit-tested centrally; the 5 sibling endpoints that adopted it don't carry redundant per-endpoint JSON tests, so none is added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)