### PR TITLE
feat(team): paginate members to 5 and search apps

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Team/page/Apps/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Apps/index.tsx
@@ -2,9 +2,11 @@
 
 import { Button } from "@/components/Button";
 import { AddCircleIcon } from "@/components/Icons/AddCircleIcon";
+import { MagnifierIcon } from "@/components/Icons/MagnifierIcon";
+import { Input } from "@/components/Input";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { useParams } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Skeleton from "react-loading-skeleton";
 import { App } from "./App";
 import { useFetchAppsQuery } from "./graphql/client/fetch-apps.generated";
@@ -31,10 +33,34 @@ export const Apps = () => {
 
   const app = data?.app;
 
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const filteredApps = useMemo(
+    () =>
+      app?.filter((a) =>
+        (a.app_metadata?.[0]?.name ?? "")
+          .toLowerCase()
+          .includes(searchQuery.toLowerCase()),
+      ),
+    [app, searchQuery],
+  );
+
   return (
     <Section>
       <Section.Header>
         <Section.Header.Title>Apps</Section.Header.Title>
+
+        <Section.Header.Search>
+          <Input
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            type="search"
+            label=""
+            addOnLeft={<MagnifierIcon className="text-grey-400" />}
+            placeholder="Search app by name"
+            className="max-w-full px-4 py-2 md:max-w-[480px]"
+          />
+        </Section.Header.Search>
 
         <Section.Header.Button className="z-10 md:hidden">
           <DecoratedButton
@@ -50,7 +76,15 @@ export const Apps = () => {
       </Section.Header>
 
       <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-4">
-        {!loading && app?.map((app) => <App key={app.id} app={app} />)}
+        {!loading && filteredApps?.map((app) => <App key={app.id} app={app} />)}
+
+        {!loading && searchQuery && filteredApps?.length === 0 && (
+          <div className="col-span-full flex h-[200px] items-center justify-center rounded-2xl border border-grey-200">
+            <Typography variant={TYPOGRAPHY.R3} className="text-grey-400">
+              No apps found
+            </Typography>
+          </div>
+        )}
 
         {loading &&
           !app &&
@@ -60,7 +94,7 @@ export const Apps = () => {
             </div>
           ))}
 
-        {!loading && app && (
+        {!loading && app && !searchQuery && (
           <Button
             className="group relative flex flex-col items-center justify-center gap-y-4 rounded-20 border border-dashed border-grey-200 px-8 pb-6 pt-10 transition-colors hover:border-blue-500 max-md:hidden"
             type="button"

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/index.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { Pagination } from "@/components/Pagination";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { Role_Enum } from "@/graphql/graphql";
 import { Auth0SessionUser } from "@/lib/types";
@@ -62,14 +63,31 @@ export const List = (props: ListProps) => {
     ] satisfies FetchTeamMembersQuery["members"][number][];
   }, [membersRes]);
 
+  const ROWS_PER_PAGE = 5;
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // reset to page 1 whenever the (server-side) search keyword changes
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [props.keyword]);
+
+  const pageCount = Math.max(1, Math.ceil(items.length / ROWS_PER_PAGE));
+  // clamp the active page so it can't fall out of range when items shrink (e.g. after remove/cancel)
+  const safePage = Math.min(currentPage, pageCount);
+
+  const paginatedItems = useMemo(() => {
+    const start = (safePage - 1) * ROWS_PER_PAGE;
+    return items.slice(start, start + ROWS_PER_PAGE);
+  }, [items, safePage]);
+
   const membersToRenderHasInvitedMember = useMemo(() => {
-    for (const member of items) {
+    for (const member of paginatedItems) {
       if (member.id.startsWith("inv_")) {
         return true;
       }
     }
     return false;
-  }, [items]);
+  }, [paginatedItems]);
 
   const onEditUser = useCallback(
     (membership: FetchTeamMembersQuery["members"][number]) => {
@@ -177,7 +195,7 @@ export const List = (props: ListProps) => {
           {membersRes.loading &&
             Array.from({ length: 3 }).map((_, i) => <Item key={i} />)}
 
-          {items.map((item) => (
+          {paginatedItems.map((item) => (
             <Item
               key={item.id}
               item={item}
@@ -191,6 +209,16 @@ export const List = (props: ListProps) => {
           ))}
         </div>
       </div>
+
+      {!membersRes.loading && items.length > ROWS_PER_PAGE && (
+        <Pagination
+          totalResults={items.length}
+          currentPage={safePage}
+          rowsPerPage={ROWS_PER_PAGE}
+          handlePageChange={setCurrentPage}
+          className="relative"
+        />
+      )}
 
       {membersRes.data && items.length === 0 && props.keyword && (
         <div className="flex h-[240px] w-full items-center justify-center rounded-2xl border border-grey-200">


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Addresses team-page UI feedback. Paginates the team members list to 5 rows per page using the shared `Pagination` component (resets to page 1 when the member search changes; the footer only appears when there are more than 5 members/invites). Adds a client-side, case-insensitive name search to the Apps section, with a "No apps found" empty state and the "Create an app" tile hidden while searching. Both reuse the existing search + pagination pattern from `ActionsListV4`; no GraphQL, schema, or new components were added.

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
