### PR TITLE
fix(reviews): freeze app metadata while awaiting_review (#3778899)

### DIFF
--- a/hasura/metadata/databases/default/tables/public_app_metadata.yaml
+++ b/hasura/metadata/databases/default/tables/public_app_metadata.yaml
@@ -334,7 +334,9 @@ update_permissions:
       filter:
         _and:
           - verification_status:
-              _neq: verified
+              _nin:
+                - verified
+                - awaiting_review
           - app:
               deleted_at:
                 _is_null: true


### PR DESCRIPTION
## Summary
Fixes HackerOne **#3778899**: a TOCTOU bait-and-switch that lands the **verified badge on swapped content**.

The `api_key` role's UPDATE permission on `app_metadata` filtered on `verification_status: { _neq: verified }` — which **includes `awaiting_review`**. Since:
1. submit-for-review flips the draft row to `awaiting_review` **in place** (no snapshot), and
2. `verify-app` promotes that **same row** to `verified`, re-setting only image/status/flag columns (name/description carry over verbatim),

a developer could submit benign content, wait for the reviewer to inspect it, then `update_app_metadata` (name/description/logo) on that `awaiting_review` row via the public `/api/v1/graphql` proxy, and have `verify-app` approve the swapped content with the verified badge — a phishing app in the World App store.

## Change
Tighten the `api_key` UPDATE row `filter` to **exclude `awaiting_review`**:

```diff
-          - verification_status:
-              _neq: verified
+          - verification_status:
+              _nin:
+                - verified
+                - awaiting_review
```

Rows under review are now frozen for the `api_key` role. This is intentionally minimal — it removes only `awaiting_review` from the editable set:
- **Drafts** (`unverified`, `changes_requested`) remain editable.
- **Submit / resubmit flips** still work: the row `filter` is evaluated on the *pre-update* row (`unverified`/`changes_requested`), and the `check` clause (unchanged) still permits the new `awaiting_review` status.
- Editing an `awaiting_review` row (the attack) is now denied.

The reviewer/service roles are unaffected (internal, not reachable via the public proxy).

## Testing / rollout
- Metadata-only change; **no jest coverage** (Hasura permission). Validated structurally (mirrors the adjacent `_in` block).
- **Requires `hasura metadata apply` on deploy.** Reviewer with Hasura access: please confirm in the console that the `api_key` UPDATE permission on `app_metadata` rejects updates to `awaiting_review` rows and still allows `unverified`/`changes_requested`, and that submit-for-review (unverified → awaiting_review) still succeeds.
- Independently revertible (revert the metadata change + re-apply).

### Defense-in-depth follow-up (optional, not in this PR)
`verify-app` could additionally snapshot the reviewed name/description at review time and re-validate at approval, so the freeze isn't the only guard. Out of scope here since it requires a review-time snapshot the current flow doesn't capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)