### PR TITLE
Improve permission visibility for restricted team actions

### DIFF
--- a/web/components/Dropdown/DisabledListItem/index.tsx
+++ b/web/components/Dropdown/DisabledListItem/index.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 import * as DropdownPrimitive from "@radix-ui/react-dropdown-menu";
 import { twMerge } from "tailwind-merge";
+import { ListItemIcon } from "../ListItemIcon";
 
 type DisabledListItemProps = DropdownPrimitive.DropdownMenuItemProps & {
   icon?: ReactNode;
@@ -20,7 +21,11 @@ export const DisabledListItem = (props: DisabledListItemProps) => {
         className,
       )}
     >
-      {icon ? <span className="[&>svg]:size-5">{icon}</span> : null}
+      {icon ? (
+        <ListItemIcon className="text-grey-300" asChild>
+          {icon}
+        </ListItemIcon>
+      ) : null}
       <span className="grid gap-y-0.5">
         <span>{children}</span>
         {description ? (

--- a/web/components/Dropdown/DisabledListItem/index.tsx
+++ b/web/components/Dropdown/DisabledListItem/index.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from "react";
+import * as DropdownPrimitive from "@radix-ui/react-dropdown-menu";
+import { twMerge } from "tailwind-merge";
+
+type DisabledListItemProps = DropdownPrimitive.DropdownMenuItemProps & {
+  icon?: ReactNode;
+  description?: ReactNode;
+};
+
+export const DisabledListItem = (props: DisabledListItemProps) => {
+  const { className, children, icon, description, ...otherProps } = props;
+
+  return (
+    <DropdownPrimitive.Item
+      {...otherProps}
+      disabled
+      aria-disabled="true"
+      className={twMerge(
+        "grid cursor-not-allowed grid-cols-auto/1fr items-start gap-x-4 px-2 py-2.5 text-start text-grey-300 outline-none md:gap-x-2 md:px-4",
+        className,
+      )}
+    >
+      {icon ? <span className="[&>svg]:size-5">{icon}</span> : null}
+      <span className="grid gap-y-0.5">
+        <span>{children}</span>
+        {description ? (
+          <span className="text-12 leading-4 text-grey-400">{description}</span>
+        ) : null}
+      </span>
+    </DropdownPrimitive.Item>
+  );
+};

--- a/web/components/Dropdown/index.tsx
+++ b/web/components/Dropdown/index.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import * as DropdownPrimitive from "@radix-ui/react-dropdown-menu";
 import { Button } from "./Button";
+import { DisabledListItem } from "./DisabledListItem";
 import { List } from "./List";
 import { ListHeader } from "./ListHeader";
 import { ListItem } from "./ListItem";
@@ -51,6 +52,7 @@ export const Dropdown = (props: DropdownProps) => {
 };
 
 Dropdown.Button = Button;
+Dropdown.DisabledListItem = DisabledListItem;
 Dropdown.List = List;
 Dropdown.ListHeader = ListHeader;
 Dropdown.ListItem = ListItem;

--- a/web/components/LoggedUserNav/index.tsx
+++ b/web/components/LoggedUserNav/index.tsx
@@ -5,14 +5,11 @@ import { HelpSquareIcon } from "@/components/Icons/HelpSquareIcon";
 import { LoginSquareIcon } from "@/components/Icons/LoginSquareIcon";
 import { TeamLogo } from "@/components/LoggedUserNav/Teams/TeamLogo";
 import { useFetchTeamQuery } from "@/components/LoggedUserNav/graphql/client/fetch-team.generated";
-import { Role_Enum } from "@/graphql/graphql";
 import { DOCS_URL } from "@/lib/constants";
-import { Auth0SessionUser } from "@/lib/types";
 import { urls } from "@/lib/urls";
-import { checkUserPermissions } from "@/lib/utils";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { colorAtom } from "@/scenes/Portal/layout/color-atom";
 import { useMeQuery } from "@/scenes/common/me-query/client";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { useAtom } from "jotai";
 import Link from "next/link";
 import { useParams } from "next/navigation";
@@ -31,7 +28,6 @@ import { Teams } from "./Teams";
 
 export const LoggedUserNav = () => {
   const [color] = useAtom(colorAtom);
-  const { user: auth0User } = useUser() as Auth0SessionUser;
   const { teamId, appId, actionId } = useParams() as {
     teamId?: string;
     appId?: string;
@@ -40,9 +36,8 @@ export const LoggedUserNav = () => {
 
   const { user } = useMeQuery();
 
-  const hasOwnerPermission = useMemo(() => {
-    return checkUserPermissions(auth0User, teamId ?? "", [Role_Enum.Owner]);
-  }, [auth0User, teamId]);
+  const settingsPerm = useTeamPermission(teamId ?? "", "edit_team_settings");
+  const apiKeysPerm = useTeamPermission(teamId ?? "", "view_api_keys");
 
   const nameFirstLetter = useMemo(
     () => user.nameToDisplay[0].toLocaleUpperCase(),
@@ -155,17 +150,19 @@ export const LoggedUserNav = () => {
                 </Link>
               </Dropdown.ListItem>
 
-              <Dropdown.ListItem asChild>
-                <Link href={`/teams/${teamId}/api-keys`}>
-                  <Dropdown.ListItemIcon asChild>
-                    <KeyIcon />
-                  </Dropdown.ListItemIcon>
+              {apiKeysPerm.allowed && (
+                <Dropdown.ListItem asChild>
+                  <Link href={`/teams/${teamId}/api-keys`}>
+                    <Dropdown.ListItemIcon asChild>
+                      <KeyIcon />
+                    </Dropdown.ListItemIcon>
 
-                  <Dropdown.ListItemText>API Keys</Dropdown.ListItemText>
-                </Link>
-              </Dropdown.ListItem>
+                    <Dropdown.ListItemText>API Keys</Dropdown.ListItemText>
+                  </Link>
+                </Dropdown.ListItem>
+              )}
 
-              {hasOwnerPermission && (
+              {settingsPerm.allowed && (
                 <Dropdown.ListItem asChild>
                   <Link href={`/teams/${teamId}/settings`}>
                     <Dropdown.ListItemIcon asChild>

--- a/web/components/RestrictedAction/index.tsx
+++ b/web/components/RestrictedAction/index.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { type ReactNode } from "react";
-import clsx from "clsx";
 import { Tooltip } from "@/components/Tooltip";
+import clsx from "clsx";
+import { type ReactNode } from "react";
 
 export type ActionRestriction = {
   allowed: boolean;
@@ -10,7 +10,6 @@ export type ActionRestriction = {
 };
 
 type RestrictedActionRenderState = {
-  allowed: boolean;
   disabled: boolean;
 };
 
@@ -18,17 +17,14 @@ type RestrictedActionProps = {
   restriction: ActionRestriction;
   children: ReactNode | ((state: RestrictedActionRenderState) => ReactNode);
   className?: string;
-  placement?: "top" | "bottom" | "left" | "right";
 };
 
 export const RestrictedAction = ({
   restriction,
   children,
   className,
-  placement,
 }: RestrictedActionProps) => {
   const state = {
-    allowed: restriction.allowed,
     disabled: !restriction.allowed,
   };
   const content = typeof children === "function" ? children(state) : children;
@@ -40,7 +36,6 @@ export const RestrictedAction = ({
   return (
     <Tooltip
       content={restriction.message}
-      placement={placement}
       triggerProps={{
         "aria-disabled": true,
         tabIndex: 0,

--- a/web/components/RestrictedAction/index.tsx
+++ b/web/components/RestrictedAction/index.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { type ReactNode } from "react";
+import clsx from "clsx";
+import { Tooltip } from "@/components/Tooltip";
+
+export type ActionRestriction = {
+  allowed: boolean;
+  message: string;
+};
+
+type RestrictedActionRenderState = {
+  allowed: boolean;
+  disabled: boolean;
+};
+
+type RestrictedActionProps = {
+  restriction: ActionRestriction;
+  children: ReactNode | ((state: RestrictedActionRenderState) => ReactNode);
+  className?: string;
+  placement?: "top" | "bottom" | "left" | "right";
+};
+
+export const RestrictedAction = ({
+  restriction,
+  children,
+  className,
+  placement,
+}: RestrictedActionProps) => {
+  const state = {
+    allowed: restriction.allowed,
+    disabled: !restriction.allowed,
+  };
+  const content = typeof children === "function" ? children(state) : children;
+
+  if (restriction.allowed) {
+    return <>{content}</>;
+  }
+
+  return (
+    <Tooltip
+      content={restriction.message}
+      placement={placement}
+      triggerProps={{
+        "aria-disabled": true,
+        tabIndex: 0,
+        className: clsx("cursor-not-allowed", className),
+      }}
+    >
+      <span className="pointer-events-none inline-flex w-full" inert>
+        {content}
+      </span>
+    </Tooltip>
+  );
+};

--- a/web/components/RestrictedButton/index.tsx
+++ b/web/components/RestrictedButton/index.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { DecoratedButton } from "@/components/DecoratedButton";
+import {
+  type ActionRestriction,
+  RestrictedAction,
+} from "@/components/RestrictedAction";
+import { type ComponentProps } from "react";
+
+type RestrictedButtonProps = ComponentProps<typeof DecoratedButton> & {
+  restriction: ActionRestriction;
+};
+
+export const RestrictedButton = ({
+  restriction,
+  ...buttonProps
+}: RestrictedButtonProps) => (
+  <RestrictedAction restriction={restriction}>
+    {({ disabled: restricted }) => (
+      <DecoratedButton
+        {...buttonProps}
+        disabled={restricted || buttonProps.disabled}
+      />
+    )}
+  </RestrictedAction>
+);

--- a/web/components/Tabs/Tab/index.tsx
+++ b/web/components/Tabs/Tab/index.tsx
@@ -4,6 +4,7 @@ import Link, { LinkProps } from "next/link";
 import { useSelectedLayoutSegment } from "next/navigation";
 import { HTMLAttributes, useMemo } from "react";
 import { tv } from "tailwind-variants";
+import { Tooltip } from "@/components/Tooltip";
 
 const tab = tv({
   base: "block cursor-pointer px-4 py-2.5 leading-5 md:px-1 md:py-3 md:leading-4",
@@ -14,6 +15,9 @@ const tab = tv({
     },
     underlined: {
       true: "",
+    },
+    disabled: {
+      true: "cursor-not-allowed text-grey-300 hover:text-grey-300",
     },
   },
   compoundVariants: [
@@ -29,6 +33,8 @@ type TabProps = HTMLAttributes<HTMLAnchorElement> &
     underlined?: boolean;
     segment: string | null;
     active?: boolean;
+    disabled?: boolean;
+    disabledReason?: string;
   };
 
 export const Tab = (props: TabProps) => {
@@ -38,6 +44,8 @@ export const Tab = (props: TabProps) => {
     style = {},
     underlined,
     active: manualActive,
+    disabled,
+    disabledReason,
     ...otherProps
   } = props;
   const selectedLayoutSegment = useSelectedLayoutSegment();
@@ -50,6 +58,42 @@ export const Tab = (props: TabProps) => {
 
     return props.segment === selectedLayoutSegment;
   }, [manualActive, props.segment, selectedLayoutSegment]);
+
+  if (disabled) {
+    const disabledTab = (
+      <span
+        aria-disabled="true"
+        className={tab({
+          active: false,
+          underlined,
+          disabled: true,
+          className,
+        })}
+        style={{ ...style, scrollSnapAlign: "start" }}
+      >
+        {children}
+      </span>
+    );
+
+    if (disabledReason) {
+      return (
+        <Tooltip
+          content={disabledReason}
+          triggerProps={{
+            "aria-disabled": true,
+            tabIndex: 0,
+            className: "inline-flex cursor-not-allowed",
+          }}
+        >
+          <span className="inline-flex" inert>
+            {disabledTab}
+          </span>
+        </Tooltip>
+      );
+    }
+
+    return disabledTab;
+  }
 
   return (
     <Link

--- a/web/components/Tooltip/index.tsx
+++ b/web/components/Tooltip/index.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import {
+  autoUpdate,
+  flip,
+  FloatingPortal,
+  offset,
+  type Placement,
+  shift,
+  useClick,
+  useDismiss,
+  useFloating,
+  useFocus,
+  useHover,
+  useInteractions,
+  useRole,
+} from "@floating-ui/react";
+import clsx from "clsx";
+import { type HTMLAttributes, type ReactNode, useState } from "react";
+
+type TooltipProps = {
+  content: ReactNode;
+  children: ReactNode;
+  placement?: Placement;
+  triggerProps?: HTMLAttributes<HTMLSpanElement> & { tabIndex?: number };
+};
+
+export const Tooltip = ({
+  content,
+  children,
+  placement = "top",
+  triggerProps,
+}: TooltipProps) => {
+  const [open, setOpen] = useState(false);
+  const { className: triggerClassName, ...otherTriggerProps } =
+    triggerProps ?? {};
+
+  const { refs, floatingStyles, context } = useFloating({
+    open,
+    onOpenChange: setOpen,
+    placement,
+    whileElementsMounted: autoUpdate,
+    middleware: [offset(8), flip(), shift({ padding: 8 })],
+  });
+
+  const hover = useHover(context, { move: false });
+  const focus = useFocus(context);
+  const click = useClick(context, { toggle: false });
+  const dismiss = useDismiss(context);
+  const role = useRole(context, { role: "tooltip" });
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    hover,
+    focus,
+    click,
+    dismiss,
+    role,
+  ]);
+
+  return (
+    <>
+      <span
+        ref={refs.setReference}
+        className={clsx("inline-flex", triggerClassName)}
+        {...getReferenceProps(otherTriggerProps)}
+      >
+        {children}
+      </span>
+
+      {open && content ? (
+        <FloatingPortal>
+          <div
+            ref={refs.setFloating}
+            style={floatingStyles}
+            {...getFloatingProps()}
+            className={clsx(
+              "z-50 max-w-xs rounded-lg border border-grey-200 bg-grey-0 px-3 py-2 text-12 leading-4 text-grey-700 shadow-lg",
+            )}
+          >
+            {content}
+          </div>
+        </FloatingPortal>
+      ) : null}
+    </>
+  );
+};

--- a/web/lib/feature-flags/world-id-4-0/server.ts
+++ b/web/lib/feature-flags/world-id-4-0/server.ts
@@ -9,9 +9,21 @@ import { isWorldId40EnabledForTeam } from "./common";
 export const isWorldId40EnabledServer = async (
   teamId: string | undefined,
 ): Promise<boolean> => {
-  const enabledTeams = await global.ParameterStore?.getParameter<string[]>(
-    "world-id-4-0/enabled-teams",
-    [],
-  );
+  // Local-dev only: never let this env var override the SSM source of truth in a
+  // deployed environment (matches the NODE_ENV === "development" gating used in lib/utils).
+  const localTeams =
+    process.env.NODE_ENV === "development"
+      ? process.env.LOCAL_DEV_WORLD_ID_40_ENABLED_TEAMS?.split(",")
+          .map((entry) => entry.trim())
+          .filter(Boolean)
+      : undefined;
+
+  const enabledTeams = localTeams?.length
+    ? localTeams
+    : await global.ParameterStore?.getParameter<string[]>(
+        "world-id-4-0/enabled-teams",
+        [],
+      );
+
   return isWorldId40EnabledForTeam(enabledTeams, teamId);
 };

--- a/web/lib/team-permissions/index.ts
+++ b/web/lib/team-permissions/index.ts
@@ -1,0 +1,116 @@
+import { Role_Enum } from "@/graphql/graphql";
+import { Auth0SessionUser } from "@/lib/types";
+import { checkUserPermissions } from "@/lib/utils";
+
+type PermissionRule = { roles: Role_Enum[]; message: string };
+
+export type TeamPermission = {
+  allowed: boolean;
+  message: string;
+};
+
+export const OWNER_ADMIN_MESSAGE =
+  "Only Owners and Admins can edit this section.";
+export const OWNER_ONLY_MESSAGE = "Only Owners can edit this section.";
+export const SELF_ROW_MESSAGE = "You cannot manage your own member row.";
+
+const ownerAdmin = (): PermissionRule => ({
+  roles: [Role_Enum.Owner, Role_Enum.Admin],
+  message: OWNER_ADMIN_MESSAGE,
+});
+
+const ownerOnly = (): PermissionRule => ({
+  roles: [Role_Enum.Owner],
+  message: OWNER_ONLY_MESSAGE,
+});
+
+export const PERMISSION_RULES = {
+  submit_app_for_review: ownerAdmin(),
+  create_app_draft: ownerAdmin(),
+  unsubmit_app: ownerAdmin(),
+  resolve_app_review: ownerAdmin(),
+  edit_app_information: ownerAdmin(),
+  edit_app_store_details: ownerAdmin(),
+  edit_app_imagery: ownerAdmin(),
+  save_app_configuration: ownerAdmin(),
+  enable_world_id_4_0: ownerAdmin(),
+  manage_world_id_4_0: ownerAdmin(),
+  create_world_id_action: ownerAdmin(),
+  edit_world_id_action: ownerAdmin(),
+  delete_world_id_action: ownerAdmin(),
+  invite_member: ownerAdmin(),
+  edit_member_role: ownerOnly(),
+  remove_member: ownerOnly(),
+  resend_invite: ownerOnly(),
+  cancel_invite: ownerOnly(),
+} satisfies Record<string, PermissionRule>;
+
+export type PermissionAction = keyof typeof PERMISSION_RULES;
+
+export const TEAM_PERMISSION_ROLES = [
+  { label: "Owner", value: Role_Enum.Owner },
+  { label: "Admin", value: Role_Enum.Admin },
+  { label: "Member", value: Role_Enum.Member },
+] as const;
+
+export type PermissionDisplayGroup = {
+  label: string;
+  roles: Role_Enum[];
+};
+
+const allTeamRoles = TEAM_PERMISSION_ROLES.map((role) => role.value);
+const rolesFor = (action: PermissionAction): Role_Enum[] =>
+  PERMISSION_RULES[action].roles;
+
+export const PERMISSION_DISPLAY_GROUPS: PermissionDisplayGroup[] = [
+  { label: "View World ID", roles: allTeamRoles },
+  {
+    label: "Enable & Manage World ID 4.0",
+    roles: rolesFor("enable_world_id_4_0"),
+  },
+  { label: "View World ID actions", roles: allTeamRoles },
+  {
+    label: "Create & Edit World ID actions",
+    roles: rolesFor("create_world_id_action"),
+  },
+  {
+    label: "Delete World ID actions",
+    roles: rolesFor("delete_world_id_action"),
+  },
+  { label: "View apps", roles: allTeamRoles },
+  {
+    label: "Create & Edit apps",
+    roles: rolesFor("edit_app_information"),
+  },
+  { label: "Delete apps", roles: [Role_Enum.Owner] },
+  { label: "View app configuration", roles: allTeamRoles },
+  {
+    label: "Create & Edit app configuration",
+    roles: rolesFor("edit_app_store_details"),
+  },
+  { label: "View API keys", roles: [Role_Enum.Owner, Role_Enum.Admin] },
+  { label: "Create & Edit API keys", roles: [Role_Enum.Owner] },
+  { label: "Delete API keys", roles: [Role_Enum.Owner] },
+  { label: "View team members & roles", roles: allTeamRoles },
+  { label: "Invite team members", roles: rolesFor("invite_member") },
+  { label: "Remove team members", roles: rolesFor("remove_member") },
+  { label: "Update team roles", roles: rolesFor("edit_member_role") },
+];
+
+export const roleHasPermission = (
+  group: PermissionDisplayGroup,
+  role: Role_Enum,
+) => group.roles.includes(role);
+
+export const getTeamPermission = (
+  user: Auth0SessionUser["user"] | undefined,
+  teamId: string,
+  action: PermissionAction,
+): TeamPermission => {
+  const rule = PERMISSION_RULES[action];
+
+  return {
+    allowed: checkUserPermissions(user, teamId, rule.roles),
+    message: rule.message,
+  };
+};

--- a/web/lib/team-permissions/index.ts
+++ b/web/lib/team-permissions/index.ts
@@ -1,6 +1,6 @@
 import { Role_Enum } from "@/graphql/graphql";
 import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
+import { getUserTeamRole } from "@/lib/utils";
 
 type PermissionRule = { roles: Role_Enum[]; message: string };
 
@@ -14,35 +14,40 @@ export const OWNER_ADMIN_MESSAGE =
 export const OWNER_ONLY_MESSAGE = "Only Owners can edit this section.";
 export const SELF_ROW_MESSAGE = "You cannot manage your own member row.";
 
-const ownerAdmin = (): PermissionRule => ({
+const OWNER_ADMIN: PermissionRule = {
   roles: [Role_Enum.Owner, Role_Enum.Admin],
   message: OWNER_ADMIN_MESSAGE,
-});
+};
 
-const ownerOnly = (): PermissionRule => ({
+const OWNER_ONLY: PermissionRule = {
   roles: [Role_Enum.Owner],
   message: OWNER_ONLY_MESSAGE,
-});
+};
 
 export const PERMISSION_RULES = {
-  submit_app_for_review: ownerAdmin(),
-  create_app_draft: ownerAdmin(),
-  unsubmit_app: ownerAdmin(),
-  resolve_app_review: ownerAdmin(),
-  edit_app_information: ownerAdmin(),
-  edit_app_store_details: ownerAdmin(),
-  edit_app_imagery: ownerAdmin(),
-  save_app_configuration: ownerAdmin(),
-  enable_world_id_4_0: ownerAdmin(),
-  manage_world_id_4_0: ownerAdmin(),
-  create_world_id_action: ownerAdmin(),
-  edit_world_id_action: ownerAdmin(),
-  delete_world_id_action: ownerAdmin(),
-  invite_member: ownerAdmin(),
-  edit_member_role: ownerOnly(),
-  remove_member: ownerOnly(),
-  resend_invite: ownerOnly(),
-  cancel_invite: ownerOnly(),
+  submit_app_for_review: OWNER_ADMIN,
+  create_app_draft: OWNER_ADMIN,
+  unsubmit_app: OWNER_ADMIN,
+  resolve_app_review: OWNER_ADMIN,
+  edit_app_information: OWNER_ADMIN,
+  edit_app_store_details: OWNER_ADMIN,
+  edit_app_imagery: OWNER_ADMIN,
+  delete_app: OWNER_ONLY,
+  enable_world_id_4_0: OWNER_ADMIN,
+  manage_world_id_4_0: OWNER_ADMIN,
+  create_world_id_action: OWNER_ADMIN,
+  edit_world_id_action: OWNER_ADMIN,
+  delete_world_id_action: OWNER_ADMIN,
+  view_api_keys: OWNER_ADMIN,
+  edit_api_keys: OWNER_ONLY,
+  delete_api_keys: OWNER_ONLY,
+  edit_team_settings: OWNER_ONLY,
+  delete_team: OWNER_ONLY,
+  invite_member: OWNER_ADMIN,
+  edit_member_role: OWNER_ONLY,
+  remove_member: OWNER_ONLY,
+  resend_invite: OWNER_ADMIN,
+  cancel_invite: OWNER_ADMIN,
 } satisfies Record<string, PermissionRule>;
 
 export type PermissionAction = keyof typeof PERMISSION_RULES;
@@ -82,15 +87,15 @@ export const PERMISSION_DISPLAY_GROUPS: PermissionDisplayGroup[] = [
     label: "Create & Edit apps",
     roles: rolesFor("edit_app_information"),
   },
-  { label: "Delete apps", roles: [Role_Enum.Owner] },
+  { label: "Delete apps", roles: rolesFor("delete_app") },
   { label: "View app configuration", roles: allTeamRoles },
   {
     label: "Create & Edit app configuration",
     roles: rolesFor("edit_app_store_details"),
   },
-  { label: "View API keys", roles: [Role_Enum.Owner, Role_Enum.Admin] },
-  { label: "Create & Edit API keys", roles: [Role_Enum.Owner] },
-  { label: "Delete API keys", roles: [Role_Enum.Owner] },
+  { label: "View API keys", roles: rolesFor("view_api_keys") },
+  { label: "Create & Edit API keys", roles: rolesFor("edit_api_keys") },
+  { label: "Delete API keys", roles: rolesFor("delete_api_keys") },
   { label: "View team members & roles", roles: allTeamRoles },
   { label: "Invite team members", roles: rolesFor("invite_member") },
   { label: "Remove team members", roles: rolesFor("remove_member") },
@@ -102,6 +107,19 @@ export const roleHasPermission = (
   role: Role_Enum,
 ) => group.roles.includes(role);
 
+export const roleCanPerformAction = (
+  role: Role_Enum | undefined,
+  action: PermissionAction,
+): boolean => {
+  return Boolean(role && PERMISSION_RULES[action].roles.includes(role));
+};
+
+export const userCanPerformAction = (
+  user: Auth0SessionUser["user"] | undefined,
+  teamId: string,
+  action: PermissionAction,
+): boolean => roleCanPerformAction(getUserTeamRole(user, teamId), action);
+
 export const getTeamPermission = (
   user: Auth0SessionUser["user"] | undefined,
   teamId: string,
@@ -110,7 +128,7 @@ export const getTeamPermission = (
   const rule = PERMISSION_RULES[action];
 
   return {
-    allowed: checkUserPermissions(user, teamId, rule.roles),
+    allowed: userCanPerformAction(user, teamId, action),
     message: rule.message,
   };
 };

--- a/web/lib/team-permissions/use-team-permission.ts
+++ b/web/lib/team-permissions/use-team-permission.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useMemo } from "react";
+import { useUser } from "@auth0/nextjs-auth0/client";
+import { Auth0SessionUser } from "@/lib/types";
+import {
+  getTeamPermission,
+  type PermissionAction,
+  type TeamPermission,
+} from "@/lib/team-permissions";
+
+export type { TeamPermission } from "@/lib/team-permissions";
+
+export const useTeamPermission = (
+  teamId: string,
+  action: PermissionAction,
+): TeamPermission => {
+  const { user } = useUser() as Auth0SessionUser;
+
+  return useMemo(
+    () => getTeamPermission(user, teamId, action),
+    [action, teamId, user],
+  );
+};

--- a/web/lib/urls.ts
+++ b/web/lib/urls.ts
@@ -30,6 +30,9 @@ export const urls = {
   worldIdActions: (params: { team_id: string; app_id?: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id}/world-id-actions`,
 
+  createWorldIdAction: (params: { team_id: string; app_id: string }): string =>
+    `/teams/${params.team_id}/apps/${params.app_id}/world-id-actions?createAction=true`,
+
   worldIdAction: (params: {
     team_id: string;
     app_id: string;

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -200,19 +200,23 @@ export const getLogoImgCDNUrl = (
  * @param validRoles - The roles to check for
  * @returns True if the user has the required roles, false otherwise
  */
+export const getUserTeamRole = (
+  user: Auth0SessionUser["user"] | undefined,
+  teamId: string,
+): Role_Enum | undefined =>
+  user?.hasura?.memberships.find((m) => m.team?.id == teamId)?.role;
+
 export const checkUserPermissions = (
   user: Auth0SessionUser["user"],
   teamId: string,
   validRoles: Role_Enum[] | string[],
 ) => {
-  const membership = user?.hasura?.memberships.find(
-    (m) => m.team?.id == teamId,
-  );
+  const role = getUserTeamRole(user, teamId);
 
-  if (!membership) {
+  if (!role) {
     return false;
   }
-  return validRoles.includes(membership?.role);
+  return validRoles.includes(role);
 };
 
 /**

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -6,10 +6,12 @@ import {
   getPrimaryAppBaseUrl,
   siblingOrigin,
 } from "@/lib/app-base-url";
-import { Role_Enum } from "./graphql/graphql";
 import { Auth0SessionUser } from "./lib/types";
 import { urls } from "./lib/urls";
-import { checkUserPermissions } from "./lib/utils";
+import {
+  userCanPerformAction,
+  type PermissionAction,
+} from "./lib/team-permissions";
 
 const cdnURLObject = new URL(
   process.env.NEXT_PUBLIC_IMAGES_CDN_URL || "https://world-id-assets.com",
@@ -110,29 +112,53 @@ const checkRouteRolesRestrictions = (
   const teamId = urlSegments[2];
 
   // Route Subset Restriction
-  const ownerOnlyRoutes = [
-    "/teams/[a-zA-Z0-9_]+/apps/[a-zA-Z0-9_]+/configuration/danger$",
-    "/teams/[a-zA-Z0-9_]+/danger$",
-    "/teams/[a-zA-Z0-9_]+/settings$",
+  const ownerOnlyRoutes: { pattern: string; action: PermissionAction }[] = [
+    {
+      pattern: "/teams/[a-zA-Z0-9_]+/apps/[a-zA-Z0-9_]+/configuration/danger$",
+      action: "delete_app",
+    },
+    {
+      pattern: "/teams/[a-zA-Z0-9_]+/danger$",
+      action: "delete_team",
+    },
+    {
+      pattern: "/teams/[a-zA-Z0-9_]+/settings$",
+      action: "edit_team_settings",
+    },
   ];
-  const ownerAndAdminRoutes = [
-    "/teams/[a-zA-Z0-9_]+/apps/[a-zA-Z0-9_]+/actions/[a-zA-Z0-9_]+/danger$",
-    "/teams/[a-zA-Z0-9_]+/apps/[a-zA-Z0-9_]+/world-id-actions/[a-zA-Z0-9_]+/danger$",
-    "/teams/[a-zA-Z0-9_]+/api-keys$",
+  const ownerAndAdminRoutes: { pattern: string; action: PermissionAction }[] = [
+    {
+      pattern:
+        "/teams/[a-zA-Z0-9_]+/apps/[a-zA-Z0-9_]+/actions/[a-zA-Z0-9_]+/danger$",
+      action: "delete_world_id_action",
+    },
+    {
+      pattern:
+        "/teams/[a-zA-Z0-9_]+/apps/[a-zA-Z0-9_]+/world-id-actions/[a-zA-Z0-9_]+/danger$",
+      action: "delete_world_id_action",
+    },
+    {
+      pattern: "/teams/[a-zA-Z0-9_]+/api-keys$",
+      action: "view_api_keys",
+    },
   ];
 
-  if (ownerOnlyRoutes.some((route) => pathname.match(route))) {
-    if (!checkUserPermissions(user, teamId, [Role_Enum.Owner])) {
-      return NextResponse.rewrite(new URL("/unauthorized", request.url));
-    }
+  if (
+    ownerOnlyRoutes.some(
+      ({ pattern, action }) =>
+        pathname.match(pattern) && !userCanPerformAction(user, teamId, action),
+    )
+  ) {
+    return NextResponse.rewrite(new URL("/unauthorized", request.url));
   }
 
-  if (ownerAndAdminRoutes.some((route) => pathname.match(route))) {
-    if (
-      !checkUserPermissions(user, teamId, [Role_Enum.Owner, Role_Enum.Admin])
-    ) {
-      return NextResponse.rewrite(new URL("/unauthorized", request.url));
-    }
+  if (
+    ownerAndAdminRoutes.some(
+      ({ pattern, action }) =>
+        pathname.match(pattern) && !userCanPerformAction(user, teamId, action),
+    )
+  ) {
+    return NextResponse.rewrite(new URL("/unauthorized", request.url));
   }
   return false;
 };

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Danger/ActionDangerZoneContent/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Danger/ActionDangerZoneContent/index.tsx
@@ -6,12 +6,10 @@ import { DialogOverlay } from "@/components/DialogOverlay";
 import { DialogPanel } from "@/components/DialogPanel";
 import { AlertIcon } from "@/components/Icons/AlertIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { truncateString } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { useRouter } from "next/navigation";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "react-toastify";
 import { GetActionsDocument } from "../../../page/graphql/client/actions.generated";
 import { GetSingleActionQuery } from "../page/graphql/client/get-single-action.generated";
@@ -25,18 +23,10 @@ export const ActionDangerZoneContent = (props: {
   const { action, appId, teamId } = props;
   const [openDeleteModal, setOpenDeleteModal] = useState(false);
   const router = useRouter();
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    const membership = user?.hasura.memberships.find(
-      (m) => m.team?.id === teamId,
-    );
-
-    return (
-      membership?.role === Role_Enum.Owner ||
-      membership?.role === Role_Enum.Admin
-    );
-  }, [teamId, user?.hasura.memberships]);
+  const deleteActionPerm = useTeamPermission(
+    teamId ?? "",
+    "delete_world_id_action",
+  );
 
   const [deleteActionQuery, { loading: deleteActionLoading }] =
     useDeleteActionMutation();
@@ -138,7 +128,7 @@ export const ActionDangerZoneContent = (props: {
             type="button"
             variant="danger"
             onClick={() => setOpenDeleteModal(true)}
-            disabled={deleteActionLoading || !isEnoughPermissions}
+            disabled={deleteActionLoading || !deleteActionPerm.allowed}
             className="w-40 bg-system-error-100 "
           >
             <Typography variant={TYPOGRAPHY.R3}>Delete action</Typography>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/layout/index.tsx
@@ -7,11 +7,9 @@ import { useAtomValue } from "jotai";
 import { worldId40Atom, isWorldId40Enabled } from "@/lib/feature-flags";
 import { Tab, Tabs } from "@/components/Tabs";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser, EngineType } from "@/lib/types";
+import { EngineType } from "@/lib/types";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { urls } from "@/lib/urls";
-import { checkUserPermissions } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { ReactNode, use } from "react";
 import { useGetSingleActionAndNullifiersQuery } from "../page/graphql/client/get-single-action.generated";
 
@@ -28,9 +26,6 @@ type ActionIdLayout = {
 
 export const ActionIdLayout = (props: ActionIdLayout) => {
   const params = use(props.params);
-  const { user } = useUser() as Auth0SessionUser;
-
-  // Fetch action data for header using user permissions
   const { data, loading } = useGetSingleActionAndNullifiersQuery({
     variables: {
       action_id: params.actionId ?? "",
@@ -45,10 +40,10 @@ export const ActionIdLayout = (props: ActionIdLayout) => {
   const worldId40Config = useAtomValue(worldId40Atom);
   const isEnabled = isWorldId40Enabled(worldId40Config, params.teamId);
 
-  const isEnoughPermissions = checkUserPermissions(user, params.teamId ?? "", [
-    Role_Enum.Owner,
-    Role_Enum.Admin,
-  ]);
+  const deleteActionPerm = useTeamPermission(
+    params.teamId ?? "",
+    "delete_world_id_action",
+  );
 
   // Handle 404 if action not found (only after loading completes)
   if (!loading && !action) {
@@ -122,7 +117,7 @@ export const ActionIdLayout = (props: ActionIdLayout) => {
             </Tab>
           )}
 
-          {isEnoughPermissions && (
+          {deleteActionPerm.allowed && (
             <Tab
               className="md:py-4"
               href={`/teams/${params!.teamId}/apps/${params!.appId}/actions/${params!.actionId}/danger`}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
@@ -12,12 +12,9 @@ import {
 } from "@/components/Select";
 import { TextArea } from "@/components/TextArea";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
 import { AppMode } from "@/lib/constants";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { RadioCard } from "@/scenes/Portal/layout/CreateAppDialog/RadioCard";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { yupResolver } from "@hookform/resolvers/yup";
 import clsx from "clsx";
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef } from "react";
@@ -76,15 +73,8 @@ const calculateRows = (
 
 export const SetupForm = (props: LinksFormProps) => {
   const { teamId, appMetadata } = props;
-  const { user } = useUser() as Auth0SessionUser;
   const isEditable = appMetadata?.verification_status === "unverified";
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamId]);
+  const editStorePerm = useTeamPermission(teamId, "edit_app_store_details");
 
   const form = useForm<UpdateSetupInitialSchema>({
     resolver: yupResolver(updateSetupInitialSchema),
@@ -162,7 +152,7 @@ export const SetupForm = (props: LinksFormProps) => {
     [appMetadata?.id],
   );
 
-  const isAdvancedEditable = isEditable && isEnoughPermissions;
+  const isAdvancedEditable = isEditable && editStorePerm.allowed;
 
   const hasInvalidWhitelistCombination = (values: UpdateSetupInitialSchema) =>
     values.app_mode === "mini-app" &&
@@ -253,7 +243,7 @@ export const SetupForm = (props: LinksFormProps) => {
         </div>
         <TextArea
           aria-label="Additional Domains"
-          disabled={!isEditable || !isEnoughPermissions}
+          disabled={!isEditable || !editStorePerm.allowed}
           placeholder="https://example.com, https://example2.com"
           register={register("associated_domains", {
             onChange: formatArrayInput,
@@ -293,7 +283,7 @@ export const SetupForm = (props: LinksFormProps) => {
             label="Whitelisted Payment Addresses"
             disabled={
               !isEditable ||
-              !isEnoughPermissions ||
+              !editStorePerm.allowed ||
               isWhitelistDisabled ||
               appMode == "external"
             }
@@ -320,7 +310,7 @@ export const SetupForm = (props: LinksFormProps) => {
             id="is_whitelist_disabled"
             register={register("is_whitelist_disabled")}
             disabled={
-              !isEditable || !isEnoughPermissions || appMode == "external"
+              !isEditable || !editStorePerm.allowed || appMode == "external"
             }
           />
 
@@ -341,7 +331,7 @@ export const SetupForm = (props: LinksFormProps) => {
         </div>
         <TextArea
           label="Permit2 Tokens"
-          disabled={!isEditable || !isEnoughPermissions}
+          disabled={!isEditable || !editStorePerm.allowed}
           placeholder="0xad312321..., 0xE901e312..."
           register={register("permit2_tokens", { onChange: formatArrayInput })}
           enableResize={false}
@@ -365,7 +355,7 @@ export const SetupForm = (props: LinksFormProps) => {
         </div>
         <TextArea
           label="Contract Entrypoints"
-          disabled={!isEditable || !isEnoughPermissions}
+          disabled={!isEditable || !editStorePerm.allowed}
           placeholder="0xb731d321..., 0xF2310312..."
           register={register("contracts", { onChange: formatArrayInput })}
           enableResize={false}
@@ -417,7 +407,7 @@ export const SetupForm = (props: LinksFormProps) => {
                     : field.value
                 }
                 onChange={field.onChange}
-                disabled={!isEditable || !isEnoughPermissions}
+                disabled={!isEditable || !editStorePerm.allowed}
               >
                 <SelectButton className="min-w-[150px] rounded-lg border border-grey-200 px-4 py-2 md:w-fit">
                   {({ value }) => (
@@ -459,7 +449,7 @@ export const SetupForm = (props: LinksFormProps) => {
             id="can_import_all_contacts"
             register={register("can_import_all_contacts")}
             disabled={
-              !isEditable || !isEnoughPermissions || appMode === "external"
+              !isEditable || !editStorePerm.allowed || appMode === "external"
             }
           />
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ContentCardImageUpload/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ContentCardImageUpload/index.tsx
@@ -45,7 +45,6 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
   const [verifiedImageError, setVerifiedImageError] = useState(false);
   const [isSecondUpload, setIsSecondUpload] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
-  const [disabled] = useState(false);
   const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
   const [viewMode] = useAtom(viewModeAtom);
   const [unverifiedImages, setUnverifiedImages] = useAtom(unverifiedImageAtom);
@@ -55,6 +54,9 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
   const { getImage, uploadViaPresignedPost, validateImageAspectRatio } =
     useImage();
   const handleUpload = () => {
+    if (!isEditable) {
+      return;
+    }
     imageInputRef.current?.click();
   };
 
@@ -162,7 +164,7 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
         ref={imageInputRef}
         type="file"
         accept=".png,.jpg,.jpeg"
-        disabled={disabled}
+        disabled={!isEditable}
         onChange={handleFileInput}
         style={{ display: "none" }}
       />
@@ -241,10 +243,13 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
         ) : (
           <label
             className={clsx(
-              "flex h-[168px] w-full cursor-pointer flex-col items-center justify-center gap-y-3 rounded-[10px] border border-dashed bg-grey-50 p-6 hover:bg-grey-100",
+              "flex h-[168px] w-full flex-col items-center justify-center gap-y-3 rounded-[10px] border border-dashed bg-grey-50 p-6",
               isError
                 ? "border-system-error-500 bg-system-error-50"
                 : "border-grey-200",
+              isEditable
+                ? "cursor-pointer hover:bg-grey-100"
+                : "cursor-not-allowed opacity-60",
             )}
             onClick={handleUpload}
           >

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/app-store.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/app-store.tsx
@@ -47,7 +47,6 @@ export const AppStoreForm = ({
   const { flushAll, displayStatus } = useSaveStatus();
 
   const editStorePerm = useTeamPermission(teamId, "edit_app_store_details");
-  const savePerm = useTeamPermission(teamId, "save_app_configuration");
 
   const isMiniApp = useAtomValue(isMiniAppAtom);
   const canEditStore = isEditable && editStorePerm.allowed;
@@ -140,7 +139,7 @@ export const AppStoreForm = ({
 
         <div className="fixed bottom-[5.25rem] right-6 z-10 flex items-center gap-x-3 md:bottom-6">
           <SaveStatusIndicator />
-          <RestrictedAction restriction={savePerm}>
+          <RestrictedAction restriction={editStorePerm}>
             {({ disabled }) => (
               <SaveButton
                 isSubmitting={displayStatus.state === "saving"}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/app-store.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/app-store.tsx
@@ -1,9 +1,6 @@
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
+import { RestrictedAction } from "@/components/RestrictedAction";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { useAtomValue } from "jotai";
-import { useMemo } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { useSaveStatus } from "../SaveStatus";
 import { useAutosaveWithStatus } from "../hook/use-autosave-with-status";
@@ -31,8 +28,6 @@ export const AppStoreForm = ({
   teamId,
   appMetadata,
 }: AppStoreFormProps) => {
-  const { user } = useUser() as Auth0SessionUser;
-
   const {
     control,
     errors,
@@ -51,21 +46,18 @@ export const AppStoreForm = ({
   // copy only while the blue pill is showing, not on every raw status flip.
   const { flushAll, displayStatus } = useSaveStatus();
 
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamId]);
+  const editStorePerm = useTeamPermission(teamId, "edit_app_store_details");
+  const savePerm = useTeamPermission(teamId, "save_app_configuration");
 
   const isMiniApp = useAtomValue(isMiniAppAtom);
+  const canEditStore = isEditable && editStorePerm.allowed;
 
   const supportedLanguages = useWatch({ control, name: "supported_languages" });
 
   useAutosaveWithStatus<AppStoreFormValues>({
     id: "app-store",
     form,
-    enabled: isEditable && isEnoughPermissions,
+    enabled: canEditStore,
     save: async (data, signal) => {
       await submitSilent(data, signal);
     },
@@ -81,23 +73,14 @@ export const AppStoreForm = ({
       >
         {isMiniApp && (
           <>
-            <ComplianceSection
-              control={control}
-              isEditable={isEditable}
-              isEnoughPermissions={isEnoughPermissions}
-            />
+            <ComplianceSection control={control} isEditable={canEditStore} />
 
-            <HumansOnlySection
-              control={control}
-              isEditable={isEditable}
-              isEnoughPermissions={isEnoughPermissions}
-            />
+            <HumansOnlySection control={control} isEditable={canEditStore} />
 
             <CategorySection
               control={control}
               errors={errors}
-              isEditable={isEditable}
-              isEnoughPermissions={isEnoughPermissions}
+              isEditable={canEditStore}
             />
 
             <SectionDivider />
@@ -105,8 +88,7 @@ export const AppStoreForm = ({
             <SupportSection
               control={control}
               errors={errors}
-              isEditable={isEditable}
-              isEnoughPermissions={isEnoughPermissions}
+              isEditable={canEditStore}
               supportType={supportType}
               onSupportTypeChange={handleSupportTypeChange}
             />
@@ -117,8 +99,7 @@ export const AppStoreForm = ({
               appId={appId}
               teamId={teamId}
               appMetadata={appMetadata}
-              isEditable={isEditable}
-              isEnoughPermissions={isEnoughPermissions}
+              isEditable={canEditStore}
               errors={errors}
             />
 
@@ -129,8 +110,7 @@ export const AppStoreForm = ({
         <CountriesSection
           control={control}
           errors={errors}
-          isEditable={isEditable}
-          isEnoughPermissions={isEnoughPermissions}
+          isEditable={canEditStore}
         />
 
         <SectionDivider />
@@ -138,8 +118,7 @@ export const AppStoreForm = ({
         <LanguagesSection
           control={control}
           errors={errors}
-          isEditable={isEditable}
-          isEnoughPermissions={isEnoughPermissions}
+          isEditable={canEditStore}
         />
 
         <SectionDivider />
@@ -148,8 +127,7 @@ export const AppStoreForm = ({
           control={control}
           errors={errors}
           localisations={localisations}
-          isEditable={isEditable}
-          isEnoughPermissions={isEnoughPermissions}
+          isEditable={canEditStore}
           appMetadata={appMetadata}
           appId={appId}
           teamId={teamId}
@@ -162,17 +140,19 @@ export const AppStoreForm = ({
 
         <div className="fixed bottom-[5.25rem] right-6 z-10 flex items-center gap-x-3 md:bottom-6">
           <SaveStatusIndicator />
-          <SaveButton
-            isSubmitting={displayStatus.state === "saving"}
-            isDisabled={
-              !isEditable ||
-              !isEnoughPermissions ||
-              displayStatus.state === "saving"
-            }
-            onSubmit={() => {
-              void flushAll();
-            }}
-          />
+          <RestrictedAction restriction={savePerm}>
+            {({ disabled }) => (
+              <SaveButton
+                isSubmitting={displayStatus.state === "saving"}
+                isDisabled={
+                  !isEditable || disabled || displayStatus.state === "saving"
+                }
+                onSubmit={() => {
+                  void flushAll();
+                }}
+              />
+            )}
+          </RestrictedAction>
         </div>
       </form>
     </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/CategorySection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/CategorySection.tsx
@@ -12,7 +12,6 @@ export const CategorySection = ({
   control,
   errors,
   isEditable,
-  isEnoughPermissions,
 }: CategorySectionProps) => {
   return (
     <Controller
@@ -22,7 +21,7 @@ export const CategorySection = ({
         <CategorySelector
           value={field.value}
           required
-          disabled={!isEditable || !isEnoughPermissions}
+          disabled={!isEditable}
           onChange={field.onChange}
           errors={errors.category}
           label="Category"

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/ComplianceSection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/ComplianceSection.tsx
@@ -11,13 +11,12 @@ type ComplianceSectionProps = FormSectionProps & {
 export const ComplianceSection = ({
   control,
   isEditable,
-  isEnoughPermissions,
 }: ComplianceSectionProps) => {
   return (
     <Controller
       name="is_android_only"
       control={control}
-      disabled={!isEditable || !isEnoughPermissions}
+      disabled={!isEditable}
       render={({ field }) => (
         <div className="rounded-[10px] border border-grey-100 px-6 py-4">
           <div className="flex items-center gap-x-4">
@@ -33,7 +32,7 @@ export const ComplianceSection = ({
             <Toggle
               checked={field.value ?? false}
               onChange={field.onChange}
-              disabled={!isEditable || !isEnoughPermissions}
+              disabled={!isEditable}
             />
           </div>
         </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/CountriesSection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/CountriesSection.tsx
@@ -19,7 +19,6 @@ export const CountriesSection = ({
   control,
   errors,
   isEditable,
-  isEnoughPermissions,
 }: CountriesSectionProps) => {
   const countries = useMemo(() => formCountriesList(), []);
   const [showClearModal, setShowClearModal] = useState(false);
@@ -60,7 +59,7 @@ export const CountriesSection = ({
               }
               items={countries}
               label=""
-              disabled={!isEditable || !isEnoughPermissions}
+              disabled={!isEditable}
               errors={errors.supported_countries}
               required
               selectAll={() => field.onChange(countries.map((c) => c.value))}
@@ -92,7 +91,7 @@ export const CountriesSection = ({
                         : [...(field.value ?? []), value],
                     );
                   }}
-                  disabled={!isEditable || !isEnoughPermissions}
+                  disabled={!isEditable}
                 />
               )}
             </SelectMultiple>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/HumansOnlySection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/HumansOnlySection.tsx
@@ -11,13 +11,12 @@ type HumansOnlySectionProps = FormSectionProps & {
 export const HumansOnlySection = ({
   control,
   isEditable,
-  isEnoughPermissions,
 }: HumansOnlySectionProps) => {
   return (
     <Controller
       name="is_for_humans_only"
       control={control}
-      disabled={!isEditable || !isEnoughPermissions}
+      disabled={!isEditable}
       render={({ field }) => (
         <div className="rounded-[10px] border border-grey-100 px-6 py-4">
           <div className="flex items-center gap-x-4">
@@ -34,7 +33,7 @@ export const HumansOnlySection = ({
             <Toggle
               checked={field.value ?? false}
               onChange={field.onChange}
-              disabled={!isEditable || !isEnoughPermissions}
+              disabled={!isEditable}
             />
           </div>
         </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/LanguagesSection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/LanguagesSection.tsx
@@ -16,7 +16,6 @@ export const LanguagesSection = ({
   control,
   errors,
   isEditable,
-  isEnoughPermissions,
 }: LanguagesSectionProps) => {
   const allPossibleLanguages = formLanguagesList;
   const [showClearModal, setShowClearModal] = useState(false);
@@ -41,7 +40,7 @@ export const LanguagesSection = ({
               values={field.value}
               items={allPossibleLanguages}
               label=""
-              disabled={!isEditable || !isEnoughPermissions}
+              disabled={!isEditable}
               errors={errors.supported_languages}
               showSelectedList
               searchPlaceholder="Enter language"
@@ -90,7 +89,7 @@ export const LanguagesSection = ({
 
                     field.onChange(newSupportedLanguages);
                   }}
-                  disabled={!isEditable || !isEnoughPermissions}
+                  disabled={!isEditable}
                 />
               )}
             </SelectMultiple>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/LocalisationsSection/LocalisationsSection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/LocalisationsSection/LocalisationsSection.tsx
@@ -33,7 +33,6 @@ export const LocalisationsSection = ({
   errors,
   localisations,
   isEditable,
-  isEnoughPermissions,
   appMetadata,
   appId,
   teamId,
@@ -83,7 +82,6 @@ export const LocalisationsSection = ({
             errors={errors}
             selectedIndex={selectedIndex}
             isEditable={isEditable}
-            isEnoughPermissions={isEnoughPermissions}
             isMiniApp={appMetadata.app_mode === "mini-app"}
           />
 
@@ -101,7 +99,7 @@ export const LocalisationsSection = ({
                     Boolean(url),
                   )}
                   onChange={field.onChange}
-                  disabled={!isEditable || !isEnoughPermissions}
+                  disabled={!isEditable}
                   appId={appId}
                   teamId={teamId}
                   locale={selectedLanguage}
@@ -129,7 +127,7 @@ export const LocalisationsSection = ({
                 <MetaTagImageField
                   value={field.value}
                   onChange={field.onChange}
-                  disabled={!isEditable || !isEnoughPermissions}
+                  disabled={!isEditable}
                   appId={appId}
                   teamId={teamId}
                   locale={selectedLanguage}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/LocalisationsSection/components/LocalisationFields.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/LocalisationsSection/components/LocalisationFields.tsx
@@ -9,7 +9,6 @@ interface LocalisationFieldsProps {
   errors: FieldErrors<AppStoreFormValues>;
   selectedIndex: number;
   isEditable: boolean;
-  isEnoughPermissions: boolean;
   isMiniApp: boolean;
 }
 
@@ -18,10 +17,9 @@ export const LocalisationFields = ({
   errors,
   selectedIndex,
   isEditable,
-  isEnoughPermissions,
   isMiniApp,
 }: LocalisationFieldsProps) => {
-  const disabled = !isEditable || !isEnoughPermissions;
+  const disabled = !isEditable;
   const fieldErrors = errors.localisations?.[selectedIndex];
 
   return (

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/SupportSection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/SupportSection.tsx
@@ -17,11 +17,10 @@ export const SupportSection = ({
   control,
   errors,
   isEditable,
-  isEnoughPermissions,
   supportType,
   onSupportTypeChange,
 }: SupportSectionProps) => {
-  const disabled = !isEditable || !isEnoughPermissions;
+  const disabled = !isEditable;
 
   return (
     <FormSection

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/types/AppStoreFormTypes.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/types/AppStoreFormTypes.ts
@@ -77,7 +77,6 @@ export type AppStoreFormProps = {
 
 export type FormSectionProps = {
   isEditable: boolean;
-  isEnoughPermissions: boolean;
 };
 
 export type SupportType = "email" | "link";

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/index.tsx
@@ -2,14 +2,16 @@
 
 import { AppStatus, StatusVariant } from "@/components/AppStatus";
 import { DecoratedButton } from "@/components/DecoratedButton";
+import { RestrictedAction } from "@/components/RestrictedAction";
+import {
+  type TeamPermission,
+  useTeamPermission,
+} from "@/lib/team-permissions/use-team-permission";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
 
 import { Button } from "@/components/Button";
-import { Auth0SessionUser } from "@/lib/types";
 import { getCDNImageUrl, getDefaultLogoImgCDNUrl } from "@/lib/utils";
 import { useRemoveFromReview } from "@/scenes/Portal/Teams/TeamId/Apps/common/hooks/use-remove-from-review";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import clsx from "clsx";
 import { useAtom } from "jotai";
 import { ErrorPage } from "@/components/ErrorPage";
@@ -54,6 +56,7 @@ type AppTopBarSubmitProps = {
   viewMode: "unverified" | "verified";
   onSubmitSuccess: () => void;
   basicInfoRef?: MutableRefObject<BasicInformationHandle | null>;
+  permission: TeamPermission;
 };
 
 const AppTopBarSubmit = ({
@@ -63,6 +66,7 @@ const AppTopBarSubmit = ({
   viewMode,
   onSubmitSuccess,
   basicInfoRef,
+  permission,
 }: AppTopBarSubmitProps) => {
   const form = useFormContext<AppStoreFormValues>();
   const searchParams = useSearchParams();
@@ -184,27 +188,37 @@ const AppTopBarSubmit = ({
   const shouldAutoSubmitForReview =
     searchParams.get("submitForReview") === "true";
   useEffect(() => {
-    if (shouldAutoSubmitForReview && !hasAutoSubmitted.current) {
+    if (
+      shouldAutoSubmitForReview &&
+      !hasAutoSubmitted.current &&
+      permission.allowed
+    ) {
       submitForReview();
       hasAutoSubmitted.current = true;
     }
-  }, [shouldAutoSubmitForReview, submitForReview]);
+  }, [shouldAutoSubmitForReview, submitForReview, permission.allowed]);
 
   return (
-    <DecoratedButton
-      type="submit"
-      className={clsx("h-12 px-6 py-3", {
-        hidden:
-          appMetadata.app_id?.includes("staging") &&
-          process.env.NEXT_PUBLIC_APP_ENV === "production",
-      })}
-      disabled={viewMode === "verified" || isSubmittingForReview}
-      onClick={submitForReview}
-    >
-      <Typography variant={TYPOGRAPHY.M3} className="whitespace-nowrap">
-        {isSubmittingForReview ? "Processing..." : "Submit for review"}
-      </Typography>
-    </DecoratedButton>
+    <RestrictedAction restriction={permission}>
+      {({ disabled }) => (
+        <DecoratedButton
+          type="submit"
+          className={clsx("h-12 px-6 py-3", {
+            hidden:
+              appMetadata.app_id?.includes("staging") &&
+              process.env.NEXT_PUBLIC_APP_ENV === "production",
+          })}
+          disabled={
+            disabled || viewMode === "verified" || isSubmittingForReview
+          }
+          onClick={submitForReview}
+        >
+          <Typography variant={TYPOGRAPHY.M3} className="whitespace-nowrap">
+            {isSubmittingForReview ? "Processing..." : "Submit for review"}
+          </Typography>
+        </DecoratedButton>
+      )}
+    </RestrictedAction>
   );
 };
 
@@ -215,6 +229,7 @@ type AppIconButtonProps = {
   viewMode: "unverified" | "verified";
   isInReview: boolean;
   isLogoError: boolean;
+  isPermissionBlocked?: boolean;
   onEdit: () => void;
 };
 
@@ -225,34 +240,73 @@ const AppIconButton = ({
   viewMode,
   isInReview,
   isLogoError,
+  isPermissionBlocked = false,
   onEdit,
-}: AppIconButtonProps) => (
-  <button
-    type="button"
-    onClick={() => {
-      if (viewMode !== "verified" && !isInReview) {
-        onEdit();
-      }
-    }}
-    className={clsx("group relative size-[125px] shrink-0 rounded-full", {
-      "cursor-default": viewMode === "verified" || isInReview,
-    })}
-  >
-    {hasLogo ? (
-      <>
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={logoImgUrl}
-          alt="logo"
-          className="size-full rounded-full object-cover drop-shadow-lg"
-        />
-        {viewMode !== "verified" && !isInReview && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 rounded-full bg-grey-900/50 opacity-0 transition-opacity group-hover:opacity-100">
+}: AppIconButtonProps) => {
+  const canEditLogo =
+    viewMode !== "verified" && !isInReview && !isPermissionBlocked;
+  const canShowEmptyLogo = viewMode !== "verified" && !isInReview;
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (canEditLogo) {
+          onEdit();
+        }
+      }}
+      className={clsx("group relative size-[125px] shrink-0 rounded-full", {
+        "cursor-default": !canEditLogo,
+      })}
+    >
+      {hasLogo ? (
+        <>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={logoImgUrl}
+            alt="logo"
+            className="size-full rounded-full object-cover drop-shadow-lg"
+          />
+          {canEditLogo && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 rounded-full bg-grey-900/50 opacity-0 transition-opacity group-hover:opacity-100">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="size-6 text-white"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M1.5 6a2.25 2.25 0 0 1 2.25-2.25h16.5A2.25 2.25 0 0 1 22.5 6v12a2.25 2.25 0 0 1-2.25 2.25H3.75A2.25 2.25 0 0 1 1.5 18V6ZM3 16.06V18c0 .414.336.75.75.75h16.5A.75.75 0 0 0 21 18v-1.94l-2.69-2.689a1.5 1.5 0 0 0-2.12 0l-.88.879.83.83a.75.75 0 1 1-1.06 1.06l-5.16-5.159a1.5 1.5 0 0 0-2.12 0L3 16.061Zm10.125-7.81a1.125 1.125 0 1 1 2.25 0 1.125 1.125 0 0 1-2.25 0Z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <Typography variant={TYPOGRAPHY.R5} className="text-white">
+                Update icon
+              </Typography>
+            </div>
+          )}
+        </>
+      ) : isLogoLoading ? (
+        <div className="flex size-full items-center justify-center rounded-full border border-dashed border-grey-200 bg-grey-50">
+          <SpinnerIcon
+            className="size-8 animate-spin text-grey-300"
+            aria-label="Loading app logo"
+          />
+        </div>
+      ) : canShowEmptyLogo ? (
+        <>
+          <div
+            className={clsx(
+              "flex size-full flex-col items-center justify-center gap-1 rounded-full border border-dashed border-grey-200 bg-grey-50",
+              isLogoError && "border-system-error-500 bg-system-error-50",
+            )}
+          >
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
               fill="currentColor"
-              className="size-6 text-white"
+              className="size-6 text-grey-900"
             >
               <path
                 fillRule="evenodd"
@@ -260,56 +314,26 @@ const AppIconButton = ({
                 clipRule="evenodd"
               />
             </svg>
-            <Typography variant={TYPOGRAPHY.R5} className="text-white">
-              Update icon
+            <Typography variant={TYPOGRAPHY.R5} className="text-grey-900">
+              App icon <span className="text-system-error-500">*</span>
             </Typography>
+            {isLogoError && (
+              <Typography
+                variant={TYPOGRAPHY.R5}
+                className="text-center text-system-error-500"
+              >
+                Logo is required.
+              </Typography>
+            )}
           </div>
-        )}
-      </>
-    ) : isLogoLoading ? (
-      <div className="flex size-full items-center justify-center rounded-full border border-dashed border-grey-200 bg-grey-50">
-        <SpinnerIcon
-          className="size-8 animate-spin text-grey-300"
-          aria-label="Loading app logo"
-        />
-      </div>
-    ) : viewMode !== "verified" && !isInReview ? (
-      <>
-        <div
-          className={clsx(
-            "flex size-full flex-col items-center justify-center gap-1 rounded-full border border-dashed border-grey-200 bg-grey-50",
-            isLogoError && "border-system-error-500 bg-system-error-50",
+          {canEditLogo && (
+            <div className="absolute inset-0 rounded-full bg-grey-900/50 opacity-0 transition-opacity group-hover:opacity-100" />
           )}
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            className="size-6 text-grey-900"
-          >
-            <path
-              fillRule="evenodd"
-              d="M1.5 6a2.25 2.25 0 0 1 2.25-2.25h16.5A2.25 2.25 0 0 1 22.5 6v12a2.25 2.25 0 0 1-2.25 2.25H3.75A2.25 2.25 0 0 1 1.5 18V6ZM3 16.06V18c0 .414.336.75.75.75h16.5A.75.75 0 0 0 21 18v-1.94l-2.69-2.689a1.5 1.5 0 0 0-2.12 0l-.88.879.83.83a.75.75 0 1 1-1.06 1.06l-5.16-5.159a1.5 1.5 0 0 0-2.12 0L3 16.061Zm10.125-7.81a1.125 1.125 0 1 1 2.25 0 1.125 1.125 0 0 1-2.25 0Z"
-              clipRule="evenodd"
-            />
-          </svg>
-          <Typography variant={TYPOGRAPHY.R5} className="text-grey-900">
-            App icon <span className="text-system-error-500">*</span>
-          </Typography>
-          {isLogoError && (
-            <Typography
-              variant={TYPOGRAPHY.R5}
-              className="text-center text-system-error-500"
-            >
-              Logo is required.
-            </Typography>
-          )}
-        </div>
-        <div className="absolute inset-0 rounded-full bg-grey-900/50 opacity-0 transition-opacity group-hover:opacity-100" />
-      </>
-    ) : null}
-  </button>
-);
+        </>
+      ) : null}
+    </button>
+  );
+};
 
 const AppIconButtonWithFormError = (
   props: Omit<AppIconButtonProps, "isLogoError">,
@@ -337,7 +361,6 @@ export const AppTopBar = (props: AppTopBarProps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [viewMode, setViewMode] = useAtom(viewModeAtom);
-  const { user } = useUser() as Auth0SessionUser;
 
   const { data: unverifiedImagesData } = useFetchImagesQuery({
     variables: { id: appId, team_id: teamId },
@@ -353,6 +376,11 @@ export const AppTopBar = (props: AppTopBarProps) => {
   const [unverifiedImages, setUnverifiedImages] = useAtom(unverifiedImageAtom);
   const [localUnverifiedLogoOverride, setLocalUnverifiedLogoOverride] =
     useState<string | null>(null);
+  const submitPerm = useTeamPermission(teamId, "submit_app_for_review");
+  const draftPerm = useTeamPermission(teamId, "create_app_draft");
+  const unsubmitPerm = useTeamPermission(teamId, "unsubmit_app");
+  const resolvePerm = useTeamPermission(teamId, "resolve_app_review");
+  const imageryPerm = useTeamPermission(teamId, "edit_app_imagery");
 
   useEffect(() => {
     setLocalUnverifiedLogoOverride(null);
@@ -373,16 +401,6 @@ export const AppTopBar = (props: AppTopBarProps) => {
       setLocalUnverifiedLogoOverride(null);
     }
   }, [unverifiedImages?.logo_img_url, unverifiedImagesData]);
-
-  const isEnoughPermissions = useMemo(() => {
-    const membership = user?.hasura.memberships.find(
-      (m) => m.team?.id === teamId,
-    );
-    return (
-      membership?.role === Role_Enum.Owner ||
-      membership?.role === Role_Enum.Admin
-    );
-  }, [teamId, user?.hasura.memberships]);
 
   const appMetadata = useMemo(() => {
     if (viewMode === "verified") {
@@ -422,6 +440,10 @@ export const AppTopBar = (props: AppTopBarProps) => {
       return;
     }
 
+    if (!imageryPerm.allowed) {
+      return;
+    }
+
     if (viewMode === "verified" && app.app_metadata.length > 0) {
       setViewMode("unverified");
     }
@@ -430,6 +452,7 @@ export const AppTopBar = (props: AppTopBarProps) => {
     hasAutoOpenedLogoDialog.current = true;
   }, [
     app.app_metadata.length,
+    imageryPerm.allowed,
     setViewMode,
     shouldAutoOpenLogoDialog,
     viewMode,
@@ -582,24 +605,40 @@ export const AppTopBar = (props: AppTopBarProps) => {
         <div className="flex flex-col items-center gap-8 sm:flex-row sm:items-center">
           {/* Logo */}
           {hasFormContext ? (
-            <AppIconButtonWithFormError
-              hasLogo={hasLogo}
-              logoImgUrl={logoImgUrl}
-              isLogoLoading={isLogoLoading}
-              viewMode={viewMode}
-              isInReview={isInReview}
-              onEdit={() => setShowLogoDialog(true)}
-            />
+            <RestrictedAction
+              restriction={imageryPerm}
+              className="rounded-full"
+            >
+              {({ disabled }) => (
+                <AppIconButtonWithFormError
+                  hasLogo={hasLogo}
+                  logoImgUrl={logoImgUrl}
+                  isLogoLoading={isLogoLoading}
+                  viewMode={viewMode}
+                  isInReview={isInReview}
+                  isPermissionBlocked={disabled}
+                  onEdit={() => setShowLogoDialog(true)}
+                />
+              )}
+            </RestrictedAction>
           ) : (
-            <AppIconButton
-              hasLogo={hasLogo}
-              logoImgUrl={logoImgUrl}
-              isLogoLoading={isLogoLoading}
-              viewMode={viewMode}
-              isInReview={isInReview}
-              isLogoError={false}
-              onEdit={() => setShowLogoDialog(true)}
-            />
+            <RestrictedAction
+              restriction={imageryPerm}
+              className="rounded-full"
+            >
+              {({ disabled }) => (
+                <AppIconButton
+                  hasLogo={hasLogo}
+                  logoImgUrl={logoImgUrl}
+                  isLogoLoading={isLogoLoading}
+                  viewMode={viewMode}
+                  isInReview={isInReview}
+                  isLogoError={false}
+                  isPermissionBlocked={disabled}
+                  onEdit={() => setShowLogoDialog(true)}
+                />
+              )}
+            </RestrictedAction>
           )}
 
           {/* Name, Status, Environment, Version */}
@@ -634,76 +673,93 @@ export const AppTopBar = (props: AppTopBarProps) => {
             )}
 
           {/* Action Buttons */}
-          {isEnoughPermissions && (
-            <div className="flex gap-3">
-              {/* Resolve button for rejected apps */}
-              {isRejected && onResolve && (
-                <DecoratedButton
-                  type="button"
-                  className="h-12 px-6 py-3"
-                  onClick={onResolve}
-                >
-                  <Typography variant={TYPOGRAPHY.M3}>Resolve</Typography>
-                </DecoratedButton>
-              )}
-
-              {/* Submit / Un-submit / Create Draft button */}
-              {isEditable ? (
-                hasFormContext ? (
-                  <AppTopBarSubmit
-                    appMetadata={appMetadata}
-                    appId={appId}
-                    teamId={teamId}
-                    viewMode={viewMode}
-                    onSubmitSuccess={handleSubmitSuccess}
-                    basicInfoRef={basicInfoRef}
-                  />
-                ) : (
+          <div className="flex gap-3">
+            {/* Resolve button for rejected apps */}
+            {isRejected && onResolve && (
+              <RestrictedAction restriction={resolvePerm}>
+                {({ disabled }) => (
                   <DecoratedButton
                     type="button"
-                    className={clsx("h-12 px-6 py-3", {
-                      hidden:
-                        appMetadata.app_id?.includes("staging") &&
-                        process.env.NEXT_PUBLIC_APP_ENV === "production",
-                    })}
-                    disabled={!canSubmitForReview}
-                    onClick={() =>
-                      router.push(
-                        `${urls.configuration({ team_id: teamId, app_id: appId })}?submitForReview=true`,
-                      )
-                    }
+                    className="h-12 px-6 py-3"
+                    disabled={disabled}
+                    onClick={onResolve}
                   >
-                    <Typography
-                      variant={TYPOGRAPHY.M3}
-                      className="whitespace-nowrap"
+                    <Typography variant={TYPOGRAPHY.M3}>Resolve</Typography>
+                  </DecoratedButton>
+                )}
+              </RestrictedAction>
+            )}
+
+            {/* Submit / Un-submit / Create Draft button */}
+            {isEditable ? (
+              hasFormContext ? (
+                <AppTopBarSubmit
+                  appMetadata={appMetadata}
+                  appId={appId}
+                  teamId={teamId}
+                  viewMode={viewMode}
+                  onSubmitSuccess={handleSubmitSuccess}
+                  basicInfoRef={basicInfoRef}
+                  permission={submitPerm}
+                />
+              ) : (
+                <RestrictedAction restriction={submitPerm}>
+                  {({ disabled }) => (
+                    <DecoratedButton
+                      type="button"
+                      className={clsx("h-12 px-6 py-3", {
+                        hidden:
+                          appMetadata.app_id?.includes("staging") &&
+                          process.env.NEXT_PUBLIC_APP_ENV === "production",
+                      })}
+                      disabled={disabled || !canSubmitForReview}
+                      onClick={() =>
+                        router.push(
+                          `${urls.configuration({ team_id: teamId, app_id: appId })}?submitForReview=true`,
+                        )
+                      }
                     >
-                      Submit for review
+                      <Typography
+                        variant={TYPOGRAPHY.M3}
+                        className="whitespace-nowrap"
+                      >
+                        Submit for review
+                      </Typography>
+                    </DecoratedButton>
+                  )}
+                </RestrictedAction>
+              )
+            ) : app?.app_metadata?.length === 0 ? (
+              <RestrictedAction restriction={draftPerm}>
+                {({ disabled }) => (
+                  <DecoratedButton
+                    type="button"
+                    className="h-12 px-6 py-3"
+                    disabled={disabled}
+                    onClick={createNewDraft}
+                  >
+                    <Typography variant={TYPOGRAPHY.M3}>
+                      Create new draft
                     </Typography>
                   </DecoratedButton>
-                )
-              ) : app?.app_metadata?.length === 0 ? (
-                <DecoratedButton
-                  type="button"
-                  className="h-12 px-6 py-3"
-                  onClick={createNewDraft}
-                >
-                  <Typography variant={TYPOGRAPHY.M3}>
-                    Create new draft
-                  </Typography>
-                </DecoratedButton>
-              ) : isInReview ? (
-                <DecoratedButton
-                  type="button"
-                  variant="secondary"
-                  className="h-14 px-6"
-                  disabled={removeLoading}
-                  onClick={removeFromReview}
-                >
-                  <Typography variant={TYPOGRAPHY.M3}>Un-submit</Typography>
-                </DecoratedButton>
-              ) : null}
-            </div>
-          )}
+                )}
+              </RestrictedAction>
+            ) : isInReview ? (
+              <RestrictedAction restriction={unsubmitPerm}>
+                {({ disabled }) => (
+                  <DecoratedButton
+                    type="button"
+                    variant="secondary"
+                    className="h-14 px-6"
+                    disabled={disabled || removeLoading}
+                    onClick={removeFromReview}
+                  >
+                    <Typography variant={TYPOGRAPHY.M3}>Un-submit</Typography>
+                  </DecoratedButton>
+                )}
+              </RestrictedAction>
+            ) : null}
+          </div>
         </div>
       </div>
     </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/index.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { AppStatus, StatusVariant } from "@/components/AppStatus";
-import { DecoratedButton } from "@/components/DecoratedButton";
 import { RestrictedAction } from "@/components/RestrictedAction";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import {
   type TeamPermission,
   useTeamPermission,
@@ -52,7 +52,6 @@ import { useCreateEditableRowMutation } from "./graphql/client/create-editable-r
 type AppTopBarSubmitProps = {
   appMetadata: FetchAppMetadataQuery["app"][0]["app_metadata"][0];
   appId: string;
-  teamId: string;
   viewMode: "unverified" | "verified";
   onSubmitSuccess: () => void;
   basicInfoRef?: MutableRefObject<BasicInformationHandle | null>;
@@ -62,7 +61,6 @@ type AppTopBarSubmitProps = {
 const AppTopBarSubmit = ({
   appMetadata,
   appId,
-  teamId,
   viewMode,
   onSubmitSuccess,
   basicInfoRef,
@@ -199,26 +197,21 @@ const AppTopBarSubmit = ({
   }, [shouldAutoSubmitForReview, submitForReview, permission.allowed]);
 
   return (
-    <RestrictedAction restriction={permission}>
-      {({ disabled }) => (
-        <DecoratedButton
-          type="submit"
-          className={clsx("h-12 px-6 py-3", {
-            hidden:
-              appMetadata.app_id?.includes("staging") &&
-              process.env.NEXT_PUBLIC_APP_ENV === "production",
-          })}
-          disabled={
-            disabled || viewMode === "verified" || isSubmittingForReview
-          }
-          onClick={submitForReview}
-        >
-          <Typography variant={TYPOGRAPHY.M3} className="whitespace-nowrap">
-            {isSubmittingForReview ? "Processing..." : "Submit for review"}
-          </Typography>
-        </DecoratedButton>
-      )}
-    </RestrictedAction>
+    <RestrictedButton
+      restriction={permission}
+      type="submit"
+      className={clsx("h-12 px-6 py-3", {
+        hidden:
+          appMetadata.app_id?.includes("staging") &&
+          process.env.NEXT_PUBLIC_APP_ENV === "production",
+      })}
+      disabled={viewMode === "verified" || isSubmittingForReview}
+      onClick={submitForReview}
+    >
+      <Typography variant={TYPOGRAPHY.M3} className="whitespace-nowrap">
+        {isSubmittingForReview ? "Processing..." : "Submit for review"}
+      </Typography>
+    </RestrictedButton>
   );
 };
 
@@ -676,18 +669,14 @@ export const AppTopBar = (props: AppTopBarProps) => {
           <div className="flex gap-3">
             {/* Resolve button for rejected apps */}
             {isRejected && onResolve && (
-              <RestrictedAction restriction={resolvePerm}>
-                {({ disabled }) => (
-                  <DecoratedButton
-                    type="button"
-                    className="h-12 px-6 py-3"
-                    disabled={disabled}
-                    onClick={onResolve}
-                  >
-                    <Typography variant={TYPOGRAPHY.M3}>Resolve</Typography>
-                  </DecoratedButton>
-                )}
-              </RestrictedAction>
+              <RestrictedButton
+                restriction={resolvePerm}
+                type="button"
+                className="h-12 px-6 py-3"
+                onClick={onResolve}
+              >
+                <Typography variant={TYPOGRAPHY.M3}>Resolve</Typography>
+              </RestrictedButton>
             )}
 
             {/* Submit / Un-submit / Create Draft button */}
@@ -696,68 +685,57 @@ export const AppTopBar = (props: AppTopBarProps) => {
                 <AppTopBarSubmit
                   appMetadata={appMetadata}
                   appId={appId}
-                  teamId={teamId}
                   viewMode={viewMode}
                   onSubmitSuccess={handleSubmitSuccess}
                   basicInfoRef={basicInfoRef}
                   permission={submitPerm}
                 />
               ) : (
-                <RestrictedAction restriction={submitPerm}>
-                  {({ disabled }) => (
-                    <DecoratedButton
-                      type="button"
-                      className={clsx("h-12 px-6 py-3", {
-                        hidden:
-                          appMetadata.app_id?.includes("staging") &&
-                          process.env.NEXT_PUBLIC_APP_ENV === "production",
-                      })}
-                      disabled={disabled || !canSubmitForReview}
-                      onClick={() =>
-                        router.push(
-                          `${urls.configuration({ team_id: teamId, app_id: appId })}?submitForReview=true`,
-                        )
-                      }
-                    >
-                      <Typography
-                        variant={TYPOGRAPHY.M3}
-                        className="whitespace-nowrap"
-                      >
-                        Submit for review
-                      </Typography>
-                    </DecoratedButton>
-                  )}
-                </RestrictedAction>
+                <RestrictedButton
+                  restriction={submitPerm}
+                  type="button"
+                  className={clsx("h-12 px-6 py-3", {
+                    hidden:
+                      appMetadata.app_id?.includes("staging") &&
+                      process.env.NEXT_PUBLIC_APP_ENV === "production",
+                  })}
+                  disabled={!canSubmitForReview}
+                  onClick={() =>
+                    router.push(
+                      `${urls.configuration({ team_id: teamId, app_id: appId })}?submitForReview=true`,
+                    )
+                  }
+                >
+                  <Typography
+                    variant={TYPOGRAPHY.M3}
+                    className="whitespace-nowrap"
+                  >
+                    Submit for review
+                  </Typography>
+                </RestrictedButton>
               )
             ) : app?.app_metadata?.length === 0 ? (
-              <RestrictedAction restriction={draftPerm}>
-                {({ disabled }) => (
-                  <DecoratedButton
-                    type="button"
-                    className="h-12 px-6 py-3"
-                    disabled={disabled}
-                    onClick={createNewDraft}
-                  >
-                    <Typography variant={TYPOGRAPHY.M3}>
-                      Create new draft
-                    </Typography>
-                  </DecoratedButton>
-                )}
-              </RestrictedAction>
+              <RestrictedButton
+                restriction={draftPerm}
+                type="button"
+                className="h-12 px-6 py-3"
+                onClick={createNewDraft}
+              >
+                <Typography variant={TYPOGRAPHY.M3}>
+                  Create new draft
+                </Typography>
+              </RestrictedButton>
             ) : isInReview ? (
-              <RestrictedAction restriction={unsubmitPerm}>
-                {({ disabled }) => (
-                  <DecoratedButton
-                    type="button"
-                    variant="secondary"
-                    className="h-14 px-6"
-                    disabled={disabled || removeLoading}
-                    onClick={removeFromReview}
-                  >
-                    <Typography variant={TYPOGRAPHY.M3}>Un-submit</Typography>
-                  </DecoratedButton>
-                )}
-              </RestrictedAction>
+              <RestrictedButton
+                restriction={unsubmitPerm}
+                type="button"
+                variant="secondary"
+                className="h-14 px-6"
+                disabled={removeLoading}
+                onClick={removeFromReview}
+              >
+                <Typography variant={TYPOGRAPHY.M3}>Un-submit</Typography>
+              </RestrictedButton>
             ) : null}
           </div>
         </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
@@ -1,13 +1,10 @@
 "use client";
 import { CopyButton } from "@/components/CopyButton";
 import { FloatingInput } from "@/components/FloatingInput";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
 import { inferHttps } from "@/lib/schema";
-import { checkUserPermissions } from "@/lib/utils";
 import { useApolloClient } from "@apollo/client";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useAtom } from "jotai";
 import React, {
@@ -50,14 +47,7 @@ export const BasicInformation = forwardRef<
   const apolloClient = useApolloClient();
 
   const [viewMode] = useAtom(viewModeAtom);
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamId]);
+  const editInfoPerm = useTeamPermission(teamId, "edit_app_information");
 
   const appMetaData = useMemo(() => {
     if (viewMode === "verified") {
@@ -151,7 +141,7 @@ export const BasicInformation = forwardRef<
   const autosave = useAutosaveWithStatus<BasicInformationFormValues>({
     id: "basic-information",
     form,
-    enabled: isEditable && isEnoughPermissions,
+    enabled: isEditable && editInfoPerm.allowed,
     save: async (data, signal) => {
       await persist(data, signal);
     },
@@ -225,13 +215,21 @@ export const BasicInformation = forwardRef<
             Basic information
           </Typography>
 
+          {!editInfoPerm.allowed && (
+            <div className="rounded-xl border border-grey-200 bg-grey-50 px-4 py-3">
+              <Typography variant={TYPOGRAPHY.R4} className="text-grey-700">
+                {editInfoPerm.message}
+              </Typography>
+            </div>
+          )}
+
           <div className="grid grid-cols-2 gap-x-4">
             <FloatingInput
               id="name"
               register={register("name")}
               errors={errors.name}
               label="App name"
-              disabled={!isEditable || !isEnoughPermissions}
+              disabled={!isEditable || !editInfoPerm.allowed}
               required
               maxLength={50}
             />
@@ -251,7 +249,7 @@ export const BasicInformation = forwardRef<
             label="App URL"
             required
             errors={errors.integration_url}
-            disabled={!isEditable || !isEnoughPermissions}
+            disabled={!isEditable || !editInfoPerm.allowed}
             register={makeUrlRegister("integration_url")}
           />
 
@@ -260,7 +258,7 @@ export const BasicInformation = forwardRef<
             label="App Official Website"
             required
             errors={errors.app_website_url}
-            disabled={!isEditable || !isEnoughPermissions}
+            disabled={!isEditable || !editInfoPerm.allowed}
             register={makeUrlRegister("app_website_url")}
           />
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Danger/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Danger/page/index.tsx
@@ -1,12 +1,9 @@
 "use client";
-import { DecoratedButton } from "@/components/DecoratedButton";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions, truncateString } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
-import clsx from "clsx";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
+import { truncateString } from "@/lib/utils";
 import { useAtom } from "jotai";
 import { ErrorPage } from "@/components/ErrorPage";
 import { useParams } from "next/navigation";
@@ -26,11 +23,7 @@ export const AppProfileDangerPage = ({ params }: AppProfileDangerPageProps) => {
   const teamId = (params?.teamId || routeParams?.teamId) as `team_${string}`;
   const [viewMode] = useAtom(viewModeAtom);
   const [openDeleteModal, setOpenDeleteModal] = useState(false);
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [Role_Enum.Owner]);
-  }, [user, teamId]);
+  const deletePerm = useTeamPermission(teamId ?? "", "delete_app");
 
   const { data, loading } = useFetchAppMetadataQuery({
     variables: {
@@ -83,14 +76,15 @@ export const AppProfileDangerPage = ({ params }: AppProfileDangerPageProps) => {
               </Typography>
             </div>
 
-            <DecoratedButton
+            <RestrictedButton
+              restriction={deletePerm}
               type="button"
               variant="destructive"
+              className="w-fit"
               onClick={() => setOpenDeleteModal(true)}
-              className={clsx("w-fit", { hidden: !isEnoughPermissions })}
             >
               <Typography variant={TYPOGRAPHY.R3}>Delete app</Typography>
-            </DecoratedButton>
+            </RestrictedButton>
           </div>
         </SizingWrapper>
         <DeleteModal

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/MiniAppConfiguration/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/MiniAppConfiguration/index.tsx
@@ -1,14 +1,11 @@
 "use client";
 
 import { Toggle } from "@/components/Toggle";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
 import { useRefetchQueries } from "@/lib/use-refetch-queries";
-import { checkUserPermissions } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { useAtom } from "jotai";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "react-toastify";
 import {
   FetchAppMetadataDocument,
@@ -30,17 +27,11 @@ export const MiniAppConfiguration = ({
   teamId,
   appMetadata,
 }: MiniAppConfigurationProps) => {
-  const { user } = useUser() as Auth0SessionUser;
   const [isUpdatingMode, setIsUpdatingMode] = useState(false);
   const modeUpdateInFlightRef = useRef(false);
   const saveStatus = useSaveStatusActions();
 
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamId]);
+  const editStorePerm = useTeamPermission(teamId, "edit_app_store_details");
 
   const isEditable = appMetadata.verification_status === "unverified";
 
@@ -128,6 +119,14 @@ export const MiniAppConfiguration = ({
         Mini App Configuration
       </Typography>
 
+      {!editStorePerm.allowed && (
+        <div className="rounded-xl border border-grey-200 bg-grey-50 px-4 py-3">
+          <Typography variant={TYPOGRAPHY.R4} className="text-grey-700">
+            {editStorePerm.message}
+          </Typography>
+        </div>
+      )}
+
       <div className="grid grid-cols-1 gap-y-10">
         {/* This is a Mini App toggle */}
         <div className="rounded-[10px] border border-grey-100 px-6 py-4">
@@ -145,7 +144,7 @@ export const MiniAppConfiguration = ({
             <Toggle
               checked={isMiniApp}
               onChange={handleAppModeToggle}
-              disabled={!isEditable || !isEnoughPermissions || isUpdatingMode}
+              disabled={!isEditable || !editStorePerm.allowed || isUpdatingMode}
             />
           </div>
         </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/layout/index.tsx
@@ -1,8 +1,7 @@
 import { SizingWrapper } from "@/components/SizingWrapper";
-import { Role_Enum } from "@/graphql/graphql";
+import { userCanPerformAction } from "@/lib/team-permissions";
 import { urls } from "@/lib/urls";
 import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
 import { auth0 } from "@/lib/auth0";
 import { ReactNode } from "react";
 import { SectionSubTabs } from "../../common/SectionSubTabs";
@@ -24,9 +23,11 @@ export const AppProfileLayout = async (props: AppProfileLayout) => {
   const session = await auth0.getSession();
   const user = session?.user as Auth0SessionUser["user"];
 
-  const isEnoughPermissions = checkUserPermissions(user, params.teamId ?? "", [
-    Role_Enum.Owner,
-  ]);
+  const canAccessAppDanger = userCanPerformAction(
+    user,
+    params.teamId ?? "",
+    "delete_app",
+  );
 
   return (
     <div className="flex flex-col items-start">
@@ -49,7 +50,7 @@ export const AppProfileLayout = async (props: AppProfileLayout) => {
                   app_id: params!.appId!,
                 })}/danger`,
                 segment: "danger",
-                hidden: !isEnoughPermissions,
+                hidden: !canAccessAppDanger,
               },
             ]}
           />

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/PermissionsForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/PermissionsForm/index.tsx
@@ -7,11 +7,8 @@ import { CheckIcon } from "@/components/Icons/CheckIcon";
 import { Link } from "@/components/Link";
 import { TextArea } from "@/components/TextArea";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
 import { AppMode } from "@/lib/constants";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { yupResolver } from "@hookform/resolvers/yup";
 import clsx from "clsx";
 import { ChangeEvent, ReactNode, useCallback, useEffect, useMemo } from "react";
@@ -183,15 +180,8 @@ export const SetupForm = ({
   teamId,
   appMetadata,
 }: PermissionsFormProps) => {
-  const { user } = useUser() as Auth0SessionUser;
   const isEditable = appMetadata?.verification_status === "unverified";
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [teamId, user]);
+  const editStorePerm = useTeamPermission(teamId, "edit_app_store_details");
 
   const form = useForm<UpdateSetupInitialSchema>({
     resolver: yupResolver(updateSetupInitialSchema),
@@ -221,7 +211,7 @@ export const SetupForm = ({
     }
   }, [appMetadata, reset, previousMetadataIdRef]);
 
-  const canEdit = isEditable && isEnoughPermissions;
+  const canEdit = isEditable && editStorePerm.allowed;
 
   const hasInvalidWhitelistCombination = useCallback(
     (values: UpdateSetupInitialSchema) =>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/ClientInformation/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/ClientInformation/index.tsx
@@ -4,11 +4,8 @@ import { DecoratedButton } from "@/components/DecoratedButton";
 import { LockIcon } from "@/components/Icons/LockIcon";
 import { Input } from "@/components/Input";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
 import { ORB_APP_TEAM_ID } from "@/lib/constants";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import clsx from "clsx";
 import { ErrorPage } from "@/components/ErrorPage";
 import { SizingWrapper } from "@/components/SizingWrapper";
@@ -26,14 +23,7 @@ export const ClientInformationPage = (props: {
 }) => {
   const { appID, teamID } = props;
   const [clientSecret, setClientSecret] = useState<string>("");
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamID ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamID]);
+  const editStorePerm = useTeamPermission(teamID, "edit_app_store_details");
 
   const { data, loading: fetchingAction } = useFetchSignInActionQuery({
     variables: { app_id: appID },
@@ -144,7 +134,7 @@ export const ClientInformationPage = (props: {
               <div
                 className={clsx(
                   "grid grid-cols-1fr/auto justify-items-end gap-x-3",
-                  { hidden: !isEnoughPermissions },
+                  { hidden: !editStorePerm.allowed },
                 )}
               >
                 <DecoratedButton
@@ -184,14 +174,14 @@ export const ClientInformationPage = (props: {
           teamId={teamID}
           isStaging={isStaging ?? false}
           appId={appID}
-          canEdit={isEnoughPermissions}
+          canEdit={editStorePerm.allowed}
         />
       </div>
 
       <LinksForm
         signInAction={signInAction!}
         teamId={teamID}
-        canEdit={isEnoughPermissions}
+        canEdit={editStorePerm.allowed}
       />
     </div>
   );

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/WorldId40Content.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/WorldId40Content.tsx
@@ -3,12 +3,16 @@
 import { CopyButton } from "@/components/CopyButton";
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { Notification } from "@/components/Notification";
+import { RestrictedAction } from "@/components/RestrictedAction";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import clsx from "clsx";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "react-toastify";
 import { useRetryRpMutation } from "./graphql/client/retry-rp.generated";
+import { getRpActionRestriction } from "./rp-action-restrictions";
 import { RotateSignerKeyDialog } from "./RotateSignerKeyDialog";
 import { SwitchToSelfManagedDialog } from "./SwitchToSelfManagedDialog";
 
@@ -45,6 +49,7 @@ const statusConfig: Record<
 };
 
 type WorldId40ContentProps = {
+  teamId: string;
   appId: string;
   rpId: string;
   initialStatus: RpStatus;
@@ -55,6 +60,7 @@ type WorldId40ContentProps = {
 };
 
 export const WorldId40Content = ({
+  teamId,
   appId,
   rpId,
   initialStatus,
@@ -74,6 +80,7 @@ export const WorldId40Content = ({
   const [retryingEnvironment, setRetryingEnvironment] = useState<string | null>(
     null,
   );
+  const managePermission = useTeamPermission(teamId, "manage_world_id_4_0");
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -116,16 +123,19 @@ export const WorldId40Content = ({
         },
       });
 
-      if (data?.retry_rp?.success) {
-        // Set the retried environment to pending and resume polling
-        if (environment === "production") {
-          setProductionStatus("pending");
-        } else {
-          setStagingStatus("pending");
-        }
+      if (!data?.retry_rp?.success) {
+        toast.error("Failed to retry RP registration");
+        return;
+      }
+
+      // Set the retried environment to pending and resume polling
+      if (environment === "production") {
+        setProductionStatus("pending");
+      } else {
+        setStagingStatus("pending");
       }
     } catch {
-      // Keep current status on error
+      toast.error("Failed to retry RP registration");
     } finally {
       setRetryingEnvironment(null);
     }
@@ -133,6 +143,18 @@ export const WorldId40Content = ({
 
   // Use production status for overall "active" checks (e.g., enabling reset button)
   const isActive = productionStatus === "registered";
+  const retryRestriction = getRpActionRestriction({
+    action: "retry",
+    permission: managePermission,
+    mode,
+    isActive,
+  });
+  const manageRegisteredRpRestriction = getRpActionRestriction({
+    action: "manage_registered_rp",
+    permission: managePermission,
+    mode,
+    isActive,
+  });
 
   const formattedDate = new Date(createdAt).toLocaleDateString("en-US", {
     year: "numeric",
@@ -168,15 +190,19 @@ export const WorldId40Content = ({
             </Typography>
           </div>
           {isFailed && (
-            <DecoratedButton
-              type="button"
-              variant="primary"
-              className="h-8 rounded-full px-4 py-0 text-xs"
-              disabled={isRetrying}
-              onClick={() => handleRetry(environment)}
-            >
-              {isRetrying ? "Retrying..." : "Try again"}
-            </DecoratedButton>
+            <RestrictedAction restriction={retryRestriction}>
+              {({ disabled }) => (
+                <DecoratedButton
+                  type="button"
+                  variant="primary"
+                  className="h-8 rounded-full px-4 py-0 text-xs"
+                  disabled={isRetrying || disabled}
+                  onClick={() => handleRetry(environment)}
+                >
+                  {isRetrying ? "Retrying..." : "Try again"}
+                </DecoratedButton>
+              )}
+            </RestrictedAction>
           )}
         </div>
       </div>
@@ -284,15 +310,19 @@ export const WorldId40Content = ({
                   This will create a new signer key and disable the existing key
                 </Typography>
               </div>
-              <DecoratedButton
-                type="button"
-                variant="secondary"
-                disabled={!isActive || mode === "self_managed"}
-                className="h-8 rounded-full px-4 py-0 text-xs"
-                onClick={() => setIsRotateDialogOpen(true)}
-              >
-                Reset
-              </DecoratedButton>
+              <RestrictedAction restriction={manageRegisteredRpRestriction}>
+                {({ disabled }) => (
+                  <DecoratedButton
+                    type="button"
+                    variant="secondary"
+                    disabled={disabled}
+                    className="h-8 rounded-full px-4 py-0 text-xs"
+                    onClick={() => setIsRotateDialogOpen(true)}
+                  >
+                    Reset
+                  </DecoratedButton>
+                )}
+              </RestrictedAction>
             </div>
           </div>
         </div>
@@ -313,27 +343,31 @@ export const WorldId40Content = ({
                   Move this RP to a self-managed configuration
                 </Typography>
               </div>
-              <DecoratedButton
-                type="button"
-                variant="danger"
-                disabled={!isActive || mode === "self_managed"}
-                className={clsx(
-                  "h-8 shrink-0 rounded-full px-4 text-[13px] font-semibold",
-                  !isActive || mode === "self_managed"
-                    ? "" // Let DecoratedButton handle disabled styles
-                    : "bg-danger text-white hover:bg-system-error-700",
+              <RestrictedAction restriction={manageRegisteredRpRestriction}>
+                {({ disabled }) => (
+                  <DecoratedButton
+                    type="button"
+                    variant="danger"
+                    disabled={disabled}
+                    className={clsx(
+                      "h-8 shrink-0 rounded-full px-4 text-[13px] font-semibold",
+                      disabled
+                        ? "" // Let DecoratedButton handle disabled styles
+                        : "bg-danger text-white hover:bg-system-error-700",
+                    )}
+                    title={
+                      mode === "self_managed"
+                        ? "Already in self-managed mode"
+                        : !isActive
+                          ? "RP must be active to switch modes"
+                          : undefined
+                    }
+                    onClick={() => setIsSwitchDialogOpen(true)}
+                  >
+                    Switch
+                  </DecoratedButton>
                 )}
-                title={
-                  mode === "self_managed"
-                    ? "Already in self-managed mode"
-                    : !isActive
-                      ? "RP must be active to switch modes"
-                      : undefined
-                }
-                onClick={() => setIsSwitchDialogOpen(true)}
-              >
-                Switch
-              </DecoratedButton>
+              </RestrictedAction>
             </div>
           </div>
         </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/WorldId40Content.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/WorldId40Content.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { CopyButton } from "@/components/CopyButton";
-import { DecoratedButton } from "@/components/DecoratedButton";
 import { Notification } from "@/components/Notification";
-import { RestrictedAction } from "@/components/RestrictedAction";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
@@ -190,19 +189,16 @@ export const WorldId40Content = ({
             </Typography>
           </div>
           {isFailed && (
-            <RestrictedAction restriction={retryRestriction}>
-              {({ disabled }) => (
-                <DecoratedButton
-                  type="button"
-                  variant="primary"
-                  className="h-8 rounded-full px-4 py-0 text-xs"
-                  disabled={isRetrying || disabled}
-                  onClick={() => handleRetry(environment)}
-                >
-                  {isRetrying ? "Retrying..." : "Try again"}
-                </DecoratedButton>
-              )}
-            </RestrictedAction>
+            <RestrictedButton
+              restriction={retryRestriction}
+              type="button"
+              variant="primary"
+              className="h-8 rounded-full px-4 py-0 text-xs"
+              disabled={isRetrying}
+              onClick={() => handleRetry(environment)}
+            >
+              {isRetrying ? "Retrying..." : "Try again"}
+            </RestrictedButton>
           )}
         </div>
       </div>
@@ -310,19 +306,15 @@ export const WorldId40Content = ({
                   This will create a new signer key and disable the existing key
                 </Typography>
               </div>
-              <RestrictedAction restriction={manageRegisteredRpRestriction}>
-                {({ disabled }) => (
-                  <DecoratedButton
-                    type="button"
-                    variant="secondary"
-                    disabled={disabled}
-                    className="h-8 rounded-full px-4 py-0 text-xs"
-                    onClick={() => setIsRotateDialogOpen(true)}
-                  >
-                    Reset
-                  </DecoratedButton>
-                )}
-              </RestrictedAction>
+              <RestrictedButton
+                restriction={manageRegisteredRpRestriction}
+                type="button"
+                variant="secondary"
+                className="h-8 rounded-full px-4 py-0 text-xs"
+                onClick={() => setIsRotateDialogOpen(true)}
+              >
+                Reset
+              </RestrictedButton>
             </div>
           </div>
         </div>
@@ -343,31 +335,20 @@ export const WorldId40Content = ({
                   Move this RP to a self-managed configuration
                 </Typography>
               </div>
-              <RestrictedAction restriction={manageRegisteredRpRestriction}>
-                {({ disabled }) => (
-                  <DecoratedButton
-                    type="button"
-                    variant="danger"
-                    disabled={disabled}
-                    className={clsx(
-                      "h-8 shrink-0 rounded-full px-4 text-[13px] font-semibold",
-                      disabled
-                        ? "" // Let DecoratedButton handle disabled styles
-                        : "bg-danger text-white hover:bg-system-error-700",
-                    )}
-                    title={
-                      mode === "self_managed"
-                        ? "Already in self-managed mode"
-                        : !isActive
-                          ? "RP must be active to switch modes"
-                          : undefined
-                    }
-                    onClick={() => setIsSwitchDialogOpen(true)}
-                  >
-                    Switch
-                  </DecoratedButton>
+              <RestrictedButton
+                restriction={manageRegisteredRpRestriction}
+                type="button"
+                variant="danger"
+                className={clsx(
+                  "h-8 shrink-0 rounded-full px-4 text-[13px] font-semibold",
+                  manageRegisteredRpRestriction.allowed
+                    ? "bg-danger text-white hover:bg-system-error-700"
+                    : "", // Let DecoratedButton handle disabled styles
                 )}
-              </RestrictedAction>
+                onClick={() => setIsSwitchDialogOpen(true)}
+              >
+                Switch
+              </RestrictedButton>
             </div>
           </div>
         </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/index.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 
 export const WorldId40Page = async ({ params }: Props) => {
-  const { appId } = params;
+  const { appId, teamId } = params;
 
   const client = await getAPIServiceGraphqlClient();
   const { rp_registration } = await getSdk(client).FetchRpRegistration({
@@ -36,6 +36,7 @@ export const WorldId40Page = async ({ params }: Props) => {
 
   return (
     <WorldId40Content
+      teamId={teamId}
       appId={appId}
       rpId={rpData.rp_id}
       initialStatus={

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/rp-action-restrictions.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/rp-action-restrictions.ts
@@ -1,0 +1,37 @@
+import type { ActionRestriction } from "@/components/RestrictedAction";
+
+type RpAction = "retry" | "manage_registered_rp";
+
+type GetRpActionRestrictionParams = {
+  action: RpAction;
+  permission: ActionRestriction;
+  mode: string;
+  isActive: boolean;
+};
+
+export const getRpActionRestriction = ({
+  action,
+  permission,
+  mode,
+  isActive,
+}: GetRpActionRestrictionParams): ActionRestriction => {
+  if (!permission.allowed) {
+    return permission;
+  }
+
+  if (mode === "self_managed") {
+    return {
+      allowed: false,
+      message: "This RP is self-managed.",
+    };
+  }
+
+  if (action === "manage_registered_rp" && !isActive) {
+    return {
+      allowed: false,
+      message: "RP must be active to reset or switch modes.",
+    };
+  }
+
+  return permission;
+};

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Danger/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Danger/page/index.tsx
@@ -3,6 +3,8 @@
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { ActionDangerZone } from "@/components/ActionDangerZone";
 import { ErrorPage } from "@/components/ErrorPage";
+import { RestrictedAction } from "@/components/RestrictedAction";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { urls } from "@/lib/urls";
 import { useRouter } from "next/navigation";
 import { useCallback, useState, use } from "react";
@@ -23,6 +25,10 @@ export const WorldIdActionIdDangerPage = (
   const appId = params?.appId;
   const router = useRouter();
   const [isDeleting, setIsDeleting] = useState(false);
+  const deletePermission = useTeamPermission(
+    teamId ?? "",
+    "delete_world_id_action",
+  );
 
   const { data, loading, error } = useGetSingleActionV4Query({
     variables: { action_id: actionId ?? "" },
@@ -73,12 +79,16 @@ export const WorldIdActionIdDangerPage = (
       {loading ? (
         <div>Loading...</div>
       ) : (
-        <ActionDangerZone
-          actionIdentifier={action!.action}
-          onDelete={handleDelete}
-          isDeleting={isDeleting}
-          canDelete={true}
-        />
+        <RestrictedAction restriction={deletePermission} className="w-fit">
+          {({ disabled }) => (
+            <ActionDangerZone
+              actionIdentifier={action!.action}
+              onDelete={handleDelete}
+              isDeleting={isDeleting}
+              canDelete={!disabled}
+            />
+          )}
+        </RestrictedAction>
       )}
     </SizingWrapper>
   );

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/UpdateActionV4Form/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/UpdateActionV4Form/index.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { CopyButton } from "@/components/CopyButton";
-import { DecoratedButton } from "@/components/DecoratedButton";
 import { Input } from "@/components/Input";
-import { RestrictedAction } from "@/components/RestrictedAction";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -106,20 +105,17 @@ export const UpdateActionV4Form = (props: UpdateActionV4FormProps) => {
       </div>
 
       <div className="flex justify-start">
-        <RestrictedAction restriction={editPermission} className="w-fit">
-          {({ disabled }) => (
-            <DecoratedButton
-              type="submit"
-              variant="primary"
-              disabled={isSubmitting || !isValid || disabled}
-              className="px-8 py-3"
-            >
-              <Typography variant={TYPOGRAPHY.R3}>
-                {isSubmitting ? "Saving..." : "Save Changes"}
-              </Typography>
-            </DecoratedButton>
-          )}
-        </RestrictedAction>
+        <RestrictedButton
+          restriction={editPermission}
+          type="submit"
+          variant="primary"
+          disabled={isSubmitting || !isValid}
+          className="px-8 py-3"
+        >
+          <Typography variant={TYPOGRAPHY.R3}>
+            {isSubmitting ? "Saving..." : "Save Changes"}
+          </Typography>
+        </RestrictedButton>
       </div>
     </form>
   );

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/UpdateActionV4Form/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/UpdateActionV4Form/index.tsx
@@ -3,7 +3,9 @@
 import { CopyButton } from "@/components/CopyButton";
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { Input } from "@/components/Input";
+import { RestrictedAction } from "@/components/RestrictedAction";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
@@ -19,12 +21,14 @@ import { updateActionV4ServerSide } from "./server";
 type UpdateActionV4FormProps = {
   action: NonNullable<GetSingleActionV4Query["action_v4_by_pk"]>;
   appId: string;
+  teamId: string;
 };
 
 export const UpdateActionV4Form = (props: UpdateActionV4FormProps) => {
-  const { action, appId } = props;
+  const { action, appId, teamId } = props;
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const editPermission = useTeamPermission(teamId, "edit_world_id_action");
 
   const {
     control,
@@ -97,20 +101,25 @@ export const UpdateActionV4Form = (props: UpdateActionV4FormProps) => {
           errors={errors.description}
           label="Short description"
           placeholder="e.g., Vote in community polls"
+          disabled={!editPermission.allowed}
         />
       </div>
 
       <div className="flex justify-start">
-        <DecoratedButton
-          type="submit"
-          variant="primary"
-          disabled={isSubmitting || !isValid}
-          className="px-8 py-3"
-        >
-          <Typography variant={TYPOGRAPHY.R3}>
-            {isSubmitting ? "Saving..." : "Save Changes"}
-          </Typography>
-        </DecoratedButton>
+        <RestrictedAction restriction={editPermission} className="w-fit">
+          {({ disabled }) => (
+            <DecoratedButton
+              type="submit"
+              variant="primary"
+              disabled={isSubmitting || !isValid || disabled}
+              className="px-8 py-3"
+            >
+              <Typography variant={TYPOGRAPHY.R3}>
+                {isSubmitting ? "Saving..." : "Save Changes"}
+              </Typography>
+            </DecoratedButton>
+          )}
+        </RestrictedAction>
       </div>
     </form>
   );

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/page/index.tsx
@@ -48,7 +48,11 @@ export const WorldIdActionIdSettingsPage = (
         {loading ? (
           <Skeleton count={4} />
         ) : (
-          <UpdateActionV4Form action={action!} appId={appId ?? ""} />
+          <UpdateActionV4Form
+            action={action!}
+            appId={appId ?? ""}
+            teamId={teamId ?? ""}
+          />
         )}
 
         {loading ? (

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/layout/index.tsx
@@ -107,19 +107,19 @@ export const WorldIdActionIdLayout = (props: WorldIdActionIdLayoutProps) => {
             <Typography variant={TYPOGRAPHY.R4}>Settings</Typography>
           </Tab>
 
-          {deletePermission.allowed && (
-            <Tab
-              className="md:py-4"
-              href={urls.worldIdActionDanger({
-                team_id: params.teamId ?? "",
-                app_id: params.appId ?? "",
-                action_id: params.actionId ?? "",
-              })}
-              segment={"danger"}
-            >
-              <Typography variant={TYPOGRAPHY.R4}>Danger zone</Typography>
-            </Tab>
-          )}
+          <Tab
+            className="md:py-4"
+            href={urls.worldIdActionDanger({
+              team_id: params.teamId ?? "",
+              app_id: params.appId ?? "",
+              action_id: params.actionId ?? "",
+            })}
+            segment={"danger"}
+            disabled={!deletePermission.allowed}
+            disabledReason={deletePermission.message}
+          >
+            <Typography variant={TYPOGRAPHY.R4}>Danger zone</Typography>
+          </Tab>
         </Tabs>
       </SizingWrapper>
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/layout/index.tsx
@@ -5,11 +5,8 @@ import { ErrorPage } from "@/components/ErrorPage";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { Tab, Tabs } from "@/components/Tabs";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { urls } from "@/lib/urls";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { ReactNode, use } from "react";
 import { useGetSingleActionV4Query } from "../page/graphql/client/get-single-action-v4.generated";
 
@@ -26,7 +23,10 @@ type WorldIdActionIdLayoutProps = {
 
 export const WorldIdActionIdLayout = (props: WorldIdActionIdLayoutProps) => {
   const params = use(props.params);
-  const { user } = useUser() as Auth0SessionUser;
+  const deletePermission = useTeamPermission(
+    params.teamId ?? "",
+    "delete_world_id_action",
+  );
 
   // Fetch action data for header using user permissions
   const { data, loading } = useGetSingleActionV4Query({
@@ -58,11 +58,6 @@ export const WorldIdActionIdLayout = (props: WorldIdActionIdLayoutProps) => {
       </SizingWrapper>
     );
   }
-
-  const isEnoughPermissions = checkUserPermissions(user, params.teamId ?? "", [
-    Role_Enum.Owner,
-    Role_Enum.Admin,
-  ]);
 
   return (
     <>
@@ -112,7 +107,7 @@ export const WorldIdActionIdLayout = (props: WorldIdActionIdLayoutProps) => {
             <Typography variant={TYPOGRAPHY.R4}>Settings</Typography>
           </Tab>
 
-          {isEnoughPermissions && (
+          {deletePermission.allowed && (
             <Tab
               className="md:py-4"
               href={urls.worldIdActionDanger({

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/ActionsListV4/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/ActionsListV4/index.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { DecoratedButton } from "@/components/DecoratedButton";
 import { SearchIcon } from "@/components/Icons/SearchIcon";
 import { Input } from "@/components/Input";
 import { Pagination } from "@/components/Pagination";
-import { RestrictedAction } from "@/components/RestrictedAction";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import { Section } from "@/components/Section";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import type { TeamPermission } from "@/lib/team-permissions";
@@ -94,26 +93,19 @@ export const ActionsListV4 = (props: ActionsListV4Props) => {
           </Section.Header.Search>
 
           <Section.Header.Button className="max-md:!bottom-[4.25rem] md:row-start-1 md:items-start">
-            <RestrictedAction restriction={createPermission}>
-              {({ disabled }) => (
-                <DecoratedButton
-                  type="button"
-                  variant="primary"
-                  className="h-12 w-[132px]"
-                  onClick={onCreateClick}
-                  disabled={disabled}
-                  testId="create-action-v4-list"
-                  aria-label="Create new action"
-                >
-                  <Typography
-                    variant={TYPOGRAPHY.M3}
-                    className="whitespace-nowrap"
-                  >
-                    New action
-                  </Typography>
-                </DecoratedButton>
-              )}
-            </RestrictedAction>
+            <RestrictedButton
+              restriction={createPermission}
+              type="button"
+              variant="primary"
+              className="h-12 w-[132px]"
+              onClick={onCreateClick}
+              testId="create-action-v4-list"
+              aria-label="Create new action"
+            >
+              <Typography variant={TYPOGRAPHY.M3} className="whitespace-nowrap">
+                New action
+              </Typography>
+            </RestrictedButton>
           </Section.Header.Button>
         </Section.Header>
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/ActionsListV4/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/ActionsListV4/index.tsx
@@ -4,8 +4,10 @@ import { DecoratedButton } from "@/components/DecoratedButton";
 import { SearchIcon } from "@/components/Icons/SearchIcon";
 import { Input } from "@/components/Input";
 import { Pagination } from "@/components/Pagination";
+import { RestrictedAction } from "@/components/RestrictedAction";
 import { Section } from "@/components/Section";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import type { TeamPermission } from "@/lib/team-permissions";
 import { useEffect, useMemo, useState } from "react";
 import { ActionRowV4 } from "./ActionRowV4";
 
@@ -16,10 +18,11 @@ type ActionsListV4Props = {
   onCreateClick: () => void;
   teamId: string;
   appId: string;
+  createPermission: TeamPermission;
 };
 
 export const ActionsListV4 = (props: ActionsListV4Props) => {
-  const { actions, onCreateClick, teamId, appId } = props;
+  const { actions, onCreateClick, teamId, appId, createPermission } = props;
   const [searchQuery, setSearchQuery] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(10);
@@ -91,18 +94,26 @@ export const ActionsListV4 = (props: ActionsListV4Props) => {
           </Section.Header.Search>
 
           <Section.Header.Button className="max-md:!bottom-[4.25rem] md:row-start-1 md:items-start">
-            <DecoratedButton
-              type="button"
-              variant="primary"
-              className="h-12 w-[132px]"
-              onClick={onCreateClick}
-              testId="create-action-v4-list"
-              aria-label="Create new action"
-            >
-              <Typography variant={TYPOGRAPHY.M3} className="whitespace-nowrap">
-                New action
-              </Typography>
-            </DecoratedButton>
+            <RestrictedAction restriction={createPermission}>
+              {({ disabled }) => (
+                <DecoratedButton
+                  type="button"
+                  variant="primary"
+                  className="h-12 w-[132px]"
+                  onClick={onCreateClick}
+                  disabled={disabled}
+                  testId="create-action-v4-list"
+                  aria-label="Create new action"
+                >
+                  <Typography
+                    variant={TYPOGRAPHY.M3}
+                    className="whitespace-nowrap"
+                  >
+                    New action
+                  </Typography>
+                </DecoratedButton>
+              )}
+            </RestrictedAction>
           </Section.Header.Button>
         </Section.Header>
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/index.tsx
@@ -2,9 +2,11 @@
 
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { UserStoryIcon } from "@/components/Icons/UserStoryIcon";
+import { RestrictedAction } from "@/components/RestrictedAction";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { useState } from "react";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
+import { useEffect, useRef, useState } from "react";
 import { ActionsListV4 } from "./ActionsListV4";
 import { CreateActionDialogV4 } from "./CreateActionDialogV4";
 import { useGetActionsV4Query } from "./graphql/client/get-actions-v4.generated";
@@ -14,10 +16,16 @@ type WorldIdActionsPageProps = {
   searchParams?: Record<string, string> | null | undefined;
 };
 
-export const WorldIdActionsPage = ({ params }: WorldIdActionsPageProps) => {
+export const WorldIdActionsPage = ({
+  params,
+  searchParams,
+}: WorldIdActionsPageProps) => {
   const appId = params?.appId as `app_${string}`;
   const teamId = params?.teamId ?? "";
   const [dialogOpen, setDialogOpen] = useState(false);
+  const hasAutoOpenedCreateAction = useRef(false);
+  const createPermission = useTeamPermission(teamId, "create_world_id_action");
+  const shouldAutoOpenCreateAction = searchParams?.createAction === "true";
 
   const { data, loading, error, refetch } = useGetActionsV4Query({
     variables: {
@@ -27,6 +35,17 @@ export const WorldIdActionsPage = ({ params }: WorldIdActionsPageProps) => {
   });
 
   const actions = data?.action_v4 || [];
+
+  useEffect(() => {
+    if (
+      shouldAutoOpenCreateAction &&
+      createPermission.allowed &&
+      !hasAutoOpenedCreateAction.current
+    ) {
+      setDialogOpen(true);
+      hasAutoOpenedCreateAction.current = true;
+    }
+  }, [createPermission.allowed, shouldAutoOpenCreateAction]);
 
   const handleDialogClose = async (success?: boolean) => {
     setDialogOpen(false);
@@ -79,15 +98,20 @@ export const WorldIdActionsPage = ({ params }: WorldIdActionsPageProps) => {
                 Actions are used to request uniqueness proofs
               </Typography>
             </div>
-            <DecoratedButton
-              variant="primary"
-              type="button"
-              onClick={() => setDialogOpen(true)}
-              testId="create-action-v4-empty"
-              aria-label="Create your first action"
-            >
-              <Typography variant={TYPOGRAPHY.M4}>Create</Typography>
-            </DecoratedButton>
+            <RestrictedAction restriction={createPermission}>
+              {({ disabled }) => (
+                <DecoratedButton
+                  variant="primary"
+                  type="button"
+                  onClick={() => setDialogOpen(true)}
+                  disabled={disabled}
+                  testId="create-action-v4-empty"
+                  aria-label="Create your first action"
+                >
+                  <Typography variant={TYPOGRAPHY.M4}>Create</Typography>
+                </DecoratedButton>
+              )}
+            </RestrictedAction>
           </div>
         </div>
       ) : (
@@ -96,6 +120,7 @@ export const WorldIdActionsPage = ({ params }: WorldIdActionsPageProps) => {
           onCreateClick={() => setDialogOpen(true)}
           teamId={teamId}
           appId={appId}
+          createPermission={createPermission}
         />
       )}
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/index.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { DecoratedButton } from "@/components/DecoratedButton";
 import { UserStoryIcon } from "@/components/Icons/UserStoryIcon";
-import { RestrictedAction } from "@/components/RestrictedAction";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
@@ -98,20 +97,16 @@ export const WorldIdActionsPage = ({
                 Actions are used to request uniqueness proofs
               </Typography>
             </div>
-            <RestrictedAction restriction={createPermission}>
-              {({ disabled }) => (
-                <DecoratedButton
-                  variant="primary"
-                  type="button"
-                  onClick={() => setDialogOpen(true)}
-                  disabled={disabled}
-                  testId="create-action-v4-empty"
-                  aria-label="Create your first action"
-                >
-                  <Typography variant={TYPOGRAPHY.M4}>Create</Typography>
-                </DecoratedButton>
-              )}
-            </RestrictedAction>
+            <RestrictedButton
+              restriction={createPermission}
+              variant="primary"
+              type="button"
+              onClick={() => setDialogOpen(true)}
+              testId="create-action-v4-empty"
+              aria-label="Create your first action"
+            >
+              <Typography variant={TYPOGRAPHY.M4}>Create</Typography>
+            </RestrictedButton>
           </div>
         </div>
       ) : (

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/AppIdChrome.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/AppIdChrome.tsx
@@ -41,6 +41,7 @@ export const AppIdChrome = ({
     return <>{children}</>;
   }
 
+  const teamsPath = urls.profileTeams();
   const isWorldIdSegment =
     segment === "world-id-4-0" ||
     segment === "world-id-actions" ||
@@ -109,6 +110,10 @@ export const AppIdChrome = ({
                 segment={"mini-app"}
               >
                 <Typography variant={TYPOGRAPHY.R4}>Mini App</Typography>
+              </Tab>
+
+              <Tab href={teamsPath} underlined segment={"teams"}>
+                <Typography variant={TYPOGRAPHY.R4}>Teams</Typography>
               </Tab>
             </Tabs>
           </SizingWrapper>
@@ -275,6 +280,10 @@ export const AppIdChrome = ({
               segment={"API Keys"}
             >
               <Typography variant={TYPOGRAPHY.R4}>API Keys</Typography>
+            </Tab>
+
+            <Tab href={teamsPath} underlined segment={"teams"}>
+              <Typography variant={TYPOGRAPHY.R4}>Teams</Typography>
             </Tab>
           </Tabs>
         </SizingWrapper>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/QuickActionsSection/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/QuickActionsSection/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { CheckmarkBadge } from "@/components/Icons/CheckmarkBadge";
 import { MultiplePlusIcon } from "@/components/Icons/MultiplePlusIcon";
 import { QuickAction } from "@/components/QuickAction";
@@ -23,7 +25,6 @@ export const QuickActionsSection = ({
     teamId,
     "create_world_id_action",
   );
-  const canCreateAction = createWorldIdActionPerm.allowed;
   const createActionHref = showWorldId40Actions
     ? urls.createWorldIdAction({ team_id: teamId, app_id: appId })
     : urls.createAction({ team_id: teamId, app_id: appId });

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/QuickActionsSection/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/QuickActionsSection/index.tsx
@@ -1,8 +1,12 @@
 import { CheckmarkBadge } from "@/components/Icons/CheckmarkBadge";
 import { MultiplePlusIcon } from "@/components/Icons/MultiplePlusIcon";
 import { QuickAction } from "@/components/QuickAction";
+import { RestrictedAction } from "@/components/RestrictedAction";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { isWorldId40Enabled, worldId40Atom } from "@/lib/feature-flags";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { urls } from "@/lib/urls";
+import { useAtomValue } from "jotai";
 
 interface QuickActionsSectionProps {
   appId: string;
@@ -13,17 +17,33 @@ export const QuickActionsSection = ({
   appId,
   teamId,
 }: QuickActionsSectionProps) => {
+  const worldId40Config = useAtomValue(worldId40Atom);
+  const showWorldId40Actions = isWorldId40Enabled(worldId40Config, teamId);
+  const createWorldIdActionPerm = useTeamPermission(
+    teamId,
+    "create_world_id_action",
+  );
+  const canCreateAction = createWorldIdActionPerm.allowed;
+  const createActionHref = showWorldId40Actions
+    ? urls.createWorldIdAction({ team_id: teamId, app_id: appId })
+    : urls.createAction({ team_id: teamId, app_id: appId });
+
   return (
     <div className="grid gap-y-6">
       <Typography variant={TYPOGRAPHY.H7}>Quick actions</Typography>
 
       <div className="grid gap-6 lg:grid-cols-3">
-        <QuickAction
-          href={urls.createAction({ team_id: teamId, app_id: appId })}
-          icon={<MultiplePlusIcon className="size-5" />}
-          title="Create an action"
-          description="Verify users as unique humans"
-        />
+        <RestrictedAction restriction={createWorldIdActionPerm}>
+          {({ disabled }) => (
+            <QuickAction
+              href={createActionHref}
+              disabled={disabled}
+              icon={<MultiplePlusIcon className="size-5" />}
+              title="Create an action"
+              description="Verify users as unique humans"
+            />
+          )}
+        </RestrictedAction>
 
         <QuickAction
           href={urls.configuration({ team_id: teamId, app_id: appId })}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/WorldId40MigrationBanner/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/WorldId40MigrationBanner/index.tsx
@@ -6,6 +6,7 @@ import {
   isWorldId40Enabled,
   worldId40Atom,
 } from "@/lib/feature-flags/world-id-4-0/client";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { CreateAppDialogV4 } from "@/scenes/Portal/layout/CreateAppDialog/index-v4";
 import { useAtomValue } from "jotai";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -15,7 +16,6 @@ interface WorldId40MigrationBannerProps {
   teamId: string;
   appId: string;
   hasRpRegistration: boolean;
-  canRegisterRp: boolean;
   isStaging: boolean;
 }
 
@@ -23,20 +23,22 @@ export const WorldId40MigrationBanner = ({
   teamId,
   appId,
   hasRpRegistration,
-  canRegisterRp,
   isStaging,
 }: WorldId40MigrationBannerProps) => {
   const worldId40Config = useAtomValue(worldId40Atom);
   const isEnabled = isWorldId40Enabled(worldId40Config, teamId);
+  const enablePerm = useTeamPermission(teamId, "enable_world_id_4_0");
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const autoOpen = searchParams.get("enableWorldId4") === "true";
-  const [dialogOpen, setDialogOpen] = useState(autoOpen && canRegisterRp);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   useEffect(() => {
-    if (autoOpen && canRegisterRp) setDialogOpen(true);
-  }, [autoOpen, canRegisterRp]);
+    if (autoOpen && enablePerm.allowed) {
+      setDialogOpen(true);
+    }
+  }, [autoOpen, enablePerm.allowed]);
 
   const closeDialog = useCallback(() => {
     setDialogOpen(false);
@@ -54,19 +56,12 @@ export const WorldId40MigrationBanner = ({
     }
   }, [pathname, router, searchParams]);
 
-  // Don't show banner if:
-  // - World ID 4.0 is not enabled for this team, OR
-  // - App already has RP registration, OR
-  // - App is a staging app, OR
-  // - User lacks ADMIN/OWNER role (register_rp Hasura action would
-  //   reject with `unauthorized` and surface a generic toast).
-  if (!isEnabled || hasRpRegistration || isStaging || !canRegisterRp) {
+  if (!isEnabled || hasRpRegistration || isStaging || !enablePerm.allowed) {
     return null;
   }
 
   return (
     <div className="relative w-full overflow-hidden rounded-xl bg-[#E6F0FF] shadow-[0px_1px_2px_0px_rgba(11,25,40,0.08)]">
-      {/* Left side - gradient with diagonal edge (27.17deg) */}
       <div
         className="absolute inset-y-0 left-0 w-[65%] bg-gradient-to-r from-[#E6F0FF] to-[#F3F8FF]"
         style={{
@@ -75,7 +70,6 @@ export const WorldId40MigrationBanner = ({
         aria-hidden="true"
       />
 
-      {/* Content */}
       <div className="relative flex items-center justify-between p-10">
         <div className="flex flex-col gap-1">
           <Typography variant={TYPOGRAPHY.H6} className="text-gray-900">

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/index.tsx
@@ -1,10 +1,6 @@
-import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { SizingWrapper } from "@/components/SizingWrapper";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
-import { auth0 } from "@/lib/auth0";
 import { BanMessageDialog } from "../../common/BanMessageDialog";
-import { getSdk as getAppEnvSdk } from "../layout/graphql/server/fetch-app-env.generated";
+import { fetchAppEnvCached } from "../layout/server/fetch-app-env";
 import { BanStatusSection } from "./BanStatusSection";
 import { DashboardWrapper } from "./DashboardWrapper";
 import { VerificationStatusSection } from "./VerificationStatusSection";
@@ -25,17 +21,9 @@ export const AppIdPage = async (props: {
 }) => {
   const { teamId, appId } = await props.params;
 
-  const client = await getAPIServiceGraphqlClient();
-  const appEnvData = await getAppEnvSdk(client).FetchAppEnv({ id: appId });
+  const appEnvData = await fetchAppEnvCached(appId);
   const appInfo = appEnvData.app[0];
   const hasRpRegistration = (appInfo?.rp_registration?.length ?? 0) > 0;
-
-  const session = await auth0.getSession();
-  const user = session?.user as Auth0SessionUser["user"] | undefined;
-  const role = user?.hasura?.memberships?.find(
-    (m) => m.team?.id === teamId,
-  )?.role;
-  const canRegisterRp = role === Role_Enum.Owner || role === Role_Enum.Admin;
 
   return (
     <SizingWrapper className="flex flex-col gap-y-8 py-4">
@@ -43,7 +31,6 @@ export const AppIdPage = async (props: {
         teamId={teamId}
         appId={appId}
         hasRpRegistration={hasRpRegistration}
-        canRegisterRp={canRegisterRp}
         isStaging={Boolean(appInfo?.is_staging)}
       />
 

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
@@ -8,12 +8,10 @@ import { FetchKeysQuery } from "../../graphql/client/fetch-keys.generated";
 import { EditIcon } from "@/components/Icons/EditIcon";
 import { KeyIcon } from "@/components/Icons/KeyIcon";
 import { TrashIcon } from "@/components/Icons/TrashIcon";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { ApolloError } from "@apollo/client";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import clsx from "clsx";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "react-toastify";
 import { ApiKeySecretModal } from "../../ApiKeySecretModal";
 import { FetchKeysDocument } from "../../graphql/client/fetch-keys.generated";
@@ -32,14 +30,8 @@ export const ApiKeyRow = (props: {
   const timeAgo = formatDistanceToNowStrict(new Date(apiKey.created_at), {
     addSuffix: true,
   });
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    const membership = user?.hasura.memberships.find(
-      (m) => m.team?.id === teamId,
-    );
-    return membership?.role === Role_Enum.Owner;
-  }, [teamId, user?.hasura.memberships]);
+  const manageApiKeyPerm = useTeamPermission(teamId, "edit_api_keys");
+  const deleteApiKeyPerm = useTeamPermission(teamId, "delete_api_keys");
 
   const [resetApiKeyMutation, { loading }] = useResetApiKeyMutation();
 
@@ -162,7 +154,7 @@ export const ApiKeyRow = (props: {
           <div
             key={`api_key_${index}_5`}
             className={clsx("flex w-full justify-end", {
-              hidden: !isEnoughPermissions,
+              hidden: !manageApiKeyPerm.allowed,
             })}
           >
             <Dropdown>
@@ -191,20 +183,22 @@ export const ApiKeyRow = (props: {
                   </button>
                 </Dropdown.ListItem>
 
-                <Dropdown.ListItem asChild>
-                  <button onClick={() => openDeleteKeyModal(apiKey)}>
-                    <Dropdown.ListItemIcon
-                      className="text-system-error-600"
-                      asChild
-                    >
-                      <TrashIcon />
-                    </Dropdown.ListItemIcon>
+                {deleteApiKeyPerm.allowed && (
+                  <Dropdown.ListItem asChild>
+                    <button onClick={() => openDeleteKeyModal(apiKey)}>
+                      <Dropdown.ListItemIcon
+                        className="text-system-error-600"
+                        asChild
+                      >
+                        <TrashIcon />
+                      </Dropdown.ListItemIcon>
 
-                    <Dropdown.ListItemText className="text-system-error-600">
-                      Remove key
-                    </Dropdown.ListItemText>
-                  </button>
-                </Dropdown.ListItem>
+                      <Dropdown.ListItemText className="text-system-error-600">
+                        Remove key
+                      </Dropdown.ListItemText>
+                    </button>
+                  </Dropdown.ListItem>
+                )}
               </Dropdown.List>
             </Dropdown>
           </div>

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/index.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { DecoratedButton } from "@/components/DecoratedButton";
 import { PlusIcon } from "@/components/Icons/PlusIcon";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import { Section } from "@/components/Section";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { useState, use } from "react";
 import Skeleton from "react-loading-skeleton";
 import { TeamProfile } from "../../common/TeamProfile";
@@ -19,6 +20,7 @@ export const TeamApiKeysPage = (props: TeamApiKeysPageProps) => {
   const params = use(props.params);
   const teamId = params?.teamId;
   const [showCreateKeyModal, setShowCreateKeyModal] = useState(false);
+  const createKeyPerm = useTeamPermission(teamId ?? "", "edit_api_keys");
   const { data, loading } = useFetchKeysQuery({
     variables: { teamId: teamId ?? "" },
   });
@@ -54,12 +56,13 @@ export const TeamApiKeysPage = (props: TeamApiKeysPageProps) => {
               </Typography>
             </div>
 
-            <DecoratedButton
+            <RestrictedButton
+              restriction={createKeyPerm}
               type="button"
               onClick={() => setShowCreateKeyModal(true)}
             >
               Create new key
-            </DecoratedButton>
+            </RestrictedButton>
           </div>
         ) : (
           <Section>
@@ -70,14 +73,15 @@ export const TeamApiKeysPage = (props: TeamApiKeysPageProps) => {
                 {loading ? (
                   <Skeleton width={150} />
                 ) : (
-                  <DecoratedButton
+                  <RestrictedButton
+                    restriction={createKeyPerm}
                     type="button"
                     variant="primary"
                     onClick={() => setShowCreateKeyModal(true)}
                     className="py-3"
                   >
                     <PlusIcon className="size-5" /> New key
-                  </DecoratedButton>
+                  </RestrictedButton>
                 )}
               </Section.Header.Button>
             </Section.Header>

--- a/web/scenes/Portal/Teams/TeamId/Team/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/layout/index.tsx
@@ -1,9 +1,8 @@
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { Tab, Tabs } from "@/components/Tabs";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
+import { userCanPerformAction } from "@/lib/team-permissions";
 import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
 import { auth0 } from "@/lib/auth0";
 import { ReactNode } from "react";
 
@@ -20,14 +19,22 @@ export const TeamLayout = async (props: TeamLayoutProps) => {
   const params = await props.params;
   const session = await auth0.getSession();
   const user = session?.user as Auth0SessionUser["user"];
-  const ownerPermission = checkUserPermissions(user, params.teamId ?? "", [
-    Role_Enum.Owner,
-  ]);
-
-  const ownerAndAdminPermission = checkUserPermissions(
+  const ownerPermission = userCanPerformAction(
     user,
     params.teamId ?? "",
-    [Role_Enum.Owner, Role_Enum.Admin],
+    "edit_team_settings",
+  );
+
+  const ownerAndAdminPermission = userCanPerformAction(
+    user,
+    params.teamId ?? "",
+    "view_api_keys",
+  );
+
+  const deleteTeamPermission = userCanPerformAction(
+    user,
+    params.teamId ?? "",
+    "delete_team",
   );
 
   return (
@@ -75,7 +82,7 @@ export const TeamLayout = async (props: TeamLayoutProps) => {
               </Tab>
             )}
 
-            {ownerPermission && (
+            {deleteTeamPermission && (
               <Tab
                 className="md:py-4"
                 href={`/teams/${params!.teamId}/danger`}

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/EditRoleDialog/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/EditRoleDialog/index.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/Select";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { Role_Enum } from "@/graphql/graphql";
+import { TEAM_PERMISSION_ROLES } from "@/lib/team-permissions";
 import { yupResolver } from "@hookform/resolvers/yup";
 import clsx from "clsx";
 import { atom, useAtom } from "jotai";
@@ -32,8 +33,6 @@ import {
 } from "../../graphql/client/fetch-team-members.generated";
 import { permissionsDialogAtom } from "../PermissionsDialog";
 import { useEditRoleMutation } from "./graphql/client/edit-role.generated";
-
-const roles = [Role_Enum.Owner, Role_Enum.Admin, Role_Enum.Member];
 
 export const editRoleDialogAtom = atom(false);
 
@@ -60,14 +59,7 @@ export const EditRoleDialog = (props: {
   );
   const { teamId } = useParams() as { teamId: string };
 
-  const roles = useMemo(
-    () => [
-      { label: "Owner", value: Role_Enum.Owner },
-      { label: "Admin", value: Role_Enum.Admin },
-      { label: "Member", value: Role_Enum.Member },
-    ],
-    [],
-  );
+  const roles = TEAM_PERMISSION_ROLES;
 
   const defaultValues = useMemo(() => {
     if (!props.membership) {

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/Item/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/Item/index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentType } from "react";
 import clsx from "clsx";
 import { FetchTeamMembersQuery } from "../../graphql/client/fetch-team-members.generated";
 import { getNullifierName } from "@/lib/utils";
@@ -10,7 +11,10 @@ import { SendIcon } from "@/components/Icons/SendIcon";
 import { TrashIcon } from "@/components/Icons/TrashIcon";
 import { Role_Enum } from "@/graphql/graphql";
 import Skeleton from "react-loading-skeleton";
-import { getMemberRowActions } from "../member-row-actions";
+import {
+  getMemberRowActions,
+  type MemberRowAction,
+} from "../member-row-actions";
 
 const roleName: Record<Role_Enum, string> = {
   [Role_Enum.Admin]: "Admin",
@@ -18,10 +22,20 @@ const roleName: Record<Role_Enum, string> = {
   [Role_Enum.Owner]: "Owner",
 };
 
+const actionIcon: Record<
+  MemberRowAction["key"],
+  ComponentType<{ className?: string }>
+> = {
+  edit_member_role: EditUserIcon,
+  remove_member: TrashIcon,
+  resend_invite: SendIcon,
+  cancel_invite: TrashIcon,
+};
+
 type ItemProps = {
   item?: FetchTeamMembersQuery["members"][number];
   isCurrent?: boolean;
-  isEnoughPermissions?: boolean;
+  userRole?: Role_Enum;
   onEdit?: () => void;
   onRemove?: () => void;
   onResendInvite?: () => void;
@@ -29,13 +43,20 @@ type ItemProps = {
 };
 
 export const Item = (props: ItemProps) => {
-  const { item, isCurrent, isEnoughPermissions } = props;
+  const { item, isCurrent, userRole } = props;
   const isInviteRow = item?.id.startsWith("inv_");
   const name =
     item?.user?.name ||
     item?.user?.email ||
     getNullifierName(item?.user?.world_id_nullifier) ||
     "Anonymous User";
+
+  const handlers: Record<MemberRowAction["key"], (() => void) | undefined> = {
+    edit_member_role: props.onEdit,
+    remove_member: props.onRemove,
+    resend_invite: props.onResendInvite,
+    cancel_invite: props.onCancelInvite,
+  };
 
   return (
     <div
@@ -116,23 +137,11 @@ export const Item = (props: ItemProps) => {
 
             <Dropdown.List align="end" heading={name}>
               {getMemberRowActions({
-                isOwner: Boolean(isEnoughPermissions),
+                userRole,
                 isCurrent: Boolean(isCurrent),
                 isInviteRow: Boolean(isInviteRow),
               }).map((action) => {
-                const handlers: Record<string, (() => void) | undefined> = {
-                  edit_member_role: props.onEdit,
-                  remove_member: props.onRemove,
-                  resend_invite: props.onResendInvite,
-                  cancel_invite: props.onCancelInvite,
-                };
-
-                const Icon =
-                  action.key === "edit_member_role"
-                    ? EditUserIcon
-                    : action.key === "resend_invite"
-                      ? SendIcon
-                      : TrashIcon;
+                const Icon = actionIcon[action.key];
 
                 if (!action.allowed) {
                   return (

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/Item/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/Item/index.tsx
@@ -10,6 +10,7 @@ import { SendIcon } from "@/components/Icons/SendIcon";
 import { TrashIcon } from "@/components/Icons/TrashIcon";
 import { Role_Enum } from "@/graphql/graphql";
 import Skeleton from "react-loading-skeleton";
+import { getMemberRowActions } from "../member-row-actions";
 
 const roleName: Record<Role_Enum, string> = {
   [Role_Enum.Admin]: "Admin",
@@ -107,67 +108,68 @@ export const Item = (props: ItemProps) => {
         ) : (
           <Dropdown>
             <Dropdown.Button
-              disabled={!isEnoughPermissions || isCurrent}
-              className={clsx("rounded-8 hover:bg-grey-100", {
-                "pointer-events-none invisible":
-                  !isEnoughPermissions || isCurrent,
-              })}
+              className="rounded-8 hover:bg-grey-100"
+              aria-label="Member actions"
             >
               <MoreVerticalIcon className="text-grey-900" />
             </Dropdown.Button>
 
-            <Dropdown.List
-              align="end"
-              heading={name} // TODO: replace heading with member card in separate task
-            >
-              {isEnoughPermissions && !isInviteRow && (
-                <Dropdown.ListItem asChild>
-                  <button onClick={props.onEdit}>
-                    <Dropdown.ListItemIcon asChild>
-                      <EditUserIcon />
-                    </Dropdown.ListItemIcon>
+            <Dropdown.List align="end" heading={name}>
+              {getMemberRowActions({
+                isOwner: Boolean(isEnoughPermissions),
+                isCurrent: Boolean(isCurrent),
+                isInviteRow: Boolean(isInviteRow),
+              }).map((action) => {
+                const handlers: Record<string, (() => void) | undefined> = {
+                  edit_member_role: props.onEdit,
+                  remove_member: props.onRemove,
+                  resend_invite: props.onResendInvite,
+                  cancel_invite: props.onCancelInvite,
+                };
 
-                    <Dropdown.ListItemText>Edit role</Dropdown.ListItemText>
-                  </button>
-                </Dropdown.ListItem>
-              )}
+                const Icon =
+                  action.key === "edit_member_role"
+                    ? EditUserIcon
+                    : action.key === "resend_invite"
+                      ? SendIcon
+                      : TrashIcon;
 
-              {isEnoughPermissions && isInviteRow && (
-                <Dropdown.ListItem asChild>
-                  <button onClick={props.onResendInvite}>
-                    <Dropdown.ListItemIcon asChild>
-                      <SendIcon />
-                    </Dropdown.ListItemIcon>
-
-                    <Dropdown.ListItemText>
-                      Re-send invite
-                    </Dropdown.ListItemText>
-                  </button>
-                </Dropdown.ListItem>
-              )}
-
-              {isEnoughPermissions && (
-                <Dropdown.ListItem className="text-system-error-600" asChild>
-                  <button
-                    onClick={() =>
-                      isInviteRow
-                        ? props.onCancelInvite?.()
-                        : props.onRemove?.()
-                    }
-                  >
-                    <Dropdown.ListItemIcon
-                      className="text-system-error-600"
-                      asChild
+                if (!action.allowed) {
+                  return (
+                    <Dropdown.DisabledListItem
+                      key={action.key}
+                      icon={<Icon />}
+                      description={action.reason}
                     >
-                      <TrashIcon />
-                    </Dropdown.ListItemIcon>
+                      {action.label}
+                    </Dropdown.DisabledListItem>
+                  );
+                }
 
-                    <Dropdown.ListItemText>
-                      {isInviteRow ? "Cancel invite" : "Remove member"}
-                    </Dropdown.ListItemText>
-                  </button>
-                </Dropdown.ListItem>
-              )}
+                return (
+                  <Dropdown.ListItem
+                    key={action.key}
+                    className={
+                      action.danger ? "text-system-error-600" : undefined
+                    }
+                    asChild
+                  >
+                    <button type="button" onClick={handlers[action.key]}>
+                      <Dropdown.ListItemIcon
+                        className={
+                          action.danger ? "text-system-error-600" : undefined
+                        }
+                        asChild
+                      >
+                        <Icon />
+                      </Dropdown.ListItemIcon>
+                      <Dropdown.ListItemText>
+                        {action.label}
+                      </Dropdown.ListItemText>
+                    </button>
+                  </Dropdown.ListItem>
+                );
+              })}
             </Dropdown.List>
           </Dropdown>
         )}

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/PermissionsDialog/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/PermissionsDialog/index.tsx
@@ -8,105 +8,16 @@ import { CheckmarkCircleIcon } from "@/components/Icons/CheckmarkCircleIcon";
 import { CollapseIcon } from "@/components/Icons/CollapseIcon";
 import { ExpandIcon } from "@/components/Icons/ExpandIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
+import {
+  PERMISSION_DISPLAY_GROUPS,
+  TEAM_PERMISSION_ROLES,
+  roleHasPermission,
+} from "@/lib/team-permissions";
 import { Disclosure } from "@headlessui/react";
 import clsx from "clsx";
 import { atom, useAtom } from "jotai";
 
 export const permissionsDialogAtom = atom(false);
-
-type PermissionsConfig = Record<
-  string,
-  Record<keyof typeof Role_Enum, boolean>
->;
-
-const config: PermissionsConfig = {
-  "Create Incognito Actions": {
-    Owner: true,
-    Admin: true,
-    Member: true,
-  },
-  "Edit Incognito Actions": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "Delete incognito actions": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "View Sign in with World ID": {
-    Owner: true,
-    Admin: true,
-    Member: true,
-  },
-  "Create & Edit Sign in with World ID": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "View apps": {
-    Owner: true,
-    Admin: true,
-    Member: true,
-  },
-  "Create & Edit apps": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "Delete apps": {
-    Owner: true,
-    Admin: false,
-    Member: false,
-  },
-  "View app configuration": {
-    Owner: true,
-    Admin: true,
-    Member: true,
-  },
-  "Create & Edit app configuration": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "View API keys": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "Create & Edit API keys": {
-    Owner: true,
-    Admin: false,
-    Member: false,
-  },
-  "Delete API keys": {
-    Owner: true,
-    Admin: false,
-    Member: false,
-  },
-  "View team members & roles": {
-    Owner: true,
-    Admin: true,
-    Member: true,
-  },
-  "Invite team members": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "Remove team members": {
-    Owner: true,
-    Admin: false,
-    Member: false,
-  },
-  "Update team roles": {
-    Owner: true,
-    Admin: false,
-    Member: false,
-  },
-};
 
 export const PermissionsDialog = () => {
   const [isOpened, setIsOpened] = useAtom(permissionsDialogAtom);
@@ -144,29 +55,35 @@ export const PermissionsDialog = () => {
               Permissions list
             </Typography>
 
-            <Typography variant={TYPOGRAPHY.M4}>Owner</Typography>
-            <Typography variant={TYPOGRAPHY.M4}>Admin</Typography>
-            <Typography variant={TYPOGRAPHY.M4}>Member</Typography>
+            {TEAM_PERMISSION_ROLES.map((role) => (
+              <Typography key={role.value} variant={TYPOGRAPHY.M4}>
+                {role.label}
+              </Typography>
+            ))}
           </div>
 
-          {Object.entries(config).map(([permission, roles], index) => (
+          {PERMISSION_DISPLAY_GROUPS.map((permission, index) => (
             <div
               className={clsx(
                 "grid grid-cols-4 items-center justify-items-center rounded-lg",
                 { "bg-grey-100": index % 2 === 0 },
               )}
-              key={permission}
+              key={permission.label}
             >
               <Typography
                 variant={TYPOGRAPHY.R4}
                 className="w-full py-3 pl-5 text-start text-grey-500"
               >
-                {permission}
+                {permission.label}
               </Typography>
 
-              {Object.entries(roles).map(([role, isAllowed]) => (
-                <Typography key={role} variant={TYPOGRAPHY.R4} className="">
-                  {isAllowed ? (
+              {TEAM_PERMISSION_ROLES.map((role) => (
+                <Typography
+                  key={role.value}
+                  variant={TYPOGRAPHY.R4}
+                  className=""
+                >
+                  {roleHasPermission(permission, role.value) ? (
                     <CheckmarkCircleIcon className="text-system-success-500" />
                   ) : (
                     ""
@@ -178,34 +95,32 @@ export const PermissionsDialog = () => {
         </div>
 
         <div className="grid w-full gap-y-4 font-gta md:hidden">
-          {["Owner", "Admin", "Member"].map((role, index) => (
-            <Disclosure key={index}>
+          {TEAM_PERMISSION_ROLES.map((role) => (
+            <Disclosure key={role.value}>
               {({ open }) => (
                 <div className="rounded-16 border border-grey-200">
                   <Disclosure.Button className="flex w-full justify-between px-5 py-4 text-18 font-medium leading-6">
-                    {role}
+                    {role.label}
 
                     {open ? <CollapseIcon /> : <ExpandIcon />}
                   </Disclosure.Button>
 
                   <Disclosure.Panel className="grid gap-y-4 px-5 pb-4">
-                    {Object.entries(config)
-                      .filter(
-                        ([_, roles]) => !!roles[role as keyof typeof Role_Enum],
-                      )
-                      .map(([permission], index) => (
-                        <div
-                          key={index}
-                          className="flex gap-x-2 text-14 leading-5"
-                        >
-                          <CheckIcon
-                            className="text-system-success-500"
-                            size="16"
-                          />
+                    {PERMISSION_DISPLAY_GROUPS.filter((permission) =>
+                      roleHasPermission(permission, role.value),
+                    ).map((permission, index) => (
+                      <div
+                        key={index}
+                        className="flex gap-x-2 text-14 leading-5"
+                      >
+                        <CheckIcon
+                          className="text-system-success-500"
+                          size="16"
+                        />
 
-                          {permission}
-                        </div>
-                      ))}
+                        {permission.label}
+                      </div>
+                    ))}
                   </Disclosure.Panel>
                 </div>
               )}

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/index.tsx
@@ -3,7 +3,8 @@ import { Pagination } from "@/components/Pagination";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { Role_Enum } from "@/graphql/graphql";
 import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
+import { roleCanPerformAction } from "@/lib/team-permissions";
+import { getUserTeamRole } from "@/lib/utils";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { useAtom } from "jotai";
 import { useParams } from "next/navigation";
@@ -41,9 +42,10 @@ export const List = (props: ListProps) => {
     FetchTeamMembersQuery["members"][number] | null
   >(null);
 
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(auth0User, teamId ?? "", [Role_Enum.Owner]);
-  }, [auth0User, teamId]);
+  const userRole = useMemo(
+    () => getUserTeamRole(auth0User, teamId),
+    [auth0User, teamId],
+  );
 
   const items = useMemo(() => {
     if (!membersRes.data) {
@@ -110,7 +112,11 @@ export const List = (props: ListProps) => {
 
   const resendInvite = useCallback(
     async (membership: FetchTeamMembersQuery["members"][number]) => {
-      if (!membership.user.email || resendMutationLoading) {
+      if (
+        !roleCanPerformAction(userRole, "resend_invite") ||
+        !membership.user.email ||
+        resendMutationLoading
+      ) {
         return;
       }
 
@@ -125,7 +131,7 @@ export const List = (props: ListProps) => {
         toast.error("Error inviting team members");
       }
     },
-    [inviteTeamMembers, resendMutationLoading, teamId],
+    [inviteTeamMembers, resendMutationLoading, teamId, userRole],
   );
 
   const [deleteInvite, { loading: deleteInviteMutationLoading }] =
@@ -137,7 +143,7 @@ export const List = (props: ListProps) => {
   const cancelInvite = useCallback(
     async (membership: FetchTeamMembersQuery["members"][number]) => {
       if (
-        !isEnoughPermissions ||
+        !roleCanPerformAction(userRole, "cancel_invite") ||
         !membership.id.startsWith("inv_") ||
         deleteInviteMutationLoading
       ) {
@@ -156,7 +162,7 @@ export const List = (props: ListProps) => {
         return toast.error("Error canceling invite");
       }
     },
-    [deleteInvite, deleteInviteMutationLoading, isEnoughPermissions],
+    [deleteInvite, deleteInviteMutationLoading, userRole],
   );
 
   const isCurrentMember = useCallback(
@@ -200,7 +206,7 @@ export const List = (props: ListProps) => {
               key={item.id}
               item={item}
               isCurrent={isCurrentMember(item)}
-              isEnoughPermissions={isEnoughPermissions}
+              userRole={userRole}
               onEdit={() => onEditUser(item)}
               onRemove={() => onRemoveUser(item)}
               onResendInvite={() => resendInvite(item)}

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/member-row-actions.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/member-row-actions.ts
@@ -1,0 +1,90 @@
+import {
+  PERMISSION_RULES,
+  SELF_ROW_MESSAGE,
+  type PermissionAction,
+} from "@/lib/team-permissions";
+
+export type MemberRowAction = {
+  key: "edit_member_role" | "remove_member" | "resend_invite" | "cancel_invite";
+  label: string;
+  danger: boolean;
+  allowed: boolean;
+  reason: string | null;
+};
+
+const reasonFor = (params: {
+  action: PermissionAction;
+  isOwner: boolean;
+  isCurrent: boolean;
+}) => {
+  if (!params.isOwner) {
+    return PERMISSION_RULES[params.action].message;
+  }
+
+  if (params.isCurrent) {
+    return SELF_ROW_MESSAGE;
+  }
+
+  return null;
+};
+
+export const getMemberRowActions = (params: {
+  isOwner: boolean;
+  isCurrent: boolean;
+  isInviteRow: boolean;
+}): MemberRowAction[] => {
+  const { isOwner, isCurrent, isInviteRow } = params;
+  const allowed = isOwner && !isCurrent;
+
+  if (isInviteRow) {
+    return [
+      {
+        key: "resend_invite",
+        label: "Re-send invite",
+        danger: false,
+        allowed,
+        reason: reasonFor({
+          action: "resend_invite",
+          isOwner,
+          isCurrent,
+        }),
+      },
+      {
+        key: "cancel_invite",
+        label: "Cancel invite",
+        danger: true,
+        allowed,
+        reason: reasonFor({
+          action: "cancel_invite",
+          isOwner,
+          isCurrent,
+        }),
+      },
+    ];
+  }
+
+  return [
+    {
+      key: "edit_member_role",
+      label: "Edit role",
+      danger: false,
+      allowed,
+      reason: reasonFor({
+        action: "edit_member_role",
+        isOwner,
+        isCurrent,
+      }),
+    },
+    {
+      key: "remove_member",
+      label: "Remove member",
+      danger: true,
+      allowed,
+      reason: reasonFor({
+        action: "remove_member",
+        isOwner,
+        isCurrent,
+      }),
+    },
+  ];
+};

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/member-row-actions.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/member-row-actions.ts
@@ -1,7 +1,8 @@
+import { Role_Enum } from "@/graphql/graphql";
 import {
   PERMISSION_RULES,
+  roleCanPerformAction,
   SELF_ROW_MESSAGE,
-  type PermissionAction,
 } from "@/lib/team-permissions";
 
 export type MemberRowAction = {
@@ -12,79 +13,52 @@ export type MemberRowAction = {
   reason: string | null;
 };
 
-const reasonFor = (params: {
-  action: PermissionAction;
-  isOwner: boolean;
-  isCurrent: boolean;
-}) => {
-  if (!params.isOwner) {
-    return PERMISSION_RULES[params.action].message;
-  }
+const buildAction = (
+  key: MemberRowAction["key"],
+  label: string,
+  danger: boolean,
+  userRole: Role_Enum | undefined,
+  isCurrent: boolean,
+): MemberRowAction => {
+  const hasRolePermission = roleCanPerformAction(userRole, key);
 
-  if (params.isCurrent) {
-    return SELF_ROW_MESSAGE;
-  }
+  const reason = !hasRolePermission
+    ? PERMISSION_RULES[key].message
+    : isCurrent
+      ? SELF_ROW_MESSAGE
+      : null;
 
-  return null;
+  return {
+    key,
+    label,
+    danger,
+    allowed: hasRolePermission && !isCurrent,
+    reason,
+  };
 };
 
 export const getMemberRowActions = (params: {
-  isOwner: boolean;
+  userRole: Role_Enum | undefined;
   isCurrent: boolean;
   isInviteRow: boolean;
 }): MemberRowAction[] => {
-  const { isOwner, isCurrent, isInviteRow } = params;
-  const allowed = isOwner && !isCurrent;
+  const { userRole, isCurrent, isInviteRow } = params;
 
   if (isInviteRow) {
     return [
-      {
-        key: "resend_invite",
-        label: "Re-send invite",
-        danger: false,
-        allowed,
-        reason: reasonFor({
-          action: "resend_invite",
-          isOwner,
-          isCurrent,
-        }),
-      },
-      {
-        key: "cancel_invite",
-        label: "Cancel invite",
-        danger: true,
-        allowed,
-        reason: reasonFor({
-          action: "cancel_invite",
-          isOwner,
-          isCurrent,
-        }),
-      },
+      buildAction(
+        "resend_invite",
+        "Re-send invite",
+        false,
+        userRole,
+        isCurrent,
+      ),
+      buildAction("cancel_invite", "Cancel invite", true, userRole, isCurrent),
     ];
   }
 
   return [
-    {
-      key: "edit_member_role",
-      label: "Edit role",
-      danger: false,
-      allowed,
-      reason: reasonFor({
-        action: "edit_member_role",
-        isOwner,
-        isCurrent,
-      }),
-    },
-    {
-      key: "remove_member",
-      label: "Remove member",
-      danger: true,
-      allowed,
-      reason: reasonFor({
-        action: "remove_member",
-        isOwner,
-        isCurrent,
-      }),
-    },
+    buildAction("edit_member_role", "Edit role", false, userRole, isCurrent),
+    buildAction("remove_member", "Remove member", true, userRole, isCurrent),
   ];
 };

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/index.tsx
@@ -4,15 +4,13 @@ import { DecoratedButton } from "@/components/DecoratedButton";
 import { MagnifierIcon } from "@/components/Icons/MagnifierIcon";
 import { PlusIcon } from "@/components/Icons/PlusIcon";
 import { Input } from "@/components/Input";
+import { RestrictedAction } from "@/components/RestrictedAction";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { Section } from "@/components/Section";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
 import { FetchMeDocument } from "@/scenes/common/me-query/client/graphql/client/me-query.generated";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useAtom } from "jotai";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import Skeleton from "react-loading-skeleton";
 import * as yup from "yup";
@@ -22,6 +20,7 @@ import {
   inviteTeamMemberDialogAtom,
 } from "./InviteTeamMemberDialog";
 import { List } from "./List";
+import { permissionsDialogAtom } from "./List/PermissionsDialog";
 
 const schema = yup
   .object({
@@ -34,14 +33,8 @@ export const Members = (props: { teamId: string }) => {
   const [, setInviteTeamMemberDialogOpened] = useAtom(
     inviteTeamMemberDialogAtom,
   );
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamId]);
+  const [, setPermissionsDialogOpened] = useAtom(permissionsDialogAtom);
+  const invitePerm = useTeamPermission(teamId, "invite_member");
 
   const { register, control } = useForm({
     resolver: yupResolver(schema),
@@ -95,17 +88,32 @@ export const Members = (props: { teamId: string }) => {
           {membersRes.loading ? (
             <Skeleton className="h-12 w-[12rem] rounded-xl" />
           ) : (
-            <DecoratedButton
-              type="button"
-              onClick={() => setInviteTeamMemberDialogOpened(true)}
-              variant="primary"
-              className="min-w-[12rem] py-2.5"
-              disabled={membersRes.data && !isEnoughPermissions}
-            >
-              <PlusIcon className="size-5 md:hidden" />
-              <span className="md:hidden">New member</span>
-              <span className="max-md:hidden">Invite new member</span>
-            </DecoratedButton>
+            <div className="flex flex-col gap-2 md:flex-row">
+              <DecoratedButton
+                type="button"
+                variant="secondary"
+                className="min-w-[10rem] py-2.5"
+                onClick={() => setPermissionsDialogOpened(true)}
+              >
+                View permissions
+              </DecoratedButton>
+
+              <RestrictedAction restriction={invitePerm}>
+                {({ disabled }) => (
+                  <DecoratedButton
+                    type="button"
+                    onClick={() => setInviteTeamMemberDialogOpened(true)}
+                    variant="primary"
+                    className="min-w-[12rem] py-2.5"
+                    disabled={disabled}
+                  >
+                    <PlusIcon className="size-5 md:hidden" />
+                    <span className="md:hidden">New member</span>
+                    <span className="max-md:hidden">Invite new member</span>
+                  </DecoratedButton>
+                )}
+              </RestrictedAction>
+            </div>
           )}
         </Section.Header.Button>
       </Section.Header>

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/index.tsx
@@ -4,7 +4,7 @@ import { DecoratedButton } from "@/components/DecoratedButton";
 import { MagnifierIcon } from "@/components/Icons/MagnifierIcon";
 import { PlusIcon } from "@/components/Icons/PlusIcon";
 import { Input } from "@/components/Input";
-import { RestrictedAction } from "@/components/RestrictedAction";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { Section } from "@/components/Section";
 import { FetchMeDocument } from "@/scenes/common/me-query/client/graphql/client/me-query.generated";
@@ -98,21 +98,17 @@ export const Members = (props: { teamId: string }) => {
                 View permissions
               </DecoratedButton>
 
-              <RestrictedAction restriction={invitePerm}>
-                {({ disabled }) => (
-                  <DecoratedButton
-                    type="button"
-                    onClick={() => setInviteTeamMemberDialogOpened(true)}
-                    variant="primary"
-                    className="min-w-[12rem] py-2.5"
-                    disabled={disabled}
-                  >
-                    <PlusIcon className="size-5 md:hidden" />
-                    <span className="md:hidden">New member</span>
-                    <span className="max-md:hidden">Invite new member</span>
-                  </DecoratedButton>
-                )}
-              </RestrictedAction>
+              <RestrictedButton
+                restriction={invitePerm}
+                type="button"
+                onClick={() => setInviteTeamMemberDialogOpened(true)}
+                variant="primary"
+                className="min-w-[12rem] py-2.5"
+              >
+                <PlusIcon className="size-5 md:hidden" />
+                <span className="md:hidden">New member</span>
+                <span className="max-md:hidden">Invite new member</span>
+              </RestrictedButton>
             </div>
           )}
         </Section.Header.Button>

--- a/web/scenes/Portal/layout/AppSelector/index.tsx
+++ b/web/scenes/Portal/layout/AppSelector/index.tsx
@@ -17,11 +17,9 @@ import { CheckmarkCircleIcon } from "@/components/Icons/CheckmarkCircleIcon";
 import { PlusCircleIcon } from "@/components/Icons/PlusCircleIcon";
 import { Placeholder } from "@/components/PlaceholderImage";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
 import { urls } from "@/lib/urls";
-import { checkUserPermissions, getCDNImageUrl } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
+import { getCDNImageUrl } from "@/lib/utils";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import clsx from "clsx";
 import { useAtom } from "jotai";
 import { useParams, useRouter } from "next/navigation";
@@ -32,14 +30,7 @@ export const AppSelector = () => {
   const router = useRouter();
   const { teamId, appId } = useParams() as { teamId?: string; appId?: string };
   const [_, setCreateAppDialogOpen] = useAtom(createAppDialogOpenedAtom);
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamId]);
+  const createAppPerm = useTeamPermission(teamId ?? "", "create_app_draft");
 
   const { data, loading, error } = useFetchAppsQuery({
     variables: { teamId: teamId! },
@@ -157,7 +148,7 @@ export const AppSelector = () => {
             )}
           </SelectOption>
         ))}
-        {isEnoughPermissions && (
+        {createAppPerm.allowed && (
           <SelectOption value={null}>
             <div className="grid grid-cols-auto/1fr/auto items-center gap-x-2">
               <PlusCircleIcon className="size-4 text-gray-500" />

--- a/web/scenes/Portal/layout/Header/index.tsx
+++ b/web/scenes/Portal/layout/Header/index.tsx
@@ -5,7 +5,6 @@ import { WorldIcon } from "@/components/Icons/WorldIcon";
 import { LoggedUserNav } from "@/components/LoggedUserNav";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { isWorldId40Enabled, worldId40Atom } from "@/lib/feature-flags";
-import { urls } from "@/lib/urls";
 import { atom, useAtom, useSetAtom } from "jotai";
 import { useParams } from "next/navigation";
 import React, { useEffect, useMemo } from "react";
@@ -21,21 +20,11 @@ export const Header = (props: { color: Color | null }) => {
   const setColor = useSetAtom(colorAtom);
   const [open, setOpen] = useAtom(createAppDialogOpenedAtom);
   const [worldId40Config] = useAtom(worldId40Atom);
-  const { teamId, appId } = useParams() as { teamId?: string; appId?: string };
+  const { teamId } = useParams() as { teamId?: string };
 
   useEffect(() => {
     setColor(props.color);
   }, [props.color, setColor]);
-
-  const logoHref = useMemo(() => {
-    if (teamId && appId) {
-      return urls.app({ team_id: teamId, app_id: appId });
-    }
-    if (teamId) {
-      return urls.teams({ team_id: teamId });
-    }
-    return "/";
-  }, [teamId, appId]);
 
   const useNewCreateAppDialog = useMemo(
     () => isWorldId40Enabled(worldId40Config, teamId),
@@ -50,7 +39,7 @@ export const Header = (props: { color: Color | null }) => {
         variant="nav"
       >
         <div className="grid grid-cols-auto/1fr gap-x-4 md:gap-x-8">
-          <Button href={logoHref}>
+          <Button href="/">
             <WorldIcon className="size-6" />
           </Button>
 

--- a/web/tests/unit/member-row-actions.test.ts
+++ b/web/tests/unit/member-row-actions.test.ts
@@ -1,34 +1,72 @@
+import { Role_Enum } from "@/graphql/graphql";
 import { getMemberRowActions } from "@/scenes/Portal/Teams/TeamId/Team/page/Members/List/member-row-actions";
 
 describe("getMemberRowActions", () => {
-  it("switches between member and invite actions", () => {
-    expect(
-      getMemberRowActions({
-        isOwner: true,
-        isCurrent: false,
-        isInviteRow: false,
-      }).map((action) => action.key),
-    ).toEqual(["edit_member_role", "remove_member"]);
+  it("allows Owners to manage other member rows", () => {
+    const actions = getMemberRowActions({
+      userRole: Role_Enum.Owner,
+      isCurrent: false,
+      isInviteRow: false,
+    });
 
-    expect(
-      getMemberRowActions({
-        isOwner: true,
-        isCurrent: false,
-        isInviteRow: true,
-      }).map((action) => action.key),
-    ).toEqual(["resend_invite", "cancel_invite"]);
+    expect(actions.map((action) => action.key)).toEqual([
+      "edit_member_role",
+      "remove_member",
+    ]);
+    expect(actions.every((action) => action.allowed)).toBe(true);
+    expect(actions.every((action) => action.reason === null)).toBe(true);
   });
 
-  it("uses Owner-only copy before self-row copy for non-owners", () => {
+  it("allows Admins to manage invite rows", () => {
     const actions = getMemberRowActions({
-      isOwner: false,
-      isCurrent: true,
+      userRole: Role_Enum.Admin,
+      isCurrent: false,
+      isInviteRow: true,
+    });
+
+    expect(actions.map((action) => action.key)).toEqual([
+      "resend_invite",
+      "cancel_invite",
+    ]);
+    expect(actions.every((action) => action.allowed)).toBe(true);
+    expect(actions.every((action) => action.reason === null)).toBe(true);
+  });
+
+  it("blocks Admins from Owner-only member row actions", () => {
+    const actions = getMemberRowActions({
+      userRole: Role_Enum.Admin,
+      isCurrent: false,
       isInviteRow: false,
     });
 
     expect(actions.every((action) => action.allowed === false)).toBe(true);
     expect(
       actions.every(
+        (action) => action.reason === "Only Owners can edit this section.",
+      ),
+    ).toBe(true);
+  });
+
+  it("uses the self-row reason only after role permission passes", () => {
+    const ownerActions = getMemberRowActions({
+      userRole: Role_Enum.Owner,
+      isCurrent: true,
+      isInviteRow: false,
+    });
+    const memberActions = getMemberRowActions({
+      userRole: Role_Enum.Member,
+      isCurrent: true,
+      isInviteRow: false,
+    });
+
+    expect(ownerActions.every((action) => action.allowed === false)).toBe(true);
+    expect(
+      ownerActions.every(
+        (action) => action.reason === "You cannot manage your own member row.",
+      ),
+    ).toBe(true);
+    expect(
+      memberActions.every(
         (action) => action.reason === "Only Owners can edit this section.",
       ),
     ).toBe(true);

--- a/web/tests/unit/member-row-actions.test.ts
+++ b/web/tests/unit/member-row-actions.test.ts
@@ -1,0 +1,36 @@
+import { getMemberRowActions } from "@/scenes/Portal/Teams/TeamId/Team/page/Members/List/member-row-actions";
+
+describe("getMemberRowActions", () => {
+  it("switches between member and invite actions", () => {
+    expect(
+      getMemberRowActions({
+        isOwner: true,
+        isCurrent: false,
+        isInviteRow: false,
+      }).map((action) => action.key),
+    ).toEqual(["edit_member_role", "remove_member"]);
+
+    expect(
+      getMemberRowActions({
+        isOwner: true,
+        isCurrent: false,
+        isInviteRow: true,
+      }).map((action) => action.key),
+    ).toEqual(["resend_invite", "cancel_invite"]);
+  });
+
+  it("uses Owner-only copy before self-row copy for non-owners", () => {
+    const actions = getMemberRowActions({
+      isOwner: false,
+      isCurrent: true,
+      isInviteRow: false,
+    });
+
+    expect(actions.every((action) => action.allowed === false)).toBe(true);
+    expect(
+      actions.every(
+        (action) => action.reason === "Only Owners can edit this section.",
+      ),
+    ).toBe(true);
+  });
+});

--- a/web/tests/unit/permissions.test.ts
+++ b/web/tests/unit/permissions.test.ts
@@ -1,0 +1,37 @@
+import { Role_Enum } from "@/graphql/graphql";
+import {
+  OWNER_ADMIN_MESSAGE,
+  OWNER_ONLY_MESSAGE,
+  PERMISSION_DISPLAY_GROUPS,
+  PERMISSION_RULES,
+} from "@/lib/team-permissions";
+
+describe("team permission policy", () => {
+  it("keeps the core edit actions Owner/Admin-only", () => {
+    expect(PERMISSION_RULES.submit_app_for_review).toMatchObject({
+      roles: [Role_Enum.Owner, Role_Enum.Admin],
+      message: OWNER_ADMIN_MESSAGE,
+    });
+    expect(PERMISSION_RULES.edit_app_information).toMatchObject({
+      roles: [Role_Enum.Owner, Role_Enum.Admin],
+      message: OWNER_ADMIN_MESSAGE,
+    });
+    expect(PERMISSION_RULES.create_world_id_action).toMatchObject({
+      roles: [Role_Enum.Owner, Role_Enum.Admin],
+      message: OWNER_ADMIN_MESSAGE,
+    });
+  });
+
+  it("keeps member management Owner-only and feeds the permissions dialog", () => {
+    expect(PERMISSION_RULES.edit_member_role).toMatchObject({
+      roles: [Role_Enum.Owner],
+      message: OWNER_ONLY_MESSAGE,
+    });
+
+    const dialogGroup = PERMISSION_DISPLAY_GROUPS.find(
+      (group) => group.label === "Update team roles",
+    );
+
+    expect(dialogGroup?.roles).toBe(PERMISSION_RULES.edit_member_role.roles);
+  });
+});

--- a/web/tests/unit/permissions.test.ts
+++ b/web/tests/unit/permissions.test.ts
@@ -4,6 +4,8 @@ import {
   OWNER_ONLY_MESSAGE,
   PERMISSION_DISPLAY_GROUPS,
   PERMISSION_RULES,
+  getTeamPermission,
+  roleCanPerformAction,
 } from "@/lib/team-permissions";
 
 describe("team permission policy", () => {
@@ -33,5 +35,50 @@ describe("team permission policy", () => {
     );
 
     expect(dialogGroup?.roles).toBe(PERMISSION_RULES.edit_member_role.roles);
+  });
+
+  it("derives delete-app and API key dialog rows from PERMISSION_RULES", () => {
+    const dialogExpectations: Array<{
+      label: string;
+      action: keyof typeof PERMISSION_RULES;
+    }> = [
+      { label: "Delete apps", action: "delete_app" },
+      { label: "View API keys", action: "view_api_keys" },
+      { label: "Create & Edit API keys", action: "edit_api_keys" },
+      { label: "Delete API keys", action: "delete_api_keys" },
+    ];
+
+    for (const { label, action } of dialogExpectations) {
+      const dialogGroup = PERMISSION_DISPLAY_GROUPS.find(
+        (group) => group.label === label,
+      );
+
+      expect(dialogGroup?.roles).toBe(PERMISSION_RULES[action].roles);
+    }
+  });
+
+  it("checks user permission from the central role rules", () => {
+    expect(getTeamPermission(undefined, "team_1", "delete_app").allowed).toBe(
+      false,
+    );
+  });
+
+  it("keeps invite lifecycle actions consistent with invite_member", () => {
+    expect(PERMISSION_RULES.resend_invite).toMatchObject({
+      roles: PERMISSION_RULES.invite_member.roles,
+      message: OWNER_ADMIN_MESSAGE,
+    });
+    expect(PERMISSION_RULES.cancel_invite).toMatchObject({
+      roles: PERMISSION_RULES.invite_member.roles,
+      message: OWNER_ADMIN_MESSAGE,
+    });
+    expect(roleCanPerformAction(Role_Enum.Admin, "resend_invite")).toBe(true);
+    expect(roleCanPerformAction(Role_Enum.Admin, "cancel_invite")).toBe(true);
+  });
+
+  it("checks action permission from the central role rules", () => {
+    expect(roleCanPerformAction(Role_Enum.Owner, "cancel_invite")).toBe(true);
+    expect(roleCanPerformAction(Role_Enum.Admin, "cancel_invite")).toBe(true);
+    expect(roleCanPerformAction(undefined, "cancel_invite")).toBe(false);
   });
 });

--- a/web/tests/unit/restricted-action.test.tsx
+++ b/web/tests/unit/restricted-action.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { RestrictedAction } from "@/components/RestrictedAction";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+(global as unknown as { ResizeObserver: unknown }).ResizeObserver =
+  ResizeObserverStub;
+
+const blocked = {
+  allowed: false,
+  message: "Only Owners can edit this section.",
+};
+
+describe("RestrictedAction", () => {
+  it("passes disabled state from the restriction object", () => {
+    render(
+      <RestrictedAction restriction={blocked}>
+        {({ disabled }) => (
+          <button type="button" disabled={disabled}>
+            Save
+          </button>
+        )}
+      </RestrictedAction>,
+    );
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("keeps blocked link children out of keyboard interaction", () => {
+    render(
+      <RestrictedAction restriction={blocked}>
+        <a href="/blocked">Create action</a>
+      </RestrictedAction>,
+    );
+
+    expect(screen.getByText("Create action").parentElement).toHaveAttribute(
+      "inert",
+    );
+  });
+
+  it("shows the restriction message from the disabled wrapper", async () => {
+    render(
+      <RestrictedAction restriction={blocked}>
+        {({ disabled }) => (
+          <button type="button" disabled={disabled}>
+            Submit
+          </button>
+        )}
+      </RestrictedAction>,
+    );
+
+    const trigger = screen
+      .getByText("Submit")
+      .closest("[aria-disabled='true']") as HTMLElement;
+
+    fireEvent.focus(trigger);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Only Owners can edit this section.",
+    );
+  });
+});

--- a/web/tests/unit/restricted-button.test.tsx
+++ b/web/tests/unit/restricted-button.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment jsdom
+ */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { RestrictedButton } from "@/components/RestrictedButton";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+(global as unknown as { ResizeObserver: unknown }).ResizeObserver =
+  ResizeObserverStub;
+
+describe("RestrictedButton", () => {
+  it("disables the button when the restriction is blocked", () => {
+    render(
+      <RestrictedButton
+        type="button"
+        restriction={{ allowed: false, message: "Only Owners can do this." }}
+      >
+        Save
+      </RestrictedButton>,
+    );
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("preserves caller disabled state when the restriction is allowed", () => {
+    render(
+      <>
+        <RestrictedButton
+          type="button"
+          restriction={{ allowed: true, message: "Allowed" }}
+          disabled
+        >
+          Saving
+        </RestrictedButton>
+        <RestrictedButton
+          type="button"
+          restriction={{ allowed: true, message: "Allowed" }}
+        >
+          Save
+        </RestrictedButton>
+      </>,
+    );
+
+    expect(screen.getByRole("button", { name: "Saving" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  });
+});

--- a/web/tests/unit/tooltip.test.tsx
+++ b/web/tests/unit/tooltip.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Tooltip } from "@/components/Tooltip";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+(global as unknown as { ResizeObserver: unknown }).ResizeObserver =
+  ResizeObserverStub;
+
+describe("Tooltip", () => {
+  it("opens on click and stays open on repeated clicks", async () => {
+    render(
+      <Tooltip content="Requires Owner role">
+        <span>Trigger</span>
+      </Tooltip>,
+    );
+
+    const trigger = screen.getByText("Trigger").parentElement as HTMLElement;
+
+    fireEvent.click(trigger);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Requires Owner role",
+    );
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Requires Owner role",
+    );
+  });
+});

--- a/web/tests/unit/use-team-permission.test.tsx
+++ b/web/tests/unit/use-team-permission.test.tsx
@@ -12,21 +12,15 @@ jest.mock("@auth0/nextjs-auth0/client", () => ({
 }));
 
 jest.mock("@/lib/utils", () => ({
-  checkUserPermissions: (
+  getUserTeamRole: (
     user: {
       hasura?: {
         memberships?: Array<{ role?: string; team?: { id?: string } }>;
       };
     },
     teamId: string,
-    roles: string[],
-  ) => {
-    const membership = user?.hasura?.memberships?.find(
-      (item) => item.team?.id === teamId,
-    );
-
-    return Boolean(membership?.role && roles.includes(membership.role));
-  },
+  ) =>
+    user?.hasura?.memberships?.find((item) => item.team?.id === teamId)?.role,
 }));
 
 const userWithRole = (role: Role_Enum) => ({

--- a/web/tests/unit/use-team-permission.test.tsx
+++ b/web/tests/unit/use-team-permission.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { Role_Enum } from "@/graphql/graphql";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
+
+const useUserMock = jest.fn();
+
+jest.mock("@auth0/nextjs-auth0/client", () => ({
+  useUser: () => useUserMock(),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  checkUserPermissions: (
+    user: {
+      hasura?: {
+        memberships?: Array<{ role?: string; team?: { id?: string } }>;
+      };
+    },
+    teamId: string,
+    roles: string[],
+  ) => {
+    const membership = user?.hasura?.memberships?.find(
+      (item) => item.team?.id === teamId,
+    );
+
+    return Boolean(membership?.role && roles.includes(membership.role));
+  },
+}));
+
+const userWithRole = (role: Role_Enum) => ({
+  user: {
+    hasura: {
+      memberships: [{ role, team: { id: "team_1" } }],
+    },
+  },
+});
+
+describe("useTeamPermission", () => {
+  it("allows Owners on Owner/Admin actions", () => {
+    useUserMock.mockReturnValue(userWithRole(Role_Enum.Owner));
+
+    const { result } = renderHook(() =>
+      useTeamPermission("team_1", "submit_app_for_review"),
+    );
+
+    expect(result.current.allowed).toBe(true);
+  });
+
+  it("fails closed with the rule message when the user lacks the role", () => {
+    useUserMock.mockReturnValue(userWithRole(Role_Enum.Member));
+
+    const { result } = renderHook(() =>
+      useTeamPermission("team_1", "submit_app_for_review"),
+    );
+
+    expect(result.current).toEqual({
+      allowed: false,
+      message: "Only Owners and Admins can edit this section.",
+    });
+  });
+});

--- a/web/tests/unit/world-id-40-restrictions.test.ts
+++ b/web/tests/unit/world-id-40-restrictions.test.ts
@@ -1,0 +1,52 @@
+import { getRpActionRestriction } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/rp-action-restrictions";
+
+const allowed = {
+  allowed: true,
+  message: "Only Owners and Admins can edit this section.",
+};
+
+const blocked = {
+  allowed: false,
+  message: "Only Owners and Admins can edit this section.",
+};
+
+describe("getRpActionRestriction", () => {
+  it("preserves permission failures before RP state checks", () => {
+    expect(
+      getRpActionRestriction({
+        action: "manage_registered_rp",
+        permission: blocked,
+        mode: "self_managed",
+        isActive: false,
+      }),
+    ).toBe(blocked);
+  });
+
+  it("blocks self-managed retries before dispatching to the server", () => {
+    expect(
+      getRpActionRestriction({
+        action: "retry",
+        permission: allowed,
+        mode: "self_managed",
+        isActive: true,
+      }),
+    ).toEqual({
+      allowed: false,
+      message: "This RP is self-managed.",
+    });
+  });
+
+  it("requires active managed RPs for reset and switch", () => {
+    expect(
+      getRpActionRestriction({
+        action: "manage_registered_rp",
+        permission: allowed,
+        mode: "managed",
+        isActive: false,
+      }),
+    ).toEqual({
+      allowed: false,
+      message: "RP must be active to reset or switch modes.",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Centralize team permission rules and use them for disabled permission UI.
- Keep restricted controls visible with explanatory tooltips instead of hiding them.
- Apply the permission UX across app configuration, World ID 4.0 flows, World ID actions, and team member management.
- Replace broad scratch coverage with focused unit tests for permission policy, restricted UI behavior, member-row reasons, and RP action restrictions.

## Validation
- `pnpm format:check`
- `npx tsc --noEmit`
- `npx jest web/tests/unit/permissions.test.ts web/tests/unit/member-row-actions.test.ts web/tests/unit/restricted-action.test.tsx web/tests/unit/tooltip.test.tsx web/tests/unit/use-team-permission.test.tsx web/tests/unit/world-id-40-restrictions.test.ts`
