### PR TITLE
chore: add warning for signing key rotation 

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/RotateSignerKeyDialog.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/RotateSignerKeyDialog.tsx
@@ -248,6 +248,9 @@ const RotateConfigureContent = ({
           <Typography as="ul" variant={TYPOGRAPHY.S4} className="mt-0.5">
             <li>• The old signer key will stop working immediately</li>
             <li>• Update your application before rotating</li>
+            <li>
+              • It may take up to 10 minutes for the change to propagate fully
+            </li>
           </Typography>
         </div>
       </Notification>


### PR DESCRIPTION
Add a warning that signing key rotation might take 10 minutes to fully propagate. 