### PR TITLE
fix(apps): stop stale /apps decider after app creation

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/page/ClientPage/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/page/ClientPage/index.tsx
@@ -9,7 +9,8 @@ import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { createAppDialogOpenedAtom } from "@/scenes/Portal/layout/Header";
 import { useAtom } from "jotai";
-import { Fragment } from "react";
+import { useRouter } from "next/navigation";
+import { Fragment, useEffect } from "react";
 
 const pathButtonClassName =
   "flex h-10 w-full items-center justify-center gap-2 rounded-12 border px-4 font-gta text-sm font-medium leading-none shadow-button transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-150 md:h-11";
@@ -60,6 +61,11 @@ const PathStep = (props: {
 
 export const ClientPage = (props: { teamId: string }) => {
   const [_, setCreateAppDialogOpen] = useAtom(createAppDialogOpenedAtom);
+
+  const router = useRouter();
+  useEffect(() => {
+    router.refresh();
+  }, []);
 
   return (
     <Fragment>

--- a/web/scenes/Portal/layout/CreateAppDialog/index-v4.tsx
+++ b/web/scenes/Portal/layout/CreateAppDialog/index-v4.tsx
@@ -146,19 +146,28 @@ export const CreateAppDialogV4 = ({
         engine: values.verification,
       });
 
+      // A successful insert must return the new app's id. If it doesn't, that's
+      // a broken contract — surface it instead of dumping the user on the stale
+      // apps list, and don't reopen the form (which would create a duplicate).
+      // The app does exist, so refresh the current route to let its server
+      // render resolve it.
+      if (!newAppId) {
+        posthog.capture("app_creation_missing_app_id", { team_id: teamId });
+        toast.error("App created, but we couldn't open it. Refreshing…");
+        reset(defaultValues);
+        props.onClose(false);
+        router.refresh();
+        return;
+      }
+
       // App creation is decoupled from World ID 4.0 onboarding: send the user
       // straight to the new app's dashboard. World ID 4.0 setup is launched
       // later, on demand, from the World ID tab — not automatically here.
       reset(defaultValues);
       props.onClose(false);
-      // Always navigate + refresh. Fall back to the apps index (which
-      // server-redirects to an existing app) so the user is never stranded if
-      // the id is somehow missing.
-      router.replace(
-        newAppId
-          ? `/teams/${teamId}/apps/${newAppId}`
-          : `/teams/${teamId}/apps`,
-      );
+      // Navigate straight to the new app's own route — a fresh route with no
+      // cached decider to go stale. No fallback to the apps list.
+      router.replace(`/teams/${teamId}/apps/${newAppId}`);
       router.refresh();
     },
     [defaultValues, refetchApps, reset, teamId, props, router],


### PR DESCRIPTION
## PR Type

- [x] Bug Fix

## Description

Builds on #1975. After that fix, two distinct paths could still land a user on the cached zero-apps "decider" screen (`ClientPage`) even though their team already has an app.

**1. Manual create flow — `CreateAppDialogV4` (`index-v4.tsx`)**

The post-create navigation fell back to the bare `/teams/{teamId}/apps` list whenever the new app id was missing — and that route renders the client-cached decider, so the user landed on a stale "create your first app" screen right after creating one. This change:

- Navigates straight to the new app's own route, `/teams/{teamId}/apps/{app_id}`, using the id the server action returns — a fresh route with no cached decider to go stale.
- **Removes the `/apps` fallback entirely.**
- Fails loud on the should-never-happen missing-id case (PostHog `app_creation_missing_app_id` + toast + `router.refresh()`) instead of stranding the user on the stale list. It does **not** reopen the form, so a retry can't create a duplicate app — the app already exists, so a refresh lets the current route resolve it.

**2. MCP / back-navigation flow — `ClientPage`**

An app created out-of-band via the MCP API (or a simple back navigation) leaves a stale `ClientPage` render in Next.js's client-side Router Cache; the server `redirect()` in `AppsPage` never re-runs, so the user sees the decider despite having an app. `ClientPage` now self-heals on mount with `router.refresh()`, forcing `AppsPage` to re-render server-side and redirect to the app when one exists.

**Why two fixes:** the dialog can only fix the path it runs in. An MCP-created app is created entirely outside the portal, so no client code of ours executes until the user lands back on the apps screen — the only place to recover that path is the screen itself.

