### PR TITLE
[codex] Add Portal v3 first-slice shell

### DIFF
--- a/web/app/(portal)/layout.tsx
+++ b/web/app/(portal)/layout.tsx
@@ -1,2 +1,5 @@
+import { renderPortalScene } from "@/lib/feature-flags/portal-v3";
 import { PortalLayout } from "@/scenes/Portal/layout";
-export default PortalLayout;
+import { PortalLayoutV3 } from "@/scenes/PortalV3/layout";
+
+export default renderPortalScene(PortalLayout, PortalLayoutV3);

--- a/web/app/(portal)/profile/layout.tsx
+++ b/web/app/(portal)/profile/layout.tsx
@@ -1,2 +1,5 @@
+import { renderPortalScene } from "@/lib/feature-flags/portal-v3";
 import { ProfileLayout } from "@/scenes/Portal/Profile/layout";
-export default ProfileLayout;
+import { ProfileLayoutV3 } from "@/scenes/PortalV3/Profile/layout";
+
+export default renderPortalScene(ProfileLayout, ProfileLayoutV3);

--- a/web/app/(portal)/teams/[teamId]/(team)/layout.tsx
+++ b/web/app/(portal)/teams/[teamId]/(team)/layout.tsx
@@ -1,2 +1,5 @@
+import { renderPortalScene } from "@/lib/feature-flags/portal-v3";
 import { TeamLayout } from "@/scenes/Portal/Teams/TeamId/Team/layout";
-export default TeamLayout;
+import { TeamLayoutV3 } from "@/scenes/PortalV3/Teams/TeamId/Team/layout";
+
+export default renderPortalScene(TeamLayout, TeamLayoutV3);

