### PR TITLE
fix(auth): v4 staging regressions — server-only client bundle + render loop

### DIFF
--- a/web/components/LoggedUserNav/index.tsx
+++ b/web/components/LoggedUserNav/index.tsx
@@ -10,7 +10,7 @@ import { DOCS_URL } from "@/lib/constants";
 import { Auth0SessionUser } from "@/lib/types";
 import { urls } from "@/lib/urls";
 import { checkUserPermissions } from "@/lib/utils";
-import { colorAtom } from "@/scenes/Portal/layout";
+import { colorAtom } from "@/scenes/Portal/layout/color-atom";
 import { useMeQuery } from "@/scenes/common/me-query/client";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { useAtom } from "jotai";

--- a/web/lib/auth0.ts
+++ b/web/lib/auth0.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { Auth0Client } from "@auth0/nextjs-auth0/server";
 import { getAllowedAppBaseUrls } from "@/lib/app-base-url";
 

--- a/web/scenes/Portal/Profile/common/UserInfo/Icon/index.tsx
+++ b/web/scenes/Portal/Profile/common/UserInfo/Icon/index.tsx
@@ -1,5 +1,5 @@
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { colorAtom } from "@/scenes/Portal/layout";
+import { colorAtom } from "@/scenes/Portal/layout/color-atom";
 import clsx from "clsx";
 import { useAtom } from "jotai";
 import { CSSProperties, HTMLAttributes } from "react";

--- a/web/scenes/Portal/Profile/page/index.tsx
+++ b/web/scenes/Portal/Profile/page/index.tsx
@@ -20,7 +20,7 @@ import { useCallback, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import * as yup from "yup";
-import { colorAtom } from "../../layout";
+import { colorAtom } from "../../layout/color-atom";
 
 const schema = yup
   .object({

--- a/web/scenes/Portal/Teams/TeamId/Team/common/TeamProfile/Image/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/common/TeamProfile/Image/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { colorAtom } from "@/scenes/Portal/layout";
+import { colorAtom } from "@/scenes/Portal/layout/color-atom";
 import clsx from "clsx";
 import { useAtom } from "jotai";
 import NextImage from "next/image";

--- a/web/scenes/Portal/layout/Header/index.tsx
+++ b/web/scenes/Portal/layout/Header/index.tsx
@@ -9,7 +9,7 @@ import { urls } from "@/lib/urls";
 import { atom, useAtom, useSetAtom } from "jotai";
 import { useParams } from "next/navigation";
 import React, { useEffect, useMemo } from "react";
-import { colorAtom } from "..";
+import { colorAtom } from "../color-atom";
 import { Color } from "../../Profile/types";
 import { AppSelector } from "../AppSelector";
 import { CreateAppDialog } from "../CreateAppDialog";

--- a/web/scenes/Portal/layout/color-atom.ts
+++ b/web/scenes/Portal/layout/color-atom.ts
@@ -1,0 +1,8 @@
+import { atom } from "jotai";
+import { Color } from "../Profile/types";
+
+// Shared jotai atom for the per-user accent color. It lives in its own module
+// (not `scenes/Portal/layout`, which is a Server Component that imports the
+// server-only Auth0 client) so client components can import it without pulling
+// `@/lib/auth0` into the client bundle.
+export const colorAtom = atom<Color | null>(null);

--- a/web/scenes/Portal/layout/index.tsx
+++ b/web/scenes/Portal/layout/index.tsx
@@ -1,12 +1,8 @@
 import { calculateColorFromString } from "@/lib/calculate-color-from-string";
 import { Auth0SessionUser } from "@/lib/types";
 import { auth0 } from "@/lib/auth0";
-import { atom } from "jotai";
 import { ReactNode } from "react";
-import { Color } from "../Profile/types";
 import { Header } from "./Header";
-
-export const colorAtom = atom<Color | null>(null);
 
 export const PortalLayout = async (props: { children: ReactNode }) => {
   const session = await auth0.getSession();


### PR DESCRIPTION
Follow-up to #1943 (Auth0 v3 → v4), found on **staging**: the browser console logs

> ⚠ WARNING: Not all required options were provided when creating an instance of Auth0Client … Missing: domain, clientId, secret, clientAuthentication

### Root cause
`web/lib/auth0.ts` constructs `new Auth0Client()` at **module scope**, and that module was being pulled into the **client bundle** and executed in the browser — where `AUTH0_DOMAIN`/`AUTH0_CLIENT_ID`/`AUTH0_SECRET` are server-only and `undefined`, hence the warning.

The leak path: `scenes/Portal/layout/index.tsx` is a Server Component that imports `auth0`, but it **also exported `colorAtom`**, which several **client** components import (`LoggedUserNav`, `Header`, `Profile/page`, `UserInfo/Icon`, `TeamProfile/Image`). Importing the atom dragged the whole module — including the `Auth0Client` construction — into the client graph. (v3 imported a `getSession` *function*, so importing executed nothing; v4 constructs at module scope.)

### Fix
- Move `colorAtom` into its own client-safe module `scenes/Portal/layout/color-atom.ts` (no `auth0` import) and repoint all 5 consumers.
- Add `import "server-only"` to `web/lib/auth0.ts` so any future client import **fails the build** instead of silently shipping the server client to the browser. (This is what surfaced the second relative-path consumer during verification.)

### Verification
`tsc` (0 errors), `next build` passes with the `server-only` guard (proves `@/lib/auth0` is no longer in any client bundle), `jest` unit+api 445/445.

### Out of scope (also seen in the same console, unrelated to this fix)
- CORS error to `world-id-server.com` — the World ID verification subsystem (sign-in-with-world-id / IDKit), not portal auth.
- `429 Too Many Requests` burst on `…/actions` — client-side Next `<Link>` prefetch (`net::ERR_ABORTED`) hitting a staging rate limiter; not introduced by the auth migration. Happy to dig into either separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)