### PR TITLE
(fix): stale /apps reroute on first time account->team->app creation flow

### DIFF
--- a/web/scenes/Portal/layout/CreateAppDialog/index-v4.tsx
+++ b/web/scenes/Portal/layout/CreateAppDialog/index-v4.tsx
@@ -128,16 +128,20 @@ export const CreateAppDialogV4 = ({
         });
         return;
       }
-      const [refetched] = await refetchApps();
+      // Navigate using the id the server action returns — NOT a guess derived
+      // from refetchApps(). On staging the user-facing read can lag the insert
+      // (replica/cache), so the refetch-and-sort approach returned a stale list
+      // and left users stranded on a stale apps page with no redirect/refresh.
+      const newAppId =
+        typeof result.app_id === "string" ? result.app_id : undefined;
 
-      const latestApp = refetched.data.app.toSorted(
-        (a: any, b: any) =>
-          new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-      )[0];
+      // Keep the client-side app list (AppSelector) fresh, but do not gate
+      // navigation on it.
+      await refetchApps();
 
       posthog.capture("app_creation_successful", {
         team_id: teamId,
-        app_id: latestApp?.id,
+        app_id: newAppId,
         environment: values.build,
         engine: values.verification,
       });
@@ -147,10 +151,15 @@ export const CreateAppDialogV4 = ({
       // later, on demand, from the World ID tab — not automatically here.
       reset(defaultValues);
       props.onClose(false);
-      if (latestApp?.id) {
-        router.replace(`/teams/${teamId}/apps/${latestApp.id}`);
-        router.refresh();
-      }
+      // Always navigate + refresh. Fall back to the apps index (which
+      // server-redirects to an existing app) so the user is never stranded if
+      // the id is somehow missing.
+      router.replace(
+        newAppId
+          ? `/teams/${teamId}/apps/${newAppId}`
+          : `/teams/${teamId}/apps`,
+      );
+      router.refresh();
     },
     [defaultValues, refetchApps, reset, teamId, props, router],
   );

--- a/web/scenes/Portal/layout/CreateAppDialog/server/v4/submit.ts
+++ b/web/scenes/Portal/layout/CreateAppDialog/server/v4/submit.ts
@@ -67,6 +67,7 @@ export async function validateAndInsertAppServerSideV4(
     return {
       success: true,
       message: "App created successfully",
+      app_id: result.insert_app_one?.id,
     };
   } catch (error) {
     return errorFormAction({


### PR DESCRIPTION
## Issue
(fix) first time account creators, after clicking through to createAppDialog, would be sent to a stale /teamid/apps/ because of refetch asking for app_id[0] despite a possible lagging first write

## Fix
return the created app_id from validateAndInsertAppServerSideV4 (the insert already had insert_app_one.id, it just wasn't passed back) and navigate straight to it instead of re-querying the app list and guessing apps[0] by newest created_at. since the id comes from the same write, there's no dependency on the read replica having caught up. also moved router.refresh() out from behind the latestApp?.id guard so it always fires, with a fallback to /<teamid>/apps so a missing id can never strand the user on a stale page.