### PR TITLE
fix(teams): guard missing Hasura session claim on teams landing page

### DIFF
--- a/web/scenes/Portal/Teams/page/index.tsx
+++ b/web/scenes/Portal/Teams/page/index.tsx
@@ -11,7 +11,14 @@ export const TeamsPage = async () => {
     return redirect(urls.logout());
   }
 
-  const memberships = user.hasura.memberships;
+  // A valid session can still be missing the Hasura claim (incomplete or
+  // legacy session). Reading `.memberships` off an undefined `hasura` throws
+  // a TypeError, so guard it and re-authenticate instead of crashing.
+  const memberships = user.hasura?.memberships;
+
+  if (!memberships) {
+    return redirect(urls.logout());
+  }
 
   if (memberships.length === 0) {
     return redirect(urls.createTeam());


### PR DESCRIPTION
> **🔶 NEEDS CAREFUL REVIEW** — this change is in the authenticated-session flow: it reads the `hasura` session claim and adds a redirect to **logout** when the claim is missing. Please confirm that forcing re-authentication is the desired handling for a session that lacks the Hasura claim (vs. the previous implicit route to create-team).

## Datadog issue
[`Cannot read properties of undefined (reading 'memberships')` — `/app/.next/server/app/(portal)/teams/page.js`](https://app.datadoghq.com/error-tracking/issue/79d37de4-65e8-11f1-93f2-da7ad0900002)
Low volume (~3 / 7d) but currently active (last_seen 2026-06-21), first_seen 2026-06-11.

## Root cause (with evidence)
`web/scenes/Portal/Teams/page/index.tsx` read:
```ts
const memberships = user.hasura.memberships;
```
with no guard on `hasura`. When a valid session is missing the `hasura` claim, `user.hasura` is `undefined` and `.memberships` throws `TypeError: Cannot read properties of undefined (reading 'memberships')` (matches the Datadog error on the `(portal)/teams` route). This is the **same class of bug** as #1957 (root landing page) — pages reading `user.hasura.<field>` without guarding the claim.

## Fix
Optional-chain the claim and guard it: a session with no `hasura` claim is a broken session, so redirect to logout (consistent with the existing `!user ⇒ logout` branch) rather than treating it as "user has zero teams." Empty memberships continue to route to team creation. Scoped to one file.

## Confidence: 90%
Throw site and trigger are unambiguous from the source and the matching Datadog message/route. The logout-vs-createTeam choice for the missing-claim case is a judgment call (logout is the safer, more correct behavior), hence not 100%.

## Test plan
- `npx tsc --noEmit` — passes
- `pnpm prettier --check` on the touched file — passes
- Manual reasoning: claim present + memberships → unchanged; claim present + empty → createTeam (unchanged); claim missing → logout instead of TypeError.

No unit test added: server component (auth0 + `redirect`), outside the `web/tests/api/` handler-test convention; testing it would require heavy mocking the repo guidelines discourage.