### PR TITLE
feat(permissions): disable-not-hide UX for restricted team actions

### DIFF
--- a/web/components/LoggedUserNav/index.tsx
+++ b/web/components/LoggedUserNav/index.tsx
@@ -5,14 +5,11 @@ import { HelpSquareIcon } from "@/components/Icons/HelpSquareIcon";
 import { LoginSquareIcon } from "@/components/Icons/LoginSquareIcon";
 import { TeamLogo } from "@/components/LoggedUserNav/Teams/TeamLogo";
 import { useFetchTeamQuery } from "@/components/LoggedUserNav/graphql/client/fetch-team.generated";
-import { Role_Enum } from "@/graphql/graphql";
 import { DOCS_URL } from "@/lib/constants";
-import { Auth0SessionUser } from "@/lib/types";
 import { urls } from "@/lib/urls";
-import { checkUserPermissions } from "@/lib/utils";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { colorAtom } from "@/scenes/Portal/layout/color-atom";
 import { useMeQuery } from "@/scenes/common/me-query/client";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { useAtom } from "jotai";
 import Link from "next/link";
 import { useParams } from "next/navigation";
@@ -31,7 +28,6 @@ import { Teams } from "./Teams";
 
 export const LoggedUserNav = () => {
   const [color] = useAtom(colorAtom);
-  const { user: auth0User } = useUser() as Auth0SessionUser;
   const { teamId, appId, actionId } = useParams() as {
     teamId?: string;
     appId?: string;
@@ -40,9 +36,8 @@ export const LoggedUserNav = () => {
 
   const { user } = useMeQuery();
 
-  const hasOwnerPermission = useMemo(() => {
-    return checkUserPermissions(auth0User, teamId ?? "", [Role_Enum.Owner]);
-  }, [auth0User, teamId]);
+  const settingsPerm = useTeamPermission(teamId ?? "", "edit_team_settings");
+  const apiKeysPerm = useTeamPermission(teamId ?? "", "view_api_keys");
 
   const nameFirstLetter = useMemo(
     () => user.nameToDisplay[0].toLocaleUpperCase(),
@@ -155,17 +150,19 @@ export const LoggedUserNav = () => {
                 </Link>
               </Dropdown.ListItem>
 
-              <Dropdown.ListItem asChild>
-                <Link href={`/teams/${teamId}/api-keys`}>
-                  <Dropdown.ListItemIcon asChild>
-                    <KeyIcon />
-                  </Dropdown.ListItemIcon>
+              {apiKeysPerm.allowed && (
+                <Dropdown.ListItem asChild>
+                  <Link href={`/teams/${teamId}/api-keys`}>
+                    <Dropdown.ListItemIcon asChild>
+                      <KeyIcon />
+                    </Dropdown.ListItemIcon>
 
-                  <Dropdown.ListItemText>API Keys</Dropdown.ListItemText>
-                </Link>
-              </Dropdown.ListItem>
+                    <Dropdown.ListItemText>API Keys</Dropdown.ListItemText>
+                  </Link>
+                </Dropdown.ListItem>
+              )}
 
-              {hasOwnerPermission && (
+              {settingsPerm.allowed && (
                 <Dropdown.ListItem asChild>
                   <Link href={`/teams/${teamId}/settings`}>
                     <Dropdown.ListItemIcon asChild>

--- a/web/lib/urls.ts
+++ b/web/lib/urls.ts
@@ -30,6 +30,9 @@ export const urls = {
   worldIdActions: (params: { team_id: string; app_id?: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id}/world-id-actions`,
 
+  createWorldIdAction: (params: { team_id: string; app_id: string }): string =>
+    `/teams/${params.team_id}/apps/${params.app_id}/world-id-actions?createAction=true`,
+
   worldIdAction: (params: {
     team_id: string;
     app_id: string;

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Danger/ActionDangerZoneContent/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Danger/ActionDangerZoneContent/index.tsx
@@ -6,12 +6,10 @@ import { DialogOverlay } from "@/components/DialogOverlay";
 import { DialogPanel } from "@/components/DialogPanel";
 import { AlertIcon } from "@/components/Icons/AlertIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { truncateString } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { useRouter } from "next/navigation";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "react-toastify";
 import { GetActionsDocument } from "../../../page/graphql/client/actions.generated";
 import { GetSingleActionQuery } from "../page/graphql/client/get-single-action.generated";
@@ -25,18 +23,10 @@ export const ActionDangerZoneContent = (props: {
   const { action, appId, teamId } = props;
   const [openDeleteModal, setOpenDeleteModal] = useState(false);
   const router = useRouter();
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    const membership = user?.hasura.memberships.find(
-      (m) => m.team?.id === teamId,
-    );
-
-    return (
-      membership?.role === Role_Enum.Owner ||
-      membership?.role === Role_Enum.Admin
-    );
-  }, [teamId, user?.hasura.memberships]);
+  const deleteActionPerm = useTeamPermission(
+    teamId ?? "",
+    "delete_world_id_action",
+  );
 
   const [deleteActionQuery, { loading: deleteActionLoading }] =
     useDeleteActionMutation();
@@ -138,7 +128,7 @@ export const ActionDangerZoneContent = (props: {
             type="button"
             variant="danger"
             onClick={() => setOpenDeleteModal(true)}
-            disabled={deleteActionLoading || !isEnoughPermissions}
+            disabled={deleteActionLoading || !deleteActionPerm.allowed}
             className="w-40 bg-system-error-100 "
           >
             <Typography variant={TYPOGRAPHY.R3}>Delete action</Typography>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/layout/index.tsx
@@ -7,11 +7,9 @@ import { useAtomValue } from "jotai";
 import { worldId40Atom, isWorldId40Enabled } from "@/lib/feature-flags";
 import { Tab, Tabs } from "@/components/Tabs";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser, EngineType } from "@/lib/types";
+import { EngineType } from "@/lib/types";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { urls } from "@/lib/urls";
-import { checkUserPermissions } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { ReactNode, use } from "react";
 import { useGetSingleActionAndNullifiersQuery } from "../page/graphql/client/get-single-action.generated";
 
@@ -28,9 +26,6 @@ type ActionIdLayout = {
 
 export const ActionIdLayout = (props: ActionIdLayout) => {
   const params = use(props.params);
-  const { user } = useUser() as Auth0SessionUser;
-
-  // Fetch action data for header using user permissions
   const { data, loading } = useGetSingleActionAndNullifiersQuery({
     variables: {
       action_id: params.actionId ?? "",
@@ -45,10 +40,10 @@ export const ActionIdLayout = (props: ActionIdLayout) => {
   const worldId40Config = useAtomValue(worldId40Atom);
   const isEnabled = isWorldId40Enabled(worldId40Config, params.teamId);
 
-  const isEnoughPermissions = checkUserPermissions(user, params.teamId ?? "", [
-    Role_Enum.Owner,
-    Role_Enum.Admin,
-  ]);
+  const deleteActionPerm = useTeamPermission(
+    params.teamId ?? "",
+    "delete_world_id_action",
+  );
 
   // Handle 404 if action not found (only after loading completes)
   if (!loading && !action) {
@@ -122,7 +117,7 @@ export const ActionIdLayout = (props: ActionIdLayout) => {
             </Tab>
           )}
 
-          {isEnoughPermissions && (
+          {deleteActionPerm.allowed && (
             <Tab
               className="md:py-4"
               href={`/teams/${params!.teamId}/apps/${params!.appId}/actions/${params!.actionId}/danger`}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
@@ -12,12 +12,9 @@ import {
 } from "@/components/Select";
 import { TextArea } from "@/components/TextArea";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
 import { AppMode } from "@/lib/constants";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { RadioCard } from "@/scenes/Portal/layout/CreateAppDialog/RadioCard";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { yupResolver } from "@hookform/resolvers/yup";
 import clsx from "clsx";
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef } from "react";
@@ -76,15 +73,8 @@ const calculateRows = (
 
 export const SetupForm = (props: LinksFormProps) => {
   const { teamId, appMetadata } = props;
-  const { user } = useUser() as Auth0SessionUser;
   const isEditable = appMetadata?.verification_status === "unverified";
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamId]);
+  const editStorePerm = useTeamPermission(teamId, "edit_app_store_details");
 
   const form = useForm<UpdateSetupInitialSchema>({
     resolver: yupResolver(updateSetupInitialSchema),
@@ -162,7 +152,7 @@ export const SetupForm = (props: LinksFormProps) => {
     [appMetadata?.id],
   );
 
-  const isAdvancedEditable = isEditable && isEnoughPermissions;
+  const isAdvancedEditable = isEditable && editStorePerm.allowed;
 
   const hasInvalidWhitelistCombination = (values: UpdateSetupInitialSchema) =>
     values.app_mode === "mini-app" &&
@@ -253,7 +243,7 @@ export const SetupForm = (props: LinksFormProps) => {
         </div>
         <TextArea
           aria-label="Additional Domains"
-          disabled={!isEditable || !isEnoughPermissions}
+          disabled={!isEditable || !editStorePerm.allowed}
           placeholder="https://example.com, https://example2.com"
           register={register("associated_domains", {
             onChange: formatArrayInput,
@@ -293,7 +283,7 @@ export const SetupForm = (props: LinksFormProps) => {
             label="Whitelisted Payment Addresses"
             disabled={
               !isEditable ||
-              !isEnoughPermissions ||
+              !editStorePerm.allowed ||
               isWhitelistDisabled ||
               appMode == "external"
             }
@@ -320,7 +310,7 @@ export const SetupForm = (props: LinksFormProps) => {
             id="is_whitelist_disabled"
             register={register("is_whitelist_disabled")}
             disabled={
-              !isEditable || !isEnoughPermissions || appMode == "external"
+              !isEditable || !editStorePerm.allowed || appMode == "external"
             }
           />
 
@@ -341,7 +331,7 @@ export const SetupForm = (props: LinksFormProps) => {
         </div>
         <TextArea
           label="Permit2 Tokens"
-          disabled={!isEditable || !isEnoughPermissions}
+          disabled={!isEditable || !editStorePerm.allowed}
           placeholder="0xad312321..., 0xE901e312..."
           register={register("permit2_tokens", { onChange: formatArrayInput })}
           enableResize={false}
@@ -365,7 +355,7 @@ export const SetupForm = (props: LinksFormProps) => {
         </div>
         <TextArea
           label="Contract Entrypoints"
-          disabled={!isEditable || !isEnoughPermissions}
+          disabled={!isEditable || !editStorePerm.allowed}
           placeholder="0xb731d321..., 0xF2310312..."
           register={register("contracts", { onChange: formatArrayInput })}
           enableResize={false}
@@ -417,7 +407,7 @@ export const SetupForm = (props: LinksFormProps) => {
                     : field.value
                 }
                 onChange={field.onChange}
-                disabled={!isEditable || !isEnoughPermissions}
+                disabled={!isEditable || !editStorePerm.allowed}
               >
                 <SelectButton className="min-w-[150px] rounded-lg border border-grey-200 px-4 py-2 md:w-fit">
                   {({ value }) => (
@@ -459,7 +449,7 @@ export const SetupForm = (props: LinksFormProps) => {
             id="can_import_all_contacts"
             register={register("can_import_all_contacts")}
             disabled={
-              !isEditable || !isEnoughPermissions || appMode === "external"
+              !isEditable || !editStorePerm.allowed || appMode === "external"
             }
           />
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ContentCardImageUpload/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ContentCardImageUpload/index.tsx
@@ -45,7 +45,6 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
   const [verifiedImageError, setVerifiedImageError] = useState(false);
   const [isSecondUpload, setIsSecondUpload] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
-  const [disabled] = useState(false);
   const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
   const [viewMode] = useAtom(viewModeAtom);
   const [unverifiedImages, setUnverifiedImages] = useAtom(unverifiedImageAtom);
@@ -55,6 +54,9 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
   const { getImage, uploadViaPresignedPost, validateImageAspectRatio } =
     useImage();
   const handleUpload = () => {
+    if (!isEditable) {
+      return;
+    }
     imageInputRef.current?.click();
   };
 
@@ -162,7 +164,7 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
         ref={imageInputRef}
         type="file"
         accept=".png,.jpg,.jpeg"
-        disabled={disabled}
+        disabled={!isEditable}
         onChange={handleFileInput}
         style={{ display: "none" }}
       />
@@ -241,10 +243,13 @@ export const ContentCardImageUpload = (props: ContentCardImageUploadProps) => {
         ) : (
           <label
             className={clsx(
-              "flex h-[168px] w-full cursor-pointer flex-col items-center justify-center gap-y-3 rounded-[10px] border border-dashed bg-grey-50 p-6 hover:bg-grey-100",
+              "flex h-[168px] w-full flex-col items-center justify-center gap-y-3 rounded-[10px] border border-dashed bg-grey-50 p-6",
               isError
                 ? "border-system-error-500 bg-system-error-50"
                 : "border-grey-200",
+              isEditable
+                ? "cursor-pointer hover:bg-grey-100"
+                : "cursor-not-allowed opacity-60",
             )}
             onClick={handleUpload}
           >

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/app-store.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/app-store.tsx
@@ -1,9 +1,6 @@
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
+import { RestrictedAction } from "@/components/RestrictedAction";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { useAtomValue } from "jotai";
-import { useMemo } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { useSaveStatus } from "../SaveStatus";
 import { useAutosaveWithStatus } from "../hook/use-autosave-with-status";
@@ -31,8 +28,6 @@ export const AppStoreForm = ({
   teamId,
   appMetadata,
 }: AppStoreFormProps) => {
-  const { user } = useUser() as Auth0SessionUser;
-
   const {
     control,
     errors,
@@ -51,21 +46,17 @@ export const AppStoreForm = ({
   // copy only while the blue pill is showing, not on every raw status flip.
   const { flushAll, displayStatus } = useSaveStatus();
 
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamId]);
+  const editStorePerm = useTeamPermission(teamId, "edit_app_store_details");
 
   const isMiniApp = useAtomValue(isMiniAppAtom);
+  const canEditStore = isEditable && editStorePerm.allowed;
 
   const supportedLanguages = useWatch({ control, name: "supported_languages" });
 
   useAutosaveWithStatus<AppStoreFormValues>({
     id: "app-store",
     form,
-    enabled: isEditable && isEnoughPermissions,
+    enabled: canEditStore,
     save: async (data, signal) => {
       await submitSilent(data, signal);
     },
@@ -81,23 +72,14 @@ export const AppStoreForm = ({
       >
         {isMiniApp && (
           <>
-            <ComplianceSection
-              control={control}
-              isEditable={isEditable}
-              isEnoughPermissions={isEnoughPermissions}
-            />
+            <ComplianceSection control={control} isEditable={canEditStore} />
 
-            <HumansOnlySection
-              control={control}
-              isEditable={isEditable}
-              isEnoughPermissions={isEnoughPermissions}
-            />
+            <HumansOnlySection control={control} isEditable={canEditStore} />
 
             <CategorySection
               control={control}
               errors={errors}
-              isEditable={isEditable}
-              isEnoughPermissions={isEnoughPermissions}
+              isEditable={canEditStore}
             />
 
             <SectionDivider />
@@ -105,8 +87,7 @@ export const AppStoreForm = ({
             <SupportSection
               control={control}
               errors={errors}
-              isEditable={isEditable}
-              isEnoughPermissions={isEnoughPermissions}
+              isEditable={canEditStore}
               supportType={supportType}
               onSupportTypeChange={handleSupportTypeChange}
             />
@@ -117,8 +98,7 @@ export const AppStoreForm = ({
               appId={appId}
               teamId={teamId}
               appMetadata={appMetadata}
-              isEditable={isEditable}
-              isEnoughPermissions={isEnoughPermissions}
+              isEditable={canEditStore}
               errors={errors}
             />
 
@@ -129,8 +109,7 @@ export const AppStoreForm = ({
         <CountriesSection
           control={control}
           errors={errors}
-          isEditable={isEditable}
-          isEnoughPermissions={isEnoughPermissions}
+          isEditable={canEditStore}
         />
 
         <SectionDivider />
@@ -138,8 +117,7 @@ export const AppStoreForm = ({
         <LanguagesSection
           control={control}
           errors={errors}
-          isEditable={isEditable}
-          isEnoughPermissions={isEnoughPermissions}
+          isEditable={canEditStore}
         />
 
         <SectionDivider />
@@ -148,8 +126,7 @@ export const AppStoreForm = ({
           control={control}
           errors={errors}
           localisations={localisations}
-          isEditable={isEditable}
-          isEnoughPermissions={isEnoughPermissions}
+          isEditable={canEditStore}
           appMetadata={appMetadata}
           appId={appId}
           teamId={teamId}
@@ -162,17 +139,19 @@ export const AppStoreForm = ({
 
         <div className="fixed bottom-[5.25rem] right-6 z-10 flex items-center gap-x-3 md:bottom-6">
           <SaveStatusIndicator />
-          <SaveButton
-            isSubmitting={displayStatus.state === "saving"}
-            isDisabled={
-              !isEditable ||
-              !isEnoughPermissions ||
-              displayStatus.state === "saving"
-            }
-            onSubmit={() => {
-              void flushAll();
-            }}
-          />
+          <RestrictedAction restriction={editStorePerm}>
+            {({ disabled }) => (
+              <SaveButton
+                isSubmitting={displayStatus.state === "saving"}
+                isDisabled={
+                  !isEditable || disabled || displayStatus.state === "saving"
+                }
+                onSubmit={() => {
+                  void flushAll();
+                }}
+              />
+            )}
+          </RestrictedAction>
         </div>
       </form>
     </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/CategorySection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/CategorySection.tsx
@@ -12,7 +12,6 @@ export const CategorySection = ({
   control,
   errors,
   isEditable,
-  isEnoughPermissions,
 }: CategorySectionProps) => {
   return (
     <Controller
@@ -22,7 +21,7 @@ export const CategorySection = ({
         <CategorySelector
           value={field.value}
           required
-          disabled={!isEditable || !isEnoughPermissions}
+          disabled={!isEditable}
           onChange={field.onChange}
           errors={errors.category}
           label="Category"

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/ComplianceSection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/ComplianceSection.tsx
@@ -11,13 +11,12 @@ type ComplianceSectionProps = FormSectionProps & {
 export const ComplianceSection = ({
   control,
   isEditable,
-  isEnoughPermissions,
 }: ComplianceSectionProps) => {
   return (
     <Controller
       name="is_android_only"
       control={control}
-      disabled={!isEditable || !isEnoughPermissions}
+      disabled={!isEditable}
       render={({ field }) => (
         <div className="rounded-[10px] border border-grey-100 px-6 py-4">
           <div className="flex items-center gap-x-4">
@@ -33,7 +32,7 @@ export const ComplianceSection = ({
             <Toggle
               checked={field.value ?? false}
               onChange={field.onChange}
-              disabled={!isEditable || !isEnoughPermissions}
+              disabled={!isEditable}
             />
           </div>
         </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/CountriesSection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/CountriesSection.tsx
@@ -19,7 +19,6 @@ export const CountriesSection = ({
   control,
   errors,
   isEditable,
-  isEnoughPermissions,
 }: CountriesSectionProps) => {
   const countries = useMemo(() => formCountriesList(), []);
   const [showClearModal, setShowClearModal] = useState(false);
@@ -60,7 +59,7 @@ export const CountriesSection = ({
               }
               items={countries}
               label=""
-              disabled={!isEditable || !isEnoughPermissions}
+              disabled={!isEditable}
               errors={errors.supported_countries}
               required
               selectAll={() => field.onChange(countries.map((c) => c.value))}
@@ -92,7 +91,7 @@ export const CountriesSection = ({
                         : [...(field.value ?? []), value],
                     );
                   }}
-                  disabled={!isEditable || !isEnoughPermissions}
+                  disabled={!isEditable}
                 />
               )}
             </SelectMultiple>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/HumansOnlySection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/HumansOnlySection.tsx
@@ -11,13 +11,12 @@ type HumansOnlySectionProps = FormSectionProps & {
 export const HumansOnlySection = ({
   control,
   isEditable,
-  isEnoughPermissions,
 }: HumansOnlySectionProps) => {
   return (
     <Controller
       name="is_for_humans_only"
       control={control}
-      disabled={!isEditable || !isEnoughPermissions}
+      disabled={!isEditable}
       render={({ field }) => (
         <div className="rounded-[10px] border border-grey-100 px-6 py-4">
           <div className="flex items-center gap-x-4">
@@ -34,7 +33,7 @@ export const HumansOnlySection = ({
             <Toggle
               checked={field.value ?? false}
               onChange={field.onChange}
-              disabled={!isEditable || !isEnoughPermissions}
+              disabled={!isEditable}
             />
           </div>
         </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/LanguagesSection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/LanguagesSection.tsx
@@ -16,7 +16,6 @@ export const LanguagesSection = ({
   control,
   errors,
   isEditable,
-  isEnoughPermissions,
 }: LanguagesSectionProps) => {
   const allPossibleLanguages = formLanguagesList;
   const [showClearModal, setShowClearModal] = useState(false);
@@ -41,7 +40,7 @@ export const LanguagesSection = ({
               values={field.value}
               items={allPossibleLanguages}
               label=""
-              disabled={!isEditable || !isEnoughPermissions}
+              disabled={!isEditable}
               errors={errors.supported_languages}
               showSelectedList
               searchPlaceholder="Enter language"
@@ -90,7 +89,7 @@ export const LanguagesSection = ({
 
                     field.onChange(newSupportedLanguages);
                   }}
-                  disabled={!isEditable || !isEnoughPermissions}
+                  disabled={!isEditable}
                 />
               )}
             </SelectMultiple>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/LocalisationsSection/LocalisationsSection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/LocalisationsSection/LocalisationsSection.tsx
@@ -33,7 +33,6 @@ export const LocalisationsSection = ({
   errors,
   localisations,
   isEditable,
-  isEnoughPermissions,
   appMetadata,
   appId,
   teamId,
@@ -83,7 +82,6 @@ export const LocalisationsSection = ({
             errors={errors}
             selectedIndex={selectedIndex}
             isEditable={isEditable}
-            isEnoughPermissions={isEnoughPermissions}
             isMiniApp={appMetadata.app_mode === "mini-app"}
           />
 
@@ -101,7 +99,7 @@ export const LocalisationsSection = ({
                     Boolean(url),
                   )}
                   onChange={field.onChange}
-                  disabled={!isEditable || !isEnoughPermissions}
+                  disabled={!isEditable}
                   appId={appId}
                   teamId={teamId}
                   locale={selectedLanguage}
@@ -129,7 +127,7 @@ export const LocalisationsSection = ({
                 <MetaTagImageField
                   value={field.value}
                   onChange={field.onChange}
-                  disabled={!isEditable || !isEnoughPermissions}
+                  disabled={!isEditable}
                   appId={appId}
                   teamId={teamId}
                   locale={selectedLanguage}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/LocalisationsSection/components/LocalisationFields.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/LocalisationsSection/components/LocalisationFields.tsx
@@ -9,7 +9,6 @@ interface LocalisationFieldsProps {
   errors: FieldErrors<AppStoreFormValues>;
   selectedIndex: number;
   isEditable: boolean;
-  isEnoughPermissions: boolean;
   isMiniApp: boolean;
 }
 
@@ -18,10 +17,9 @@ export const LocalisationFields = ({
   errors,
   selectedIndex,
   isEditable,
-  isEnoughPermissions,
   isMiniApp,
 }: LocalisationFieldsProps) => {
-  const disabled = !isEditable || !isEnoughPermissions;
+  const disabled = !isEditable;
   const fieldErrors = errors.localisations?.[selectedIndex];
 
   return (

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/SupportSection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/SupportSection.tsx
@@ -17,11 +17,10 @@ export const SupportSection = ({
   control,
   errors,
   isEditable,
-  isEnoughPermissions,
   supportType,
   onSupportTypeChange,
 }: SupportSectionProps) => {
-  const disabled = !isEditable || !isEnoughPermissions;
+  const disabled = !isEditable;
 
   return (
     <FormSection

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/types/AppStoreFormTypes.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/types/AppStoreFormTypes.ts
@@ -77,7 +77,6 @@ export type AppStoreFormProps = {
 
 export type FormSectionProps = {
   isEditable: boolean;
-  isEnoughPermissions: boolean;
 };
 
 export type SupportType = "email" | "link";

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppTopBar/index.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { AppStatus, StatusVariant } from "@/components/AppStatus";
-import { DecoratedButton } from "@/components/DecoratedButton";
+import { RestrictedAction } from "@/components/RestrictedAction";
+import { RestrictedButton } from "@/components/RestrictedButton";
+import {
+  type TeamPermission,
+  useTeamPermission,
+} from "@/lib/team-permissions/use-team-permission";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
 
 import { Button } from "@/components/Button";
-import { Auth0SessionUser } from "@/lib/types";
 import { getCDNImageUrl, getDefaultLogoImgCDNUrl } from "@/lib/utils";
 import { useRemoveFromReview } from "@/scenes/Portal/Teams/TeamId/Apps/common/hooks/use-remove-from-review";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import clsx from "clsx";
 import { useAtom } from "jotai";
 import { ErrorPage } from "@/components/ErrorPage";
@@ -50,19 +52,19 @@ import { useCreateEditableRowMutation } from "./graphql/client/create-editable-r
 type AppTopBarSubmitProps = {
   appMetadata: FetchAppMetadataQuery["app"][0]["app_metadata"][0];
   appId: string;
-  teamId: string;
   viewMode: "unverified" | "verified";
   onSubmitSuccess: () => void;
   basicInfoRef?: MutableRefObject<BasicInformationHandle | null>;
+  permission: TeamPermission;
 };
 
 const AppTopBarSubmit = ({
   appMetadata,
   appId,
-  teamId,
   viewMode,
   onSubmitSuccess,
   basicInfoRef,
+  permission,
 }: AppTopBarSubmitProps) => {
   const form = useFormContext<AppStoreFormValues>();
   const searchParams = useSearchParams();
@@ -184,14 +186,19 @@ const AppTopBarSubmit = ({
   const shouldAutoSubmitForReview =
     searchParams.get("submitForReview") === "true";
   useEffect(() => {
-    if (shouldAutoSubmitForReview && !hasAutoSubmitted.current) {
+    if (
+      shouldAutoSubmitForReview &&
+      !hasAutoSubmitted.current &&
+      permission.allowed
+    ) {
       submitForReview();
       hasAutoSubmitted.current = true;
     }
-  }, [shouldAutoSubmitForReview, submitForReview]);
+  }, [shouldAutoSubmitForReview, submitForReview, permission.allowed]);
 
   return (
-    <DecoratedButton
+    <RestrictedButton
+      restriction={permission}
       type="submit"
       className={clsx("h-12 px-6 py-3", {
         hidden:
@@ -204,7 +211,7 @@ const AppTopBarSubmit = ({
       <Typography variant={TYPOGRAPHY.M3} className="whitespace-nowrap">
         {isSubmittingForReview ? "Processing..." : "Submit for review"}
       </Typography>
-    </DecoratedButton>
+    </RestrictedButton>
   );
 };
 
@@ -215,6 +222,7 @@ type AppIconButtonProps = {
   viewMode: "unverified" | "verified";
   isInReview: boolean;
   isLogoError: boolean;
+  isPermissionBlocked?: boolean;
   onEdit: () => void;
 };
 
@@ -225,34 +233,73 @@ const AppIconButton = ({
   viewMode,
   isInReview,
   isLogoError,
+  isPermissionBlocked = false,
   onEdit,
-}: AppIconButtonProps) => (
-  <button
-    type="button"
-    onClick={() => {
-      if (viewMode !== "verified" && !isInReview) {
-        onEdit();
-      }
-    }}
-    className={clsx("group relative size-[125px] shrink-0 rounded-full", {
-      "cursor-default": viewMode === "verified" || isInReview,
-    })}
-  >
-    {hasLogo ? (
-      <>
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={logoImgUrl}
-          alt="logo"
-          className="size-full rounded-full object-cover drop-shadow-lg"
-        />
-        {viewMode !== "verified" && !isInReview && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 rounded-full bg-grey-900/50 opacity-0 transition-opacity group-hover:opacity-100">
+}: AppIconButtonProps) => {
+  const canEditLogo =
+    viewMode !== "verified" && !isInReview && !isPermissionBlocked;
+  const canShowEmptyLogo = viewMode !== "verified" && !isInReview;
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (canEditLogo) {
+          onEdit();
+        }
+      }}
+      className={clsx("group relative size-[125px] shrink-0 rounded-full", {
+        "cursor-default": !canEditLogo,
+      })}
+    >
+      {hasLogo ? (
+        <>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={logoImgUrl}
+            alt="logo"
+            className="size-full rounded-full object-cover drop-shadow-lg"
+          />
+          {canEditLogo && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 rounded-full bg-grey-900/50 opacity-0 transition-opacity group-hover:opacity-100">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="size-6 text-white"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M1.5 6a2.25 2.25 0 0 1 2.25-2.25h16.5A2.25 2.25 0 0 1 22.5 6v12a2.25 2.25 0 0 1-2.25 2.25H3.75A2.25 2.25 0 0 1 1.5 18V6ZM3 16.06V18c0 .414.336.75.75.75h16.5A.75.75 0 0 0 21 18v-1.94l-2.69-2.689a1.5 1.5 0 0 0-2.12 0l-.88.879.83.83a.75.75 0 1 1-1.06 1.06l-5.16-5.159a1.5 1.5 0 0 0-2.12 0L3 16.061Zm10.125-7.81a1.125 1.125 0 1 1 2.25 0 1.125 1.125 0 0 1-2.25 0Z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <Typography variant={TYPOGRAPHY.R5} className="text-white">
+                Update icon
+              </Typography>
+            </div>
+          )}
+        </>
+      ) : isLogoLoading ? (
+        <div className="flex size-full items-center justify-center rounded-full border border-dashed border-grey-200 bg-grey-50">
+          <SpinnerIcon
+            className="size-8 animate-spin text-grey-300"
+            aria-label="Loading app logo"
+          />
+        </div>
+      ) : canShowEmptyLogo ? (
+        <>
+          <div
+            className={clsx(
+              "flex size-full flex-col items-center justify-center gap-1 rounded-full border border-dashed border-grey-200 bg-grey-50",
+              isLogoError && "border-system-error-500 bg-system-error-50",
+            )}
+          >
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
               fill="currentColor"
-              className="size-6 text-white"
+              className="size-6 text-grey-900"
             >
               <path
                 fillRule="evenodd"
@@ -260,56 +307,26 @@ const AppIconButton = ({
                 clipRule="evenodd"
               />
             </svg>
-            <Typography variant={TYPOGRAPHY.R5} className="text-white">
-              Update icon
+            <Typography variant={TYPOGRAPHY.R5} className="text-grey-900">
+              App icon <span className="text-system-error-500">*</span>
             </Typography>
+            {isLogoError && (
+              <Typography
+                variant={TYPOGRAPHY.R5}
+                className="text-center text-system-error-500"
+              >
+                Logo is required.
+              </Typography>
+            )}
           </div>
-        )}
-      </>
-    ) : isLogoLoading ? (
-      <div className="flex size-full items-center justify-center rounded-full border border-dashed border-grey-200 bg-grey-50">
-        <SpinnerIcon
-          className="size-8 animate-spin text-grey-300"
-          aria-label="Loading app logo"
-        />
-      </div>
-    ) : viewMode !== "verified" && !isInReview ? (
-      <>
-        <div
-          className={clsx(
-            "flex size-full flex-col items-center justify-center gap-1 rounded-full border border-dashed border-grey-200 bg-grey-50",
-            isLogoError && "border-system-error-500 bg-system-error-50",
+          {canEditLogo && (
+            <div className="absolute inset-0 rounded-full bg-grey-900/50 opacity-0 transition-opacity group-hover:opacity-100" />
           )}
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            className="size-6 text-grey-900"
-          >
-            <path
-              fillRule="evenodd"
-              d="M1.5 6a2.25 2.25 0 0 1 2.25-2.25h16.5A2.25 2.25 0 0 1 22.5 6v12a2.25 2.25 0 0 1-2.25 2.25H3.75A2.25 2.25 0 0 1 1.5 18V6ZM3 16.06V18c0 .414.336.75.75.75h16.5A.75.75 0 0 0 21 18v-1.94l-2.69-2.689a1.5 1.5 0 0 0-2.12 0l-.88.879.83.83a.75.75 0 1 1-1.06 1.06l-5.16-5.159a1.5 1.5 0 0 0-2.12 0L3 16.061Zm10.125-7.81a1.125 1.125 0 1 1 2.25 0 1.125 1.125 0 0 1-2.25 0Z"
-              clipRule="evenodd"
-            />
-          </svg>
-          <Typography variant={TYPOGRAPHY.R5} className="text-grey-900">
-            App icon <span className="text-system-error-500">*</span>
-          </Typography>
-          {isLogoError && (
-            <Typography
-              variant={TYPOGRAPHY.R5}
-              className="text-center text-system-error-500"
-            >
-              Logo is required.
-            </Typography>
-          )}
-        </div>
-        <div className="absolute inset-0 rounded-full bg-grey-900/50 opacity-0 transition-opacity group-hover:opacity-100" />
-      </>
-    ) : null}
-  </button>
-);
+        </>
+      ) : null}
+    </button>
+  );
+};
 
 const AppIconButtonWithFormError = (
   props: Omit<AppIconButtonProps, "isLogoError">,
@@ -337,7 +354,6 @@ export const AppTopBar = (props: AppTopBarProps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [viewMode, setViewMode] = useAtom(viewModeAtom);
-  const { user } = useUser() as Auth0SessionUser;
 
   const { data: unverifiedImagesData } = useFetchImagesQuery({
     variables: { id: appId, team_id: teamId },
@@ -353,6 +369,11 @@ export const AppTopBar = (props: AppTopBarProps) => {
   const [unverifiedImages, setUnverifiedImages] = useAtom(unverifiedImageAtom);
   const [localUnverifiedLogoOverride, setLocalUnverifiedLogoOverride] =
     useState<string | null>(null);
+  const submitPerm = useTeamPermission(teamId, "submit_app_for_review");
+  const draftPerm = useTeamPermission(teamId, "create_app_draft");
+  const unsubmitPerm = useTeamPermission(teamId, "unsubmit_app");
+  const resolvePerm = useTeamPermission(teamId, "resolve_app_review");
+  const imageryPerm = useTeamPermission(teamId, "edit_app_imagery");
 
   useEffect(() => {
     setLocalUnverifiedLogoOverride(null);
@@ -373,16 +394,6 @@ export const AppTopBar = (props: AppTopBarProps) => {
       setLocalUnverifiedLogoOverride(null);
     }
   }, [unverifiedImages?.logo_img_url, unverifiedImagesData]);
-
-  const isEnoughPermissions = useMemo(() => {
-    const membership = user?.hasura.memberships.find(
-      (m) => m.team?.id === teamId,
-    );
-    return (
-      membership?.role === Role_Enum.Owner ||
-      membership?.role === Role_Enum.Admin
-    );
-  }, [teamId, user?.hasura.memberships]);
 
   const appMetadata = useMemo(() => {
     if (viewMode === "verified") {
@@ -422,6 +433,10 @@ export const AppTopBar = (props: AppTopBarProps) => {
       return;
     }
 
+    if (!imageryPerm.allowed) {
+      return;
+    }
+
     if (viewMode === "verified" && app.app_metadata.length > 0) {
       setViewMode("unverified");
     }
@@ -430,6 +445,7 @@ export const AppTopBar = (props: AppTopBarProps) => {
     hasAutoOpenedLogoDialog.current = true;
   }, [
     app.app_metadata.length,
+    imageryPerm.allowed,
     setViewMode,
     shouldAutoOpenLogoDialog,
     viewMode,
@@ -582,24 +598,40 @@ export const AppTopBar = (props: AppTopBarProps) => {
         <div className="flex flex-col items-center gap-8 sm:flex-row sm:items-center">
           {/* Logo */}
           {hasFormContext ? (
-            <AppIconButtonWithFormError
-              hasLogo={hasLogo}
-              logoImgUrl={logoImgUrl}
-              isLogoLoading={isLogoLoading}
-              viewMode={viewMode}
-              isInReview={isInReview}
-              onEdit={() => setShowLogoDialog(true)}
-            />
+            <RestrictedAction
+              restriction={imageryPerm}
+              className="rounded-full"
+            >
+              {({ disabled }) => (
+                <AppIconButtonWithFormError
+                  hasLogo={hasLogo}
+                  logoImgUrl={logoImgUrl}
+                  isLogoLoading={isLogoLoading}
+                  viewMode={viewMode}
+                  isInReview={isInReview}
+                  isPermissionBlocked={disabled}
+                  onEdit={() => setShowLogoDialog(true)}
+                />
+              )}
+            </RestrictedAction>
           ) : (
-            <AppIconButton
-              hasLogo={hasLogo}
-              logoImgUrl={logoImgUrl}
-              isLogoLoading={isLogoLoading}
-              viewMode={viewMode}
-              isInReview={isInReview}
-              isLogoError={false}
-              onEdit={() => setShowLogoDialog(true)}
-            />
+            <RestrictedAction
+              restriction={imageryPerm}
+              className="rounded-full"
+            >
+              {({ disabled }) => (
+                <AppIconButton
+                  hasLogo={hasLogo}
+                  logoImgUrl={logoImgUrl}
+                  isLogoLoading={isLogoLoading}
+                  viewMode={viewMode}
+                  isInReview={isInReview}
+                  isLogoError={false}
+                  isPermissionBlocked={disabled}
+                  onEdit={() => setShowLogoDialog(true)}
+                />
+              )}
+            </RestrictedAction>
           )}
 
           {/* Name, Status, Environment, Version */}
@@ -634,76 +666,78 @@ export const AppTopBar = (props: AppTopBarProps) => {
             )}
 
           {/* Action Buttons */}
-          {isEnoughPermissions && (
-            <div className="flex gap-3">
-              {/* Resolve button for rejected apps */}
-              {isRejected && onResolve && (
-                <DecoratedButton
-                  type="button"
-                  className="h-12 px-6 py-3"
-                  onClick={onResolve}
-                >
-                  <Typography variant={TYPOGRAPHY.M3}>Resolve</Typography>
-                </DecoratedButton>
-              )}
+          <div className="flex gap-3">
+            {/* Resolve button for rejected apps */}
+            {isRejected && onResolve && (
+              <RestrictedButton
+                restriction={resolvePerm}
+                type="button"
+                className="h-12 px-6 py-3"
+                onClick={onResolve}
+              >
+                <Typography variant={TYPOGRAPHY.M3}>Resolve</Typography>
+              </RestrictedButton>
+            )}
 
-              {/* Submit / Un-submit / Create Draft button */}
-              {isEditable ? (
-                hasFormContext ? (
-                  <AppTopBarSubmit
-                    appMetadata={appMetadata}
-                    appId={appId}
-                    teamId={teamId}
-                    viewMode={viewMode}
-                    onSubmitSuccess={handleSubmitSuccess}
-                    basicInfoRef={basicInfoRef}
-                  />
-                ) : (
-                  <DecoratedButton
-                    type="button"
-                    className={clsx("h-12 px-6 py-3", {
-                      hidden:
-                        appMetadata.app_id?.includes("staging") &&
-                        process.env.NEXT_PUBLIC_APP_ENV === "production",
-                    })}
-                    disabled={!canSubmitForReview}
-                    onClick={() =>
-                      router.push(
-                        `${urls.configuration({ team_id: teamId, app_id: appId })}?submitForReview=true`,
-                      )
-                    }
+            {/* Submit / Un-submit / Create Draft button */}
+            {isEditable ? (
+              hasFormContext ? (
+                <AppTopBarSubmit
+                  appMetadata={appMetadata}
+                  appId={appId}
+                  viewMode={viewMode}
+                  onSubmitSuccess={handleSubmitSuccess}
+                  basicInfoRef={basicInfoRef}
+                  permission={submitPerm}
+                />
+              ) : (
+                <RestrictedButton
+                  restriction={submitPerm}
+                  type="button"
+                  className={clsx("h-12 px-6 py-3", {
+                    hidden:
+                      appMetadata.app_id?.includes("staging") &&
+                      process.env.NEXT_PUBLIC_APP_ENV === "production",
+                  })}
+                  disabled={!canSubmitForReview}
+                  onClick={() =>
+                    router.push(
+                      `${urls.configuration({ team_id: teamId, app_id: appId })}?submitForReview=true`,
+                    )
+                  }
+                >
+                  <Typography
+                    variant={TYPOGRAPHY.M3}
+                    className="whitespace-nowrap"
                   >
-                    <Typography
-                      variant={TYPOGRAPHY.M3}
-                      className="whitespace-nowrap"
-                    >
-                      Submit for review
-                    </Typography>
-                  </DecoratedButton>
-                )
-              ) : app?.app_metadata?.length === 0 ? (
-                <DecoratedButton
-                  type="button"
-                  className="h-12 px-6 py-3"
-                  onClick={createNewDraft}
-                >
-                  <Typography variant={TYPOGRAPHY.M3}>
-                    Create new draft
+                    Submit for review
                   </Typography>
-                </DecoratedButton>
-              ) : isInReview ? (
-                <DecoratedButton
-                  type="button"
-                  variant="secondary"
-                  className="h-14 px-6"
-                  disabled={removeLoading}
-                  onClick={removeFromReview}
-                >
-                  <Typography variant={TYPOGRAPHY.M3}>Un-submit</Typography>
-                </DecoratedButton>
-              ) : null}
-            </div>
-          )}
+                </RestrictedButton>
+              )
+            ) : app?.app_metadata?.length === 0 ? (
+              <RestrictedButton
+                restriction={draftPerm}
+                type="button"
+                className="h-12 px-6 py-3"
+                onClick={createNewDraft}
+              >
+                <Typography variant={TYPOGRAPHY.M3}>
+                  Create new draft
+                </Typography>
+              </RestrictedButton>
+            ) : isInReview ? (
+              <RestrictedButton
+                restriction={unsubmitPerm}
+                type="button"
+                variant="secondary"
+                className="h-14 px-6"
+                disabled={removeLoading}
+                onClick={removeFromReview}
+              >
+                <Typography variant={TYPOGRAPHY.M3}>Un-submit</Typography>
+              </RestrictedButton>
+            ) : null}
+          </div>
         </div>
       </div>
     </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/index.tsx
@@ -1,13 +1,10 @@
 "use client";
 import { CopyButton } from "@/components/CopyButton";
 import { FloatingInput } from "@/components/FloatingInput";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
 import { inferHttps } from "@/lib/schema";
-import { checkUserPermissions } from "@/lib/utils";
 import { useApolloClient } from "@apollo/client";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useAtom } from "jotai";
 import React, {
@@ -50,14 +47,7 @@ export const BasicInformation = forwardRef<
   const apolloClient = useApolloClient();
 
   const [viewMode] = useAtom(viewModeAtom);
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamId]);
+  const editInfoPerm = useTeamPermission(teamId, "edit_app_information");
 
   const appMetaData = useMemo(() => {
     if (viewMode === "verified") {
@@ -151,7 +141,7 @@ export const BasicInformation = forwardRef<
   const autosave = useAutosaveWithStatus<BasicInformationFormValues>({
     id: "basic-information",
     form,
-    enabled: isEditable && isEnoughPermissions,
+    enabled: isEditable && editInfoPerm.allowed,
     save: async (data, signal) => {
       await persist(data, signal);
     },
@@ -225,13 +215,21 @@ export const BasicInformation = forwardRef<
             Basic information
           </Typography>
 
+          {!editInfoPerm.allowed && (
+            <div className="rounded-xl border border-grey-200 bg-grey-50 px-4 py-3">
+              <Typography variant={TYPOGRAPHY.R4} className="text-grey-700">
+                {editInfoPerm.message}
+              </Typography>
+            </div>
+          )}
+
           <div className="grid grid-cols-2 gap-x-4">
             <FloatingInput
               id="name"
               register={register("name")}
               errors={errors.name}
               label="App name"
-              disabled={!isEditable || !isEnoughPermissions}
+              disabled={!isEditable || !editInfoPerm.allowed}
               required
               maxLength={50}
             />
@@ -251,7 +249,7 @@ export const BasicInformation = forwardRef<
             label="App URL"
             required
             errors={errors.integration_url}
-            disabled={!isEditable || !isEnoughPermissions}
+            disabled={!isEditable || !editInfoPerm.allowed}
             register={makeUrlRegister("integration_url")}
           />
 
@@ -260,7 +258,7 @@ export const BasicInformation = forwardRef<
             label="App Official Website"
             required
             errors={errors.app_website_url}
-            disabled={!isEditable || !isEnoughPermissions}
+            disabled={!isEditable || !editInfoPerm.allowed}
             register={makeUrlRegister("app_website_url")}
           />
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Danger/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Danger/page/index.tsx
@@ -1,12 +1,9 @@
 "use client";
-import { DecoratedButton } from "@/components/DecoratedButton";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions, truncateString } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
-import clsx from "clsx";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
+import { truncateString } from "@/lib/utils";
 import { useAtom } from "jotai";
 import { ErrorPage } from "@/components/ErrorPage";
 import { useParams } from "next/navigation";
@@ -26,11 +23,7 @@ export const AppProfileDangerPage = ({ params }: AppProfileDangerPageProps) => {
   const teamId = (params?.teamId || routeParams?.teamId) as `team_${string}`;
   const [viewMode] = useAtom(viewModeAtom);
   const [openDeleteModal, setOpenDeleteModal] = useState(false);
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [Role_Enum.Owner]);
-  }, [user, teamId]);
+  const deletePerm = useTeamPermission(teamId ?? "", "delete_app");
 
   const { data, loading } = useFetchAppMetadataQuery({
     variables: {
@@ -83,14 +76,15 @@ export const AppProfileDangerPage = ({ params }: AppProfileDangerPageProps) => {
               </Typography>
             </div>
 
-            <DecoratedButton
+            <RestrictedButton
+              restriction={deletePerm}
               type="button"
               variant="destructive"
+              className="w-fit"
               onClick={() => setOpenDeleteModal(true)}
-              className={clsx("w-fit", { hidden: !isEnoughPermissions })}
             >
               <Typography variant={TYPOGRAPHY.R3}>Delete app</Typography>
-            </DecoratedButton>
+            </RestrictedButton>
           </div>
         </SizingWrapper>
         <DeleteModal

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/MiniAppConfiguration/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/MiniAppConfiguration/index.tsx
@@ -1,14 +1,11 @@
 "use client";
 
 import { Toggle } from "@/components/Toggle";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
 import { useRefetchQueries } from "@/lib/use-refetch-queries";
-import { checkUserPermissions } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { useAtom } from "jotai";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "react-toastify";
 import {
   FetchAppMetadataDocument,
@@ -30,17 +27,11 @@ export const MiniAppConfiguration = ({
   teamId,
   appMetadata,
 }: MiniAppConfigurationProps) => {
-  const { user } = useUser() as Auth0SessionUser;
   const [isUpdatingMode, setIsUpdatingMode] = useState(false);
   const modeUpdateInFlightRef = useRef(false);
   const saveStatus = useSaveStatusActions();
 
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamId]);
+  const editStorePerm = useTeamPermission(teamId, "edit_app_store_details");
 
   const isEditable = appMetadata.verification_status === "unverified";
 
@@ -128,6 +119,14 @@ export const MiniAppConfiguration = ({
         Mini App Configuration
       </Typography>
 
+      {!editStorePerm.allowed && (
+        <div className="rounded-xl border border-grey-200 bg-grey-50 px-4 py-3">
+          <Typography variant={TYPOGRAPHY.R4} className="text-grey-700">
+            {editStorePerm.message}
+          </Typography>
+        </div>
+      )}
+
       <div className="grid grid-cols-1 gap-y-10">
         {/* This is a Mini App toggle */}
         <div className="rounded-[10px] border border-grey-100 px-6 py-4">
@@ -145,7 +144,7 @@ export const MiniAppConfiguration = ({
             <Toggle
               checked={isMiniApp}
               onChange={handleAppModeToggle}
-              disabled={!isEditable || !isEnoughPermissions || isUpdatingMode}
+              disabled={!isEditable || !editStorePerm.allowed || isUpdatingMode}
             />
           </div>
         </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/layout/index.tsx
@@ -1,8 +1,7 @@
 import { SizingWrapper } from "@/components/SizingWrapper";
-import { Role_Enum } from "@/graphql/graphql";
+import { userCanPerformAction } from "@/lib/team-permissions";
 import { urls } from "@/lib/urls";
 import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
 import { auth0 } from "@/lib/auth0";
 import { ReactNode } from "react";
 import { SectionSubTabs } from "../../common/SectionSubTabs";
@@ -24,9 +23,11 @@ export const AppProfileLayout = async (props: AppProfileLayout) => {
   const session = await auth0.getSession();
   const user = session?.user as Auth0SessionUser["user"];
 
-  const isEnoughPermissions = checkUserPermissions(user, params.teamId ?? "", [
-    Role_Enum.Owner,
-  ]);
+  const canAccessAppDanger = userCanPerformAction(
+    user,
+    params.teamId ?? "",
+    "delete_app",
+  );
 
   return (
     <div className="flex flex-col items-start">
@@ -49,7 +50,7 @@ export const AppProfileLayout = async (props: AppProfileLayout) => {
                   app_id: params!.appId!,
                 })}/danger`,
                 segment: "danger",
-                hidden: !isEnoughPermissions,
+                hidden: !canAccessAppDanger,
               },
             ]}
           />

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/PermissionsForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/PermissionsForm/index.tsx
@@ -7,11 +7,8 @@ import { CheckIcon } from "@/components/Icons/CheckIcon";
 import { Link } from "@/components/Link";
 import { TextArea } from "@/components/TextArea";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
 import { AppMode } from "@/lib/constants";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { yupResolver } from "@hookform/resolvers/yup";
 import clsx from "clsx";
 import { ChangeEvent, ReactNode, useCallback, useEffect, useMemo } from "react";
@@ -183,15 +180,8 @@ export const SetupForm = ({
   teamId,
   appMetadata,
 }: PermissionsFormProps) => {
-  const { user } = useUser() as Auth0SessionUser;
   const isEditable = appMetadata?.verification_status === "unverified";
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [teamId, user]);
+  const editStorePerm = useTeamPermission(teamId, "edit_app_store_details");
 
   const form = useForm<UpdateSetupInitialSchema>({
     resolver: yupResolver(updateSetupInitialSchema),
@@ -221,7 +211,7 @@ export const SetupForm = ({
     }
   }, [appMetadata, reset, previousMetadataIdRef]);
 
-  const canEdit = isEditable && isEnoughPermissions;
+  const canEdit = isEditable && editStorePerm.allowed;
 
   const hasInvalidWhitelistCombination = useCallback(
     (values: UpdateSetupInitialSchema) =>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/ClientInformation/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/ClientInformation/index.tsx
@@ -4,11 +4,8 @@ import { DecoratedButton } from "@/components/DecoratedButton";
 import { LockIcon } from "@/components/Icons/LockIcon";
 import { Input } from "@/components/Input";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
 import { ORB_APP_TEAM_ID } from "@/lib/constants";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import clsx from "clsx";
 import { ErrorPage } from "@/components/ErrorPage";
 import { SizingWrapper } from "@/components/SizingWrapper";
@@ -26,14 +23,7 @@ export const ClientInformationPage = (props: {
 }) => {
   const { appID, teamID } = props;
   const [clientSecret, setClientSecret] = useState<string>("");
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamID ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamID]);
+  const editStorePerm = useTeamPermission(teamID, "edit_app_store_details");
 
   const { data, loading: fetchingAction } = useFetchSignInActionQuery({
     variables: { app_id: appID },
@@ -144,7 +134,7 @@ export const ClientInformationPage = (props: {
               <div
                 className={clsx(
                   "grid grid-cols-1fr/auto justify-items-end gap-x-3",
-                  { hidden: !isEnoughPermissions },
+                  { hidden: !editStorePerm.allowed },
                 )}
               >
                 <DecoratedButton
@@ -184,14 +174,14 @@ export const ClientInformationPage = (props: {
           teamId={teamID}
           isStaging={isStaging ?? false}
           appId={appID}
-          canEdit={isEnoughPermissions}
+          canEdit={editStorePerm.allowed}
         />
       </div>
 
       <LinksForm
         signInAction={signInAction!}
         teamId={teamID}
-        canEdit={isEnoughPermissions}
+        canEdit={editStorePerm.allowed}
       />
     </div>
   );

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/WorldId40Content.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/WorldId40Content.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import { CopyButton } from "@/components/CopyButton";
-import { DecoratedButton } from "@/components/DecoratedButton";
 import { Notification } from "@/components/Notification";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import clsx from "clsx";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "react-toastify";
 import { useRetryRpMutation } from "./graphql/client/retry-rp.generated";
+import { getRpActionRestriction, type RpMode } from "./rp-action-restrictions";
 import { RotateSignerKeyDialog } from "./RotateSignerKeyDialog";
 import { SwitchToSelfManagedDialog } from "./SwitchToSelfManagedDialog";
 
@@ -45,16 +48,18 @@ const statusConfig: Record<
 };
 
 type WorldId40ContentProps = {
+  teamId: string;
   appId: string;
   rpId: string;
   initialStatus: RpStatus;
   initialStagingStatus: RpStatus | null;
-  mode: string;
+  mode: RpMode;
   signerAddress?: string | null;
   createdAt: string;
 };
 
 export const WorldId40Content = ({
+  teamId,
   appId,
   rpId,
   initialStatus,
@@ -74,6 +79,7 @@ export const WorldId40Content = ({
   const [retryingEnvironment, setRetryingEnvironment] = useState<string | null>(
     null,
   );
+  const managePermission = useTeamPermission(teamId, "manage_world_id_4_0");
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -116,16 +122,19 @@ export const WorldId40Content = ({
         },
       });
 
-      if (data?.retry_rp?.success) {
-        // Set the retried environment to pending and resume polling
-        if (environment === "production") {
-          setProductionStatus("pending");
-        } else {
-          setStagingStatus("pending");
-        }
+      if (!data?.retry_rp?.success) {
+        toast.error("Failed to retry RP registration");
+        return;
+      }
+
+      // Set the retried environment to pending and resume polling
+      if (environment === "production") {
+        setProductionStatus("pending");
+      } else {
+        setStagingStatus("pending");
       }
     } catch {
-      // Keep current status on error
+      toast.error("Failed to retry RP registration");
     } finally {
       setRetryingEnvironment(null);
     }
@@ -133,6 +142,18 @@ export const WorldId40Content = ({
 
   // Use production status for overall "active" checks (e.g., enabling reset button)
   const isActive = productionStatus === "registered";
+  const retryRestriction = getRpActionRestriction({
+    action: "retry",
+    permission: managePermission,
+    mode,
+    isActive,
+  });
+  const manageRegisteredRpRestriction = getRpActionRestriction({
+    action: "manage_registered_rp",
+    permission: managePermission,
+    mode,
+    isActive,
+  });
 
   const formattedDate = new Date(createdAt).toLocaleDateString("en-US", {
     year: "numeric",
@@ -168,7 +189,8 @@ export const WorldId40Content = ({
             </Typography>
           </div>
           {isFailed && (
-            <DecoratedButton
+            <RestrictedButton
+              restriction={retryRestriction}
               type="button"
               variant="primary"
               className="h-8 rounded-full px-4 py-0 text-xs"
@@ -176,7 +198,7 @@ export const WorldId40Content = ({
               onClick={() => handleRetry(environment)}
             >
               {isRetrying ? "Retrying..." : "Try again"}
-            </DecoratedButton>
+            </RestrictedButton>
           )}
         </div>
       </div>
@@ -284,15 +306,15 @@ export const WorldId40Content = ({
                   This will create a new signer key and disable the existing key
                 </Typography>
               </div>
-              <DecoratedButton
+              <RestrictedButton
+                restriction={manageRegisteredRpRestriction}
                 type="button"
                 variant="secondary"
-                disabled={!isActive || mode === "self_managed"}
                 className="h-8 rounded-full px-4 py-0 text-xs"
                 onClick={() => setIsRotateDialogOpen(true)}
               >
                 Reset
-              </DecoratedButton>
+              </RestrictedButton>
             </div>
           </div>
         </div>
@@ -313,27 +335,20 @@ export const WorldId40Content = ({
                   Move this RP to a self-managed configuration
                 </Typography>
               </div>
-              <DecoratedButton
+              <RestrictedButton
+                restriction={manageRegisteredRpRestriction}
                 type="button"
                 variant="danger"
-                disabled={!isActive || mode === "self_managed"}
                 className={clsx(
                   "h-8 shrink-0 rounded-full px-4 text-[13px] font-semibold",
-                  !isActive || mode === "self_managed"
-                    ? "" // Let DecoratedButton handle disabled styles
-                    : "bg-danger text-white hover:bg-system-error-700",
+                  manageRegisteredRpRestriction.allowed
+                    ? "bg-danger text-white hover:bg-system-error-700"
+                    : "", // Let DecoratedButton handle disabled styles
                 )}
-                title={
-                  mode === "self_managed"
-                    ? "Already in self-managed mode"
-                    : !isActive
-                      ? "RP must be active to switch modes"
-                      : undefined
-                }
                 onClick={() => setIsSwitchDialogOpen(true)}
               >
                 Switch
-              </DecoratedButton>
+              </RestrictedButton>
             </div>
           </div>
         </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/index.tsx
@@ -2,6 +2,7 @@ import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { getSdk } from "./graphql/server/fetch-rp-registration.generated";
+import { type RpMode } from "./rp-action-restrictions";
 import { WorldId40Content } from "./WorldId40Content";
 
 type Props = {
@@ -12,7 +13,7 @@ type Props = {
 };
 
 export const WorldId40Page = async ({ params }: Props) => {
-  const { appId } = params;
+  const { appId, teamId } = params;
 
   const client = await getAPIServiceGraphqlClient();
   const { rp_registration } = await getSdk(client).FetchRpRegistration({
@@ -36,6 +37,7 @@ export const WorldId40Page = async ({ params }: Props) => {
 
   return (
     <WorldId40Content
+      teamId={teamId}
       appId={appId}
       rpId={rpData.rp_id}
       initialStatus={
@@ -50,7 +52,7 @@ export const WorldId40Page = async ({ params }: Props) => {
           | null
           | undefined) ?? null
       }
-      mode={rpData.mode as string}
+      mode={rpData.mode as RpMode}
       signerAddress={rpData.signer_address ?? null}
       createdAt={rpData.created_at}
     />

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/rp-action-restrictions.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/rp-action-restrictions.ts
@@ -1,0 +1,39 @@
+import type { ActionRestriction } from "@/components/RestrictedAction";
+
+export type RpMode = "managed" | "self_managed";
+
+type RpAction = "retry" | "manage_registered_rp";
+
+type GetRpActionRestrictionParams = {
+  action: RpAction;
+  permission: ActionRestriction;
+  mode: RpMode;
+  isActive: boolean;
+};
+
+export const getRpActionRestriction = ({
+  action,
+  permission,
+  mode,
+  isActive,
+}: GetRpActionRestrictionParams): ActionRestriction => {
+  if (!permission.allowed) {
+    return permission;
+  }
+
+  if (mode === "self_managed") {
+    return {
+      allowed: false,
+      message: "This RP is self-managed.",
+    };
+  }
+
+  if (action === "manage_registered_rp" && !isActive) {
+    return {
+      allowed: false,
+      message: "RP must be active to reset or switch modes.",
+    };
+  }
+
+  return permission;
+};

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Danger/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Danger/page/index.tsx
@@ -3,6 +3,8 @@
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { ActionDangerZone } from "@/components/ActionDangerZone";
 import { ErrorPage } from "@/components/ErrorPage";
+import { RestrictedAction } from "@/components/RestrictedAction";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { urls } from "@/lib/urls";
 import { useRouter } from "next/navigation";
 import { useCallback, useState, use } from "react";
@@ -23,6 +25,10 @@ export const WorldIdActionIdDangerPage = (
   const appId = params?.appId;
   const router = useRouter();
   const [isDeleting, setIsDeleting] = useState(false);
+  const deletePermission = useTeamPermission(
+    teamId ?? "",
+    "delete_world_id_action",
+  );
 
   const { data, loading, error } = useGetSingleActionV4Query({
     variables: { action_id: actionId ?? "" },
@@ -73,12 +79,16 @@ export const WorldIdActionIdDangerPage = (
       {loading ? (
         <div>Loading...</div>
       ) : (
-        <ActionDangerZone
-          actionIdentifier={action!.action}
-          onDelete={handleDelete}
-          isDeleting={isDeleting}
-          canDelete={true}
-        />
+        <RestrictedAction restriction={deletePermission} className="w-fit">
+          {({ disabled }) => (
+            <ActionDangerZone
+              actionIdentifier={action!.action}
+              onDelete={handleDelete}
+              isDeleting={isDeleting}
+              canDelete={!disabled}
+            />
+          )}
+        </RestrictedAction>
       )}
     </SizingWrapper>
   );

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/UpdateActionV4Form/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/UpdateActionV4Form/index.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { CopyButton } from "@/components/CopyButton";
-import { DecoratedButton } from "@/components/DecoratedButton";
 import { Input } from "@/components/Input";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
@@ -19,12 +20,14 @@ import { updateActionV4ServerSide } from "./server";
 type UpdateActionV4FormProps = {
   action: NonNullable<GetSingleActionV4Query["action_v4_by_pk"]>;
   appId: string;
+  teamId: string;
 };
 
 export const UpdateActionV4Form = (props: UpdateActionV4FormProps) => {
-  const { action, appId } = props;
+  const { action, appId, teamId } = props;
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const editPermission = useTeamPermission(teamId, "edit_world_id_action");
 
   const {
     control,
@@ -97,11 +100,13 @@ export const UpdateActionV4Form = (props: UpdateActionV4FormProps) => {
           errors={errors.description}
           label="Short description"
           placeholder="e.g., Vote in community polls"
+          disabled={!editPermission.allowed}
         />
       </div>
 
       <div className="flex justify-start">
-        <DecoratedButton
+        <RestrictedButton
+          restriction={editPermission}
           type="submit"
           variant="primary"
           disabled={isSubmitting || !isValid}
@@ -110,7 +115,7 @@ export const UpdateActionV4Form = (props: UpdateActionV4FormProps) => {
           <Typography variant={TYPOGRAPHY.R3}>
             {isSubmitting ? "Saving..." : "Save Changes"}
           </Typography>
-        </DecoratedButton>
+        </RestrictedButton>
       </div>
     </form>
   );

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/page/index.tsx
@@ -48,7 +48,11 @@ export const WorldIdActionIdSettingsPage = (
         {loading ? (
           <Skeleton count={4} />
         ) : (
-          <UpdateActionV4Form action={action!} appId={appId ?? ""} />
+          <UpdateActionV4Form
+            action={action!}
+            appId={appId ?? ""}
+            teamId={teamId ?? ""}
+          />
         )}
 
         {loading ? (

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/layout/index.tsx
@@ -5,11 +5,8 @@ import { ErrorPage } from "@/components/ErrorPage";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { Tab, Tabs } from "@/components/Tabs";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { urls } from "@/lib/urls";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { ReactNode, use } from "react";
 import { useGetSingleActionV4Query } from "../page/graphql/client/get-single-action-v4.generated";
 
@@ -26,7 +23,10 @@ type WorldIdActionIdLayoutProps = {
 
 export const WorldIdActionIdLayout = (props: WorldIdActionIdLayoutProps) => {
   const params = use(props.params);
-  const { user } = useUser() as Auth0SessionUser;
+  const deletePermission = useTeamPermission(
+    params.teamId ?? "",
+    "delete_world_id_action",
+  );
 
   // Fetch action data for header using user permissions
   const { data, loading } = useGetSingleActionV4Query({
@@ -58,11 +58,6 @@ export const WorldIdActionIdLayout = (props: WorldIdActionIdLayoutProps) => {
       </SizingWrapper>
     );
   }
-
-  const isEnoughPermissions = checkUserPermissions(user, params.teamId ?? "", [
-    Role_Enum.Owner,
-    Role_Enum.Admin,
-  ]);
 
   return (
     <>
@@ -112,19 +107,19 @@ export const WorldIdActionIdLayout = (props: WorldIdActionIdLayoutProps) => {
             <Typography variant={TYPOGRAPHY.R4}>Settings</Typography>
           </Tab>
 
-          {isEnoughPermissions && (
-            <Tab
-              className="md:py-4"
-              href={urls.worldIdActionDanger({
-                team_id: params.teamId ?? "",
-                app_id: params.appId ?? "",
-                action_id: params.actionId ?? "",
-              })}
-              segment={"danger"}
-            >
-              <Typography variant={TYPOGRAPHY.R4}>Danger zone</Typography>
-            </Tab>
-          )}
+          <Tab
+            className="md:py-4"
+            href={urls.worldIdActionDanger({
+              team_id: params.teamId ?? "",
+              app_id: params.appId ?? "",
+              action_id: params.actionId ?? "",
+            })}
+            segment={"danger"}
+            disabled={!deletePermission.allowed}
+            disabledReason={deletePermission.message}
+          >
+            <Typography variant={TYPOGRAPHY.R4}>Danger zone</Typography>
+          </Tab>
         </Tabs>
       </SizingWrapper>
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/ActionsListV4/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/ActionsListV4/index.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { DecoratedButton } from "@/components/DecoratedButton";
 import { SearchIcon } from "@/components/Icons/SearchIcon";
 import { Input } from "@/components/Input";
 import { Pagination } from "@/components/Pagination";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import { Section } from "@/components/Section";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import type { TeamPermission } from "@/lib/team-permissions";
 import { useEffect, useMemo, useState } from "react";
 import { ActionRowV4 } from "./ActionRowV4";
 
@@ -16,10 +17,11 @@ type ActionsListV4Props = {
   onCreateClick: () => void;
   teamId: string;
   appId: string;
+  createPermission: TeamPermission;
 };
 
 export const ActionsListV4 = (props: ActionsListV4Props) => {
-  const { actions, onCreateClick, teamId, appId } = props;
+  const { actions, onCreateClick, teamId, appId, createPermission } = props;
   const [searchQuery, setSearchQuery] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(10);
@@ -91,7 +93,8 @@ export const ActionsListV4 = (props: ActionsListV4Props) => {
           </Section.Header.Search>
 
           <Section.Header.Button className="max-md:!bottom-[4.25rem] md:row-start-1 md:items-start">
-            <DecoratedButton
+            <RestrictedButton
+              restriction={createPermission}
               type="button"
               variant="primary"
               className="h-12 w-[132px]"
@@ -102,7 +105,7 @@ export const ActionsListV4 = (props: ActionsListV4Props) => {
               <Typography variant={TYPOGRAPHY.M3} className="whitespace-nowrap">
                 New action
               </Typography>
-            </DecoratedButton>
+            </RestrictedButton>
           </Section.Header.Button>
         </Section.Header>
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page/index.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { DecoratedButton } from "@/components/DecoratedButton";
 import { UserStoryIcon } from "@/components/Icons/UserStoryIcon";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { useState } from "react";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
+import { useEffect, useRef, useState } from "react";
 import { ActionsListV4 } from "./ActionsListV4";
 import { CreateActionDialogV4 } from "./CreateActionDialogV4";
 import { useGetActionsV4Query } from "./graphql/client/get-actions-v4.generated";
@@ -14,10 +15,16 @@ type WorldIdActionsPageProps = {
   searchParams?: Record<string, string> | null | undefined;
 };
 
-export const WorldIdActionsPage = ({ params }: WorldIdActionsPageProps) => {
+export const WorldIdActionsPage = ({
+  params,
+  searchParams,
+}: WorldIdActionsPageProps) => {
   const appId = params?.appId as `app_${string}`;
   const teamId = params?.teamId ?? "";
   const [dialogOpen, setDialogOpen] = useState(false);
+  const hasAutoOpenedCreateAction = useRef(false);
+  const createPermission = useTeamPermission(teamId, "create_world_id_action");
+  const shouldAutoOpenCreateAction = searchParams?.createAction === "true";
 
   const { data, loading, error, refetch } = useGetActionsV4Query({
     variables: {
@@ -27,6 +34,17 @@ export const WorldIdActionsPage = ({ params }: WorldIdActionsPageProps) => {
   });
 
   const actions = data?.action_v4 || [];
+
+  useEffect(() => {
+    if (
+      shouldAutoOpenCreateAction &&
+      createPermission.allowed &&
+      !hasAutoOpenedCreateAction.current
+    ) {
+      setDialogOpen(true);
+      hasAutoOpenedCreateAction.current = true;
+    }
+  }, [createPermission.allowed, shouldAutoOpenCreateAction]);
 
   const handleDialogClose = async (success?: boolean) => {
     setDialogOpen(false);
@@ -79,7 +97,8 @@ export const WorldIdActionsPage = ({ params }: WorldIdActionsPageProps) => {
                 Actions are used to request uniqueness proofs
               </Typography>
             </div>
-            <DecoratedButton
+            <RestrictedButton
+              restriction={createPermission}
               variant="primary"
               type="button"
               onClick={() => setDialogOpen(true)}
@@ -87,7 +106,7 @@ export const WorldIdActionsPage = ({ params }: WorldIdActionsPageProps) => {
               aria-label="Create your first action"
             >
               <Typography variant={TYPOGRAPHY.M4}>Create</Typography>
-            </DecoratedButton>
+            </RestrictedButton>
           </div>
         </div>
       ) : (
@@ -96,6 +115,7 @@ export const WorldIdActionsPage = ({ params }: WorldIdActionsPageProps) => {
           onCreateClick={() => setDialogOpen(true)}
           teamId={teamId}
           appId={appId}
+          createPermission={createPermission}
         />
       )}
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/AppIdChrome.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/layout/AppIdChrome.tsx
@@ -41,6 +41,7 @@ export const AppIdChrome = ({
     return <>{children}</>;
   }
 
+  const teamsPath = urls.profileTeams();
   const isWorldIdSegment =
     segment === "world-id-4-0" ||
     segment === "world-id-actions" ||
@@ -109,6 +110,10 @@ export const AppIdChrome = ({
                 segment={"mini-app"}
               >
                 <Typography variant={TYPOGRAPHY.R4}>Mini App</Typography>
+              </Tab>
+
+              <Tab href={teamsPath} underlined segment={"teams"}>
+                <Typography variant={TYPOGRAPHY.R4}>Teams</Typography>
               </Tab>
             </Tabs>
           </SizingWrapper>
@@ -275,6 +280,10 @@ export const AppIdChrome = ({
               segment={"API Keys"}
             >
               <Typography variant={TYPOGRAPHY.R4}>API Keys</Typography>
+            </Tab>
+
+            <Tab href={teamsPath} underlined segment={"teams"}>
+              <Typography variant={TYPOGRAPHY.R4}>Teams</Typography>
             </Tab>
           </Tabs>
         </SizingWrapper>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/QuickActionsSection/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/QuickActionsSection/index.tsx
@@ -1,8 +1,14 @@
+"use client";
+
 import { CheckmarkBadge } from "@/components/Icons/CheckmarkBadge";
 import { MultiplePlusIcon } from "@/components/Icons/MultiplePlusIcon";
 import { QuickAction } from "@/components/QuickAction";
+import { RestrictedAction } from "@/components/RestrictedAction";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { isWorldId40Enabled, worldId40Atom } from "@/lib/feature-flags";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { urls } from "@/lib/urls";
+import { useAtomValue } from "jotai";
 
 interface QuickActionsSectionProps {
   appId: string;
@@ -13,17 +19,32 @@ export const QuickActionsSection = ({
   appId,
   teamId,
 }: QuickActionsSectionProps) => {
+  const worldId40Config = useAtomValue(worldId40Atom);
+  const showWorldId40Actions = isWorldId40Enabled(worldId40Config, teamId);
+  const createWorldIdActionPerm = useTeamPermission(
+    teamId,
+    "create_world_id_action",
+  );
+  const createActionHref = showWorldId40Actions
+    ? urls.createWorldIdAction({ team_id: teamId, app_id: appId })
+    : urls.createAction({ team_id: teamId, app_id: appId });
+
   return (
     <div className="grid gap-y-6">
       <Typography variant={TYPOGRAPHY.H7}>Quick actions</Typography>
 
       <div className="grid gap-6 lg:grid-cols-3">
-        <QuickAction
-          href={urls.createAction({ team_id: teamId, app_id: appId })}
-          icon={<MultiplePlusIcon className="size-5" />}
-          title="Create an action"
-          description="Verify users as unique humans"
-        />
+        <RestrictedAction restriction={createWorldIdActionPerm}>
+          {({ disabled }) => (
+            <QuickAction
+              href={createActionHref}
+              disabled={disabled}
+              icon={<MultiplePlusIcon className="size-5" />}
+              title="Create an action"
+              description="Verify users as unique humans"
+            />
+          )}
+        </RestrictedAction>
 
         <QuickAction
           href={urls.configuration({ team_id: teamId, app_id: appId })}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/WorldId40MigrationBanner/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/WorldId40MigrationBanner/index.tsx
@@ -6,6 +6,7 @@ import {
   isWorldId40Enabled,
   worldId40Atom,
 } from "@/lib/feature-flags/world-id-4-0/client";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { CreateAppDialogV4 } from "@/scenes/Portal/layout/CreateAppDialog/index-v4";
 import { useAtomValue } from "jotai";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -15,7 +16,6 @@ interface WorldId40MigrationBannerProps {
   teamId: string;
   appId: string;
   hasRpRegistration: boolean;
-  canRegisterRp: boolean;
   isStaging: boolean;
 }
 
@@ -23,20 +23,22 @@ export const WorldId40MigrationBanner = ({
   teamId,
   appId,
   hasRpRegistration,
-  canRegisterRp,
   isStaging,
 }: WorldId40MigrationBannerProps) => {
   const worldId40Config = useAtomValue(worldId40Atom);
   const isEnabled = isWorldId40Enabled(worldId40Config, teamId);
+  const enablePerm = useTeamPermission(teamId, "enable_world_id_4_0");
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const autoOpen = searchParams.get("enableWorldId4") === "true";
-  const [dialogOpen, setDialogOpen] = useState(autoOpen && canRegisterRp);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   useEffect(() => {
-    if (autoOpen && canRegisterRp) setDialogOpen(true);
-  }, [autoOpen, canRegisterRp]);
+    if (autoOpen && enablePerm.allowed) {
+      setDialogOpen(true);
+    }
+  }, [autoOpen, enablePerm.allowed]);
 
   const closeDialog = useCallback(() => {
     setDialogOpen(false);
@@ -54,19 +56,12 @@ export const WorldId40MigrationBanner = ({
     }
   }, [pathname, router, searchParams]);
 
-  // Don't show banner if:
-  // - World ID 4.0 is not enabled for this team, OR
-  // - App already has RP registration, OR
-  // - App is a staging app, OR
-  // - User lacks ADMIN/OWNER role (register_rp Hasura action would
-  //   reject with `unauthorized` and surface a generic toast).
-  if (!isEnabled || hasRpRegistration || isStaging || !canRegisterRp) {
+  if (!isEnabled || hasRpRegistration || isStaging || !enablePerm.allowed) {
     return null;
   }
 
   return (
     <div className="relative w-full overflow-hidden rounded-xl bg-[#E6F0FF] shadow-[0px_1px_2px_0px_rgba(11,25,40,0.08)]">
-      {/* Left side - gradient with diagonal edge (27.17deg) */}
       <div
         className="absolute inset-y-0 left-0 w-[65%] bg-gradient-to-r from-[#E6F0FF] to-[#F3F8FF]"
         style={{
@@ -75,7 +70,6 @@ export const WorldId40MigrationBanner = ({
         aria-hidden="true"
       />
 
-      {/* Content */}
       <div className="relative flex items-center justify-between p-10">
         <div className="flex flex-col gap-1">
           <Typography variant={TYPOGRAPHY.H6} className="text-gray-900">

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/index.tsx
@@ -1,10 +1,6 @@
-import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { SizingWrapper } from "@/components/SizingWrapper";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
-import { auth0 } from "@/lib/auth0";
 import { BanMessageDialog } from "../../common/BanMessageDialog";
-import { getSdk as getAppEnvSdk } from "../layout/graphql/server/fetch-app-env.generated";
+import { fetchAppEnvCached } from "../layout/server/fetch-app-env";
 import { BanStatusSection } from "./BanStatusSection";
 import { DashboardWrapper } from "./DashboardWrapper";
 import { VerificationStatusSection } from "./VerificationStatusSection";
@@ -25,17 +21,9 @@ export const AppIdPage = async (props: {
 }) => {
   const { teamId, appId } = await props.params;
 
-  const client = await getAPIServiceGraphqlClient();
-  const appEnvData = await getAppEnvSdk(client).FetchAppEnv({ id: appId });
+  const appEnvData = await fetchAppEnvCached(appId);
   const appInfo = appEnvData.app[0];
   const hasRpRegistration = (appInfo?.rp_registration?.length ?? 0) > 0;
-
-  const session = await auth0.getSession();
-  const user = session?.user as Auth0SessionUser["user"] | undefined;
-  const role = user?.hasura?.memberships?.find(
-    (m) => m.team?.id === teamId,
-  )?.role;
-  const canRegisterRp = role === Role_Enum.Owner || role === Role_Enum.Admin;
 
   return (
     <SizingWrapper className="flex flex-col gap-y-8 py-4">
@@ -43,7 +31,6 @@ export const AppIdPage = async (props: {
         teamId={teamId}
         appId={appId}
         hasRpRegistration={hasRpRegistration}
-        canRegisterRp={canRegisterRp}
         isStaging={Boolean(appInfo?.is_staging)}
       />
 

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/index.tsx
@@ -8,12 +8,10 @@ import { FetchKeysQuery } from "../../graphql/client/fetch-keys.generated";
 import { EditIcon } from "@/components/Icons/EditIcon";
 import { KeyIcon } from "@/components/Icons/KeyIcon";
 import { TrashIcon } from "@/components/Icons/TrashIcon";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { ApolloError } from "@apollo/client";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import clsx from "clsx";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "react-toastify";
 import { ApiKeySecretModal } from "../../ApiKeySecretModal";
 import { FetchKeysDocument } from "../../graphql/client/fetch-keys.generated";
@@ -32,14 +30,8 @@ export const ApiKeyRow = (props: {
   const timeAgo = formatDistanceToNowStrict(new Date(apiKey.created_at), {
     addSuffix: true,
   });
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    const membership = user?.hasura.memberships.find(
-      (m) => m.team?.id === teamId,
-    );
-    return membership?.role === Role_Enum.Owner;
-  }, [teamId, user?.hasura.memberships]);
+  const manageApiKeyPerm = useTeamPermission(teamId, "edit_api_keys");
+  const deleteApiKeyPerm = useTeamPermission(teamId, "delete_api_keys");
 
   const [resetApiKeyMutation, { loading }] = useResetApiKeyMutation();
 
@@ -162,7 +154,7 @@ export const ApiKeyRow = (props: {
           <div
             key={`api_key_${index}_5`}
             className={clsx("flex w-full justify-end", {
-              hidden: !isEnoughPermissions,
+              hidden: !manageApiKeyPerm.allowed,
             })}
           >
             <Dropdown>
@@ -191,20 +183,22 @@ export const ApiKeyRow = (props: {
                   </button>
                 </Dropdown.ListItem>
 
-                <Dropdown.ListItem asChild>
-                  <button onClick={() => openDeleteKeyModal(apiKey)}>
-                    <Dropdown.ListItemIcon
-                      className="text-system-error-600"
-                      asChild
-                    >
-                      <TrashIcon />
-                    </Dropdown.ListItemIcon>
+                {deleteApiKeyPerm.allowed && (
+                  <Dropdown.ListItem asChild>
+                    <button onClick={() => openDeleteKeyModal(apiKey)}>
+                      <Dropdown.ListItemIcon
+                        className="text-system-error-600"
+                        asChild
+                      >
+                        <TrashIcon />
+                      </Dropdown.ListItemIcon>
 
-                    <Dropdown.ListItemText className="text-system-error-600">
-                      Remove key
-                    </Dropdown.ListItemText>
-                  </button>
-                </Dropdown.ListItem>
+                      <Dropdown.ListItemText className="text-system-error-600">
+                        Remove key
+                      </Dropdown.ListItemText>
+                    </button>
+                  </Dropdown.ListItem>
+                )}
               </Dropdown.List>
             </Dropdown>
           </div>

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/index.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { DecoratedButton } from "@/components/DecoratedButton";
 import { PlusIcon } from "@/components/Icons/PlusIcon";
+import { RestrictedButton } from "@/components/RestrictedButton";
 import { Section } from "@/components/Section";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { useState, use } from "react";
 import Skeleton from "react-loading-skeleton";
 import { TeamProfile } from "../../common/TeamProfile";
@@ -19,6 +20,7 @@ export const TeamApiKeysPage = (props: TeamApiKeysPageProps) => {
   const params = use(props.params);
   const teamId = params?.teamId;
   const [showCreateKeyModal, setShowCreateKeyModal] = useState(false);
+  const createKeyPerm = useTeamPermission(teamId ?? "", "edit_api_keys");
   const { data, loading } = useFetchKeysQuery({
     variables: { teamId: teamId ?? "" },
   });
@@ -54,12 +56,13 @@ export const TeamApiKeysPage = (props: TeamApiKeysPageProps) => {
               </Typography>
             </div>
 
-            <DecoratedButton
+            <RestrictedButton
+              restriction={createKeyPerm}
               type="button"
               onClick={() => setShowCreateKeyModal(true)}
             >
               Create new key
-            </DecoratedButton>
+            </RestrictedButton>
           </div>
         ) : (
           <Section>
@@ -70,14 +73,15 @@ export const TeamApiKeysPage = (props: TeamApiKeysPageProps) => {
                 {loading ? (
                   <Skeleton width={150} />
                 ) : (
-                  <DecoratedButton
+                  <RestrictedButton
+                    restriction={createKeyPerm}
                     type="button"
                     variant="primary"
                     onClick={() => setShowCreateKeyModal(true)}
                     className="py-3"
                   >
                     <PlusIcon className="size-5" /> New key
-                  </DecoratedButton>
+                  </RestrictedButton>
                 )}
               </Section.Header.Button>
             </Section.Header>

--- a/web/scenes/Portal/Teams/TeamId/Team/layout/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/layout/index.tsx
@@ -1,9 +1,8 @@
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { Tab, Tabs } from "@/components/Tabs";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
+import { userCanPerformAction } from "@/lib/team-permissions";
 import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
 import { auth0 } from "@/lib/auth0";
 import { ReactNode } from "react";
 
@@ -20,14 +19,22 @@ export const TeamLayout = async (props: TeamLayoutProps) => {
   const params = await props.params;
   const session = await auth0.getSession();
   const user = session?.user as Auth0SessionUser["user"];
-  const ownerPermission = checkUserPermissions(user, params.teamId ?? "", [
-    Role_Enum.Owner,
-  ]);
-
-  const ownerAndAdminPermission = checkUserPermissions(
+  const ownerPermission = userCanPerformAction(
     user,
     params.teamId ?? "",
-    [Role_Enum.Owner, Role_Enum.Admin],
+    "edit_team_settings",
+  );
+
+  const ownerAndAdminPermission = userCanPerformAction(
+    user,
+    params.teamId ?? "",
+    "view_api_keys",
+  );
+
+  const deleteTeamPermission = userCanPerformAction(
+    user,
+    params.teamId ?? "",
+    "delete_team",
   );
 
   return (
@@ -75,7 +82,7 @@ export const TeamLayout = async (props: TeamLayoutProps) => {
               </Tab>
             )}
 
-            {ownerPermission && (
+            {deleteTeamPermission && (
               <Tab
                 className="md:py-4"
                 href={`/teams/${params!.teamId}/danger`}

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/EditRoleDialog/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/EditRoleDialog/index.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/Select";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { Role_Enum } from "@/graphql/graphql";
+import { TEAM_PERMISSION_ROLES } from "@/lib/team-permissions";
 import { yupResolver } from "@hookform/resolvers/yup";
 import clsx from "clsx";
 import { atom, useAtom } from "jotai";
@@ -32,8 +33,6 @@ import {
 } from "../../graphql/client/fetch-team-members.generated";
 import { permissionsDialogAtom } from "../PermissionsDialog";
 import { useEditRoleMutation } from "./graphql/client/edit-role.generated";
-
-const roles = [Role_Enum.Owner, Role_Enum.Admin, Role_Enum.Member];
 
 export const editRoleDialogAtom = atom(false);
 
@@ -60,14 +59,7 @@ export const EditRoleDialog = (props: {
   );
   const { teamId } = useParams() as { teamId: string };
 
-  const roles = useMemo(
-    () => [
-      { label: "Owner", value: Role_Enum.Owner },
-      { label: "Admin", value: Role_Enum.Admin },
-      { label: "Member", value: Role_Enum.Member },
-    ],
-    [],
-  );
+  const roles = TEAM_PERMISSION_ROLES;
 
   const defaultValues = useMemo(() => {
     if (!props.membership) {

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/Item/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/Item/index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentType } from "react";
 import clsx from "clsx";
 import { FetchTeamMembersQuery } from "../../graphql/client/fetch-team-members.generated";
 import { getNullifierName } from "@/lib/utils";
@@ -10,6 +11,10 @@ import { SendIcon } from "@/components/Icons/SendIcon";
 import { TrashIcon } from "@/components/Icons/TrashIcon";
 import { Role_Enum } from "@/graphql/graphql";
 import Skeleton from "react-loading-skeleton";
+import {
+  getMemberRowActions,
+  type MemberRowAction,
+} from "../member-row-actions";
 
 const roleName: Record<Role_Enum, string> = {
   [Role_Enum.Admin]: "Admin",
@@ -17,10 +22,20 @@ const roleName: Record<Role_Enum, string> = {
   [Role_Enum.Owner]: "Owner",
 };
 
+const actionIcon: Record<
+  MemberRowAction["key"],
+  ComponentType<{ className?: string }>
+> = {
+  edit_member_role: EditUserIcon,
+  remove_member: TrashIcon,
+  resend_invite: SendIcon,
+  cancel_invite: TrashIcon,
+};
+
 type ItemProps = {
   item?: FetchTeamMembersQuery["members"][number];
   isCurrent?: boolean;
-  isEnoughPermissions?: boolean;
+  userRole?: Role_Enum;
   onEdit?: () => void;
   onRemove?: () => void;
   onResendInvite?: () => void;
@@ -28,13 +43,20 @@ type ItemProps = {
 };
 
 export const Item = (props: ItemProps) => {
-  const { item, isCurrent, isEnoughPermissions } = props;
+  const { item, isCurrent, userRole } = props;
   const isInviteRow = item?.id.startsWith("inv_");
   const name =
     item?.user?.name ||
     item?.user?.email ||
     getNullifierName(item?.user?.world_id_nullifier) ||
     "Anonymous User";
+
+  const handlers: Record<MemberRowAction["key"], (() => void) | undefined> = {
+    edit_member_role: props.onEdit,
+    remove_member: props.onRemove,
+    resend_invite: props.onResendInvite,
+    cancel_invite: props.onCancelInvite,
+  };
 
   return (
     <div
@@ -107,67 +129,56 @@ export const Item = (props: ItemProps) => {
         ) : (
           <Dropdown>
             <Dropdown.Button
-              disabled={!isEnoughPermissions || isCurrent}
-              className={clsx("rounded-8 hover:bg-grey-100", {
-                "pointer-events-none invisible":
-                  !isEnoughPermissions || isCurrent,
-              })}
+              className="rounded-8 hover:bg-grey-100"
+              aria-label="Member actions"
             >
               <MoreVerticalIcon className="text-grey-900" />
             </Dropdown.Button>
 
-            <Dropdown.List
-              align="end"
-              heading={name} // TODO: replace heading with member card in separate task
-            >
-              {isEnoughPermissions && !isInviteRow && (
-                <Dropdown.ListItem asChild>
-                  <button onClick={props.onEdit}>
-                    <Dropdown.ListItemIcon asChild>
-                      <EditUserIcon />
-                    </Dropdown.ListItemIcon>
+            <Dropdown.List align="end" heading={name}>
+              {getMemberRowActions({
+                userRole,
+                isCurrent: Boolean(isCurrent),
+                isInviteRow: Boolean(isInviteRow),
+              }).map((action) => {
+                const Icon = actionIcon[action.key];
 
-                    <Dropdown.ListItemText>Edit role</Dropdown.ListItemText>
-                  </button>
-                </Dropdown.ListItem>
-              )}
-
-              {isEnoughPermissions && isInviteRow && (
-                <Dropdown.ListItem asChild>
-                  <button onClick={props.onResendInvite}>
-                    <Dropdown.ListItemIcon asChild>
-                      <SendIcon />
-                    </Dropdown.ListItemIcon>
-
-                    <Dropdown.ListItemText>
-                      Re-send invite
-                    </Dropdown.ListItemText>
-                  </button>
-                </Dropdown.ListItem>
-              )}
-
-              {isEnoughPermissions && (
-                <Dropdown.ListItem className="text-system-error-600" asChild>
-                  <button
-                    onClick={() =>
-                      isInviteRow
-                        ? props.onCancelInvite?.()
-                        : props.onRemove?.()
-                    }
-                  >
-                    <Dropdown.ListItemIcon
-                      className="text-system-error-600"
-                      asChild
+                if (!action.allowed) {
+                  return (
+                    <Dropdown.DisabledListItem
+                      key={action.key}
+                      icon={<Icon />}
+                      description={action.reason}
                     >
-                      <TrashIcon />
-                    </Dropdown.ListItemIcon>
+                      {action.label}
+                    </Dropdown.DisabledListItem>
+                  );
+                }
 
-                    <Dropdown.ListItemText>
-                      {isInviteRow ? "Cancel invite" : "Remove member"}
-                    </Dropdown.ListItemText>
-                  </button>
-                </Dropdown.ListItem>
-              )}
+                return (
+                  <Dropdown.ListItem
+                    key={action.key}
+                    className={
+                      action.danger ? "text-system-error-600" : undefined
+                    }
+                    asChild
+                  >
+                    <button type="button" onClick={handlers[action.key]}>
+                      <Dropdown.ListItemIcon
+                        className={
+                          action.danger ? "text-system-error-600" : undefined
+                        }
+                        asChild
+                      >
+                        <Icon />
+                      </Dropdown.ListItemIcon>
+                      <Dropdown.ListItemText>
+                        {action.label}
+                      </Dropdown.ListItemText>
+                    </button>
+                  </Dropdown.ListItem>
+                );
+              })}
             </Dropdown.List>
           </Dropdown>
         )}

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/PermissionsDialog/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/PermissionsDialog/index.tsx
@@ -8,105 +8,16 @@ import { CheckmarkCircleIcon } from "@/components/Icons/CheckmarkCircleIcon";
 import { CollapseIcon } from "@/components/Icons/CollapseIcon";
 import { ExpandIcon } from "@/components/Icons/ExpandIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
+import {
+  PERMISSION_DISPLAY_GROUPS,
+  TEAM_PERMISSION_ROLES,
+  roleHasPermission,
+} from "@/lib/team-permissions";
 import { Disclosure } from "@headlessui/react";
 import clsx from "clsx";
 import { atom, useAtom } from "jotai";
 
 export const permissionsDialogAtom = atom(false);
-
-type PermissionsConfig = Record<
-  string,
-  Record<keyof typeof Role_Enum, boolean>
->;
-
-const config: PermissionsConfig = {
-  "Create Incognito Actions": {
-    Owner: true,
-    Admin: true,
-    Member: true,
-  },
-  "Edit Incognito Actions": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "Delete incognito actions": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "View Sign in with World ID": {
-    Owner: true,
-    Admin: true,
-    Member: true,
-  },
-  "Create & Edit Sign in with World ID": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "View apps": {
-    Owner: true,
-    Admin: true,
-    Member: true,
-  },
-  "Create & Edit apps": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "Delete apps": {
-    Owner: true,
-    Admin: false,
-    Member: false,
-  },
-  "View app configuration": {
-    Owner: true,
-    Admin: true,
-    Member: true,
-  },
-  "Create & Edit app configuration": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "View API keys": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "Create & Edit API keys": {
-    Owner: true,
-    Admin: false,
-    Member: false,
-  },
-  "Delete API keys": {
-    Owner: true,
-    Admin: false,
-    Member: false,
-  },
-  "View team members & roles": {
-    Owner: true,
-    Admin: true,
-    Member: true,
-  },
-  "Invite team members": {
-    Owner: true,
-    Admin: true,
-    Member: false,
-  },
-  "Remove team members": {
-    Owner: true,
-    Admin: false,
-    Member: false,
-  },
-  "Update team roles": {
-    Owner: true,
-    Admin: false,
-    Member: false,
-  },
-};
 
 export const PermissionsDialog = () => {
   const [isOpened, setIsOpened] = useAtom(permissionsDialogAtom);
@@ -144,29 +55,35 @@ export const PermissionsDialog = () => {
               Permissions list
             </Typography>
 
-            <Typography variant={TYPOGRAPHY.M4}>Owner</Typography>
-            <Typography variant={TYPOGRAPHY.M4}>Admin</Typography>
-            <Typography variant={TYPOGRAPHY.M4}>Member</Typography>
+            {TEAM_PERMISSION_ROLES.map((role) => (
+              <Typography key={role.value} variant={TYPOGRAPHY.M4}>
+                {role.label}
+              </Typography>
+            ))}
           </div>
 
-          {Object.entries(config).map(([permission, roles], index) => (
+          {PERMISSION_DISPLAY_GROUPS.map((permission, index) => (
             <div
               className={clsx(
                 "grid grid-cols-4 items-center justify-items-center rounded-lg",
                 { "bg-grey-100": index % 2 === 0 },
               )}
-              key={permission}
+              key={permission.label}
             >
               <Typography
                 variant={TYPOGRAPHY.R4}
                 className="w-full py-3 pl-5 text-start text-grey-500"
               >
-                {permission}
+                {permission.label}
               </Typography>
 
-              {Object.entries(roles).map(([role, isAllowed]) => (
-                <Typography key={role} variant={TYPOGRAPHY.R4} className="">
-                  {isAllowed ? (
+              {TEAM_PERMISSION_ROLES.map((role) => (
+                <Typography
+                  key={role.value}
+                  variant={TYPOGRAPHY.R4}
+                  className=""
+                >
+                  {roleHasPermission(permission, role.value) ? (
                     <CheckmarkCircleIcon className="text-system-success-500" />
                   ) : (
                     ""
@@ -178,34 +95,32 @@ export const PermissionsDialog = () => {
         </div>
 
         <div className="grid w-full gap-y-4 font-gta md:hidden">
-          {["Owner", "Admin", "Member"].map((role, index) => (
-            <Disclosure key={index}>
+          {TEAM_PERMISSION_ROLES.map((role) => (
+            <Disclosure key={role.value}>
               {({ open }) => (
                 <div className="rounded-16 border border-grey-200">
                   <Disclosure.Button className="flex w-full justify-between px-5 py-4 text-18 font-medium leading-6">
-                    {role}
+                    {role.label}
 
                     {open ? <CollapseIcon /> : <ExpandIcon />}
                   </Disclosure.Button>
 
                   <Disclosure.Panel className="grid gap-y-4 px-5 pb-4">
-                    {Object.entries(config)
-                      .filter(
-                        ([_, roles]) => !!roles[role as keyof typeof Role_Enum],
-                      )
-                      .map(([permission], index) => (
-                        <div
-                          key={index}
-                          className="flex gap-x-2 text-14 leading-5"
-                        >
-                          <CheckIcon
-                            className="text-system-success-500"
-                            size="16"
-                          />
+                    {PERMISSION_DISPLAY_GROUPS.filter((permission) =>
+                      roleHasPermission(permission, role.value),
+                    ).map((permission, index) => (
+                      <div
+                        key={index}
+                        className="flex gap-x-2 text-14 leading-5"
+                      >
+                        <CheckIcon
+                          className="text-system-success-500"
+                          size="16"
+                        />
 
-                          {permission}
-                        </div>
-                      ))}
+                        {permission.label}
+                      </div>
+                    ))}
                   </Disclosure.Panel>
                 </div>
               )}

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/index.tsx
@@ -3,7 +3,8 @@ import { Pagination } from "@/components/Pagination";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { Role_Enum } from "@/graphql/graphql";
 import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
+import { roleCanPerformAction } from "@/lib/team-permissions";
+import { getUserTeamRole } from "@/lib/utils";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { useAtom } from "jotai";
 import { useParams } from "next/navigation";
@@ -41,9 +42,10 @@ export const List = (props: ListProps) => {
     FetchTeamMembersQuery["members"][number] | null
   >(null);
 
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(auth0User, teamId ?? "", [Role_Enum.Owner]);
-  }, [auth0User, teamId]);
+  const userRole = useMemo(
+    () => getUserTeamRole(auth0User, teamId),
+    [auth0User, teamId],
+  );
 
   const items = useMemo(() => {
     if (!membersRes.data) {
@@ -110,7 +112,11 @@ export const List = (props: ListProps) => {
 
   const resendInvite = useCallback(
     async (membership: FetchTeamMembersQuery["members"][number]) => {
-      if (!membership.user.email || resendMutationLoading) {
+      if (
+        !roleCanPerformAction(userRole, "resend_invite") ||
+        !membership.user.email ||
+        resendMutationLoading
+      ) {
         return;
       }
 
@@ -125,7 +131,7 @@ export const List = (props: ListProps) => {
         toast.error("Error inviting team members");
       }
     },
-    [inviteTeamMembers, resendMutationLoading, teamId],
+    [inviteTeamMembers, resendMutationLoading, teamId, userRole],
   );
 
   const [deleteInvite, { loading: deleteInviteMutationLoading }] =
@@ -137,7 +143,7 @@ export const List = (props: ListProps) => {
   const cancelInvite = useCallback(
     async (membership: FetchTeamMembersQuery["members"][number]) => {
       if (
-        !isEnoughPermissions ||
+        !roleCanPerformAction(userRole, "cancel_invite") ||
         !membership.id.startsWith("inv_") ||
         deleteInviteMutationLoading
       ) {
@@ -156,7 +162,7 @@ export const List = (props: ListProps) => {
         return toast.error("Error canceling invite");
       }
     },
-    [deleteInvite, deleteInviteMutationLoading, isEnoughPermissions],
+    [deleteInvite, deleteInviteMutationLoading, userRole],
   );
 
   const isCurrentMember = useCallback(
@@ -200,7 +206,7 @@ export const List = (props: ListProps) => {
               key={item.id}
               item={item}
               isCurrent={isCurrentMember(item)}
-              isEnoughPermissions={isEnoughPermissions}
+              userRole={userRole}
               onEdit={() => onEditUser(item)}
               onRemove={() => onRemoveUser(item)}
               onResendInvite={() => resendInvite(item)}

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/member-row-actions.ts
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/List/member-row-actions.ts
@@ -1,0 +1,64 @@
+import { Role_Enum } from "@/graphql/graphql";
+import {
+  PERMISSION_RULES,
+  roleCanPerformAction,
+  SELF_ROW_MESSAGE,
+} from "@/lib/team-permissions";
+
+export type MemberRowAction = {
+  key: "edit_member_role" | "remove_member" | "resend_invite" | "cancel_invite";
+  label: string;
+  danger: boolean;
+  allowed: boolean;
+  reason: string | null;
+};
+
+const buildAction = (
+  key: MemberRowAction["key"],
+  label: string,
+  danger: boolean,
+  userRole: Role_Enum | undefined,
+  isCurrent: boolean,
+): MemberRowAction => {
+  const hasRolePermission = roleCanPerformAction(userRole, key);
+
+  const reason = !hasRolePermission
+    ? PERMISSION_RULES[key].message
+    : isCurrent
+      ? SELF_ROW_MESSAGE
+      : null;
+
+  return {
+    key,
+    label,
+    danger,
+    allowed: hasRolePermission && !isCurrent,
+    reason,
+  };
+};
+
+export const getMemberRowActions = (params: {
+  userRole: Role_Enum | undefined;
+  isCurrent: boolean;
+  isInviteRow: boolean;
+}): MemberRowAction[] => {
+  const { userRole, isCurrent, isInviteRow } = params;
+
+  if (isInviteRow) {
+    return [
+      buildAction(
+        "resend_invite",
+        "Re-send invite",
+        false,
+        userRole,
+        isCurrent,
+      ),
+      buildAction("cancel_invite", "Cancel invite", true, userRole, isCurrent),
+    ];
+  }
+
+  return [
+    buildAction("edit_member_role", "Edit role", false, userRole, isCurrent),
+    buildAction("remove_member", "Remove member", true, userRole, isCurrent),
+  ];
+};

--- a/web/scenes/Portal/Teams/TeamId/Team/page/Members/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/page/Members/index.tsx
@@ -4,15 +4,13 @@ import { DecoratedButton } from "@/components/DecoratedButton";
 import { MagnifierIcon } from "@/components/Icons/MagnifierIcon";
 import { PlusIcon } from "@/components/Icons/PlusIcon";
 import { Input } from "@/components/Input";
+import { RestrictedButton } from "@/components/RestrictedButton";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import { Section } from "@/components/Section";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
-import { checkUserPermissions } from "@/lib/utils";
 import { FetchMeDocument } from "@/scenes/common/me-query/client/graphql/client/me-query.generated";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useAtom } from "jotai";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import Skeleton from "react-loading-skeleton";
 import * as yup from "yup";
@@ -22,6 +20,7 @@ import {
   inviteTeamMemberDialogAtom,
 } from "./InviteTeamMemberDialog";
 import { List } from "./List";
+import { permissionsDialogAtom } from "./List/PermissionsDialog";
 
 const schema = yup
   .object({
@@ -34,14 +33,8 @@ export const Members = (props: { teamId: string }) => {
   const [, setInviteTeamMemberDialogOpened] = useAtom(
     inviteTeamMemberDialogAtom,
   );
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamId]);
+  const [, setPermissionsDialogOpened] = useAtom(permissionsDialogAtom);
+  const invitePerm = useTeamPermission(teamId, "invite_member");
 
   const { register, control } = useForm({
     resolver: yupResolver(schema),
@@ -95,17 +88,28 @@ export const Members = (props: { teamId: string }) => {
           {membersRes.loading ? (
             <Skeleton className="h-12 w-[12rem] rounded-xl" />
           ) : (
-            <DecoratedButton
-              type="button"
-              onClick={() => setInviteTeamMemberDialogOpened(true)}
-              variant="primary"
-              className="min-w-[12rem] py-2.5"
-              disabled={membersRes.data && !isEnoughPermissions}
-            >
-              <PlusIcon className="size-5 md:hidden" />
-              <span className="md:hidden">New member</span>
-              <span className="max-md:hidden">Invite new member</span>
-            </DecoratedButton>
+            <div className="flex flex-col gap-2 md:flex-row">
+              <DecoratedButton
+                type="button"
+                variant="secondary"
+                className="min-w-[10rem] py-2.5"
+                onClick={() => setPermissionsDialogOpened(true)}
+              >
+                View permissions
+              </DecoratedButton>
+
+              <RestrictedButton
+                restriction={invitePerm}
+                type="button"
+                onClick={() => setInviteTeamMemberDialogOpened(true)}
+                variant="primary"
+                className="min-w-[12rem] py-2.5"
+              >
+                <PlusIcon className="size-5 md:hidden" />
+                <span className="md:hidden">New member</span>
+                <span className="max-md:hidden">Invite new member</span>
+              </RestrictedButton>
+            </div>
           )}
         </Section.Header.Button>
       </Section.Header>

--- a/web/scenes/Portal/layout/AppSelector/index.tsx
+++ b/web/scenes/Portal/layout/AppSelector/index.tsx
@@ -17,11 +17,9 @@ import { CheckmarkCircleIcon } from "@/components/Icons/CheckmarkCircleIcon";
 import { PlusCircleIcon } from "@/components/Icons/PlusCircleIcon";
 import { Placeholder } from "@/components/PlaceholderImage";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
 import { urls } from "@/lib/urls";
-import { checkUserPermissions, getCDNImageUrl } from "@/lib/utils";
-import { useUser } from "@auth0/nextjs-auth0/client";
+import { getCDNImageUrl } from "@/lib/utils";
+import { useTeamPermission } from "@/lib/team-permissions/use-team-permission";
 import clsx from "clsx";
 import { useAtom } from "jotai";
 import { useParams, useRouter } from "next/navigation";
@@ -32,14 +30,7 @@ export const AppSelector = () => {
   const router = useRouter();
   const { teamId, appId } = useParams() as { teamId?: string; appId?: string };
   const [_, setCreateAppDialogOpen] = useAtom(createAppDialogOpenedAtom);
-  const { user } = useUser() as Auth0SessionUser;
-
-  const isEnoughPermissions = useMemo(() => {
-    return checkUserPermissions(user, teamId ?? "", [
-      Role_Enum.Owner,
-      Role_Enum.Admin,
-    ]);
-  }, [user, teamId]);
+  const createAppPerm = useTeamPermission(teamId ?? "", "create_app_draft");
 
   const { data, loading, error } = useFetchAppsQuery({
     variables: { teamId: teamId! },
@@ -157,7 +148,7 @@ export const AppSelector = () => {
             )}
           </SelectOption>
         ))}
-        {isEnoughPermissions && (
+        {createAppPerm.allowed && (
           <SelectOption value={null}>
             <div className="grid grid-cols-auto/1fr/auto items-center gap-x-2">
               <PlusCircleIcon className="size-4 text-gray-500" />

--- a/web/scenes/Portal/layout/Header/index.tsx
+++ b/web/scenes/Portal/layout/Header/index.tsx
@@ -5,7 +5,6 @@ import { WorldIcon } from "@/components/Icons/WorldIcon";
 import { LoggedUserNav } from "@/components/LoggedUserNav";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { isWorldId40Enabled, worldId40Atom } from "@/lib/feature-flags";
-import { urls } from "@/lib/urls";
 import { atom, useAtom, useSetAtom } from "jotai";
 import { useParams } from "next/navigation";
 import React, { useEffect, useMemo } from "react";
@@ -21,21 +20,11 @@ export const Header = (props: { color: Color | null }) => {
   const setColor = useSetAtom(colorAtom);
   const [open, setOpen] = useAtom(createAppDialogOpenedAtom);
   const [worldId40Config] = useAtom(worldId40Atom);
-  const { teamId, appId } = useParams() as { teamId?: string; appId?: string };
+  const { teamId } = useParams() as { teamId?: string };
 
   useEffect(() => {
     setColor(props.color);
   }, [props.color, setColor]);
-
-  const logoHref = useMemo(() => {
-    if (teamId && appId) {
-      return urls.app({ team_id: teamId, app_id: appId });
-    }
-    if (teamId) {
-      return urls.teams({ team_id: teamId });
-    }
-    return "/";
-  }, [teamId, appId]);
 
   const useNewCreateAppDialog = useMemo(
     () => isWorldId40Enabled(worldId40Config, teamId),
@@ -50,7 +39,7 @@ export const Header = (props: { color: Color | null }) => {
         variant="nav"
       >
         <div className="grid grid-cols-auto/1fr gap-x-4 md:gap-x-8">
-          <Button href={logoHref}>
+          <Button href="/">
             <WorldIcon className="size-6" />
           </Button>
 

--- a/web/tests/unit/member-row-actions.test.ts
+++ b/web/tests/unit/member-row-actions.test.ts
@@ -1,0 +1,74 @@
+import { Role_Enum } from "@/graphql/graphql";
+import { getMemberRowActions } from "@/scenes/Portal/Teams/TeamId/Team/page/Members/List/member-row-actions";
+
+describe("getMemberRowActions", () => {
+  it("allows Owners to manage other member rows", () => {
+    const actions = getMemberRowActions({
+      userRole: Role_Enum.Owner,
+      isCurrent: false,
+      isInviteRow: false,
+    });
+
+    expect(actions.map((action) => action.key)).toEqual([
+      "edit_member_role",
+      "remove_member",
+    ]);
+    expect(actions.every((action) => action.allowed)).toBe(true);
+    expect(actions.every((action) => action.reason === null)).toBe(true);
+  });
+
+  it("allows Admins to manage invite rows", () => {
+    const actions = getMemberRowActions({
+      userRole: Role_Enum.Admin,
+      isCurrent: false,
+      isInviteRow: true,
+    });
+
+    expect(actions.map((action) => action.key)).toEqual([
+      "resend_invite",
+      "cancel_invite",
+    ]);
+    expect(actions.every((action) => action.allowed)).toBe(true);
+    expect(actions.every((action) => action.reason === null)).toBe(true);
+  });
+
+  it("blocks Admins from Owner-only member row actions", () => {
+    const actions = getMemberRowActions({
+      userRole: Role_Enum.Admin,
+      isCurrent: false,
+      isInviteRow: false,
+    });
+
+    expect(actions.every((action) => action.allowed === false)).toBe(true);
+    expect(
+      actions.every(
+        (action) => action.reason === "Only Owners can edit this section.",
+      ),
+    ).toBe(true);
+  });
+
+  it("uses the self-row reason only after role permission passes", () => {
+    const ownerActions = getMemberRowActions({
+      userRole: Role_Enum.Owner,
+      isCurrent: true,
+      isInviteRow: false,
+    });
+    const memberActions = getMemberRowActions({
+      userRole: Role_Enum.Member,
+      isCurrent: true,
+      isInviteRow: false,
+    });
+
+    expect(ownerActions.every((action) => action.allowed === false)).toBe(true);
+    expect(
+      ownerActions.every(
+        (action) => action.reason === "You cannot manage your own member row.",
+      ),
+    ).toBe(true);
+    expect(
+      memberActions.every(
+        (action) => action.reason === "Only Owners can edit this section.",
+      ),
+    ).toBe(true);
+  });
+});

--- a/web/tests/unit/world-id-40-restrictions.test.ts
+++ b/web/tests/unit/world-id-40-restrictions.test.ts
@@ -1,0 +1,52 @@
+import { getRpActionRestriction } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/rp-action-restrictions";
+
+const allowed = {
+  allowed: true,
+  message: "Only Owners and Admins can edit this section.",
+};
+
+const blocked = {
+  allowed: false,
+  message: "Only Owners and Admins can edit this section.",
+};
+
+describe("getRpActionRestriction", () => {
+  it("preserves permission failures before RP state checks", () => {
+    expect(
+      getRpActionRestriction({
+        action: "manage_registered_rp",
+        permission: blocked,
+        mode: "self_managed",
+        isActive: false,
+      }),
+    ).toBe(blocked);
+  });
+
+  it("blocks self-managed retries before dispatching to the server", () => {
+    expect(
+      getRpActionRestriction({
+        action: "retry",
+        permission: allowed,
+        mode: "self_managed",
+        isActive: true,
+      }),
+    ).toEqual({
+      allowed: false,
+      message: "This RP is self-managed.",
+    });
+  });
+
+  it("requires active managed RPs for reset and switch", () => {
+    expect(
+      getRpActionRestriction({
+        action: "manage_registered_rp",
+        permission: allowed,
+        mode: "managed",
+        isActive: false,
+      }),
+    ).toEqual({
+      allowed: false,
+      message: "RP must be active to reset or switch modes.",
+    });
+  });
+});


### PR DESCRIPTION
## Disable-not-hide UX for restricted team actions

Replaces role-based **hiding** with the shared permission policy across the app. Restricted controls now render **disabled with an explanatory tooltip** instead of disappearing — so users can discover a capability exists and learn who can use it.

### Scope (49 files)
- **App configuration** — AppTopBar, BasicInformation, MiniApp config, and the AppStore form sections (gating folded into the `isEditable`/`canEditStore` prop)
- **World ID 4.0** — incl. RP action restrictions (`rp-action-restrictions`)
- **World ID actions** — list, settings, danger
- **Team** — members (row actions + `PermissionsDialog` now derives rows from the policy), API keys, navigation tabs
- Nav: `LoggedUserNav`, `AppSelector`

### Verification
- `tsc --noEmit`: clean
- `jest` (17 suites): 100 passed
- `prettier --check`: clean

> The local-dev auth/flag shim used while testing locally was intentionally **excluded** from all three PRs.

---
Stacked on #1972 (which is stacked on #1971) — merge in order. Largest layer of the 3-PR stack.
