### PR TITLE
fix(auth): stop v4 useUser().invalidate render loop (429 storm)

### DIFF
--- a/web/scenes/Onboarding/JoinCallback/page/JoinCallbackPageContent/index.tsx
+++ b/web/scenes/Onboarding/JoinCallback/page/JoinCallbackPageContent/index.tsx
@@ -4,12 +4,18 @@ import { WorldIcon } from "@/components/Icons/WorldIcon";
 import { urls } from "@/lib/urls";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { toast } from "react-toastify";
 
 export const JoinCallbackPageContent = (props: { invite_id: string }) => {
   const router = useRouter();
   const { invalidate } = useUser();
+
+  // `invalidate` from useUser() is a new reference each render; hold the latest
+  // in a ref so `joinUser` stays stable and the mount effect runs once instead
+  // of re-firing (POST /api/join-callback) on every render.
+  const invalidateRef = useRef(invalidate);
+  invalidateRef.current = invalidate;
 
   const joinUser = useCallback(async () => {
     let returnTo: string | null = null;
@@ -20,7 +26,7 @@ export const JoinCallbackPageContent = (props: { invite_id: string }) => {
         body: JSON.stringify({ invite_id: props.invite_id }),
       });
 
-      await invalidate();
+      await invalidateRef.current();
       const data = await res.json();
 
       if (!data.returnTo) {
@@ -41,7 +47,7 @@ export const JoinCallbackPageContent = (props: { invite_id: string }) => {
     }
 
     router.push(returnTo);
-  }, [invalidate, props.invite_id, router]);
+  }, [props.invite_id, router]);
 
   useEffect(() => {
     joinUser();

--- a/web/scenes/common/me-query/client/index.tsx
+++ b/web/scenes/common/me-query/client/index.tsx
@@ -1,13 +1,21 @@
 import { Auth0SessionUser } from "@/lib/types";
 import { getNullifierName } from "@/lib/utils";
 import { useUser } from "@auth0/nextjs-auth0/client";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFetchMeQuery } from "./graphql/client/me-query.generated";
 
 export const useMeQuery = (options?: Parameters<typeof useFetchMeQuery>[0]) => {
   const { user: auth0User } = useUser() as Auth0SessionUser;
   const [updating, setUpdating] = useState(true);
   const { invalidate } = useUser();
+
+  // `invalidate` from useUser() is a new function reference on every render.
+  // Keep the latest in a ref and call it via the ref so `updateSession` below
+  // stays referentially stable — depending on `invalidate` directly would
+  // recreate updateSession each render and re-run the effect in a loop
+  // (POST /api/update-session + profile refetch on every render).
+  const invalidateRef = useRef(invalidate);
+  invalidateRef.current = invalidate;
 
   const {
     data,
@@ -51,8 +59,8 @@ export const useMeQuery = (options?: Parameters<typeof useFetchMeQuery>[0]) => {
       return;
     }
 
-    await invalidate();
-  }, [invalidate, data?.user_by_pk]);
+    await invalidateRef.current();
+  }, [data?.user_by_pk]);
 
   useEffect(() => {
     if (!data || fetchLoading) {


### PR DESCRIPTION
Follow-up to the Auth0 v4 migration (#1943), found on **staging**: a flood of `429 Too Many Requests` (visible on the current page route, e.g. `…/configuration`).

### Root cause — an infinite render loop
v4's `useUser()` returns a **new `invalidate` function on every render**. Two client hooks put `invalidate` in a `useCallback` dependency that a `useEffect` then depends on, so the callback was recreated each render and the effect re-fired indefinitely:

- **`me-query`** (used on every authenticated page, e.g. via the nav/header) — looped **`POST /api/update-session` + a profile refetch on every render**. That unthrottled storm trips the rate limiter, which then `429`s everything from that client — including the page-route RSC/prefetch GETs you see in the console.
- **`JoinCallback`** — looped **`POST /api/join-callback`** on the join page (latent; same pattern).

v3's `checkSession()` was referentially stable, so this regressed when I swapped it for `invalidate()` during the migration. (`CreateTeam/Form` uses `invalidate` only inside a submit handler — no effect — so it was unaffected.)

### Fix
Hold `invalidate` in a ref and call it via `invalidateRef.current()`, so the callbacks stay referentially stable — the effects now run once / only on real data changes. Also satisfies `react-hooks/exhaustive-deps` (refs don't need to be deps), so no lint suppression.

### Verification
`tsc` (0), `next lint` (clean — no exhaustive-deps warnings), `next build`, `jest` unit+api 445/445.

### Note on the other staging console error
The CORS failure to `world-id-server.com` is a separate subsystem (World ID verification / sign-in-with-world-id), not portal auth — likely a staging CORS config; happy to investigate separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)