### PR TITLE
fix(verify): surface verified issuer_schema_id in v4 verify results (#3751156)

### DIFF
--- a/web/api/v4/verify/session-proof/verify-util.ts
+++ b/web/api/v4/verify/session-proof/verify-util.ts
@@ -5,6 +5,10 @@ import { getSessionCommitment } from "@worldcoin/idkit-server";
 
 export interface SessionResult {
   identifier: string;
+  // The cryptographically-verified credential type. Present only on success,
+  // where the on-chain proof is bound to this value. Relying parties should
+  // authorize on `issuer_schema_id`, not the caller-supplied `identifier`.
+  issuer_schema_id?: string;
   sessionId: string;
   success: boolean;
   nullifier?: string;
@@ -70,6 +74,8 @@ export async function processSessionProof(
         // For session proofs, use session_nullifier[0] as the nullifier for deduplication
         return {
           identifier: item.identifier,
+          // Bound to the verified proof — authorize on this, not `identifier`.
+          issuer_schema_id: item.issuer_schema_id,
           sessionId: sessionProofRequest.session_id,
           success: true,
           nullifier: item.session_nullifier[0],

--- a/web/api/v4/verify/uniqueness-proof/handler.ts
+++ b/web/api/v4/verify/uniqueness-proof/handler.ts
@@ -23,6 +23,10 @@ import { processUniquenessProofV4 } from "./verify-v4";
 // Unified result type for both v3 and v4
 export interface UniquenessResult {
   identifier: string;
+  // The cryptographically-verified credential type. Present only on success,
+  // where the on-chain proof is bound to this value. Relying parties should
+  // authorize on `issuer_schema_id`, not the caller-supplied `identifier`.
+  issuer_schema_id?: string;
   success: boolean;
   nullifier?: string;
   code?: string;

--- a/web/api/v4/verify/uniqueness-proof/verify-v4.ts
+++ b/web/api/v4/verify/uniqueness-proof/verify-v4.ts
@@ -56,6 +56,8 @@ export async function processUniquenessProofV4(
 
         return {
           identifier: item.identifier,
+          // Bound to the verified proof — authorize on this, not `identifier`.
+          issuer_schema_id: item.issuer_schema_id,
           success: true,
           nullifier: item.nullifier,
         };

--- a/web/tests/api/v4/process-uniqueness-proof-v4.test.ts
+++ b/web/tests/api/v4/process-uniqueness-proof-v4.test.ts
@@ -1,0 +1,66 @@
+import { processUniquenessProofV4 } from "@/api/v4/verify/uniqueness-proof/verify-v4";
+
+// #region Mocks
+const verifyProofOnChain = jest.fn();
+
+jest.mock("@/api/helpers/temporal-rpc", () => ({
+  verifyProofOnChain: (...args: unknown[]) => verifyProofOnChain(...args),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+// #endregion
+
+// #region Test Data
+const baseItem = {
+  // `identifier` is a caller-supplied passthrough label — not bound to the proof.
+  identifier: "orb",
+  signal_hash: "0x0",
+  // `issuer_schema_id` is the credential type the proof is verified against.
+  issuer_schema_id: "7",
+  nullifier: "0x2",
+  expires_at_min: 1772584197,
+  proof: ["0x1", "0x2", "0x3", "0x4", "0x5"],
+};
+
+const run = (item: Record<string, unknown>) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  processUniquenessProofV4(1n, "1", "verify", [item as any], "0xverifier");
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// #region issuer_schema_id binding (#3751156)
+describe("processUniquenessProofV4 [verified credential type]", () => {
+  it("surfaces the verified issuer_schema_id on success, alongside the echoed identifier", async () => {
+    verifyProofOnChain.mockResolvedValue({ success: true });
+
+    const [result] = await run(baseItem);
+
+    expect(result).toMatchObject({
+      success: true,
+      // passthrough label preserved for backwards compatibility...
+      identifier: "orb",
+      // ...but the verified credential type is now surfaced so relying parties
+      // can authorize on it rather than on the caller-controlled identifier.
+      issuer_schema_id: "7",
+      nullifier: "0x2",
+    });
+  });
+
+  it("does not surface issuer_schema_id when verification fails", async () => {
+    verifyProofOnChain.mockResolvedValue({
+      success: false,
+      error: { code: "invalid_proof", detail: "nope" },
+    });
+
+    const [result] = await run(baseItem);
+
+    expect(result.success).toBe(false);
+    expect(result.issuer_schema_id).toBeUndefined();
+  });
+});
+// #endregion


### PR DESCRIPTION
## Summary
Fixes HackerOne **#3751156**: the World ID 4.0 verify endpoint copied the caller-supplied `responses[].identifier` verbatim into `results[].identifier` with **no binding** to the cryptographically-verified `issuer_schema_id` — and the result didn't expose `issuer_schema_id` at all. A relying party that authorized on the echoed `identifier` label could be misled (e.g. a device-level proof labeled `"orb"`).

(Triaged *difficult / low*: `issuer_schema_id` is the authoritative field and **is** verified on-chain; `identifier` is never used for any authorization decision in this codebase. Real impact requires a downstream RP misusing the echoed label. This is a hardening fix.)

## Change
Surface the **verified** `issuer_schema_id` in the success results of both verify paths:
- `uniqueness-proof/verify-v4.ts` → `UniquenessResult.issuer_schema_id`
- `session-proof/verify-util.ts` → `SessionResult.issuer_schema_id`

On success the on-chain proof is bound to `issuer_schema_id` (verification fails for any other value), so RPs can now authorize on the verified field instead of the caller-controlled `identifier`. The field is present **only on success** (where it's confirmed). `identifier` is preserved as a passthrough/correlation label for backwards compatibility — it is intentionally *not* removed or enum-constrained, since v4 treats it as a free-form caller tag (unlike v3's credential-level enum).

## Testing
- `npx tsc --noEmit` ✅
- `npx jest tests/api/v4/verify.test.ts tests/api/v4/session-proof.test.ts` ✅
- New `tests/api/v4/process-uniqueness-proof-v4.test.ts` ✅ — asserts the verified `issuer_schema_id` is surfaced on success and absent on failure (mocks only the on-chain RPC boundary).
- `prettier` ✅

## Rollout
Purely additive to the response (new optional field). No schema/migration change, no breaking change for existing integrations. Independently revertible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)