### PR TITLE
fix(auth): stop error-level log noise on the appBaseUrl canonical redirect

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -198,7 +198,9 @@ export async function middleware(request: NextRequest) {
     // to the canonical host — whose origin IS allow-listed — rather than surfacing
     // the SDK's 500. Public origins are accepted by the SDK and never reach here;
     // the `!== canonical` guard keeps a (would-be) canonical-origin throw from
-    // self-redirecting, and the warn leaves a breadcrumb for genuine misconfig.
+    // self-redirecting. We deliberately do NOT log here: this path is dominated by
+    // benign, high-volume internal probes, and `console.*` from Edge middleware is
+    // indexed as `status:error`, so logging each hit floods the error dashboards.
     const canonical = getPrimaryAppBaseUrl();
     if (
       error instanceof InvalidConfigurationError &&
@@ -206,10 +208,6 @@ export async function middleware(request: NextRequest) {
       canonical &&
       normalizedOrigin !== new URL(canonical).origin
     ) {
-      console.warn(
-        "Auth route reached on a non-allow-listed origin; redirecting to canonical host",
-        { origin: normalizedOrigin, pathname },
-      );
       return NextResponse.redirect(
         new URL(pathname + request.nextUrl.search, canonical),
       );


### PR DESCRIPTION
## What

Follow-up to #1953. The graceful-redirect path that handles auth requests from non-allow-listed origins (internal/health-check hosts probing `/api/auth/login`) emitted a `console.warn` breadcrumb on every hit. This removes that log.

## Why

Found while checking staging after #1953 deployed. The fix works — the internal probe `https://developer.staging-internal.worldcoin.org/api/auth/login` recurred (≈865 hits / 47 min, ~18/min) and every one was handled with a 307 to the canonical host instead of the old `InvalidConfigurationError` 500. **Error Tracking shows zero `InvalidConfigurationError` today.**

But the breadcrumb itself became a regression: `console.*` from Edge middleware is indexed at **`status:error`** in our Datadog pipeline, so the benign probe path generated **~865 error-level logs in a single 47-minute burst** — a false error-rate spike that masks real errors and can trip log/error-rate monitors. (Different trace IDs, consistent internal origin → it's the probe's cadence, not a redirect loop.)

## Change

Drop the `console.warn` in the catch branch. The 307 redirect is the graceful behavior and is unchanged. A genuine `APP_BASE_URL` misconfiguration would break login for real users on the canonical host (visible in login metrics / QA), so it doesn't rely on this hot-path log.

## Verification

`tsc` 0 · `prettier` clean · 477/477 unit+api tests · `next build` succeeds (middleware compiles). Existing middleware tests (redirect, loop-guard re-throw, open-redirect, header normalization) still pass — none asserted the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)