### PR TITLE
fix(next16): build with webpack — Turbopack standalone is missing server chunks (staging 500s)

### DIFF
--- a/web/empty.ts
+++ b/web/empty.ts
@@ -1,4 +1,0 @@
-// Empty stub aliased in for `fs` in the browser bundle (see `turbopack.resolveAlias`
-// in next.config.mjs). winston (server-only) pulls `fs` into the client graph; this
-// keeps Turbopack from trying to bundle the Node built-in for the browser.
-export default {};

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -31,14 +31,20 @@ const nextConfig = {
 
   poweredByHeader: false,
 
-  // Turbopack is the default bundler in Next 16; a `webpack` config would make
-  // `next build` fail. winston (server-only) gets pulled into the client graph and
-  // references `fs`, so alias it to an empty module for the browser — the Turbopack
-  // equivalent of the old webpack `resolve.fallback: { fs: false }`.
-  turbopack: {
-    resolveAlias: {
-      fs: { browser: "./empty.ts" },
-    },
+  // We build with webpack (`next build --webpack`), not Turbopack: Next 16's
+  // Turbopack `output: standalone` build omits server chunks that
+  // `instrumentation.ts` (dd-trace) requires, so the standalone server crashes at
+  // runtime ("Cannot find module .../.next/server/chunks/[root-of-the-server]...").
+  // winston (server-only) gets pulled into the client graph and references `fs`;
+  // alias it to an empty module for the browser.
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        fs: false,
+      };
+    }
+    return config;
   },
 
   async headers() {

--- a/web/package.json
+++ b/web/package.json
@@ -147,8 +147,8 @@
   "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0",
   "private": true,
   "scripts": {
-    "build": "next build",
-    "dev": "next dev",
+    "build": "next build --webpack",
+    "dev": "next dev --webpack",
     "format": "prettier -w ./",
     "format:check": "prettier --check ./",
     "generate:graphql-schema": "graphql-codegen --config graphql-codegen.schema.js",


### PR DESCRIPTION
## Problem (staging, after #1955 deployed)

The deployed **standalone** server crashes loading chunks:
```
Failed to load chunk … Cannot find module '/app/.next/server/chunks/[root-of-the-server]…._.js'
Require stack: …[turbopack]_runtime.js → .next/server/instrumentation.js → … → /app/server.js
```
277+ such errors on staging. Visible symptom in the browser: **500s on the metadata-icon routes** (`/icon32.png`, `/icon16.png`, `/apple-icon.png`, `/icon.ico` — these are `app/icon*.png` files).

**Root cause:** Next 16's **Turbopack `output: standalone`** build omits server chunks that `instrumentation.ts` (dd-trace) requires, so the standalone `server.js` can't resolve them at runtime. CI didn't catch it — the *Test Docker build* job builds the image but doesn't run `server.js`, and E2E runs the dev server.

## Fix

Build (and dev) with **`--webpack`** — the proven Next 15 bundler. Its standalone output is complete (verified locally: `.next/standalone/server.js` + `instrumentation.js` + **142 server chunks** present, vs the Turbopack build that omitted them). Restored the webpack `fs:false` client fallback for winston; dropped the Turbopack config + `empty.ts`. Turbopack can be re-enabled once the upstream standalone bug is fixed.

## Verification
`next build --webpack` succeeds (one benign pre-existing Auth0-SDK `dpopUtils` "Critical dependency" warning) · tsc 0 · prettier clean. Integration/E2E run in CI.

> Note: two other staging console errors were observed but are **separate** from this — the logout `/v2/logout` 400 (relative `returnTo=/login`) and the `world-id-assets.com` font CORS (`Access-Control-Allow-Origin: https://world.org`). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)