### PR TITLE
remove "enableWorldId4" from URL params if user X out flow

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/WorldId40MigrationBanner/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/WorldId40MigrationBanner/index.tsx
@@ -8,8 +8,8 @@ import {
 } from "@/lib/feature-flags/world-id-4-0/client";
 import { CreateAppDialogV4 } from "@/scenes/Portal/layout/CreateAppDialog/index-v4";
 import { useAtomValue } from "jotai";
-import { useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 
 interface WorldId40MigrationBannerProps {
   teamId: string;
@@ -28,6 +28,8 @@ export const WorldId40MigrationBanner = ({
 }: WorldId40MigrationBannerProps) => {
   const worldId40Config = useAtomValue(worldId40Atom);
   const isEnabled = isWorldId40Enabled(worldId40Config, teamId);
+  const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const autoOpen = searchParams.get("enableWorldId4") === "true";
   const [dialogOpen, setDialogOpen] = useState(autoOpen && canRegisterRp);
@@ -35,6 +37,22 @@ export const WorldId40MigrationBanner = ({
   useEffect(() => {
     if (autoOpen && canRegisterRp) setDialogOpen(true);
   }, [autoOpen, canRegisterRp]);
+
+  const closeDialog = useCallback(() => {
+    setDialogOpen(false);
+
+    // Strip the `enableWorldId4` param so the World ID tab link returns to its
+    // clean state. Otherwise the URL keeps the param and clicking the tab again
+    // is a no-op (same URL), leaving the user unable to re-open the flow.
+    if (searchParams.has("enableWorldId4")) {
+      const params = new URLSearchParams(searchParams);
+      params.delete("enableWorldId4");
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, {
+        scroll: false,
+      });
+    }
+  }, [pathname, router, searchParams]);
 
   // Don't show banner if:
   // - World ID 4.0 is not enabled for this team, OR
@@ -90,7 +108,7 @@ export const WorldId40MigrationBanner = ({
 
       <CreateAppDialogV4
         open={dialogOpen}
-        onClose={() => setDialogOpen(false)}
+        onClose={closeDialog}
         initialStep="enable-world-id-4-0"
         appId={appId}
       />


### PR DESCRIPTION
## Issue
Users started World ID 4.0 onboarding via the tab in the developer portal. If they X'd out from the first scene, enableWorldID4.0=true was left in the URL params, making the tab unclickable

## Fix
Created a closeDialog function to remove ^^ from params on X out

## Files changed
```web/scenes/Portal/Teams/TeamId/Apps/AppId/page/WorldId40MigrationBanner/index.tsx```