--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/layout.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/layout.tsx
@@ -1,3 +1,5 @@
+import { pickPortalComponent } from "@/lib/feature-flags/portal-v3";
+import { ActionsLayoutV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/layout";
 import { ReactNode } from "react";
 import { AppLayoutRouteParams } from "../layout-params";
 
@@ -6,7 +8,16 @@ type Props = {
   children: ReactNode;
 };
 
-export default async function Layout(props: Props) {
-  await props.params;
+const ActionsLayout = async (props: {
+  params: { teamId: string; appId: string };
+  children: ReactNode;
+}) => {
+  await Promise.resolve(props.params);
   return <>{props.children}</>;
+};
+
+export default async function Layout(props: Props) {
+  const params = await props.params;
+  const Chosen = pickPortalComponent(ActionsLayout, ActionsLayoutV3);
+  return <Chosen params={params}>{props.children}</Chosen>;
 }

--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/page.tsx
@@ -1,3 +1,4 @@
+import { renderPortalScene } from "@/lib/feature-flags/portal-v3";
 import { generateMetaTitle } from "@/lib/genarate-title";
 import { ActionsPage } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page";
 import { Metadata } from "next";
@@ -6,4 +7,4 @@ export const metadata: Metadata = {
   title: generateMetaTitle({ left: "Incognito actions" }),
 };
 
-export default ActionsPage;
+export default renderPortalScene(ActionsPage, null);

--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/layout.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/layout.tsx
@@ -1,4 +1,6 @@
+import { pickPortalComponent } from "@/lib/feature-flags/portal-v3";
 import { AppIdLayout } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout";
+import { AppIdLayoutV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout";
 import { ReactNode } from "react";
 import { AppLayoutRouteParams } from "./layout-params";
 
@@ -10,5 +12,6 @@ type Props = {
 export default async function Layout(props: Props) {
   const params = await props.params;
   const { children } = props;
-  return <AppIdLayout params={params}>{children}</AppIdLayout>;
+  const Chosen = pickPortalComponent(AppIdLayout, AppIdLayoutV3);
+  return <Chosen params={params}>{children}</Chosen>;
 }

--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/page.tsx
@@ -1,9 +1,11 @@
+import { renderPortalScene } from "@/lib/feature-flags/portal-v3";
 import { generateMetaTitle } from "@/lib/genarate-title";
-import { AppIdPage } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/page";
+import { AppIdPage as PortalV2AppIdPage } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/page";
+import { AppIdPage as PortalV3AppIdPage } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/page";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: generateMetaTitle({ left: "Dashboard" }),
 };
 
-export default AppIdPage;
+export default renderPortalScene(PortalV2AppIdPage, PortalV3AppIdPage);

--- a/web/app/(portal)/teams/[teamId]/layout.tsx
+++ b/web/app/(portal)/teams/[teamId]/layout.tsx
@@ -1,2 +1,5 @@
+import { renderPortalScene } from "@/lib/feature-flags/portal-v3";
 import { TeamIdLayout } from "@/scenes/Portal/Teams/TeamId/layout";
-export default TeamIdLayout;
+import { TeamIdLayoutV3 } from "@/scenes/PortalV3/Teams/TeamId/layout";
+
+export default renderPortalScene(TeamIdLayout, TeamIdLayoutV3);

--- a/web/lib/apps/fetch-apps-for-switcher.ts
+++ b/web/lib/apps/fetch-apps-for-switcher.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { gql, useQuery } from "@apollo/client";
+
+export type FetchAppsForSwitcherQuery = {
+  app: Array<{
+    id: string;
+    app_metadata: Array<{
+      id: string;
+      name: string;
+    }>;
+    verified_app_metadata: Array<{
+      id: string;
+      logo_img_url: string;
+    }>;
+  }>;
+};
+
+type FetchAppsForSwitcherVariables = {
+  teamId: string;
+};
+
+const FetchAppsForSwitcherDocument = gql`
+  query FetchAppsForSwitcher($teamId: String!) {
+    app(where: { team_id: { _eq: $teamId } }) {
+      id
+      app_metadata {
+        id
+        name
+      }
+      verified_app_metadata: app_metadata(
+        where: { verification_status: { _eq: "verified" } }
+      ) {
+        id
+        logo_img_url
+      }
+    }
+  }
+`;
+
+export const useFetchAppsForSwitcherQuery = (props: { teamId?: string }) =>
+  useQuery<FetchAppsForSwitcherQuery, FetchAppsForSwitcherVariables>(
+    FetchAppsForSwitcherDocument,
+    {
+      variables: { teamId: props.teamId ?? "" },
+      skip: !props.teamId,
+    },
+  );

--- a/web/lib/feature-flags/portal-v3/flag.ts
+++ b/web/lib/feature-flags/portal-v3/flag.ts
@@ -1,0 +1,4 @@
+import "server-only";
+
+export const isPortalV3Enabled = (): boolean =>
+  process.env.LOCAL_DEV_PORTAL_V3_ENABLED === "true";

--- a/web/lib/feature-flags/portal-v3/index.ts
+++ b/web/lib/feature-flags/portal-v3/index.ts
@@ -1,0 +1,8 @@
+export { isPortalV3Enabled } from "./flag";
+export {
+  getPortalV3RouteMode,
+  shouldRenderPortalV3Page,
+  shouldRenderPortalV3Shell,
+} from "./route-mode";
+export type { PortalV3RouteMode } from "./route-mode";
+export { pickPortalComponent, renderPortalScene } from "./render-portal-scene";

--- a/web/lib/feature-flags/portal-v3/render-portal-scene.tsx
+++ b/web/lib/feature-flags/portal-v3/render-portal-scene.tsx
@@ -1,0 +1,18 @@
+import { ComponentType, createElement } from "react";
+import { isPortalV3Enabled } from "./flag";
+
+export function pickPortalComponent<P>(
+  V2: ComponentType<P>,
+  V3: ComponentType<P> | null,
+): ComponentType<P> {
+  return isPortalV3Enabled() && V3 ? V3 : V2;
+}
+
+export function renderPortalScene<P extends object>(
+  V2: ComponentType<P>,
+  V3: ComponentType<P> | null,
+) {
+  return function PortalSceneChooser(props: P) {
+    return createElement(pickPortalComponent(V2, V3), props);
+  };
+}

--- a/web/lib/feature-flags/portal-v3/route-mode.ts
+++ b/web/lib/feature-flags/portal-v3/route-mode.ts
@@ -1,0 +1,63 @@
+export type PortalV3RouteMode =
+  | "v3-active"
+  | "v2-compat"
+  | "public-exempt"
+  | "redirect-alias"
+  | "unbranched";
+
+const stripQuery = (pathname: string): string => pathname.split("?")[0] ?? "";
+
+const isAppRoute = (pathname: string): boolean =>
+  /^\/teams\/[^/]+\/apps\/[^/]+(?:\/.*)?$/.test(pathname);
+
+export function getPortalV3RouteMode(
+  pathnameWithQuery: string,
+): PortalV3RouteMode {
+  const pathname = stripQuery(pathnameWithQuery).replace(/\/+$/, "") || "/";
+
+  if (pathname === "/teams" || pathname.startsWith("/api/")) {
+    return "unbranched";
+  }
+
+  if (/^\/kiosk\/[^/]+\/[^/]+$/.test(pathname)) {
+    return "public-exempt";
+  }
+
+  if (
+    /^\/teams\/[^/]+\/apps\/[^/]+\/(?:transactions\/permissions|transactions|notifications)$/.test(
+      pathname,
+    )
+  ) {
+    return "redirect-alias";
+  }
+
+  if (
+    /^\/teams\/[^/]+\/apps\/[^/]+\/(?:actions|sign-in-with-world-id)(?:\/.*)?$/.test(
+      pathname,
+    )
+  ) {
+    return "v2-compat";
+  }
+
+  if (
+    /^\/teams\/[^/]+(?:\/.*)?$/.test(pathname) ||
+    /^\/profile(?:\/.*)?$/.test(pathname)
+  ) {
+    return isAppRoute(pathname) ||
+      pathname.startsWith("/teams/") ||
+      pathname.startsWith("/profile")
+      ? "v3-active"
+      : "unbranched";
+  }
+
+  return "unbranched";
+}
+
+export function shouldRenderPortalV3Shell(pathname: string): boolean {
+  const mode = getPortalV3RouteMode(pathname);
+  return mode === "v3-active" || mode === "v2-compat";
+}
+
+export function shouldRenderPortalV3Page(pathname: string): boolean {
+  return getPortalV3RouteMode(pathname) === "v3-active";
+}

--- a/web/scenes/PortalV3/Profile/layout/index.tsx
+++ b/web/scenes/PortalV3/Profile/layout/index.tsx
@@ -1,0 +1,6 @@
+import { V3Shell } from "@/scenes/PortalV3/Shell";
+import { ReactNode } from "react";
+
+export const ProfileLayoutV3 = (props: { children: ReactNode }) => (
+  <V3Shell>{props.children}</V3Shell>
+);

--- a/web/scenes/PortalV3/Shell/AppSwitcher.tsx
+++ b/web/scenes/PortalV3/Shell/AppSwitcher.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { CaretIcon } from "@/components/Icons/CaretIcon";
+import { urls } from "@/lib/urls";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import Link from "next/link";
+
+export type AppSwitcherApp = {
+  id: string;
+  name: string;
+};
+
+export const AppSwitcher = (props: {
+  teamId: string;
+  currentAppId?: string;
+  apps: AppSwitcherApp[];
+  onCreateApp: () => void;
+}) => {
+  const currentApp = props.apps.find((app) => app.id === props.currentAppId);
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger className="flex h-9 max-w-[280px] items-center gap-2 rounded-8 border border-border bg-card px-3 font-gta text-14 font-medium text-foreground outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring">
+        <span className="truncate">{currentApp?.name ?? "Select app"}</span>
+        <CaretIcon className="size-3 shrink-0 text-muted-foreground" />
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          side="bottom"
+          align="start"
+          sideOffset={8}
+          className="z-50 min-w-[224px] rounded-12 border border-border bg-card p-1 text-foreground shadow-lg"
+        >
+          {props.apps.map((app) => (
+            <DropdownMenu.Item key={app.id} asChild>
+              <Link
+                href={urls.app({ team_id: props.teamId, app_id: app.id })}
+                className="flex rounded-8 px-2.5 py-2 font-gta text-14 outline-none data-[highlighted]:bg-muted"
+              >
+                <span className="truncate">{app.name}</span>
+              </Link>
+            </DropdownMenu.Item>
+          ))}
+          <DropdownMenu.Separator className="my-1 h-px bg-border" />
+          <DropdownMenu.Item
+            onSelect={props.onCreateApp}
+            className="cursor-pointer rounded-8 px-2.5 py-2 font-gta text-14 text-muted-foreground outline-none data-[highlighted]:bg-muted data-[highlighted]:text-foreground"
+          >
+            Create app
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+};

--- a/web/scenes/PortalV3/Shell/AppSwitcherContainer.tsx
+++ b/web/scenes/PortalV3/Shell/AppSwitcherContainer.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import {
+  FetchAppsForSwitcherQuery,
+  useFetchAppsForSwitcherQuery,
+} from "@/lib/apps/fetch-apps-for-switcher";
+import { urls } from "@/lib/urls";
+import { useParams } from "next/navigation";
+import { useMemo, useRef } from "react";
+import { AppSwitcher, AppSwitcherApp } from "./AppSwitcher";
+
+const appName = (app: FetchAppsForSwitcherQuery["app"][number]) =>
+  app.app_metadata?.[0]?.name ?? "Untitled app";
+
+export const AppSwitcherContainer = () => {
+  const { teamId, appId } = useParams() as { teamId?: string; appId?: string };
+  const lastAppIdRef = useRef<string | undefined>(appId);
+  if (appId) lastAppIdRef.current = appId;
+  const currentAppId = appId ?? lastAppIdRef.current;
+
+  const { data } = useFetchAppsForSwitcherQuery({ teamId });
+
+  const apps = useMemo<AppSwitcherApp[]>(() => {
+    const list = data?.app ?? [];
+    return [...list]
+      .map((app) => ({ id: app.id, name: appName(app) }))
+      .sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+      );
+  }, [data?.app]);
+
+  if (!teamId) return null;
+
+  return (
+    <AppSwitcher
+      teamId={teamId}
+      currentAppId={currentAppId}
+      apps={apps}
+      onCreateApp={() => {
+        window.location.assign(urls.apps({ team_id: teamId }));
+      }}
+    />
+  );
+};

--- a/web/scenes/PortalV3/Shell/NavItem.tsx
+++ b/web/scenes/PortalV3/Shell/NavItem.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import clsx from "clsx";
+import Link from "next/link";
+
+export const NavItem = (props: {
+  label: string;
+  href: string;
+  active?: boolean;
+  dimmed?: boolean;
+}) => (
+  <Link
+    href={props.href}
+    aria-current={props.active ? "page" : undefined}
+    className={clsx(
+      "flex h-9 items-center rounded-8 px-3 font-gta text-14 font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+      props.active
+        ? "bg-muted text-foreground"
+        : "text-muted-foreground hover:bg-muted hover:text-foreground",
+      props.dimmed && "pointer-events-none opacity-50",
+    )}
+  >
+    {props.label}
+  </Link>
+);

--- a/web/scenes/PortalV3/Shell/ShellFrame.tsx
+++ b/web/scenes/PortalV3/Shell/ShellFrame.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from "react";
+
+export const ShellFrame = (props: {
+  sidebar: ReactNode;
+  header: ReactNode;
+  children: ReactNode;
+}) => (
+  <div
+    data-testid="portal-v3-shell"
+    className="grid min-h-[100dvh] bg-background text-foreground"
+    style={{ gridTemplateColumns: "clamp(14rem, 17vw, 16rem) 1fr" }}
+  >
+    <aside className="sticky top-0 flex h-[100dvh] flex-col border-r border-border bg-sidebar">
+      {props.sidebar}
+    </aside>
+    <div className="flex min-w-0 flex-col">
+      <header className="flex h-14 items-center gap-3 border-b border-border px-4">
+        {props.header}
+      </header>
+      <main className="min-w-0 flex-1 overflow-auto">{props.children}</main>
+    </div>
+  </div>
+);

--- a/web/scenes/PortalV3/Shell/SidebarNav.tsx
+++ b/web/scenes/PortalV3/Shell/SidebarNav.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { urls } from "@/lib/urls";
+import { useParams, usePathname } from "next/navigation";
+import { NavItem } from "./NavItem";
+
+export const SidebarNav = (props: {
+  canSeeApiKeys: boolean;
+  canSeeSettings: boolean;
+}) => {
+  const pathname = usePathname() ?? "";
+  const params = useParams() as { teamId?: string; appId?: string };
+  const teamId = params?.teamId;
+  const appId = params?.appId;
+
+  const appBase =
+    teamId && appId ? urls.app({ team_id: teamId, app_id: appId }) : undefined;
+  const appsListHref = teamId ? urls.apps({ team_id: teamId }) : undefined;
+
+  const appItems = teamId
+    ? [
+        {
+          label: "Dashboard",
+          href: appBase ?? appsListHref ?? "#",
+          exact: Boolean(appBase),
+          dimmed: !appBase,
+        },
+        {
+          label: "World ID",
+          href: appBase
+            ? urls.worldId40({ team_id: teamId, app_id: appId! })
+            : appsListHref ?? "#",
+          dimmed: !appBase,
+        },
+        {
+          label: "Configuration",
+          href: appBase
+            ? urls.configuration({ team_id: teamId, app_id: appId! })
+            : appsListHref ?? "#",
+          dimmed: !appBase,
+        },
+        {
+          label: "Mini App",
+          href: appBase ? `${appBase}/mini-app` : appsListHref ?? "#",
+          dimmed: !appBase,
+        },
+      ]
+    : [];
+
+  const teamItems = teamId
+    ? [
+        {
+          label: "Members",
+          href: urls.teams({ team_id: teamId }),
+          exact: true,
+        },
+        ...(props.canSeeApiKeys
+          ? [{ label: "API Keys", href: `/teams/${teamId}/api-keys` }]
+          : []),
+        ...(props.canSeeSettings
+          ? [
+              {
+                label: "Settings",
+                href: urls.teamSettings({ team_id: teamId }),
+              },
+            ]
+          : []),
+      ]
+    : [];
+
+  const isActive = (href: string, exact?: boolean) =>
+    exact ? pathname === href : pathname.startsWith(href);
+
+  return (
+    <nav className="no-scrollbar flex flex-1 flex-col gap-1 overflow-y-auto p-2">
+      {appItems.map((item) => (
+        <NavItem
+          key={item.label}
+          label={item.label}
+          href={item.href}
+          active={!item.dimmed && isActive(item.href, item.exact)}
+          dimmed={item.dimmed}
+        />
+      ))}
+
+      {appItems.length > 0 && teamItems.length > 0 ? (
+        <div className="my-2 border-t border-border" />
+      ) : null}
+
+      {teamItems.map((item) => (
+        <NavItem
+          key={item.label}
+          label={item.label}
+          href={item.href}
+          active={isActive(item.href, item.exact)}
+        />
+      ))}
+    </nav>
+  );
+};

--- a/web/scenes/PortalV3/Shell/TeamSwitcher.tsx
+++ b/web/scenes/PortalV3/Shell/TeamSwitcher.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { CaretIcon } from "@/components/Icons/CaretIcon";
+import { urls } from "@/lib/urls";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import Link from "next/link";
+
+export type TeamSwitcherTeam = {
+  id: string;
+  name: string;
+};
+
+const avatarClass =
+  "flex size-6 shrink-0 items-center justify-center rounded-full bg-accent-muted font-gta text-12 font-medium uppercase text-accent";
+
+export const TeamSwitcher = (props: {
+  currentTeam: TeamSwitcherTeam;
+  teams: TeamSwitcherTeam[];
+}) => (
+  <DropdownMenu.Root>
+    <DropdownMenu.Trigger className="flex h-14 w-full items-center gap-2 border-b border-border px-3 text-left outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring">
+      <div className={avatarClass}>{props.currentTeam.name[0]}</div>
+      <span className="min-w-0 flex-1 truncate font-gta text-14 font-medium text-sidebar-foreground">
+        {props.currentTeam.name}
+      </span>
+      <CaretIcon className="size-3 shrink-0 text-muted-foreground" />
+    </DropdownMenu.Trigger>
+
+    <DropdownMenu.Portal>
+      <DropdownMenu.Content
+        side="bottom"
+        align="start"
+        sideOffset={6}
+        className="z-50 min-w-[224px] rounded-12 border border-border bg-card p-1 text-foreground shadow-lg"
+      >
+        {props.teams.map((team) => (
+          <DropdownMenu.Item key={team.id} asChild>
+            <Link
+              href={urls.teams({ team_id: team.id })}
+              className="flex items-center gap-2 rounded-8 px-2.5 py-2 font-gta text-14 outline-none data-[highlighted]:bg-muted"
+            >
+              <span className={avatarClass}>{team.name[0]}</span>
+              <span className="truncate">{team.name}</span>
+            </Link>
+          </DropdownMenu.Item>
+        ))}
+        <DropdownMenu.Separator className="my-1 h-px bg-border" />
+        <DropdownMenu.Item asChild>
+          <Link
+            href={urls.createTeam()}
+            className="flex rounded-8 px-2.5 py-2 font-gta text-14 text-muted-foreground outline-none data-[highlighted]:bg-muted data-[highlighted]:text-foreground"
+          >
+            Create team
+          </Link>
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Portal>
+  </DropdownMenu.Root>
+);

--- a/web/scenes/PortalV3/Shell/UserPopup.tsx
+++ b/web/scenes/PortalV3/Shell/UserPopup.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { CaretIcon } from "@/components/Icons/CaretIcon";
+import { DOCS_URL, FAQ_URL } from "@/lib/constants";
+import { Color } from "@/lib/calculate-color-from-string";
+import { urls } from "@/lib/urls";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import Link from "next/link";
+import { CSSProperties, ReactNode } from "react";
+
+export type PortalUser = { name: string; email?: string };
+
+const itemClass =
+  "flex cursor-pointer items-center gap-2 rounded-8 px-2.5 py-1.5 font-gta text-14 outline-none data-[highlighted]:bg-muted";
+
+const LinkItem = (props: {
+  href: string;
+  children: ReactNode;
+  external?: boolean;
+}) => (
+  <DropdownMenu.Item asChild>
+    {props.external ? (
+      <a
+        href={props.href}
+        target="_blank"
+        rel="noreferrer"
+        className={itemClass}
+      >
+        {props.children}
+      </a>
+    ) : (
+      <Link href={props.href} className={itemClass}>
+        {props.children}
+      </Link>
+    )}
+  </DropdownMenu.Item>
+);
+
+const UserAvatar = (props: { name: string; color: Color | null }) => (
+  <div
+    className="flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold uppercase"
+    style={
+      props.color
+        ? ({
+            backgroundColor: props.color[100],
+            color: props.color[500],
+          } as CSSProperties)
+        : { backgroundColor: "#e5e7eb", color: "#6b7280" }
+    }
+  >
+    {props.name[0]}
+  </div>
+);
+
+export const UserPopup = (props: { user: PortalUser; color: Color | null }) => {
+  const { user } = props;
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger className="flex w-full items-center gap-2.5 rounded-8 px-2 py-2 text-left outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring">
+        <UserAvatar name={user.name} color={props.color} />
+        <span className="min-w-0 flex-1 truncate font-gta text-14 font-medium">
+          {user.email ?? user.name}
+        </span>
+        <CaretIcon className="size-3 shrink-0 rotate-180 text-muted-foreground" />
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          side="top"
+          align="start"
+          sideOffset={8}
+          className="z-50 w-[var(--radix-dropdown-menu-trigger-width)] min-w-[224px] rounded-12 border border-border bg-card p-1 text-foreground shadow-lg"
+        >
+          {user.email ? (
+            <div className="truncate px-2.5 py-1.5 text-12 text-muted-foreground">
+              {user.email}
+            </div>
+          ) : null}
+          <LinkItem href={urls.profile()}>Profile</LinkItem>
+          <LinkItem href={urls.profileTeams()}>My Teams</LinkItem>
+          <LinkItem href={FAQ_URL} external>
+            Help
+          </LinkItem>
+          <LinkItem href={DOCS_URL} external>
+            Docs
+          </LinkItem>
+          <DropdownMenu.Separator className="my-1 h-px bg-border" />
+          <DropdownMenu.Item asChild>
+            <a href={urls.logout()} className={itemClass}>
+              Log out
+            </a>
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+};

--- a/web/scenes/PortalV3/Shell/index.tsx
+++ b/web/scenes/PortalV3/Shell/index.tsx
@@ -1,0 +1,75 @@
+import { Role_Enum } from "@/graphql/graphql";
+import {
+  Color,
+  calculateColorFromString,
+} from "@/lib/calculate-color-from-string";
+import { Auth0SessionUser } from "@/lib/types";
+import { auth0 } from "@/lib/auth0";
+import { checkUserPermissions } from "@/lib/utils";
+import { urls } from "@/lib/urls";
+import { redirect } from "next/navigation";
+import { ReactNode } from "react";
+import { AppSwitcherContainer } from "./AppSwitcherContainer";
+import { ShellFrame } from "./ShellFrame";
+import { SidebarNav } from "./SidebarNav";
+import { TeamSwitcher, TeamSwitcherTeam } from "./TeamSwitcher";
+import { UserPopup } from "./UserPopup";
+
+const toPortalTeams = (user: Auth0SessionUser["user"]): TeamSwitcherTeam[] =>
+  (user?.hasura?.memberships ?? [])
+    .map((membership) => membership.team)
+    .filter((team): team is NonNullable<typeof team> => Boolean(team?.id))
+    .map((team) => ({ id: team.id, name: team.name ?? "Untitled team" }));
+
+export const V3Shell = async (props: {
+  teamId?: string;
+  children: ReactNode;
+}) => {
+  const session = await auth0.getSession();
+  if (!session) {
+    redirect(urls.login());
+  }
+
+  const user = session.user as Auth0SessionUser["user"];
+  const color = calculateColorFromString(
+    user?.name ?? user?.email ?? user?.sid,
+  ) as Color | null;
+  const teams = toPortalTeams(user);
+  const currentTeam = teams.find((team) => team.id === props.teamId);
+
+  const canSeeApiKeys = checkUserPermissions(user, props.teamId ?? "", [
+    Role_Enum.Owner,
+    Role_Enum.Admin,
+  ]);
+  const canSeeSettings = checkUserPermissions(user, props.teamId ?? "", [
+    Role_Enum.Owner,
+  ]);
+
+  return (
+    <ShellFrame
+      header={<AppSwitcherContainer />}
+      sidebar={
+        <>
+          {currentTeam ? (
+            <TeamSwitcher currentTeam={currentTeam} teams={teams} />
+          ) : null}
+          <SidebarNav
+            canSeeApiKeys={canSeeApiKeys}
+            canSeeSettings={canSeeSettings}
+          />
+          <div className="border-t border-border p-2">
+            <UserPopup
+              color={color}
+              user={{
+                name: user?.name ?? user?.email ?? "Account",
+                email: user?.email,
+              }}
+            />
+          </div>
+        </>
+      }
+    >
+      {props.children}
+    </ShellFrame>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/layout/index.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from "react";
+
+type Params = {
+  teamId: string;
+  appId: string;
+};
+
+export const ActionsLayoutV3 = async (props: {
+  params: Params;
+  children: ReactNode;
+}) => {
+  await Promise.resolve(props.params);
+  return <>{props.children}</>;
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/index.tsx
@@ -1,0 +1,50 @@
+import { ErrorPage } from "@/components/ErrorPage";
+import { logger } from "@/lib/logger";
+import { Auth0SessionUser } from "@/lib/types";
+import { auth0 } from "@/lib/auth0";
+import { fetchAppEnvCached } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout/server/fetch-app-env";
+import { ReactNode } from "react";
+
+type Params = {
+  teamId?: string;
+  appId?: string;
+};
+
+export const AppIdLayoutV3 = async (props: {
+  params: Params;
+  children: ReactNode;
+}) => {
+  const params = props.params;
+  const session = await auth0.getSession();
+  const user = session?.user as Auth0SessionUser["user"];
+  const isTeamMember = user?.hasura?.memberships?.some(
+    (membership) => membership.team?.id === params.teamId,
+  );
+
+  if (!isTeamMember) {
+    return <ErrorPage statusCode={404} title="App not found" />;
+  }
+
+  if (params.appId) {
+    try {
+      const { app } = await fetchAppEnvCached(params.appId);
+
+      if (!app?.[0]) {
+        logger.warn("AppIdLayoutV3 could not resolve app from FetchAppEnv", {
+          appId: params.appId,
+          teamId: params.teamId,
+        });
+        return <ErrorPage statusCode={404} title="App not found" />;
+      }
+    } catch (error) {
+      logger.error("AppIdLayoutV3 FetchAppEnv failed", {
+        error,
+        appId: params.appId,
+        teamId: params.teamId,
+      });
+      return <ErrorPage statusCode={500} title="Failed to load app" />;
+    }
+  }
+
+  return <>{props.children}</>;
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/page/index.tsx
@@ -1,0 +1,137 @@
+import { AddCircleIcon } from "@/components/Icons/AddCircleIcon";
+import { CaretIcon } from "@/components/Icons/CaretIcon";
+import { CheckmarkBadge } from "@/components/Icons/CheckmarkBadge";
+import { OutgoingLinkIcon } from "@/components/Icons/OutgoingLink";
+import { urls } from "@/lib/urls";
+import { fetchAppEnvCached } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout/server/fetch-app-env";
+import Link from "next/link";
+
+const metrics = [
+  ["Impressions", "0"],
+  ["Sessions", "0"],
+  ["Users", "0"],
+  ["New users", "0"],
+];
+
+const tabs = ["Verifications", "Payments", "Notifications"];
+
+export const AppIdPage = async (props: {
+  params: Promise<{
+    teamId: string;
+    appId: string;
+  }>;
+}) => {
+  const { teamId, appId } = await props.params;
+  await fetchAppEnvCached(appId);
+
+  const quickActions = [
+    {
+      title: "Create an action",
+      description: "Verify users as unique humans",
+      href: urls.worldIdActions({ team_id: teamId, app_id: appId }),
+      icon: <AddCircleIcon className="size-5" />,
+    },
+    {
+      title: "Get your app verified",
+      description: "Verified apps get more users.",
+      href: urls.configuration({ team_id: teamId, app_id: appId }),
+      icon: <CheckmarkBadge className="size-5" />,
+    },
+  ];
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-10 px-8 py-8">
+      <section className="flex flex-col gap-8">
+        <div className="flex items-center justify-between gap-4">
+          <h1 className="font-gta text-24 font-medium text-foreground">
+            Overview
+          </h1>
+          <button
+            type="button"
+            className="flex h-10 items-center gap-3 rounded-8 border border-border bg-card px-4 font-gta text-14 font-medium text-muted-foreground"
+          >
+            Weekly
+            <CaretIcon className="size-3" />
+          </button>
+        </div>
+
+        <div className="flex flex-wrap gap-8 font-gta">
+          {metrics.map(([label, value], index) => (
+            <div key={label} className="flex items-center gap-8">
+              <div>
+                <div className="text-12 font-medium text-faint-foreground">
+                  {label}
+                </div>
+                <div className="text-24 font-medium text-foreground">
+                  {value}
+                </div>
+              </div>
+              {index < metrics.length - 1 ? (
+                <div className="h-6 w-px bg-border" />
+              ) : null}
+            </div>
+          ))}
+        </div>
+
+        <div className="flex gap-6 border-b border-border font-gta text-14 font-medium">
+          {tabs.map((tab, index) => (
+            <button
+              key={tab}
+              type="button"
+              className={
+                index === 0
+                  ? "-mb-px border-b-2 border-foreground pb-3 text-foreground"
+                  : "pb-3 text-muted-foreground"
+              }
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex min-h-[320px] items-center justify-center rounded-16 border border-border">
+          <div className="text-center font-gta">
+            <div className="text-20 font-medium text-muted-foreground">
+              No available data
+            </div>
+            <div className="mt-2 text-14 text-faint-foreground">
+              Your data will show up here
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-5">
+        <h2 className="font-gta text-18 font-medium text-foreground">
+          Quick actions
+        </h2>
+        <div className="grid max-w-[760px] grid-cols-2 gap-5">
+          {quickActions.map((action) => (
+            <Link
+              key={action.title}
+              href={action.href}
+              className="flex items-center justify-between rounded-16 border border-border p-5 outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <div className="flex min-w-0 items-center gap-4">
+                <div className="flex size-12 shrink-0 items-center justify-center rounded-full bg-accent-muted text-accent">
+                  {action.icon}
+                </div>
+                <div className="min-w-0 font-gta">
+                  <div className="truncate text-16 font-medium text-foreground">
+                    {action.title}
+                  </div>
+                  <div className="truncate text-13 text-muted-foreground">
+                    {action.description}
+                  </div>
+                </div>
+              </div>
+              <div className="flex size-7 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground">
+                <OutgoingLinkIcon className="size-4" />
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Team/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/layout/index.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from "react";
+
+export const TeamLayoutV3 = (props: { children: ReactNode }) => (
+  <>{props.children}</>
+);

--- a/web/scenes/PortalV3/Teams/TeamId/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/layout/index.tsx
@@ -1,0 +1,15 @@
+import { V3Shell } from "@/scenes/PortalV3/Shell";
+import { ReactNode } from "react";
+
+type Params = {
+  teamId?: string;
+};
+
+export const TeamIdLayoutV3 = async (props: {
+  params: Promise<Params>;
+  children: ReactNode;
+}) => {
+  const params = await props.params;
+
+  return <V3Shell teamId={params.teamId}>{props.children}</V3Shell>;
+};

--- a/web/scenes/PortalV3/layout/PortalHeaderGate.tsx
+++ b/web/scenes/PortalV3/layout/PortalHeaderGate.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { shouldRenderPortalV3Shell } from "@/lib/feature-flags/portal-v3/route-mode";
+import { usePathname } from "next/navigation";
+import { ReactNode } from "react";
+
+export const PortalHeaderGate = (props: { header: ReactNode }) => {
+  const pathname = usePathname() ?? "";
+  return shouldRenderPortalV3Shell(pathname) ? null : <>{props.header}</>;
+};

--- a/web/scenes/PortalV3/layout/index.tsx
+++ b/web/scenes/PortalV3/layout/index.tsx
@@ -1,0 +1,21 @@
+import { calculateColorFromString } from "@/lib/calculate-color-from-string";
+import { Auth0SessionUser } from "@/lib/types";
+import { auth0 } from "@/lib/auth0";
+import { Header } from "@/scenes/Portal/layout/Header";
+import { ReactNode } from "react";
+import { PortalHeaderGate } from "./PortalHeaderGate";
+
+export const PortalLayoutV3 = async (props: { children: ReactNode }) => {
+  const session = await auth0.getSession();
+  const user = session?.user as Auth0SessionUser["user"];
+  const initialColor = calculateColorFromString(
+    user?.name ?? user?.email ?? user?.sid,
+  );
+
+  return (
+    <div className="grid min-h-[100dvh] grid-rows-[auto_1fr]">
+      <PortalHeaderGate header={<Header color={initialColor} />} />
+      {props.children}
+    </div>
+  );
+};

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -75,6 +75,23 @@
   --toastify-icon-color-warning: #ff4732;
 }
 
+/* Portal v3 light semantic tokens. */
+:root {
+  --v3-background: #ffffff;
+  --v3-foreground: #191c20;
+  --v3-muted-foreground: #657080;
+  --v3-faint-foreground: #9ba3ae;
+  --v3-card: #ffffff;
+  --v3-sidebar: #fbfbfc;
+  --v3-sidebar-foreground: #191c20;
+  --v3-border: #ebecef;
+  --v3-muted: #f3f4f5;
+  --v3-accent: #4940e0;
+  --v3-accent-foreground: #ffffff;
+  --v3-accent-muted: #f0f0fd;
+  --v3-ring: #4940e0;
+}
+
 .Toastify__toast {
   border-radius: 0.75rem;
   display: flex;

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -35,6 +35,19 @@ const config: Config = {
       },
 
       colors: {
+        background: "var(--v3-background)",
+        foreground: "var(--v3-foreground)",
+        "muted-foreground": "var(--v3-muted-foreground)",
+        "faint-foreground": "var(--v3-faint-foreground)",
+        card: "var(--v3-card)",
+        sidebar: "var(--v3-sidebar)",
+        "sidebar-foreground": "var(--v3-sidebar-foreground)",
+        border: "var(--v3-border)",
+        muted: "var(--v3-muted)",
+        accent: "var(--v3-accent)",
+        "accent-foreground": "var(--v3-accent-foreground)",
+        "accent-muted": "var(--v3-accent-muted)",
+        ring: "var(--v3-ring)",
         danger: "#F2280D", // Primary danger red for delete actions
 
         blue: {

--- a/web/tests/unit/portal-v3-flag.test.ts
+++ b/web/tests/unit/portal-v3-flag.test.ts
@@ -1,0 +1,31 @@
+import { isPortalV3Enabled } from "@/lib/feature-flags/portal-v3";
+
+describe("isPortalV3Enabled", () => {
+  const previous = process.env.LOCAL_DEV_PORTAL_V3_ENABLED;
+
+  afterEach(() => {
+    if (previous === undefined) {
+      delete process.env.LOCAL_DEV_PORTAL_V3_ENABLED;
+    } else {
+      process.env.LOCAL_DEV_PORTAL_V3_ENABLED = previous;
+    }
+  });
+
+  it("is false when LOCAL_DEV_PORTAL_V3_ENABLED is unset", () => {
+    delete process.env.LOCAL_DEV_PORTAL_V3_ENABLED;
+    expect(isPortalV3Enabled()).toBe(false);
+  });
+
+  it("is true only for the exact string true", () => {
+    process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "true";
+    expect(isPortalV3Enabled()).toBe(true);
+  });
+
+  it("is false for all other values", () => {
+    process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "1";
+    expect(isPortalV3Enabled()).toBe(false);
+
+    process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "TRUE";
+    expect(isPortalV3Enabled()).toBe(false);
+  });
+});

--- a/web/tests/unit/portal-v3-portal-header-gate.test.tsx
+++ b/web/tests/unit/portal-v3-portal-header-gate.test.tsx
@@ -1,0 +1,31 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { PortalHeaderGate } from "@/scenes/PortalV3/layout/PortalHeaderGate";
+
+const Header = () => <div data-testid="v2-header">header</div>;
+
+let pathname = "/teams/team_1/apps/app_1";
+jest.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+}));
+
+describe("PortalHeaderGate", () => {
+  it("hides the v2 header for v3 shell routes", () => {
+    pathname = "/teams/team_1/apps/app_1";
+    render(<PortalHeaderGate header={<Header />} />);
+    expect(screen.queryByTestId("v2-header")).not.toBeInTheDocument();
+  });
+
+  it("keeps the v2 header for kiosk", () => {
+    pathname = "/kiosk/app_1/action_1";
+    render(<PortalHeaderGate header={<Header />} />);
+    expect(screen.getByTestId("v2-header")).toBeInTheDocument();
+  });
+
+  it("keeps the v2 header for /teams resolver", () => {
+    pathname = "/teams";
+    render(<PortalHeaderGate header={<Header />} />);
+    expect(screen.getByTestId("v2-header")).toBeInTheDocument();
+  });
+});

--- a/web/tests/unit/portal-v3-render-scene.test.tsx
+++ b/web/tests/unit/portal-v3-render-scene.test.tsx
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import {
+  pickPortalComponent,
+  renderPortalScene,
+} from "@/lib/feature-flags/portal-v3";
+
+const V2 = (props: { label?: string }) => <div>v2 {props.label}</div>;
+const V3 = (props: { label?: string }) => <div>v3 {props.label}</div>;
+
+describe("portal v3 scene chooser", () => {
+  afterEach(() => {
+    delete process.env.LOCAL_DEV_PORTAL_V3_ENABLED;
+  });
+
+  it("renders v2 when the flag is off", () => {
+    const Chosen = renderPortalScene(V2, V3);
+    render(<Chosen label="dashboard" />);
+    expect(screen.getByText("v2 dashboard")).toBeInTheDocument();
+  });
+
+  it("renders v3 when the flag is on", () => {
+    process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "true";
+    const Chosen = renderPortalScene(V2, V3);
+    render(<Chosen label="dashboard" />);
+    expect(screen.getByText("v3 dashboard")).toBeInTheDocument();
+  });
+
+  it("falls back to v2 when the v3 component is null", () => {
+    process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "true";
+    const Chosen = renderPortalScene(V2, null);
+    render(<Chosen label="actions" />);
+    expect(screen.getByText("v2 actions")).toBeInTheDocument();
+  });
+
+  it("returns the chosen component for async shims", () => {
+    process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "true";
+    expect(pickPortalComponent(V2, V3)).toBe(V3);
+    expect(pickPortalComponent(V2, null)).toBe(V2);
+    delete process.env.LOCAL_DEV_PORTAL_V3_ENABLED;
+    expect(pickPortalComponent(V2, V3)).toBe(V2);
+  });
+});

--- a/web/tests/unit/portal-v3-route-mode.test.ts
+++ b/web/tests/unit/portal-v3-route-mode.test.ts
@@ -1,0 +1,62 @@
+import {
+  getPortalV3RouteMode,
+  shouldRenderPortalV3Page,
+  shouldRenderPortalV3Shell,
+} from "@/lib/feature-flags/portal-v3/route-mode";
+
+describe("portal v3 route mode", () => {
+  it.each([
+    ["/teams/team_1", "v3-active"],
+    ["/teams/team_1/apps", "v3-active"],
+    ["/teams/team_1/apps/app_1", "v3-active"],
+    ["/teams/team_1/apps/app_1/configuration", "v3-active"],
+    ["/teams/team_1/apps/app_1/mini-app/permissions", "v3-active"],
+    ["/teams/team_1/apps/app_1/world-id-4-0", "v3-active"],
+    ["/teams/team_1/apps/app_1/world-id-actions", "v3-active"],
+    ["/profile", "v3-active"],
+    ["/profile/teams", "v3-active"],
+    ["/teams/team_1/apps/app_1/actions", "v2-compat"],
+    ["/teams/team_1/apps/app_1/actions/action_1/settings", "v2-compat"],
+    ["/teams/team_1/apps/app_1/sign-in-with-world-id", "v2-compat"],
+    [
+      "/teams/team_1/apps/app_1/sign-in-with-world-id/proof-debugging",
+      "v2-compat",
+    ],
+    ["/kiosk/app_1/action_1", "public-exempt"],
+    ["/teams/team_1/apps/app_1/transactions", "redirect-alias"],
+    ["/teams/team_1/apps/app_1/transactions/permissions", "redirect-alias"],
+    ["/teams/team_1/apps/app_1/notifications", "redirect-alias"],
+    ["/teams", "unbranched"],
+    ["/api/auth/login", "unbranched"],
+  ] as const)("classifies %s as %s", (pathname, expected) => {
+    expect(getPortalV3RouteMode(pathname)).toBe(expected);
+  });
+
+  it("ignores query strings", () => {
+    expect(
+      getPortalV3RouteMode("/teams/team_1/apps/app_1?enableWorldId4=true"),
+    ).toBe("v3-active");
+  });
+
+  it("classifies structurally without validating ids", () => {
+    expect(getPortalV3RouteMode("/teams/not-a-team/apps/not-an-app")).toBe(
+      "v3-active",
+    );
+  });
+
+  it("renders the v3 shell for active and compatibility routes only", () => {
+    expect(shouldRenderPortalV3Shell("/teams/team_1/apps/app_1")).toBe(true);
+    expect(shouldRenderPortalV3Shell("/teams/team_1/apps/app_1/actions")).toBe(
+      true,
+    );
+    expect(shouldRenderPortalV3Shell("/kiosk/app_1/action_1")).toBe(false);
+    expect(shouldRenderPortalV3Shell("/teams")).toBe(false);
+  });
+
+  it("renders v3 page bodies only for v3-active routes", () => {
+    expect(shouldRenderPortalV3Page("/teams/team_1/apps/app_1")).toBe(true);
+    expect(shouldRenderPortalV3Page("/teams/team_1/apps/app_1/actions")).toBe(
+      false,
+    );
+  });
+});

--- a/web/tests/unit/portal-v3-sidebar-nav.test.tsx
+++ b/web/tests/unit/portal-v3-sidebar-nav.test.tsx
@@ -1,0 +1,57 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { SidebarNav } from "@/scenes/PortalV3/Shell/SidebarNav";
+
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ teamId: "team_1", appId: "app_1" }),
+  usePathname: () => "/teams/team_1/apps/app_1",
+}));
+
+describe("PortalV3 SidebarNav", () => {
+  it("renders active app and team links without legacy routes", () => {
+    render(<SidebarNav canSeeApiKeys canSeeSettings />);
+
+    expect(screen.getByRole("link", { name: "Dashboard" })).toHaveAttribute(
+      "href",
+      "/teams/team_1/apps/app_1",
+    );
+    expect(screen.getByRole("link", { name: "World ID" })).toHaveAttribute(
+      "href",
+      "/teams/team_1/apps/app_1/world-id-4-0",
+    );
+    expect(screen.getByRole("link", { name: "Configuration" })).toHaveAttribute(
+      "href",
+      "/teams/team_1/apps/app_1/configuration",
+    );
+    expect(screen.getByRole("link", { name: "Mini App" })).toHaveAttribute(
+      "href",
+      "/teams/team_1/apps/app_1/mini-app",
+    );
+    expect(screen.getByRole("link", { name: "Members" })).toHaveAttribute(
+      "href",
+      "/teams/team_1",
+    );
+    expect(screen.getByRole("link", { name: "API Keys" })).toHaveAttribute(
+      "href",
+      "/teams/team_1/api-keys",
+    );
+    expect(screen.getByRole("link", { name: "Settings" })).toHaveAttribute(
+      "href",
+      "/teams/team_1/settings",
+    );
+
+    expect(screen.queryByText("Actions")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sign in with World ID")).not.toBeInTheDocument();
+  });
+
+  it("hides gated team links when permissions are false", () => {
+    render(<SidebarNav canSeeApiKeys={false} canSeeSettings={false} />);
+    expect(
+      screen.queryByRole("link", { name: "API Keys" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Settings" }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add local-only Portal v3 feature flag and route-mode helpers
- branch portal layouts/pages through the v2/v3 chooser
- add the first v3 shell/sidebar/app-switcher/dashboard slice and compatibility route handling
- add focused unit tests for flag, route modes, shell/header gating, and sidebar nav

## Scope
This PR intentionally contains only the shallow foundation slice at commit `fe25b7e0`. It does not include the staged full route mirror work in the local workspace.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:unit`
