### PR TITLE
fix(actions): portal-authoritative external_nullifier (#3749623)

### DIFF
--- a/web/api/_gen-external-nullifier/index.ts
+++ b/web/api/_gen-external-nullifier/index.ts
@@ -1,6 +1,7 @@
 import { errorResponse } from "@/api/helpers/errors";
 import { protectInternalEndpoint } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
+import { APPS_WITH_CUSTOM_EXTERNAL_NULLIFIER } from "@/lib/constants";
 import { generateExternalNullifier } from "@/lib/hashing";
 import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
@@ -58,11 +59,16 @@ export async function POST(request: NextRequest) {
 
   const action = parsedParams.event.data.new;
 
-  if (
-    action.external_nullifier &&
-    action.external_nullifier !== action.app_id // If it's app_id this is the default sign in action
-  ) {
-    return NextResponse.json({ success: true, already_generated: true });
+  // Apps that legitimately use a custom external_nullifier keep their stored
+  // value. For every other app the portal is the sole authority for the value:
+  // recompute and overwrite so a client-supplied external_nullifier (e.g. one
+  // inserted directly via the api_key GraphQL role) cannot pin an arbitrary
+  // proof domain instead of the canonical hash(app_id, action).
+  if (APPS_WITH_CUSTOM_EXTERNAL_NULLIFIER.includes(action.app_id)) {
+    return NextResponse.json({
+      success: true,
+      custom_external_nullifier: true,
+    });
   }
 
   const external_nullifier = generateExternalNullifier(
@@ -73,7 +79,8 @@ export async function POST(request: NextRequest) {
   const client = await getAPIServiceGraphqlClient();
   const setExternalNullifierSdk = getSetExternalNullifierSdk(client);
 
-  // Mutation will fail anyways if external nullifier is already set due to permissions.
+  // Runs as the service role, which overwrites any existing value so a
+  // client-supplied external_nullifier cannot persist.
   const response = await setExternalNullifierSdk.SetExternalNullifier({
     action_id: action.id,
     external_nullifier,

--- a/web/api/_gen-external-nullifier/index.ts
+++ b/web/api/_gen-external-nullifier/index.ts
@@ -60,11 +60,18 @@ export async function POST(request: NextRequest) {
   const action = parsedParams.event.data.new;
 
   // Apps that legitimately use a custom external_nullifier keep their stored
-  // value. For every other app the portal is the sole authority for the value:
+  // value — but only for real custom values. The default sign-in action is
+  // seeded with external_nullifier == app_id; that sentinel must still be
+  // normalized to hash(app_id, "") (precheck looks it up that way), so it is
+  // excluded here. For every other app the portal is the sole authority:
   // recompute and overwrite so a client-supplied external_nullifier (e.g. one
   // inserted directly via the api_key GraphQL role) cannot pin an arbitrary
   // proof domain instead of the canonical hash(app_id, action).
-  if (APPS_WITH_CUSTOM_EXTERNAL_NULLIFIER.includes(action.app_id)) {
+  if (
+    APPS_WITH_CUSTOM_EXTERNAL_NULLIFIER.includes(action.app_id) &&
+    action.external_nullifier &&
+    action.external_nullifier !== action.app_id
+  ) {
     return NextResponse.json({
       success: true,
       custom_external_nullifier: true,

--- a/web/api/v1/precheck/[app_id]/index.ts
+++ b/web/api/v1/precheck/[app_id]/index.ts
@@ -5,6 +5,7 @@ import { RpRegistrationStatus } from "@/api/helpers/rp-utils";
 import { corsHandler } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { canVerifyForAction } from "@/api/helpers/verify";
+import { APPS_WITH_CUSTOM_EXTERNAL_NULLIFIER } from "@/lib/constants";
 import { generateExternalNullifier } from "@/lib/hashing";
 import { CanUserVerifyType, EngineType } from "@/lib/types";
 import { getCDNImageUrl } from "@/lib/utils";
@@ -14,15 +15,6 @@ import { getSdk as getAppPrecheckByActionSdk } from "./graphql/app-precheck-by-a
 import { getSdk as getAppPrecheckSdk } from "./graphql/app-precheck.generated";
 import { getSdk as getFetchRpRegistrationForPrecheckSdk } from "./graphql/fetch-rp-registration-for-precheck.generated";
 
-/**
- * Apps that use custom external_nullifier values (not computed from app_id + action).
- * For these apps, we query by action name instead of computed external_nullifier.
- * This supports legacy integrations that need specific external_nullifier values
- * to maintain nullifier_hash compatibility.
- */
-const APPS_WITH_CUSTOM_EXTERNAL_NULLIFIER = [
-  "app_1f7f2c379f20307a414f6cf8b544ec8a", // Grants app - uses 0xB16B00B5 for humanity verification
-];
 // Whitelist some partner demo apps, that are not verified but we want to show their logos
 const APPS_TO_SHOW_UNVERIFIED_LOGO = [
   "app_staging_c8137371ceac59890774ccc932e11dcf",

--- a/web/lib/constants.ts
+++ b/web/lib/constants.ts
@@ -10,6 +10,17 @@ import {
 
 export { Categories } from "./categories";
 
+/**
+ * Apps that legitimately use a custom external_nullifier (NOT derived from
+ * app_id + action), kept for legacy nullifier_hash compatibility. For every
+ * other app the portal is the sole authority for external_nullifier, so a
+ * client-supplied value must never be preserved (see HackerOne #3749623) and
+ * precheck computes the value from app_id + action instead of trusting storage.
+ */
+export const APPS_WITH_CUSTOM_EXTERNAL_NULLIFIER = [
+  "app_1f7f2c379f20307a414f6cf8b544ec8a", // Grants app - uses 0xB16B00B5 for humanity verification
+];
+
 // ANCHOR: Production Sequencers
 export const ORB_SEQUENCER = "https://signup-orb-ethereum.crypto.worldcoin.org";
 export const PHONE_SEQUENCER =


### PR DESCRIPTION
## Summary
Fixes HackerOne **#3749623**: the `api_key` Hasura role can insert an **arbitrary `external_nullifier`** on an action, and the `generate_external_nullifier` event trigger deliberately **preserved** a pre-supplied value (early-returned unless it equalled `app_id`). This let a developer pin a non-canonical proof domain on their own action, bypassing the server-computed `hash(app_id, action)` invariant the first-party create paths enforce. (Triaged *difficult / low* — scoped to the attacker's own apps, no secret gained — but a real least-privilege/validation gap worth closing at the source.)

## Why fix it at the trigger (write side), not at verify
Recomputing the domain at **verify** time risks breaking verification for legacy/edge action types. Fixing it at the **trigger** is behavior-preserving for every legitimate flow and removes the tampered value before it can ever be used:
- **UI create-action** already let the trigger compute → unchanged.
- **v2 create-action** computes the same `hash(app_id, action)` server-side → the trigger now recomputes the identical value (idempotent overwrite).
- **Attacker raw `insert_action_one`** with an arbitrary value → trigger overwrites with the canonical value → **fixed**.
- **Legacy custom-nullifier apps** (`APPS_WITH_CUSTOM_EXTERNAL_NULLIFIER`, e.g. Grants `0xB16B00B5`) → preserved.

## Changes
- `api/_gen-external-nullifier`: replace "preserve any pre-supplied value" with "recompute & overwrite, except for `APPS_WITH_CUSTOM_EXTERNAL_NULLIFIER`". The `SetExternalNullifier` mutation runs as the service role, which overwrites (the old "will fail due to permissions" comment was inaccurate).
- Hoist `APPS_WITH_CUSTOM_EXTERNAL_NULLIFIER` to `lib/constants` and import it in both `precheck` (previously a local duplicate) and the trigger, so the legacy allowlist has a single source of truth.

## Testing
- `npx tsc --noEmit` ✅
- `npx jest tests/api/gen-external-nullifier.test.ts tests/api/v1/precheck.test.ts` ✅ (14/14)
- `prettier` ✅
- Per prior repo guidance, no new heavy-SDK-mock handler tests were added for this Hasura event-trigger endpoint; the change is behavior-preserving and the legacy allowlist is shared with precheck's existing semantics.

## Rollout
- No schema/migration change. The trigger is async (fires after insert), so there is a brief eventual-consistency window before a tampered value is overwritten — acceptable for this low-severity, own-app-scoped gap. Independently revertible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)