### PR TITLE
fix(onboarding): redirected to stale /apps bceause of /apps fallback and soft router.replace in CreateAppDialog/index-v4.tsx

### DIFF
--- a/web/scenes/Portal/layout/CreateAppDialog/index-v4.tsx
+++ b/web/scenes/Portal/layout/CreateAppDialog/index-v4.tsx
@@ -154,11 +154,11 @@ export const CreateAppDialogV4 = ({
       // Always navigate + refresh. Fall back to the apps index (which
       // server-redirects to an existing app) so the user is never stranded if
       // the id is somehow missing.
-      router.replace(
-        newAppId
-          ? `/teams/${teamId}/apps/${newAppId}`
-          : `/teams/${teamId}/apps`,
-      );
+      if (newAppId) {
+        window.location.assign(`/teams/${teamId}/apps/${newAppId}`);
+      } else {
+        window.location.assign(`/teams/${teamId}`);
+      }
       router.refresh();
     },
     [defaultValues, refetchApps, reset, teamId, props, router],

--- a/web/scenes/Portal/layout/CreateAppDialog/index-v4.tsx
+++ b/web/scenes/Portal/layout/CreateAppDialog/index-v4.tsx
@@ -155,11 +155,10 @@ export const CreateAppDialogV4 = ({
       // server-redirects to an existing app) so the user is never stranded if
       // the id is somehow missing.
       if (newAppId) {
-        window.location.assign(`/teams/${teamId}/apps/${newAppId}`);
+        window.location.replace(`/teams/${teamId}/apps/${newAppId}`);
       } else {
-        window.location.assign(`/teams/${teamId}`);
+        window.location.replace(`/teams/${teamId}`);
       }
-      router.refresh();
     },
     [defaultValues, refetchApps, reset, teamId, props, router],
   );


### PR DESCRIPTION
## Issue
Users that went through the regular onboarding flow for the very first time (ClientPage->CreateAppDialog) would create app and find them at stale /teams/${teamId}/apps/ because of a soft router.replace() redirect. they would then have to hard refresh to see /teams/${teamId}/apps/${newAppId}

## Fix
deterministically route the user to their new app id page or their team home page where they can route themselves to the app they just created
```typescript
      if (newAppId) {
        window.location.replace(`/teams/${teamId}/apps/${newAppId}`);
      } else {
        window.location.replace(`/teams/${teamId}`);
      }
```