### PR TITLE
Remove MiniKiosk from TryAction settings panel.

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/MiniKiosk/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/MiniKiosk/index.tsx
@@ -1,6 +1,3 @@
-/*
- * MiniKiosk disabled — TryAction now shows code samples only.
- *
 import { LegacyVerificationLevel } from "@/lib/idkit";
 import { KioskScreen } from "@/lib/types";
 import type { IDKitResult } from "@worldcoin/idkit";
@@ -198,6 +195,3 @@ export const MiniKiosk = (props: MiniKioskProps) => {
     </div>
   );
 };
-*/
-
-export {};

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/MiniKiosk/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/MiniKiosk/index.tsx
@@ -1,3 +1,6 @@
+/*
+ * MiniKiosk disabled — TryAction now shows code samples only.
+ *
 import { LegacyVerificationLevel } from "@/lib/idkit";
 import { KioskScreen } from "@/lib/types";
 import type { IDKitResult } from "@worldcoin/idkit";
@@ -195,3 +198,6 @@ export const MiniKiosk = (props: MiniKioskProps) => {
     </div>
   );
 };
+*/
+
+export {};

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/index.tsx
@@ -1,91 +1,32 @@
 "use client";
 
-import { Button } from "@/components/Button";
-import { CodeIcon } from "@/components/Icons/CodeIcon";
-import { QRIcon } from "@/components/Icons/QRIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { EngineType } from "@/lib/types";
-import clsx from "clsx";
-import { useState } from "react";
 import { CodeBlock } from "./CodeBlock";
