### PR TITLE
fix(root): guard missing Hasura session claim on landing page

### DIFF
--- a/web/scenes/Root/page/index.tsx
+++ b/web/scenes/Root/page/index.tsx
@@ -18,12 +18,24 @@ export const RootPage = async () => {
     return redirect(urls.login());
   }
 
+  // A valid session can still be missing the Hasura claim (e.g. an incomplete
+  // or legacy session). Reading `.id` off an undefined `hasura` throws a
+  // TypeError, so guard it explicitly and re-authenticate instead of crashing.
+  const hasuraUserId = auth0User?.hasura?.id;
+
+  if (!hasuraUserId) {
+    logger.warn(
+      "Active session is missing a Hasura user id on the root page; logging out to re-authenticate",
+    );
+    return redirect(urls.logout());
+  }
+
   const client = await getAPIServiceGraphqlClient();
   let membership: FetchMembershipsQuery["membership"] | null = null;
 
   try {
     const data = await getSdk(client).FetchMemberships({
-      userId: auth0User?.hasura.id,
+      userId: hasuraUserId,
     });
 
     membership = data.membership;


### PR DESCRIPTION
> **🔶 NEEDS CAREFUL REVIEW** — this change is in the authenticated-session flow: it reads the `hasura` session claim and adds a redirect to **logout** when the claim is missing. Logic for healthy sessions is unchanged, but please confirm that forcing re-authentication (vs. routing to create-team or surfacing an error) is the desired handling for a session that lacks the Hasura claim.

## Datadog issue
[`Cannot read properties of undefined (reading 'id')` — `/app/.next/server/app/page.js`](https://app.datadoghq.com/error-tracking/issue/d144172a-5f79-11f1-89f9-da7ad0900002)
~89 occurrences / 7d (59 / 3d), steady since first_seen 2026-06-03. Resource `GET` (root route `/`).

## Root cause (with evidence)
`web/scenes/Root/page/index.tsx` looked up memberships with:
```ts
userId: auth0User?.hasura.id
```
The optional chain stops at `auth0User`, but `.id` is then read off `auth0User.hasura` unconditionally. When a valid Auth0 session exists **without** a populated `hasura` claim (incomplete/legacy sessions), `auth0User.hasura` is `undefined`, so `.id` throws `TypeError: Cannot read properties of undefined (reading 'id')`.

The Datadog stack confirms this: `TypeError: Cannot read properties of undefined (reading 'id')` at `k (/app/.next/server/app/page.js:8:300)`, captured inside the `FetchMemberships` try block where that argument is evaluated. The net effect for the affected user is forced logout plus error-level log noise on every load of `/`.

## Fix
Read the claim with full optional chaining and guard it before issuing the GraphQL query. If the session has no Hasura user id, log a `warn` and redirect to logout to re-authenticate — matching the existing "bad session ⇒ logout" behavior in the same handler, without throwing. Scoped to the one file; no logic change for healthy sessions.

## Confidence: 88%
The throw site and trigger are unambiguous from the stack trace and source. Slightly below 100% only because the *upstream* reason a session can lack the `hasura` claim isn't addressed here (out of scope) — this PR stops the crash and the error-log noise.

## Test plan
- `npx tsc --noEmit` — passes
- `pnpm prettier --check` on the touched file — passes
- Manual reasoning: healthy session (claim present) → unchanged path (FetchMemberships → apps/createTeam); session missing claim → `warn` + redirect to logout instead of TypeError.

No unit test added: this is a server component (auth0 + `redirect` + GraphQL), outside the `web/tests/api/` handler-test convention, and a test here would require heavy SDK/redirect mocking that the repo guidelines discourage.