### PR TITLE
style(team): make team-page search bars full width

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Team/page/Apps/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Apps/index.tsx
@@ -50,7 +50,7 @@ export const Apps = () => {
       <Section.Header>
         <Section.Header.Title>Apps</Section.Header.Title>
 
-        <Section.Header.Search>
+        <Section.Header.Search className="md:col-span-2">
           <Input
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
@@ -58,7 +58,7 @@ export const Apps = () => {
             label=""
             addOnLeft={<MagnifierIcon className="text-grey-400" />}
             placeholder="Search app by name"
-            className="max-w-full px-4 py-2 md:max-w-[480px]"
+            className="w-full px-4 py-2"
           />
         </Section.Header.Search>
 

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/index.tsx
@@ -80,18 +80,18 @@ export const Members = (props: { teamId: string }) => {
       <Section.Header>
         <Section.Header.Title>Members</Section.Header.Title>
 
-        <Section.Header.Search>
+        <Section.Header.Search className="md:col-span-2">
           <Input
             register={register("search")}
             type="search"
             label=""
             addOnLeft={<MagnifierIcon className="text-grey-400" />}
             placeholder="Search member by name or email"
-            className="max-w-full px-4 py-2 md:max-w-[480px]"
+            className="w-full px-4 py-2"
           />
         </Section.Header.Search>
 
-        <Section.Header.Button>
+        <Section.Header.Button className="md:row-start-1">
           {membersRes.loading ? (
             <Skeleton className="h-12 w-[12rem] rounded-xl" />
           ) : (


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Follow-up to #1952. Makes the Members and Apps search bars on the team page span the full page width (matching the Actions search bar) by letting the `Section.Header.Search` container span both header columns (`md:col-span-2`) and removing the `md:max-w-[480px]` cap in favor of `w-full`. The Members "Invite new member" button is pinned to row 1 (`md:row-start-1`) so the now full-width search row doesn't displace it.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