-import { MiniKiosk } from "./MiniKiosk";
 
 type TryActionProps = {
   action: {
-    name: string;
-    description: string;
     action: string;
     app_id: string;
     app: {
-      is_staging: boolean;
       engine: string;
-      app_metadata: { app_mode: string }[];
     };
   };
-  is_v4_action: boolean;
 };
 
 export const TryAction = (props: TryActionProps) => {
-  const { action, is_v4_action } = props;
-  const [showCode, setShowCode] = useState(
-    action.app.engine === EngineType.OnChain,
-  );
+  const { action } = props;
 
   return (
     <div className="grid h-full grid-rows-auto/1fr items-start gap-y-5 lg:w-[480px]">
-      <div className="grid w-full grid-cols-2 items-center justify-between">
-        <Typography variant={TYPOGRAPHY.M3} className="text-grey-900">
-          Try it out
-        </Typography>
-        <div className="flex w-full justify-end gap-x-4">
-          <Button
-            type="button"
-            onClick={() => setShowCode(false)}
-            className={clsx(
-              "flex size-11 items-center justify-center rounded-xl bg-white shadow-button hover:bg-grey-50",
-              { "border border-grey-200": !showCode },
-              { hidden: action.app.engine === EngineType.OnChain },
-            )}
-          >
-            <QRIcon
-              className={clsx("size-4", {
-                "text-blue-500": !showCode,
-                "text-grey-700": showCode,
-              })}
-            />
-          </Button>
-          <Button
-            type="button"
-            onClick={() => setShowCode(true)}
-            className={clsx(
-              "flex size-11 items-center justify-center rounded-xl bg-white shadow-button hover:bg-grey-50",
-              { "border border-grey-200": showCode },
-              {
-                hidden: action.app.app_metadata.some(
-                  ({ app_mode }) => app_mode === "mini-app",
-                ),
-              },
-            )}
-          >
-            <CodeIcon
-              className={clsx("size-4", {
-                "text-blue-500 ": showCode,
-                "text-grey-700": !showCode,
-              })}
-            />
-          </Button>
-        </div>
-      </div>
+      <Typography variant={TYPOGRAPHY.M3} className="text-grey-900">
+        Try it out
+      </Typography>
       <div className="size-full">
-        {showCode ? (
-          <CodeBlock
-            appId={action.app_id}
-            action_identifier={action.action}
-            engine={action.app.engine}
-          />
-        ) : (
-          <MiniKiosk action={action} is_v4_action={is_v4_action} />
-        )}
+        <CodeBlock
+          appId={action.app_id}
+          action_identifier={action.action}
+          engine={action.app.engine}
+        />
       </div>
     </div>
   );

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/index.tsx
@@ -39,6 +39,10 @@ export const TryAction = (props: TryActionProps) => {
   const showCodeView = canShowCode && (showCode || !canShowKiosk);
   const showKioskView = canShowKiosk && !showCodeView;
 
+  if (!canShowCode && !canShowKiosk) {
+    return null;
+  }
+
   return (
     <div className="grid h-full grid-rows-auto/1fr items-start gap-y-5 lg:w-[480px]">
       <div className="grid w-full grid-cols-2 items-center justify-between">
@@ -92,18 +96,6 @@ export const TryAction = (props: TryActionProps) => {
         )}
         {showKioskView && (
           <MiniKiosk action={action} is_v4_action={is_v4_action} />
-        )}
-        {!showCodeView && !showKioskView && (
-          <div className="grid h-full min-h-[400px] items-center rounded-3xl border border-grey-100 bg-grey-50 px-8 text-center">
-            <div className="grid gap-y-2">
-              <Typography variant={TYPOGRAPHY.M4} className="text-grey-900">
-                Mini App integration
-              </Typography>
-              <Typography variant={TYPOGRAPHY.R4} className="text-grey-500">
-                Use MiniKit to integrate this action in your Mini App.
-              </Typography>
-            </div>
-          </div>
         )}
       </div>
     </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/index.tsx
@@ -1,32 +1,110 @@
 "use client";
 
+import { Button } from "@/components/Button";
+import { CodeIcon } from "@/components/Icons/CodeIcon";
+import { QRIcon } from "@/components/Icons/QRIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { EngineType } from "@/lib/types";
+import clsx from "clsx";
+import { useState } from "react";
 import { CodeBlock } from "./CodeBlock";
+import { MiniKiosk } from "./MiniKiosk";
 
 type TryActionProps = {
   action: {
+    name: string;
+    description: string;
     action: string;
     app_id: string;
     app: {
+      is_staging: boolean;
       engine: string;
+      app_metadata: { app_mode: string }[];
     };
   };
+  is_v4_action: boolean;
+  enableKiosk?: boolean;
 };
 
 export const TryAction = (props: TryActionProps) => {
-  const { action } = props;
+  const { action, is_v4_action, enableKiosk = true } = props;
+  const isMiniApp = action.app.app_metadata.some(
+    ({ app_mode }) => app_mode === "mini-app",
+  );
+  const canShowKiosk = enableKiosk && action.app.engine !== EngineType.OnChain;
+  const canShowCode = !isMiniApp;
+  const [showCode, setShowCode] = useState(
+    action.app.engine === EngineType.OnChain || !canShowKiosk,
+  );
+  const showCodeView = canShowCode && (showCode || !canShowKiosk);
+  const showKioskView = canShowKiosk && !showCodeView;
 
   return (
     <div className="grid h-full grid-rows-auto/1fr items-start gap-y-5 lg:w-[480px]">
-      <Typography variant={TYPOGRAPHY.M3} className="text-grey-900">
-        Try it out
-      </Typography>
+      <div className="grid w-full grid-cols-2 items-center justify-between">
+        <Typography variant={TYPOGRAPHY.M3} className="text-grey-900">
+          Try it out
+        </Typography>
+        <div className="flex w-full justify-end gap-x-4">
+          {canShowKiosk && (
+            <Button
+              type="button"
+              onClick={() => setShowCode(false)}
+              className={clsx(
+                "flex size-11 items-center justify-center rounded-xl bg-white shadow-button hover:bg-grey-50",
+                { "border border-grey-200": showKioskView },
+              )}
+            >
+              <QRIcon
+                className={clsx("size-4", {
+                  "text-blue-500": showKioskView,
+                  "text-grey-700": !showKioskView,
+                })}
+              />
+            </Button>
+          )}
+          {canShowCode && (
+            <Button
+              type="button"
+              onClick={() => setShowCode(true)}
+              className={clsx(
+                "flex size-11 items-center justify-center rounded-xl bg-white shadow-button hover:bg-grey-50",
+                { "border border-grey-200": showCodeView },
+              )}
+            >
+              <CodeIcon
+                className={clsx("size-4", {
+                  "text-blue-500": showCodeView,
+                  "text-grey-700": !showCodeView,
+                })}
+              />
+            </Button>
+          )}
+        </div>
+      </div>
       <div className="size-full">
-        <CodeBlock
-          appId={action.app_id}
-          action_identifier={action.action}
-          engine={action.app.engine}
-        />
+        {showCodeView && (
+          <CodeBlock
+            appId={action.app_id}
+            action_identifier={action.action}
+            engine={action.app.engine}
+          />
+        )}
+        {showKioskView && (
+          <MiniKiosk action={action} is_v4_action={is_v4_action} />
+        )}
+        {!showCodeView && !showKioskView && (
+          <div className="grid h-full min-h-[400px] items-center rounded-3xl border border-grey-100 bg-grey-50 px-8 text-center">
+            <div className="grid gap-y-2">
+              <Typography variant={TYPOGRAPHY.M4} className="text-grey-900">
+                Mini App integration
+              </Typography>
+              <Typography variant={TYPOGRAPHY.R4} className="text-grey-500">
+                Use MiniKit to integrate this action in your Mini App.
+              </Typography>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/index.tsx
@@ -28,20 +28,16 @@ type TryActionProps = {
 
 export const TryAction = (props: TryActionProps) => {
   const { action, is_v4_action, enableKiosk = true } = props;
-  const isMiniApp = action.app.app_metadata.some(
-    ({ app_mode }) => app_mode === "mini-app",
-  );
   const canShowKiosk = enableKiosk && action.app.engine !== EngineType.OnChain;
-  const canShowCode = !isMiniApp;
+  // World ID verification for Mini Apps is implemented with @worldcoin/idkit
+  // (MiniKit 2.x no longer proxies verification), so the IDKit CodeBlock is the
+  // correct integration path for every app type — show it for all apps.
+  const canShowCode = true;
   const [showCode, setShowCode] = useState(
     action.app.engine === EngineType.OnChain || !canShowKiosk,
   );
   const showCodeView = canShowCode && (showCode || !canShowKiosk);
   const showKioskView = canShowKiosk && !showCodeView;
-
-  if (!canShowCode && !canShowKiosk) {
-    return null;
-  }
 
   return (
     <div className="grid h-full grid-rows-auto/1fr items-start gap-y-5 lg:w-[480px]">

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/index.tsx
@@ -55,7 +55,7 @@ export const ActionIdSettingsPage = (props: ActionIdSettingsPageProps) => {
           {loading ? (
             <Skeleton className="md:w-[480px]" height={400} />
           ) : (
-            <TryAction action={action!} is_v4_action={false} />
+            <TryAction action={action!} />
           )}
         </div>
       </SizingWrapper>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/page/index.tsx
@@ -55,7 +55,11 @@ export const ActionIdSettingsPage = (props: ActionIdSettingsPageProps) => {
           {loading ? (
             <Skeleton className="md:w-[480px]" height={400} />
           ) : (
-            <TryAction action={action!} />
+            <TryAction
+              action={action!}
+              is_v4_action={false}
+              enableKiosk={false}
+            />
           )}
         </div>
       </SizingWrapper>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/page/index.tsx
@@ -63,6 +63,8 @@ export const WorldIdActionIdSettingsPage = (
                 app_id: action!.rp_registration.app_id,
               },
             })}
+            is_v4_action={true}
+            enableKiosk={false}
           />
         )}
       </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/page/index.tsx
@@ -63,7 +63,6 @@ export const WorldIdActionIdSettingsPage = (
                 app_id: action!.rp_registration.app_id,
               },
             })}
-            is_v4_action={true}
           />
         )}
       </div>


### PR DESCRIPTION
## Issue
We were hardcoding the signature in field in legacyKioskRequest, making the authenticator unable to trust the request. No clear solution as to how to make MiniKiosk functional since we need an actual RP signing key.

## Fix
Updated TryAction with an enableKiosk flag to show only try-it-out helper CodeBlocks when the app is NOT a mini app and nothing if it is.