### PR TITLE
feat(portal-v3): first-slice shell

### DIFF
--- a/web/app/(portal)/layout.tsx
+++ b/web/app/(portal)/layout.tsx
@@ -1,2 +1,5 @@
+import { renderPortalScene } from "@/lib/feature-flags/portal-v3/render-portal-scene";
 import { PortalLayout } from "@/scenes/Portal/layout";
-export default PortalLayout;
+import { PortalLayoutV3 } from "@/scenes/PortalV3/layout";
+
+export default renderPortalScene(PortalLayout, PortalLayoutV3);

--- a/web/app/(portal)/profile/layout.tsx
+++ b/web/app/(portal)/profile/layout.tsx
@@ -1,2 +1,5 @@
+import { renderPortalScene } from "@/lib/feature-flags/portal-v3/render-portal-scene";
 import { ProfileLayout } from "@/scenes/Portal/Profile/layout";
-export default ProfileLayout;
+import { ProfileLayoutV3 } from "@/scenes/PortalV3/Profile/layout";
+
+export default renderPortalScene(ProfileLayout, ProfileLayoutV3);

--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   title: generateMetaTitle({ left: "Incognito actions" }),
 };
 
-// v2-compat: V3=null renders the existing v2 ActionsPage body inside the
+// Compat route: V3=null renders the existing v2 ActionsPage body inside the
 // already-mounted v3 shell (the AppId v3 layout drops AppIdChrome). No v3
 // Actions page is created; the v3 sidebar does not link here.
 export default renderPortalScene(ActionsPage, null);

--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/page.tsx
@@ -1,3 +1,4 @@
+import { renderPortalScene } from "@/lib/feature-flags/portal-v3/render-portal-scene";
 import { generateMetaTitle } from "@/lib/genarate-title";
 import { ActionsPage } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page";
 import { Metadata } from "next";
@@ -6,4 +7,7 @@ export const metadata: Metadata = {
   title: generateMetaTitle({ left: "Incognito actions" }),
 };
 
-export default ActionsPage;
+// v2-compat: V3=null renders the existing v2 ActionsPage body inside the
+// already-mounted v3 shell (the AppId v3 layout drops AppIdChrome). No v3
+// Actions page is created; the v3 sidebar does not link here.
+export default renderPortalScene(ActionsPage, null);

--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/layout.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/layout.tsx
@@ -1,4 +1,6 @@
+import { pickPortalComponent } from "@/lib/feature-flags/portal-v3/render-portal-scene";
 import { AppIdLayout } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout";
+import { AppIdLayoutV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout";
 import { ReactNode } from "react";
 import { AppLayoutRouteParams } from "./layout-params";
 
@@ -10,5 +12,6 @@ type Props = {
 export default async function Layout(props: Props) {
   const params = await props.params;
   const { children } = props;
-  return <AppIdLayout params={params}>{children}</AppIdLayout>;
+  const C = pickPortalComponent(AppIdLayout, AppIdLayoutV3);
+  return <C params={params}>{children}</C>;
 }

--- a/web/app/(portal)/teams/[teamId]/layout.tsx
+++ b/web/app/(portal)/teams/[teamId]/layout.tsx
@@ -1,2 +1,5 @@
+import { renderPortalScene } from "@/lib/feature-flags/portal-v3/render-portal-scene";
 import { TeamIdLayout } from "@/scenes/Portal/Teams/TeamId/layout";
-export default TeamIdLayout;
+import { TeamIdLayoutV3 } from "@/scenes/PortalV3/Teams/TeamId/layout";
+
+export default renderPortalScene(TeamIdLayout, TeamIdLayoutV3);

--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -20,6 +20,15 @@ const customJestConfig: Config = {
     // data helper (scenes/.../layout/server/fetch-app-env) at the I/O boundary;
     // without it only @/api and @/lib are resolvable in jest.mock().
     "^@/scenes/(.*)$": "<rootDir>/scenes/$1",
+    // Same explicit style. Lets a test mock shared UI primitives (e.g.
+    // @/components/ErrorPage) at the I/O boundary in jest.mock(); imports are
+    // already rewritten by next/jest's transform, but jest.mock() string args
+    // resolve via this map only.
+    "^@/components/(.*)$": "<rootDir>/components/$1",
+    // @/graphql/* (generated types + enums like Role_Enum) — mockable in
+    // jest.mock() so tests can stub it without loading the GraphQL stack
+    // (which needs TextEncoder, absent in jsdom).
+    "^@/graphql/(.*)$": "<rootDir>/graphql/$1",
   },
 };
 

--- a/web/lib/feature-flags/portal-v3/flag.ts
+++ b/web/lib/feature-flags/portal-v3/flag.ts
@@ -1,0 +1,12 @@
+import "server-only";
+
+/**
+ * Local-only kill switch for Developer Portal v3.
+ *
+ * Gated on LOCAL_DEV_PORTAL_V3_ENABLED so v3 stays off in every deployed
+ * environment unless an engineer explicitly sets the var to the exact string
+ * "true" in their local shell. Any other value (unset, "1", "false", "TRUE")
+ * is treated as off — fail-safe to the v2 experience.
+ */
+export const isPortalV3Enabled = (): boolean =>
+  process.env.LOCAL_DEV_PORTAL_V3_ENABLED === "true";

--- a/web/lib/feature-flags/portal-v3/index.ts
+++ b/web/lib/feature-flags/portal-v3/index.ts
@@ -4,7 +4,6 @@ export { isPortalV3Enabled } from "./flag";
 export {
   getPortalV3RouteMode,
   shouldRenderPortalV3Shell,
-  shouldRenderPortalV3Page,
   type PortalV3RouteMode,
 } from "./route-mode";
 export { pickPortalComponent, renderPortalScene } from "./render-portal-scene";

--- a/web/lib/feature-flags/portal-v3/index.ts
+++ b/web/lib/feature-flags/portal-v3/index.ts
@@ -1,0 +1,10 @@
+// Public surface of the Portal v3 feature-flag layer. New consumers import from
+// "@/lib/feature-flags/portal-v3" rather than deep paths.
+export { isPortalV3Enabled } from "./flag";
+export {
+  getPortalV3RouteMode,
+  shouldRenderPortalV3Shell,
+  shouldRenderPortalV3Page,
+  type PortalV3RouteMode,
+} from "./route-mode";
+export { pickPortalComponent, renderPortalScene } from "./render-portal-scene";

--- a/web/lib/feature-flags/portal-v3/render-portal-scene.tsx
+++ b/web/lib/feature-flags/portal-v3/render-portal-scene.tsx
@@ -1,0 +1,35 @@
+import { createElement, type ComponentType, type JSX } from "react";
+import { isPortalV3Enabled } from "@/lib/feature-flags/portal-v3/flag";
+
+/**
+ * Pick the v3 component when the flag is on and a v3 counterpart exists,
+ * otherwise fall back to the copied v2 component.
+ *
+ * Synchronous on purpose — isPortalV3Enabled() is a plain env read — so this
+ * works in both server and client components without an await. Passing
+ * V3 = null is the v2-compat shim case: always renders v2.
+ */
+export function pickPortalComponent<P>(
+  V2: ComponentType<P>,
+  V3: ComponentType<P> | null,
+): ComponentType<P> {
+  return isPortalV3Enabled() && V3 ? V3 : V2;
+}
+
+/**
+ * Build a scene component that defers the v2/v3 choice to render time.
+ * Used as the Style-A shim default export:
+ *   export default renderPortalScene(V2Page, V3Page);
+ * A v2-compat route passes V3 = null so the v2 page renders inside the shell.
+ */
+export function renderPortalScene<P extends object>(
+  V2: ComponentType<P>,
+  V3: ComponentType<P> | null,
+): (props: P) => JSX.Element {
+  const PortalScene = (props: P) =>
+    createElement(pickPortalComponent(V2, V3), props);
+  // Named so it shows up in React DevTools / stacks instead of "Anonymous"
+  // (also satisfies the react/display-name lint rule).
+  PortalScene.displayName = "PortalScene";
+  return PortalScene;
+}

--- a/web/lib/feature-flags/portal-v3/render-portal-scene.tsx
+++ b/web/lib/feature-flags/portal-v3/render-portal-scene.tsx
@@ -7,7 +7,7 @@ import { isPortalV3Enabled } from "@/lib/feature-flags/portal-v3/flag";
  *
  * Synchronous on purpose — isPortalV3Enabled() is a plain env read — so this
  * works in both server and client components without an await. Passing
- * V3 = null is the v2-compat shim case: always renders v2.
+ * V3 = null is the compat shim case: always renders the v2 component.
  */
 export function pickPortalComponent<P>(
   V2: ComponentType<P>,
@@ -20,7 +20,7 @@ export function pickPortalComponent<P>(
  * Build a scene component that defers the v2/v3 choice to render time.
  * Used as the Style-A shim default export:
  *   export default renderPortalScene(V2Page, V3Page);
- * A v2-compat route passes V3 = null so the v2 page renders inside the shell.
+ * A compat route passes V3 = null so the v2 page renders inside the shell.
  */
 export function renderPortalScene<P extends object>(
   V2: ComponentType<P>,

--- a/web/lib/feature-flags/portal-v3/route-mode.ts
+++ b/web/lib/feature-flags/portal-v3/route-mode.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure structural router classification for Developer Portal v3.
+ *
+ * Input is ONLY the pathname. No headers, no env, no route params, and the
+ * query string is ignored. Keeping this pure means routing decisions are
+ * exhaustively unit-testable and request state can never leak into them.
+ *
+ * Branch modes:
+ *  - "v3-active"     render the v3 shell AND the v3 page
+ *  - "v2-compat"     render the v2 page body INSIDE the v3 shell
+ *  - "public-exempt" unauthenticated public surface (kiosk); never v3
+ *  - "redirect-alias" legacy path that will redirect into a v3 location
+ *  - "unbranched"    untouched (API + everything outside the branched trees)
+ */
+export type PortalV3RouteMode =
+  | "v3-active"
+  | "v2-compat"
+  | "public-exempt"
+  | "redirect-alias"
+  | "unbranched";
+
+/**
+ * Ordered, most-specific-first rules. The first match wins. The compat / alias
+ * rules MUST precede the broad /teams catch because they live under it.
+ *
+ * `[^/]+` matches a single path segment (a team id or app id) and never spans
+ * a `/`, which is what keeps `/actions` from matching `/world-id-actions`
+ * (the latter is a distinct segment and is left to the /teams v3-active rule).
+ * Trailing `(?:/|$)` anchors each rule to a full segment boundary.
+ */
+const RULES: Array<{ test: RegExp; mode: PortalV3RouteMode }> = [
+  // Public, unauthenticated kiosk — never branched into v3.
+  { test: /^\/kiosk(?:\/|$)/, mode: "public-exempt" },
+
+  // API routes are never UI-branched.
+  { test: /^\/api(?:\/|$)/, mode: "unbranched" },
+
+  // v2-compat: the v2 page body rendered inside the v3 shell.
+  // `actions` is a standalone segment — `[^/]+` cannot cross the `/` in
+  // `world-id-actions`, so this rule does NOT match /world-id-actions.
+  {
+    test: /^\/teams\/[^/]+\/apps\/[^/]+\/actions(?:\/|$)/,
+    mode: "v2-compat",
+  },
+  {
+    test: /^\/teams\/[^/]+\/apps\/[^/]+\/sign-in-with-world-id(?:\/|$)/,
+    mode: "v2-compat",
+  },
+
+  // redirect-alias: legacy paths that redirect into v3 destinations.
+  {
+    test: /^\/teams\/[^/]+\/apps\/[^/]+\/transactions(?:\/|$)/,
+    mode: "redirect-alias",
+  },
+  {
+    test: /^\/teams\/[^/]+\/apps\/[^/]+\/notifications(?:\/|$)/,
+    mode: "redirect-alias",
+  },
+
+  // v3-active: the new shell + new pages.
+  { test: /^\/teams\/[^/]+(?:\/|$)/, mode: "v3-active" },
+
+  // /profile/** (account: User profile / Teams / Danger zone) renders the v2
+  // account pages inside a minimal v3 chrome (ProfileLayoutV3 — a close-X back
+  // to the main app). Marked v3-active so the (portal) Header gate hands chrome
+  // over to that layout instead of drawing the v2 Header.
+  { test: /^\/profile(?:\/|$)/, mode: "v3-active" },
+];
+
+/**
+ * Classify a pathname into its v3 branch mode. Pure: query string is stripped
+ * before matching so `?foo=bar` can never change the result.
+ */
+export function getPortalV3RouteMode(pathname: string): PortalV3RouteMode {
+  const path = pathname.split("?")[0];
+  for (const rule of RULES) {
+    if (rule.test.test(path)) {
+      return rule.mode;
+    }
+  }
+  return "unbranched";
+}
+
+/** The v3 chrome (sidebar/team switcher/header) wraps both v3 and compat pages. */
+export function shouldRenderPortalV3Shell(pathname: string): boolean {
+  const mode = getPortalV3RouteMode(pathname);
+  return mode === "v3-active" || mode === "v2-compat";
+}
+
+/** A v3 page body is rendered only for fully-branched v3-active routes. */
+export function shouldRenderPortalV3Page(pathname: string): boolean {
+  return getPortalV3RouteMode(pathname) === "v3-active";
+}

--- a/web/lib/feature-flags/portal-v3/route-mode.ts
+++ b/web/lib/feature-flags/portal-v3/route-mode.ts
@@ -6,88 +6,43 @@
  * exhaustively unit-testable and request state can never leak into them.
  *
  * Branch modes:
- *  - "v3-active"     render the v3 shell AND the v3 page
- *  - "v2-compat"     render the v2 page body INSIDE the v3 shell
+ *  - "v3"     render the v3 shell (the page body is v2 or v3 per the
+ *                    per-route page shim; compat routes pass V3 = null)
  *  - "public-exempt" unauthenticated public surface (kiosk); never v3
- *  - "redirect-alias" legacy path that will redirect into a v3 location
- *  - "unbranched"    untouched (API + everything outside the branched trees)
+ *  - "v2"            stays on the v2 experience (API + routes outside v3)
  */
-export type PortalV3RouteMode =
-  | "v3-active"
-  | "v2-compat"
-  | "public-exempt"
-  | "redirect-alias"
-  | "unbranched";
+export type PortalV3RouteMode = "v3" | "public-exempt" | "v2";
 
 /**
- * Ordered, most-specific-first rules. The first match wins. The compat / alias
- * rules MUST precede the broad /teams catch because they live under it.
+ * Classify a pathname into its v3 branch mode by its first path segment.
  *
- * `[^/]+` matches a single path segment (a team id or app id) and never spans
- * a `/`, which is what keeps `/actions` from matching `/world-id-actions`
- * (the latter is a distinct segment and is left to the /teams v3-active rule).
- * Trailing `(?:/|$)` anchors each rule to a full segment boundary.
- */
-const RULES: Array<{ test: RegExp; mode: PortalV3RouteMode }> = [
-  // Public, unauthenticated kiosk — never branched into v3.
-  { test: /^\/kiosk(?:\/|$)/, mode: "public-exempt" },
-
-  // API routes are never UI-branched.
-  { test: /^\/api(?:\/|$)/, mode: "unbranched" },
-
-  // v2-compat: the v2 page body rendered inside the v3 shell.
-  // `actions` is a standalone segment — `[^/]+` cannot cross the `/` in
-  // `world-id-actions`, so this rule does NOT match /world-id-actions.
-  {
-    test: /^\/teams\/[^/]+\/apps\/[^/]+\/actions(?:\/|$)/,
-    mode: "v2-compat",
-  },
-  {
-    test: /^\/teams\/[^/]+\/apps\/[^/]+\/sign-in-with-world-id(?:\/|$)/,
-    mode: "v2-compat",
-  },
-
-  // redirect-alias: legacy paths that redirect into v3 destinations.
-  {
-    test: /^\/teams\/[^/]+\/apps\/[^/]+\/transactions(?:\/|$)/,
-    mode: "redirect-alias",
-  },
-  {
-    test: /^\/teams\/[^/]+\/apps\/[^/]+\/notifications(?:\/|$)/,
-    mode: "redirect-alias",
-  },
-
-  // v3-active: the new shell + new pages.
-  { test: /^\/teams\/[^/]+(?:\/|$)/, mode: "v3-active" },
-
-  // /profile/** (account: User profile / Teams / Danger zone) renders the v2
-  // account pages inside a minimal v3 chrome (ProfileLayoutV3 — a close-X back
-  // to the main app). Marked v3-active so the (portal) Header gate hands chrome
-  // over to that layout instead of drawing the v2 Header.
-  { test: /^\/profile(?:\/|$)/, mode: "v3-active" },
-];
-
-/**
- * Classify a pathname into its v3 branch mode. Pure: query string is stripped
- * before matching so `?foo=bar` can never change the result.
+ * Pure: the query string is stripped and the path is split into segments, so
+ * only the structural shape decides the mode — `?foo=bar` can never change it,
+ * and matching on a whole segment means `/kioskfoo` is NOT treated as `/kiosk`.
  */
 export function getPortalV3RouteMode(pathname: string): PortalV3RouteMode {
   const path = pathname.split("?")[0];
-  for (const rule of RULES) {
-    if (rule.test.test(path)) {
-      return rule.mode;
-    }
-  }
-  return "unbranched";
+  const [first, second] = path.split("/").filter(Boolean);
+
+  // Public, unauthenticated kiosk — never branched into v3.
+  if (first === "kiosk") return "public-exempt";
+
+  // API routes are never UI-branched.
+  if (first === "api") return "v2";
+
+  // /profile/** (account: User profile / Teams / Danger zone) renders the v2
+  // account pages inside a minimal v3 chrome (ProfileLayoutV3 — a close-X back
+  // to the main app). Marked v3 so the (portal) Header gate hands chrome over
+  // to that layout instead of drawing the v2 Header.
+  if (first === "profile") return "v3";
+
+  // A team page needs a team-id segment; the bare /teams index stays v2.
+  if (first === "teams" && second) return "v3";
+
+  return "v2";
 }
 
-/** The v3 chrome (sidebar/team switcher/header) wraps both v3 and compat pages. */
+/** The v3 chrome (sidebar/team switcher/header) wraps every v3 route. */
 export function shouldRenderPortalV3Shell(pathname: string): boolean {
-  const mode = getPortalV3RouteMode(pathname);
-  return mode === "v3-active" || mode === "v2-compat";
-}
-
-/** A v3 page body is rendered only for fully-branched v3-active routes. */
-export function shouldRenderPortalV3Page(pathname: string): boolean {
-  return getPortalV3RouteMode(pathname) === "v3-active";
+  return getPortalV3RouteMode(pathname) === "v3";
 }

--- a/web/scenes/PortalV3/Profile/layout/index.tsx
+++ b/web/scenes/PortalV3/Profile/layout/index.tsx
@@ -1,15 +1,26 @@
 import { CloseIcon } from "@/components/Icons/CloseIcon";
+import { auth0 } from "@/lib/auth0";
+import { calculateColorFromString } from "@/lib/calculate-color-from-string";
+import { Auth0SessionUser } from "@/lib/types";
+import { ColorInitializer } from "@/scenes/PortalV3/Shell/ColorInitializer";
+import { UserPopup } from "@/scenes/PortalV3/Shell/UserPopup";
 import Link from "next/link";
 import { ReactNode } from "react";
 
 /**
  * Minimal v3 chrome for the account area (/profile/**). Mirrors the v3 shell's
- * grid (left rail + content) but the rail holds ONLY a close-X — no nav, no
- * team/app switcher, no account tabs. The v2 account page renders as-is in the
- * content column. The X returns to the main app ("/" resolves a signed-in user
- * back to their team's dashboard). Used for User profile and My Teams.
+ * grid (left rail + content) but the rail holds ONLY a close-X (top) and the
+ * shared user menu (bottom) — no app nav, no team/app switcher, no account
+ * tabs. The v2 account page renders as-is in the content column. The X returns
+ * to the main app ("/" resolves a signed-in user to their team's dashboard).
  */
-export const ProfileLayoutV3 = (props: { children: ReactNode }) => {
+export const ProfileLayoutV3 = async (props: { children: ReactNode }) => {
+  const session = await auth0.getSession();
+  const user = session?.user as Auth0SessionUser["user"];
+  const color = calculateColorFromString(
+    user?.name ?? user?.email ?? user?.sid,
+  );
+
   return (
     <div
       data-testid="portal-v3-account-shell"
@@ -26,6 +37,19 @@ export const ProfileLayoutV3 = (props: { children: ReactNode }) => {
             <CloseIcon className="size-4" strokeWidth={1.5} />
           </Link>
         </div>
+
+        <ColorInitializer color={color} />
+
+        {user ? (
+          <div className="mt-auto border-t border-border p-2">
+            <UserPopup
+              user={{
+                name: user.name ?? user.email ?? "Account",
+                email: user.email,
+              }}
+            />
+          </div>
+        ) : null}
       </aside>
 
       <div className="flex min-w-0 flex-col">

--- a/web/scenes/PortalV3/Profile/layout/index.tsx
+++ b/web/scenes/PortalV3/Profile/layout/index.tsx
@@ -1,0 +1,37 @@
+import { CloseIcon } from "@/components/Icons/CloseIcon";
+import Link from "next/link";
+import { ReactNode } from "react";
+
+/**
+ * Minimal v3 chrome for the account area (/profile/**). Mirrors the v3 shell's
+ * grid (left rail + content) but the rail holds ONLY a close-X — no nav, no
+ * team/app switcher, no account tabs. The v2 account page renders as-is in the
+ * content column. The X returns to the main app ("/" resolves a signed-in user
+ * back to their team's dashboard). Used for User profile and My Teams.
+ */
+export const ProfileLayoutV3 = (props: { children: ReactNode }) => {
+  return (
+    <div
+      data-testid="portal-v3-account-shell"
+      className="grid min-h-[100dvh] bg-background text-foreground"
+      style={{ gridTemplateColumns: "clamp(4rem, 20%, 16rem) 1fr" }}
+    >
+      <aside className="sticky top-0 flex h-[100dvh] flex-col border-r border-border">
+        <div className="flex h-14 items-center border-b border-border px-3">
+          <Link
+            href="/"
+            aria-label="Back to dashboard"
+            className="flex size-8 items-center justify-center rounded-8 text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <CloseIcon className="size-4" strokeWidth={1.5} />
+          </Link>
+        </div>
+      </aside>
+
+      <div className="flex min-w-0 flex-col">
+        <div className="h-14 shrink-0 border-b border-border" />
+        <main className="min-w-0 flex-1 overflow-auto">{props.children}</main>
+      </div>
+    </div>
+  );
+};

--- a/web/scenes/PortalV3/Shell/AppSwitcher.tsx
+++ b/web/scenes/PortalV3/Shell/AppSwitcher.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { CaretIcon } from "@/components/Icons/CaretIcon";
+import { urls } from "@/lib/urls";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import clsx from "clsx";
+import { useRouter } from "next/navigation";
+
+export type AppSwitcherApp = { id: string; name: string };
+
+/**
+ * Content-header app switcher (presentational).
+ * Receives the app list as props (fetched by AppSwitcherContainer) so it stays
+ * pure and testable. No "All Apps" entry — the apps grid is reached via the
+ * team name. "Create app" routes to the grid for now (create dialog later).
+ */
+export const AppSwitcher = (props: {
+  teamId: string;
+  currentAppId?: string;
+  apps: AppSwitcherApp[];
+  onCreateApp?: () => void;
+}) => {
+  const router = useRouter();
+  const { teamId, currentAppId, apps, onCreateApp } = props;
+
+  if (apps.length === 0) {
+    return (
+      <button
+        onClick={() => onCreateApp?.()}
+        className="flex items-center gap-2 rounded-8 border border-border px-2.5 py-1.5 font-gta text-14 font-medium text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        Create app
+      </button>
+    );
+  }
+
+  const current = apps.find((app) => app.id === currentAppId);
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger className="flex items-center gap-2 rounded-8 border border-border px-2.5 py-1.5 font-gta text-14 font-medium text-foreground outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring">
+        <span className="max-w-[220px] truncate">
+          {current?.name ?? "Select app"}
+        </span>
+        <CaretIcon className="size-3 text-muted-foreground" />
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="start"
+          sideOffset={6}
+          className="z-50 max-h-[60vh] min-w-[240px] overflow-y-auto rounded-12 border border-border bg-card p-1 text-foreground shadow-lg"
+        >
+          {apps.map((app) => (
+            <DropdownMenu.Item
+              key={app.id}
+              onSelect={() =>
+                router.push(urls.app({ team_id: teamId, app_id: app.id }))
+              }
+              className={clsx(
+                "flex cursor-pointer items-center gap-3 rounded-8 px-2.5 py-1.5 font-gta text-14 outline-none data-[highlighted]:bg-muted",
+                app.id === currentAppId && "font-medium",
+              )}
+            >
+              <span className="truncate">{app.name}</span>
+            </DropdownMenu.Item>
+          ))}
+          <DropdownMenu.Separator className="my-1 h-px bg-border" />
+          <DropdownMenu.Item
+            onSelect={() => onCreateApp?.()}
+            className="flex cursor-pointer items-center gap-2 rounded-8 px-2.5 py-1.5 font-gta text-14 text-muted-foreground outline-none data-[highlighted]:bg-muted data-[highlighted]:text-foreground"
+          >
+            Create app
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+};

--- a/web/scenes/PortalV3/Shell/AppSwitcherContainer.tsx
+++ b/web/scenes/PortalV3/Shell/AppSwitcherContainer.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import {
+  FetchAppsQuery,
+  useFetchAppsQuery,
+} from "@/scenes/Portal/layout/AppSelector/graphql/client/fetch-apps.generated";
+import { CreateAppDialogV4 } from "@/scenes/Portal/layout/CreateAppDialog/index-v4";
+import { useParams } from "next/navigation";
+import { useMemo, useRef, useState } from "react";
+import { AppSwitcher, AppSwitcherApp } from "./AppSwitcher";
+
+const appName = (app: FetchAppsQuery["app"][number]) =>
+  app.app_metadata?.[0]?.name ?? "Untitled app";
+
+export const AppSwitcherContainer = () => {
+  const { teamId, appId } = useParams() as { teamId?: string; appId?: string };
+  // Keep showing the last selected app when navigating to team-scope routes
+  // (Members, API Keys, Settings) that don't have an appId in the URL.
+  const lastAppIdRef = useRef<string | undefined>(appId);
+  if (appId) lastAppIdRef.current = appId;
+  const currentAppId = appId ?? lastAppIdRef.current;
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const { data } = useFetchAppsQuery({
+    variables: { teamId: teamId! },
+    skip: !teamId,
+  });
+
+  const apps = useMemo<AppSwitcherApp[]>(() => {
+    const list = data?.app ?? [];
+    return [...list]
+      .map((app) => ({ id: app.id, name: appName(app) }))
+      .sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+      );
+  }, [data?.app]);
+
+  if (!teamId) return null;
+
+  return (
+    <>
+      <CreateAppDialogV4 open={dialogOpen} onClose={setDialogOpen} />
+      <AppSwitcher
+        teamId={teamId}
+        currentAppId={currentAppId}
+        apps={apps}
+        onCreateApp={() => setDialogOpen(true)}
+      />
+    </>
+  );
+};

--- a/web/scenes/PortalV3/Shell/ColorInitializer.tsx
+++ b/web/scenes/PortalV3/Shell/ColorInitializer.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { colorAtom } from "@/scenes/Portal/layout/color-atom";
+import { Color } from "@/scenes/Portal/Profile/types";
+import { useSetAtom } from "jotai";
+import { useEffect } from "react";
+
+export const ColorInitializer = (props: { color: Color | null }) => {
+  const setColor = useSetAtom(colorAtom);
+  useEffect(() => {
+    setColor(props.color);
+  }, [props.color, setColor]);
+  return null;
+};

--- a/web/scenes/PortalV3/Shell/NavItem.tsx
+++ b/web/scenes/PortalV3/Shell/NavItem.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
+
+export const NavItem = (props: {
+  href: string;
+  label: string;
+  icon?: ReactNode;
+  active?: boolean;
+  dimmed?: boolean;
+}) => {
+  const { href, label, icon, active, dimmed } = props;
+
+  const className = twMerge(
+    "flex min-w-0 items-center gap-2.5 rounded-8 px-2.5 py-1.5 font-gta text-14 font-medium outline-none transition-colors",
+    "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
+    active
+      ? "bg-muted text-foreground"
+      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+    dimmed && "opacity-40",
+  );
+
+  const content = (
+    <>
+      {icon ? <span className="shrink-0">{icon}</span> : null}
+      <span className="truncate">{label}</span>
+    </>
+  );
+
+  return (
+    <Link
+      href={href}
+      className={className}
+      aria-current={active ? "page" : undefined}
+    >
+      {content}
+    </Link>
+  );
+};

--- a/web/scenes/PortalV3/Shell/ShellFrame.tsx
+++ b/web/scenes/PortalV3/Shell/ShellFrame.tsx
@@ -1,0 +1,45 @@
+import { Color } from "@/scenes/Portal/Profile/types";
+import { ReactNode } from "react";
+import { ColorInitializer } from "./ColorInitializer";
+import { UserPopup } from "./UserPopup";
+
+export const ShellFrame = (props: {
+  color: Color | null;
+  user: { name: string; email?: string } | null;
+  nav: ReactNode;
+  topSlot?: ReactNode;
+  header?: ReactNode;
+  children: ReactNode;
+}) => {
+  const { color, user, nav, topSlot, header, children } = props;
+
+  return (
+    <div
+      data-testid="portal-v3-shell"
+      className="grid min-h-[100dvh] bg-background text-foreground"
+      style={{ gridTemplateColumns: "clamp(4rem, 20%, 16rem) 1fr" }}
+    >
+      <aside className="sticky top-0 flex h-[100dvh] flex-col border-r border-border bg-sidebar">
+        <ColorInitializer color={color} />
+        {topSlot ?? null}
+
+        {nav}
+
+        {user ? (
+          <div className="border-t border-border p-2">
+            <UserPopup user={{ name: user.name, email: user.email }} />
+          </div>
+        ) : null}
+      </aside>
+
+      <div className="flex min-w-0 flex-col">
+        {header ? (
+          <header className="flex h-14 items-center gap-3 border-b border-border px-4">
+            {header}
+          </header>
+        ) : null}
+        <main className="min-w-0 flex-1 overflow-auto">{children}</main>
+      </div>
+    </div>
+  );
+};

--- a/web/scenes/PortalV3/Shell/SidebarNav.tsx
+++ b/web/scenes/PortalV3/Shell/SidebarNav.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { urls } from "@/lib/urls";
+import { useParams, usePathname } from "next/navigation";
+import { NavItem } from "./NavItem";
+
+export const SidebarNav = (props: {
+  canSeeApiKeys?: boolean;
+  canSeeSettings?: boolean;
+}) => {
+  const { canSeeApiKeys = false, canSeeSettings = false } = props;
+  const pathname = usePathname() ?? "";
+  const params = useParams<{ teamId?: string; appId?: string }>();
+  const teamId = params?.teamId;
+  const appId = params?.appId;
+
+  const appBase =
+    teamId && appId ? urls.app({ team_id: teamId, app_id: appId }) : undefined;
+
+  // When no app is selected, app items still render but link to the apps
+  // resolver (urls.apps) so clicking them prompts the user to pick an app.
+  const appsListHref = teamId ? urls.apps({ team_id: teamId }) : undefined;
+
+  const appItems = teamId
+    ? [
+        {
+          label: "Dashboard",
+          href: appBase ?? appsListHref ?? "#",
+          exact: !!appBase,
+          dimmed: !appBase,
+        },
+        {
+          label: "World ID",
+          href: appBase ? `${appBase}/world-id-4-0` : appsListHref ?? "#",
+          dimmed: !appBase,
+        },
+        {
+          label: "Configuration",
+          href: appBase ? `${appBase}/configuration` : appsListHref ?? "#",
+          dimmed: !appBase,
+        },
+        {
+          label: "Mini App",
+          href: appBase ? `${appBase}/mini-app` : appsListHref ?? "#",
+          dimmed: !appBase,
+        },
+      ]
+    : [];
+
+  // Members is visible to every team member; API Keys / Settings are role-gated
+  // (the caller resolves the permissions server-side via checkUserPermissions).
+  const teamItems: { label: string; href: string; exact?: boolean }[] = teamId
+    ? [
+        { label: "Members", href: `/teams/${teamId}`, exact: true },
+        ...(canSeeApiKeys
+          ? [{ label: "API Keys", href: `/teams/${teamId}/api-keys` }]
+          : []),
+        ...(canSeeSettings
+          ? [{ label: "Settings", href: `/teams/${teamId}/settings` }]
+          : []),
+      ]
+    : [];
+
+  const isActive = (href: string, exact?: boolean) =>
+    exact ? pathname === href : pathname.startsWith(href);
+
+  return (
+    <nav className="no-scrollbar flex flex-1 flex-col gap-1 overflow-y-auto p-2">
+      {appItems.map((item) => (
+        <NavItem
+          key={item.label}
+          label={item.label}
+          href={item.href}
+          active={!item.dimmed && isActive(item.href, item.exact)}
+          dimmed={item.dimmed}
+        />
+      ))}
+      {appItems.length > 0 && teamItems.length > 0 ? (
+        <div className="my-2 border-t border-border" />
+      ) : null}
+      {teamItems.map((item) => (
+        <NavItem
+          key={item.label}
+          label={item.label}
+          href={item.href}
+          active={isActive(item.href, item.exact)}
+        />
+      ))}
+    </nav>
+  );
+};

--- a/web/scenes/PortalV3/Shell/TeamSwitcher.tsx
+++ b/web/scenes/PortalV3/Shell/TeamSwitcher.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { CaretIcon } from "@/components/Icons/CaretIcon";
+import { WorldIcon } from "@/components/Icons/WorldIcon";
+import { Placeholder } from "@/components/PlaceholderImage";
+import { urls } from "@/lib/urls";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import clsx from "clsx";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+export type SwitcherTeam = { id: string; name: string };
+
+/**
+ * Sidebar-header team switcher (presentational). Two targets, Vercel-style:
+ * clicking the team name goes to the apps grid; the chevron opens a dropdown to
+ * switch teams (or create one).
+ */
+export const TeamSwitcher = (props: {
+  currentTeam: SwitcherTeam;
+  teams: SwitcherTeam[];
+}) => {
+  const router = useRouter();
+  const { currentTeam, teams } = props;
+
+  return (
+    <div className="flex h-14 items-center gap-1 border-b border-border px-2">
+      <Link
+        href={urls.apps({ team_id: currentTeam.id })}
+        className="flex min-w-0 flex-1 items-center gap-2.5 rounded-8 p-1.5 outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <WorldIcon className="size-6 shrink-0" />
+        <span className="min-w-0 flex-1 truncate font-gta text-14 font-medium">
+          {currentTeam.name}
+        </span>
+      </Link>
+
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger
+          aria-label="Switch team"
+          className="flex size-7 shrink-0 items-center justify-center rounded-8 text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <CaretIcon className="size-3" />
+        </DropdownMenu.Trigger>
+
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            align="end"
+            sideOffset={6}
+            collisionPadding={12}
+            className="z-50 max-h-[60vh] w-[232px] overflow-y-auto rounded-12 border border-border bg-card p-1 text-foreground shadow-lg"
+          >
+            {teams.map((team) => (
+              <DropdownMenu.Item
+                key={team.id}
+                onSelect={() => router.push(urls.teams({ team_id: team.id }))}
+                className={clsx(
+                  "flex cursor-pointer items-center gap-2 rounded-8 px-2.5 py-1.5 font-gta text-14 outline-none data-[highlighted]:bg-muted",
+                  team.id === currentTeam.id && "font-medium",
+                )}
+              >
+                <Placeholder
+                  name={team.name}
+                  seed={team.id}
+                  className="size-5 shrink-0 text-xs"
+                />
+                <span className="truncate">{team.name}</span>
+              </DropdownMenu.Item>
+            ))}
+            <DropdownMenu.Separator className="my-1 h-px bg-border" />
+            <DropdownMenu.Item
+              onSelect={() => router.push(urls.createTeam())}
+              className="flex cursor-pointer items-center gap-2 rounded-8 px-2.5 py-1.5 font-gta text-14 text-muted-foreground outline-none data-[highlighted]:bg-muted data-[highlighted]:text-foreground"
+            >
+              Create team
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+    </div>
+  );
+};

--- a/web/scenes/PortalV3/Shell/UserPopup.tsx
+++ b/web/scenes/PortalV3/Shell/UserPopup.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { CaretIcon } from "@/components/Icons/CaretIcon";
+import {
+  DISCORD_URL,
+  DOCS_URL,
+  FAQ_URL,
+  TELEGRAM_DEVELOPERS_GROUP_URL,
+  TELEGRAM_MATEO_URL,
+  WORLD_PRIVACY_URL,
+  WORLD_STATUS_URL,
+} from "@/lib/constants";
+import { urls } from "@/lib/urls";
+import { colorAtom } from "@/scenes/Portal/layout/color-atom";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { useAtomValue } from "jotai";
+import Link from "next/link";
+import { CSSProperties, ReactNode } from "react";
+
+export type PortalUser = { name: string; email?: string };
+
+const itemClass =
+  "flex cursor-pointer items-center gap-2 rounded-8 px-2.5 py-1.5 font-gta text-14 outline-none data-[highlighted]:bg-muted";
+
+const LinkItem = (props: {
+  href: string;
+  children: ReactNode;
+  external?: boolean;
+}) => (
+  <DropdownMenu.Item asChild>
+    {props.external ? (
+      <a
+        href={props.href}
+        target="_blank"
+        rel="noreferrer"
+        className={itemClass}
+      >
+        {props.children}
+      </a>
+    ) : (
+      <Link href={props.href} className={itemClass}>
+        {props.children}
+      </Link>
+    )}
+  </DropdownMenu.Item>
+);
+
+const SectionHeader = (props: { children: ReactNode }) => (
+  <DropdownMenu.Label className="px-2.5 pb-1 pt-2 font-gta text-12 text-muted-foreground">
+    {props.children}
+  </DropdownMenu.Label>
+);
+
+const Separator = () => (
+  <DropdownMenu.Separator className="my-1 h-px bg-border" />
+);
+
+/**
+ * Bottom-left user popup (presentational): Profile · My Teams · the help menu
+ * (mirrored from the main repo's <Help />: support · community · references) ·
+ * Docs · Log out.
+ */
+const UserAvatar = (props: { name: string }) => {
+  const color = useAtomValue(colorAtom);
+  return (
+    <div
+      className="flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold uppercase"
+      style={
+        color
+          ? ({
+              backgroundColor: color[100],
+              color: color[500],
+            } as CSSProperties)
+          : { backgroundColor: "#e5e7eb", color: "#6b7280" }
+      }
+    >
+      {props.name[0]}
+    </div>
+  );
+};
+
+export const UserPopup = (props: { user: PortalUser }) => {
+  const { user } = props;
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger className="flex w-full items-center gap-2.5 rounded-8 p-2 text-left outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring">
+        <UserAvatar name={user.name} />
+        <span className="min-w-0 flex-1 truncate font-gta text-14 font-medium">
+          {user.name}
+        </span>
+        <CaretIcon className="size-3 shrink-0 rotate-180 text-muted-foreground" />
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          side="top"
+          align="start"
+          sideOffset={8}
+          className="z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] w-[var(--radix-dropdown-menu-trigger-width)] min-w-[224px] overflow-y-auto rounded-12 border border-border bg-card p-1 text-foreground shadow-lg"
+        >
+          {user.email ? (
+            <div className="truncate px-2.5 py-1.5 text-12 text-muted-foreground">
+              {user.email}
+            </div>
+          ) : null}
+
+          <LinkItem href={urls.profile()}>Profile</LinkItem>
+          <LinkItem href={`${urls.profile()}/teams`}>My Teams</LinkItem>
+
+          <Separator />
+
+          <SectionHeader>Need help with your app?</SectionHeader>
+          <LinkItem href={WORLD_PRIVACY_URL} external>
+            Data Privacy & Security
+          </LinkItem>
+          <LinkItem href={WORLD_STATUS_URL} external>
+            World Status
+          </LinkItem>
+          <LinkItem href={FAQ_URL} external>
+            FAQ
+          </LinkItem>
+
+          <Separator />
+
+          <SectionHeader>Community support</SectionHeader>
+          <LinkItem href={TELEGRAM_DEVELOPERS_GROUP_URL} external>
+            Join our Telegram
+          </LinkItem>
+          <LinkItem href={TELEGRAM_MATEO_URL} external>
+            Text Mateo
+          </LinkItem>
+          <LinkItem href={DISCORD_URL} external>
+            Join our Discord
+          </LinkItem>
+
+          <Separator />
+
+          <SectionHeader>References</SectionHeader>
+          <LinkItem href={urls.privacyStatement()} external>
+            Privacy Policy
+          </LinkItem>
+          <LinkItem href={urls.tos()} external>
+            Terms of service
+          </LinkItem>
+
+          <Separator />
+
+          <LinkItem href={DOCS_URL} external>
+            Docs
+          </LinkItem>
+
+          <Separator />
+
+          <DropdownMenu.Item asChild>
+            <a
+              href={urls.logout()}
+              onClick={(e) => {
+                e.preventDefault();
+                window.location.assign(urls.logout(window.location.origin));
+              }}
+              className={itemClass}
+            >
+              Log out
+            </a>
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+};

--- a/web/scenes/PortalV3/Shell/index.tsx
+++ b/web/scenes/PortalV3/Shell/index.tsx
@@ -1,0 +1,75 @@
+import { Role_Enum } from "@/graphql/graphql";
+import { auth0 } from "@/lib/auth0";
+import { calculateColorFromString } from "@/lib/calculate-color-from-string";
+import { Auth0SessionUser } from "@/lib/types";
+import { urls } from "@/lib/urls";
+import { checkUserPermissions } from "@/lib/utils";
+import { redirect } from "next/navigation";
+import { ReactNode } from "react";
+import { AppSwitcherContainer } from "./AppSwitcherContainer";
+import { ShellFrame } from "./ShellFrame";
+import { SidebarNav } from "./SidebarNav";
+import { TeamSwitcher } from "./TeamSwitcher";
+
+/**
+ * Async server shell for the authenticated v3 portal. Fetches the session, maps
+ * the user's team memberships into the switcher list, and composes the
+ * presentational ShellFrame with the team switcher / nav / app-switcher slots.
+ *
+ * Reuses the SAME session + membership reads v2 already uses (auth0.getSession,
+ * user.hasura.memberships) — no new data path. ShellFrame owns the markup +
+ * data-testid + ColorInitializer + UserPopup.
+ */
+export const V3Shell = async (props: {
+  teamId?: string;
+  children: ReactNode;
+}) => {
+  const session = await auth0.getSession();
+  if (!session) {
+    redirect(urls.login());
+  }
+  const user = session.user as Auth0SessionUser["user"];
+  const color = calculateColorFromString(
+    user?.name ?? user?.email ?? user?.sid,
+  );
+
+  const memberships = user?.hasura?.memberships ?? [];
+  const teams = memberships
+    .map((m) => m.team)
+    .filter((t): t is NonNullable<typeof t> => !!t?.id)
+    .map((t) => ({ id: t.id, name: t.name ?? "Untitled team" }));
+  const currentTeam = teams.find((t) => t.id === props.teamId);
+
+  // Role-gate the team-scope nav items, matching v2's permission model.
+  const teamId = props.teamId ?? "";
+  const canSeeApiKeys = checkUserPermissions(user, teamId, [
+    Role_Enum.Owner,
+    Role_Enum.Admin,
+  ]);
+  const canSeeSettings = checkUserPermissions(user, teamId, [Role_Enum.Owner]);
+
+  return (
+    <ShellFrame
+      color={color}
+      user={
+        user
+          ? { name: user.name ?? user.email ?? "Account", email: user.email }
+          : null
+      }
+      topSlot={
+        currentTeam ? (
+          <TeamSwitcher currentTeam={currentTeam} teams={teams} />
+        ) : null
+      }
+      nav={
+        <SidebarNav
+          canSeeApiKeys={canSeeApiKeys}
+          canSeeSettings={canSeeSettings}
+        />
+      }
+      header={<AppSwitcherContainer />}
+    >
+      {props.children}
+    </ShellFrame>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/index.tsx
@@ -1,0 +1,68 @@
+import { ErrorPage } from "@/components/ErrorPage";
+import { auth0 } from "@/lib/auth0";
+import { logger } from "@/lib/logger";
+import { Auth0SessionUser } from "@/lib/types";
+import { fetchAppEnvCached } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout/server/fetch-app-env";
+import { ReactNode } from "react";
+
+type Params = {
+  teamId?: string;
+  appId?: string;
+};
+
+type AppIdLayoutV3Props = {
+  params: Params;
+  children: ReactNode;
+};
+
+/**
+ * v3 app-scope layout. The access/data guard is copied VERBATIM from the v2
+ * AppIdLayout for behavior parity; the only change is rendering {children}
+ * instead of <AppIdChrome> (the v3 shell from V3Shell supplies all chrome).
+ *
+ * SECURITY — KNOWN IDOR, copied bug-for-bug from v2 (MUST be fixed before any
+ * production flip of the v3 flag): the guard only checks that the user is a
+ * member of params.teamId — it does NOT verify that params.appId actually
+ * belongs to that team, and fetchAppEnvCached resolves the app via a
+ * service-role fetch unscoped to the team. So a member of team A can load an
+ * app owned by team B via /teams/A/apps/<B's app>. Tracked as a hard
+ * pre-prod-flip gate; do not "fix" here without revisiting the parity decision.
+ */
+export const AppIdLayoutV3 = async (props: AppIdLayoutV3Props) => {
+  const params = props.params;
+
+  const session = await auth0.getSession();
+  const user = session?.user as Auth0SessionUser["user"];
+  const isTeamMember = user?.hasura?.memberships?.some(
+    (membership) => membership.team?.id === params.teamId,
+  );
+
+  if (!isTeamMember) {
+    return <ErrorPage statusCode={404} title="App not found" />;
+  }
+
+  if (params.appId) {
+    try {
+      const { app } = await fetchAppEnvCached(params.appId);
+
+      if (!app?.[0]) {
+        logger.warn("AppIdLayoutV3 could not resolve app from FetchAppEnv", {
+          appId: params.appId,
+          teamId: params.teamId,
+        });
+        return <ErrorPage statusCode={404} title="App not found" />;
+      }
+    } catch (error) {
+      logger.error("AppIdLayoutV3 FetchAppEnv failed", {
+        error,
+        appId: params.appId,
+        teamId: params.teamId,
+      });
+      return <ErrorPage statusCode={500} title="Failed to load app" />;
+    }
+  }
+
+  // The v3 shell (V3Shell, mounted by the teams/[teamId] layout) supplies all
+  // chrome, so this layout renders children directly — no AppIdChrome.
+  return <>{props.children}</>;
+};

--- a/web/scenes/PortalV3/Teams/TeamId/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/layout/index.tsx
@@ -1,0 +1,17 @@
+import { V3Shell } from "@/scenes/PortalV3/Shell";
+import { ReactNode } from "react";
+
+type Params = {
+  teamId?: string;
+};
+
+type TeamIdLayoutV3Props = {
+  params: Promise<Params>;
+  children: ReactNode;
+};
+
+export const TeamIdLayoutV3 = async (props: TeamIdLayoutV3Props) => {
+  const { teamId } = await props.params;
+
+  return <V3Shell teamId={teamId}>{props.children}</V3Shell>;
+};

--- a/web/scenes/PortalV3/layout/PortalChromeGate.tsx
+++ b/web/scenes/PortalV3/layout/PortalChromeGate.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { shouldRenderPortalV3Shell } from "@/lib/feature-flags/portal-v3/route-mode";
+import { Header } from "@/scenes/Portal/layout/Header";
+import { Color } from "@/scenes/Portal/Profile/types";
+import { usePathname } from "next/navigation";
+
+export const PortalChromeGate = (props: { color: Color | null }) => {
+  const pathname = usePathname() ?? "";
+
+  // When the v3 shell owns this route, it supplies its own chrome — suppress
+  // the shared v2 Header. For kiosk/exempt + the /teams index, keep the v2
+  // Header (shared chrome for v2/exempt routes).
+  if (shouldRenderPortalV3Shell(pathname)) {
+    return null;
+  }
+
+  return <Header color={props.color} />;
+};

--- a/web/scenes/PortalV3/layout/index.tsx
+++ b/web/scenes/PortalV3/layout/index.tsx
@@ -1,0 +1,20 @@
+import { auth0 } from "@/lib/auth0";
+import { calculateColorFromString } from "@/lib/calculate-color-from-string";
+import { Auth0SessionUser } from "@/lib/types";
+import { ReactNode } from "react";
+import { PortalChromeGate } from "./PortalChromeGate";
+
+export const PortalLayoutV3 = async (props: { children: ReactNode }) => {
+  const session = await auth0.getSession();
+  const user = session?.user as Auth0SessionUser["user"];
+  const color = calculateColorFromString(
+    user?.name ?? user?.email ?? user?.sid,
+  );
+
+  return (
+    <div className="grid min-h-[100dvh] grid-rows-[auto_1fr]">
+      <PortalChromeGate color={color} />
+      {props.children}
+    </div>
+  );
+};

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -122,3 +122,23 @@
     scrollbar-width: none; /* Firefox */
   }
 }
+
+/* === v3 design tokens (semantic, light-only). World palette, Vercel structure.
+   World blue is the accent (focus rings + primary CTAs only). Additive: these
+   feed the unprefixed semantic Tailwind color keys registered in
+   tailwind.config.ts. No v2 utility uses these keys, so this cannot alter v2. === */
+:root {
+  --v3-background: #ffffff; /* grey.0  — content surface */
+  --v3-foreground: #191c20; /* grey.900 — primary text */
+  --v3-muted-foreground: #657080; /* grey.500 — secondary text, default nav */
+  --v3-faint-foreground: #9ba3ae; /* grey.400 — disabled (disable-not-hide) */
+  --v3-card: #ffffff; /* grey.0  — cards on the content surface */
+  --v3-sidebar: #fbfbfc; /* grey.25 — sidebar, a hair off the content bg */
+  --v3-sidebar-foreground: #191c20;
+  --v3-border: #ebecef; /* grey.200 — hairline borders/dividers */
+  --v3-muted: #f3f4f5; /* grey.100 — hover surface */
+  --v3-accent: #4940e0; /* blue.500 — World blue (active / focus / CTA only) */
+  --v3-accent-foreground: #ffffff;
+  --v3-accent-muted: #f0f0fd; /* blue.100 — subtle accent fill */
+  --v3-ring: #4940e0;
+}

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -37,6 +37,23 @@ const config: Config = {
       colors: {
         danger: "#F2280D", // Primary danger red for delete actions
 
+        // --- v3 semantic tokens (CSS-variable backed; light-only this
+        // milestone — values defined in styles/globals.css). Additive: no v2
+        // utility class references these keys, so v2 rendering is unchanged. ---
+        background: "var(--v3-background)",
+        foreground: "var(--v3-foreground)",
+        "muted-foreground": "var(--v3-muted-foreground)",
+        "faint-foreground": "var(--v3-faint-foreground)",
+        card: "var(--v3-card)",
+        sidebar: "var(--v3-sidebar)",
+        "sidebar-foreground": "var(--v3-sidebar-foreground)",
+        border: "var(--v3-border)",
+        muted: "var(--v3-muted)",
+        accent: "var(--v3-accent)",
+        "accent-foreground": "var(--v3-accent-foreground)",
+        "accent-muted": "var(--v3-accent-muted)",
+        ring: "var(--v3-ring)",
+
         blue: {
           50: "#F9F9FE",
           100: "#F0F0FD",

--- a/web/tests/unit/portal-v3-actions-compat.test.tsx
+++ b/web/tests/unit/portal-v3-actions-compat.test.tsx
@@ -1,0 +1,52 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("server-only", () => ({}));
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/teams/team_1/apps/app_1",
+  useParams: () => ({ teamId: "team_1", appId: "app_1" }),
+}));
+
+import { SidebarNav } from "@/scenes/PortalV3/Shell/SidebarNav";
+
+describe("PortalV3 actions compatibility route", () => {
+  it("renderPortalScene with V3=null renders the v2 ActionsPage body", async () => {
+    // Stub the v2 ActionsPage so we don't pull Apollo/GraphQL.
+    jest.doMock("@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page", () => ({
+      ActionsPage: (props: { searchParams: Promise<unknown> }) => (
+        <div data-testid="v2-actions-body">legacy actions</div>
+      ),
+    }));
+    process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "true";
+    jest.resetModules();
+
+    const { renderPortalScene } = await import(
+      "@/lib/feature-flags/portal-v3/render-portal-scene"
+    );
+    const { ActionsPage } = await import(
+      "@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page"
+    );
+    const Scene = renderPortalScene(ActionsPage, null);
+    render(
+      Scene({
+        params: Promise.resolve({ teamId: "team_1", appId: "app_1" }),
+        searchParams: Promise.resolve({}),
+      } as never),
+    );
+    // V3=null => v2 body renders (inside the v3 shell at runtime).
+    expect(screen.getByTestId("v2-actions-body")).toBeInTheDocument();
+  });
+
+  it("v3 SidebarNav renders no /actions or sign-in-with-world-id link", () => {
+    const { container } = render(<SidebarNav />);
+    const hrefs = Array.from(container.querySelectorAll("a")).map((a) =>
+      a.getAttribute("href"),
+    );
+    expect(hrefs.some((h) => h?.includes("/actions"))).toBe(false);
+    expect(hrefs.some((h) => h?.includes("/sign-in-with-world-id"))).toBe(
+      false,
+    );
+    expect(hrefs.some((h) => h?.includes("proof-debugging"))).toBe(false);
+  });
+});

--- a/web/tests/unit/portal-v3-flag.test.ts
+++ b/web/tests/unit/portal-v3-flag.test.ts
@@ -1,0 +1,39 @@
+// #region Mocks
+jest.mock("server-only", () => ({}));
+// #endregion
+
+import { isPortalV3Enabled } from "@/lib/feature-flags/portal-v3/flag";
+
+const ENV_KEY = "LOCAL_DEV_PORTAL_V3_ENABLED";
+
+describe("isPortalV3Enabled", () => {
+  const original = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = original;
+    }
+  });
+
+  it("returns false when the env var is unset", () => {
+    delete process.env[ENV_KEY];
+    expect(isPortalV3Enabled()).toBe(false);
+  });
+
+  it('returns true only for the exact string "true"', () => {
+    process.env[ENV_KEY] = "true";
+    expect(isPortalV3Enabled()).toBe(true);
+  });
+
+  it('returns false for a truthy-but-not-"true" value like "1"', () => {
+    process.env[ENV_KEY] = "1";
+    expect(isPortalV3Enabled()).toBe(false);
+  });
+
+  it('returns false for "false"', () => {
+    process.env[ENV_KEY] = "false";
+    expect(isPortalV3Enabled()).toBe(false);
+  });
+});

--- a/web/tests/unit/portal-v3-kiosk-exempt.test.tsx
+++ b/web/tests/unit/portal-v3-kiosk-exempt.test.tsx
@@ -4,15 +4,12 @@ import { render, screen } from "@testing-library/react";
 
 describe("PortalV3 kiosk exemption", () => {
   it("kiosk path is public-exempt and never renders the v3 shell/page", async () => {
-    const {
-      getPortalV3RouteMode,
-      shouldRenderPortalV3Shell,
-      shouldRenderPortalV3Page,
-    } = await import("@/lib/feature-flags/portal-v3/route-mode");
+    const { getPortalV3RouteMode, shouldRenderPortalV3Shell } = await import(
+      "@/lib/feature-flags/portal-v3/route-mode"
+    );
     const path = "/kiosk/app_1234/action_5678";
     expect(getPortalV3RouteMode(path)).toBe("public-exempt");
     expect(shouldRenderPortalV3Shell(path)).toBe(false);
-    expect(shouldRenderPortalV3Page(path)).toBe(false);
   });
 
   it("PortalChromeGate keeps the v2 Header and does NOT render portal-v3-shell on kiosk", async () => {

--- a/web/tests/unit/portal-v3-kiosk-exempt.test.tsx
+++ b/web/tests/unit/portal-v3-kiosk-exempt.test.tsx
@@ -1,0 +1,35 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+describe("PortalV3 kiosk exemption", () => {
+  it("kiosk path is public-exempt and never renders the v3 shell/page", async () => {
+    const {
+      getPortalV3RouteMode,
+      shouldRenderPortalV3Shell,
+      shouldRenderPortalV3Page,
+    } = await import("@/lib/feature-flags/portal-v3/route-mode");
+    const path = "/kiosk/app_1234/action_5678";
+    expect(getPortalV3RouteMode(path)).toBe("public-exempt");
+    expect(shouldRenderPortalV3Shell(path)).toBe(false);
+    expect(shouldRenderPortalV3Page(path)).toBe(false);
+  });
+
+  it("PortalChromeGate keeps the v2 Header and does NOT render portal-v3-shell on kiosk", async () => {
+    jest.resetModules();
+    process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "true";
+    jest.doMock("next/navigation", () => ({
+      usePathname: () => "/kiosk/app_1234/action_5678",
+    }));
+    // Stub the v2 Header so we don't pull its full dependency tree.
+    jest.doMock("@/scenes/Portal/layout/Header", () => ({
+      Header: () => <header data-testid="v2-header">v2 header</header>,
+    }));
+    const { PortalChromeGate } = await import(
+      "@/scenes/PortalV3/layout/PortalChromeGate"
+    );
+    render(<PortalChromeGate color={null} />);
+    expect(screen.getByTestId("v2-header")).toBeInTheDocument();
+    expect(screen.queryByTestId("portal-v3-shell")).not.toBeInTheDocument();
+  });
+});

--- a/web/tests/unit/portal-v3-render-scene.test.tsx
+++ b/web/tests/unit/portal-v3-render-scene.test.tsx
@@ -37,7 +37,7 @@ describe("pickPortalComponent", () => {
     expect(pickPortalComponent(V2, V3)).toBe(V3);
   });
 
-  it("returns V2 when the flag is on but V3 is null (v2-compat shim)", () => {
+  it("returns V2 when the flag is on but V3 is null (compat shim)", () => {
     isPortalV3Enabled.mockReturnValue(true);
     expect(pickPortalComponent(V2, null)).toBe(V2);
   });

--- a/web/tests/unit/portal-v3-render-scene.test.tsx
+++ b/web/tests/unit/portal-v3-render-scene.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+// #region Mocks
+jest.mock("server-only", () => ({}));
+
+const isPortalV3Enabled = jest.fn<boolean, []>();
+jest.mock("@/lib/feature-flags/portal-v3/flag", () => ({
+  isPortalV3Enabled: () => isPortalV3Enabled(),
+}));
+// #endregion
+
+import {
+  pickPortalComponent,
+  renderPortalScene,
+} from "@/lib/feature-flags/portal-v3/render-portal-scene";
+
+type Props = { label: string };
+const V2 = ({ label }: Props) => <div data-testid="v2">{`v2:${label}`}</div>;
+const V3 = ({ label }: Props) => <div data-testid="v3">{`v3:${label}`}</div>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("pickPortalComponent", () => {
+  it("returns V2 when the flag is off", () => {
+    isPortalV3Enabled.mockReturnValue(false);
+    expect(pickPortalComponent(V2, V3)).toBe(V2);
+  });
+
+  it("returns V3 when the flag is on and a V3 component exists", () => {
+    isPortalV3Enabled.mockReturnValue(true);
+    expect(pickPortalComponent(V2, V3)).toBe(V3);
+  });
+
+  it("returns V2 when the flag is on but V3 is null (v2-compat shim)", () => {
+    isPortalV3Enabled.mockReturnValue(true);
+    expect(pickPortalComponent(V2, null)).toBe(V2);
+  });
+});
+
+describe("renderPortalScene", () => {
+  it("renders V2 when the flag is off", () => {
+    isPortalV3Enabled.mockReturnValue(false);
+    const Scene = renderPortalScene(V2, V3);
+    render(<Scene label="x" />);
+    expect(screen.getByTestId("v2")).toHaveTextContent("v2:x");
+    expect(screen.queryByTestId("v3")).not.toBeInTheDocument();
+  });
+
+  it("renders V3 when the flag is on", () => {
+    isPortalV3Enabled.mockReturnValue(true);
+    const Scene = renderPortalScene(V2, V3);
+    render(<Scene label="y" />);
+    expect(screen.getByTestId("v3")).toHaveTextContent("v3:y");
+    expect(screen.queryByTestId("v2")).not.toBeInTheDocument();
+  });
+
+  it("renders V2 when V3 is null even if the flag is on", () => {
+    isPortalV3Enabled.mockReturnValue(true);
+    const Scene = renderPortalScene(V2, null);
+    render(<Scene label="z" />);
+    expect(screen.getByTestId("v2")).toHaveTextContent("v2:z");
+  });
+});

--- a/web/tests/unit/portal-v3-route-mode.test.ts
+++ b/web/tests/unit/portal-v3-route-mode.test.ts
@@ -1,6 +1,5 @@
 import {
   getPortalV3RouteMode,
-  shouldRenderPortalV3Page,
   shouldRenderPortalV3Shell,
   type PortalV3RouteMode,
 } from "@/lib/feature-flags/portal-v3/route-mode";
@@ -14,47 +13,33 @@ describe("getPortalV3RouteMode", () => {
     [`/kiosk/${APP}/action_xyz`, "public-exempt"],
     [`/kiosk/${APP}`, "public-exempt"],
 
-    // unbranched: API + anything outside the branched trees
-    ["/api/v2/something", "unbranched"],
-    ["/api", "unbranched"],
-    ["/", "unbranched"],
-    ["/login", "unbranched"],
+    // v2: API + anything outside the v3 migration
+    ["/api/v2/something", "v2"],
+    ["/api", "v2"],
+    ["/", "v2"],
+    ["/login", "v2"],
 
-    // v2-compat: v2 body inside the v3 shell
-    [`/teams/${TEAM}/apps/${APP}/actions`, "v2-compat"],
-    [`/teams/${TEAM}/apps/${APP}/actions/create`, "v2-compat"],
-    [`/teams/${TEAM}/apps/${APP}/sign-in-with-world-id`, "v2-compat"],
-
-    // redirect-alias: old paths that will redirect into v3
-    [`/teams/${TEAM}/apps/${APP}/transactions`, "redirect-alias"],
-    [`/teams/${TEAM}/apps/${APP}/notifications`, "redirect-alias"],
-
-    // v3-active: the new shell + new pages
-    [`/teams/${TEAM}`, "v3-active"],
-    [`/teams/${TEAM}/apps/${APP}`, "v3-active"],
-    [`/teams/${TEAM}/apps/${APP}/world-id-actions`, "v3-active"],
+    // v3: every authenticated /teams route mounts the v3 shell. Compat
+    // pages (actions, sign-in-with-world-id) and the legacy redirect aliases
+    // (transactions, notifications) all fall through here; the v2-vs-v3 page
+    // body is chosen by the per-route page shim, not by this classifier.
+    [`/teams/${TEAM}`, "v3"],
+    [`/teams/${TEAM}/apps/${APP}`, "v3"],
+    [`/teams/${TEAM}/apps/${APP}/world-id-actions`, "v3"],
+    [`/teams/${TEAM}/apps/${APP}/actions`, "v3"],
+    [`/teams/${TEAM}/apps/${APP}/actions/create`, "v3"],
+    [`/teams/${TEAM}/apps/${APP}/sign-in-with-world-id`, "v3"],
+    [`/teams/${TEAM}/apps/${APP}/transactions`, "v3"],
+    [`/teams/${TEAM}/apps/${APP}/notifications`, "v3"],
 
     // /profile/** renders v2 account pages inside the minimal v3 chrome
     // (ProfileLayoutV3, a close-X back to the app), so it mounts the v3 shell.
-    [`/profile`, "v3-active"],
-    [`/profile/teams`, "v3-active"],
+    [`/profile`, "v3"],
+    [`/profile/teams`, "v3"],
   ];
 
   it.each(cases)("classifies %s as %s", (pathname, expected) => {
     expect(getPortalV3RouteMode(pathname)).toBe(expected);
-  });
-
-  // The load-bearing trap: /world-id-actions ends in "actions" but is a v3
-  // page, NOT v2-compat. /actions must only match the standalone segment.
-  it("does NOT classify /world-id-actions as v2-compat", () => {
-    expect(
-      getPortalV3RouteMode(`/teams/${TEAM}/apps/${APP}/world-id-actions`),
-    ).toBe("v3-active");
-    expect(
-      getPortalV3RouteMode(
-        `/teams/${TEAM}/apps/${APP}/world-id-actions/action_1`,
-      ),
-    ).toBe("v3-active");
   });
 
   // Purity: the query string is irrelevant to the mode.
@@ -63,15 +48,16 @@ describe("getPortalV3RouteMode", () => {
       getPortalV3RouteMode(
         `/teams/${TEAM}/apps/${APP}/actions?createAction=true`,
       ),
-    ).toBe("v2-compat");
-    expect(getPortalV3RouteMode(`/teams/${TEAM}?foo=bar`)).toBe("v3-active");
+    ).toBe("v3");
+    expect(getPortalV3RouteMode(`/teams/${TEAM}?foo=bar`)).toBe("v3");
     expect(getPortalV3RouteMode(`/kiosk/${APP}/a_1?x=1`)).toBe("public-exempt");
   });
 });
 
 describe("shouldRenderPortalV3Shell", () => {
-  it("is true for v3-active and v2-compat", () => {
+  it("is true for every v3 route (incl. compat pages)", () => {
     expect(shouldRenderPortalV3Shell(`/teams/${TEAM}`)).toBe(true);
+    // Compat pages still mount the shell; only the page body stays v2.
     expect(
       shouldRenderPortalV3Shell(`/teams/${TEAM}/apps/${APP}/actions`),
     ).toBe(true);
@@ -79,31 +65,9 @@ describe("shouldRenderPortalV3Shell", () => {
     expect(shouldRenderPortalV3Shell("/profile")).toBe(true);
   });
 
-  it("is false for public-exempt, redirect-alias, and unbranched", () => {
+  it("is false for public-exempt and v2 routes", () => {
     expect(shouldRenderPortalV3Shell(`/kiosk/${APP}/a_1`)).toBe(false);
-    expect(
-      shouldRenderPortalV3Shell(`/teams/${TEAM}/apps/${APP}/transactions`),
-    ).toBe(false);
     expect(shouldRenderPortalV3Shell("/api/v2/x")).toBe(false);
-  });
-});
-
-describe("shouldRenderPortalV3Page", () => {
-  it("is true only for v3-active", () => {
-    expect(shouldRenderPortalV3Page(`/teams/${TEAM}/apps/${APP}`)).toBe(true);
-  });
-
-  it("is false for v2-compat (shell yes, page no)", () => {
-    expect(shouldRenderPortalV3Page(`/teams/${TEAM}/apps/${APP}/actions`)).toBe(
-      false,
-    );
-  });
-
-  it("is false for public-exempt / redirect-alias / unbranched", () => {
-    expect(shouldRenderPortalV3Page(`/kiosk/${APP}/a_1`)).toBe(false);
-    expect(
-      shouldRenderPortalV3Page(`/teams/${TEAM}/apps/${APP}/notifications`),
-    ).toBe(false);
-    expect(shouldRenderPortalV3Page("/api/x")).toBe(false);
+    expect(shouldRenderPortalV3Shell("/login")).toBe(false);
   });
 });

--- a/web/tests/unit/portal-v3-route-mode.test.ts
+++ b/web/tests/unit/portal-v3-route-mode.test.ts
@@ -1,0 +1,109 @@
+import {
+  getPortalV3RouteMode,
+  shouldRenderPortalV3Page,
+  shouldRenderPortalV3Shell,
+  type PortalV3RouteMode,
+} from "@/lib/feature-flags/portal-v3/route-mode";
+
+const TEAM = "team_abc";
+const APP = "app_0123456789abcdef0123456789abcdef";
+
+describe("getPortalV3RouteMode", () => {
+  const cases: Array<[string, PortalV3RouteMode]> = [
+    // public-exempt: kiosk is unauthenticated and must never mount v3
+    [`/kiosk/${APP}/action_xyz`, "public-exempt"],
+    [`/kiosk/${APP}`, "public-exempt"],
+
+    // unbranched: API + anything outside the branched trees
+    ["/api/v2/something", "unbranched"],
+    ["/api", "unbranched"],
+    ["/", "unbranched"],
+    ["/login", "unbranched"],
+
+    // v2-compat: v2 body inside the v3 shell
+    [`/teams/${TEAM}/apps/${APP}/actions`, "v2-compat"],
+    [`/teams/${TEAM}/apps/${APP}/actions/create`, "v2-compat"],
+    [`/teams/${TEAM}/apps/${APP}/sign-in-with-world-id`, "v2-compat"],
+
+    // redirect-alias: old paths that will redirect into v3
+    [`/teams/${TEAM}/apps/${APP}/transactions`, "redirect-alias"],
+    [`/teams/${TEAM}/apps/${APP}/notifications`, "redirect-alias"],
+
+    // v3-active: the new shell + new pages
+    [`/teams/${TEAM}`, "v3-active"],
+    [`/teams/${TEAM}/apps/${APP}`, "v3-active"],
+    [`/teams/${TEAM}/apps/${APP}/world-id-actions`, "v3-active"],
+
+    // /profile/** renders v2 account pages inside the minimal v3 chrome
+    // (ProfileLayoutV3, a close-X back to the app), so it mounts the v3 shell.
+    [`/profile`, "v3-active"],
+    [`/profile/teams`, "v3-active"],
+  ];
+
+  it.each(cases)("classifies %s as %s", (pathname, expected) => {
+    expect(getPortalV3RouteMode(pathname)).toBe(expected);
+  });
+
+  // The load-bearing trap: /world-id-actions ends in "actions" but is a v3
+  // page, NOT v2-compat. /actions must only match the standalone segment.
+  it("does NOT classify /world-id-actions as v2-compat", () => {
+    expect(
+      getPortalV3RouteMode(`/teams/${TEAM}/apps/${APP}/world-id-actions`),
+    ).toBe("v3-active");
+    expect(
+      getPortalV3RouteMode(
+        `/teams/${TEAM}/apps/${APP}/world-id-actions/action_1`,
+      ),
+    ).toBe("v3-active");
+  });
+
+  // Purity: the query string is irrelevant to the mode.
+  it("ignores the query string", () => {
+    expect(
+      getPortalV3RouteMode(
+        `/teams/${TEAM}/apps/${APP}/actions?createAction=true`,
+      ),
+    ).toBe("v2-compat");
+    expect(getPortalV3RouteMode(`/teams/${TEAM}?foo=bar`)).toBe("v3-active");
+    expect(getPortalV3RouteMode(`/kiosk/${APP}/a_1?x=1`)).toBe("public-exempt");
+  });
+});
+
+describe("shouldRenderPortalV3Shell", () => {
+  it("is true for v3-active and v2-compat", () => {
+    expect(shouldRenderPortalV3Shell(`/teams/${TEAM}`)).toBe(true);
+    expect(
+      shouldRenderPortalV3Shell(`/teams/${TEAM}/apps/${APP}/actions`),
+    ).toBe(true);
+    // /profile mounts the minimal v3 account chrome.
+    expect(shouldRenderPortalV3Shell("/profile")).toBe(true);
+  });
+
+  it("is false for public-exempt, redirect-alias, and unbranched", () => {
+    expect(shouldRenderPortalV3Shell(`/kiosk/${APP}/a_1`)).toBe(false);
+    expect(
+      shouldRenderPortalV3Shell(`/teams/${TEAM}/apps/${APP}/transactions`),
+    ).toBe(false);
+    expect(shouldRenderPortalV3Shell("/api/v2/x")).toBe(false);
+  });
+});
+
+describe("shouldRenderPortalV3Page", () => {
+  it("is true only for v3-active", () => {
+    expect(shouldRenderPortalV3Page(`/teams/${TEAM}/apps/${APP}`)).toBe(true);
+  });
+
+  it("is false for v2-compat (shell yes, page no)", () => {
+    expect(shouldRenderPortalV3Page(`/teams/${TEAM}/apps/${APP}/actions`)).toBe(
+      false,
+    );
+  });
+
+  it("is false for public-exempt / redirect-alias / unbranched", () => {
+    expect(shouldRenderPortalV3Page(`/kiosk/${APP}/a_1`)).toBe(false);
+    expect(
+      shouldRenderPortalV3Page(`/teams/${TEAM}/apps/${APP}/notifications`),
+    ).toBe(false);
+    expect(shouldRenderPortalV3Page("/api/x")).toBe(false);
+  });
+});

--- a/web/tests/unit/portal-v3/app-id-layout-v3.test.tsx
+++ b/web/tests/unit/portal-v3/app-id-layout-v3.test.tsx
@@ -1,0 +1,100 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import React from "react";
+
+const getSession = jest.fn();
+jest.mock("@/lib/auth0", () => ({
+  auth0: { getSession: () => getSession() },
+}));
+
+const fetchAppEnvCached = jest.fn();
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout/server/fetch-app-env",
+  () => ({
+    fetchAppEnvCached: (appId: string) => fetchAppEnvCached(appId),
+  }),
+);
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+// ErrorPage stub exposes the status code so we can assert on the guard branch.
+jest.mock("@/components/ErrorPage", () => ({
+  ErrorPage: (props: { statusCode: number; title?: string }) => (
+    <div data-testid="error-page" data-status={props.statusCode}>
+      {props.title}
+    </div>
+  ),
+}));
+
+import { AppIdLayoutV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout";
+
+const TEAM_ID = "team_123";
+const APP_ID = "app_00000000000000000000000000000000";
+
+const sessionForTeam = (teamId: string) => ({
+  user: { hasura: { memberships: [{ team: { id: teamId } }] } },
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("AppIdLayoutV3 guard", () => {
+  it("renders 404 when the user is not a member of the team", async () => {
+    getSession.mockResolvedValue(sessionForTeam("some_other_team"));
+    const element = await AppIdLayoutV3({
+      params: { teamId: TEAM_ID, appId: APP_ID },
+      children: <div data-testid="page-body">body</div>,
+    });
+    const { getByTestId, queryByTestId } = render(element);
+    expect(getByTestId("error-page")).toHaveAttribute("data-status", "404");
+    expect(queryByTestId("page-body")).not.toBeInTheDocument();
+    expect(fetchAppEnvCached).not.toHaveBeenCalled();
+  });
+
+  it("renders 404 when fetchAppEnvCached returns no app", async () => {
+    getSession.mockResolvedValue(sessionForTeam(TEAM_ID));
+    fetchAppEnvCached.mockResolvedValue({ app: [], action: [] });
+    const element = await AppIdLayoutV3({
+      params: { teamId: TEAM_ID, appId: APP_ID },
+      children: <div data-testid="page-body">body</div>,
+    });
+    const { getByTestId } = render(element);
+    expect(getByTestId("error-page")).toHaveAttribute("data-status", "404");
+  });
+
+  it("renders 500 when fetchAppEnvCached throws", async () => {
+    getSession.mockResolvedValue(sessionForTeam(TEAM_ID));
+    fetchAppEnvCached.mockRejectedValue(new Error("boom"));
+    const element = await AppIdLayoutV3({
+      params: { teamId: TEAM_ID, appId: APP_ID },
+      children: <div data-testid="page-body">body</div>,
+    });
+    const { getByTestId } = render(element);
+    expect(getByTestId("error-page")).toHaveAttribute("data-status", "500");
+  });
+
+  it("renders children (no AppIdChrome) on the happy path", async () => {
+    getSession.mockResolvedValue(sessionForTeam(TEAM_ID));
+    fetchAppEnvCached.mockResolvedValue({
+      app: [
+        {
+          engine: "cloud",
+          rp_registration: [],
+          is_staging: false,
+        },
+      ],
+      action: [],
+    });
+    const element = await AppIdLayoutV3({
+      params: { teamId: TEAM_ID, appId: APP_ID },
+      children: <div data-testid="page-body">body</div>,
+    });
+    const { getByTestId, queryByTestId } = render(element);
+    expect(getByTestId("page-body")).toBeInTheDocument();
+    expect(queryByTestId("error-page")).not.toBeInTheDocument();
+  });
+});

--- a/web/tests/unit/portal-v3/portal-chrome-gate.test.tsx
+++ b/web/tests/unit/portal-v3/portal-chrome-gate.test.tsx
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import React from "react";
+import { PortalChromeGate } from "@/scenes/PortalV3/layout/PortalChromeGate";
+
+// Drive the pathname the gate reads.
+let mockPathname = "/";
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+}));
+
+// Stub the v2 Header so we assert on the gate's branching, not Header internals.
+jest.mock("@/scenes/Portal/layout/Header", () => ({
+  Header: (props: { color: unknown }) => (
+    <div data-testid="v2-header">header</div>
+  ),
+}));
+
+describe("PortalChromeGate", () => {
+  it("renders the v2 Header on a kiosk (exempt) route", () => {
+    mockPathname = "/kiosk/app_00000000000000000000000000000000/action_x";
+    const { queryByTestId } = render(<PortalChromeGate color={null} />);
+    expect(queryByTestId("v2-header")).toBeInTheDocument();
+  });
+
+  it("renders the v2 Header on the /teams index (no team id) route", () => {
+    mockPathname = "/teams";
+    const { queryByTestId } = render(<PortalChromeGate color={null} />);
+    expect(queryByTestId("v2-header")).toBeInTheDocument();
+  });
+
+  it("hides the v2 Header on a v3-active route (/teams/<id>/apps/<id>)", () => {
+    mockPathname = "/teams/team_123/apps/app_00000000000000000000000000000000";
+    const { queryByTestId } = render(<PortalChromeGate color={null} />);
+    expect(queryByTestId("v2-header")).not.toBeInTheDocument();
+  });
+
+  it("hides the v2 Header on a v2-compat route (apps/<id>/actions)", () => {
+    mockPathname =
+      "/teams/team_123/apps/app_00000000000000000000000000000000/actions";
+    const { queryByTestId } = render(<PortalChromeGate color={null} />);
+    expect(queryByTestId("v2-header")).not.toBeInTheDocument();
+  });
+});

--- a/web/tests/unit/portal-v3/portal-chrome-gate.test.tsx
+++ b/web/tests/unit/portal-v3/portal-chrome-gate.test.tsx
@@ -30,13 +30,13 @@ describe("PortalChromeGate", () => {
     expect(queryByTestId("v2-header")).toBeInTheDocument();
   });
 
-  it("hides the v2 Header on a v3-active route (/teams/<id>/apps/<id>)", () => {
+  it("hides the v2 Header on a v3 route (/teams/<id>/apps/<id>)", () => {
     mockPathname = "/teams/team_123/apps/app_00000000000000000000000000000000";
     const { queryByTestId } = render(<PortalChromeGate color={null} />);
     expect(queryByTestId("v2-header")).not.toBeInTheDocument();
   });
 
-  it("hides the v2 Header on a v2-compat route (apps/<id>/actions)", () => {
+  it("hides the v2 Header on a compat route (apps/<id>/actions)", () => {
     mockPathname =
       "/teams/team_123/apps/app_00000000000000000000000000000000/actions";
     const { queryByTestId } = render(<PortalChromeGate color={null} />);

--- a/web/tests/unit/portal-v3/portal-layout-chooser.test.tsx
+++ b/web/tests/unit/portal-v3/portal-layout-chooser.test.tsx
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import React from "react";
+
+// Flag ON for this suite.
+process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "true";
+
+// flag.ts (reached transitively via the chooser) does `import "server-only"`,
+// which throws in the jsdom environment — mock it at the boundary.
+jest.mock("server-only", () => ({}));
+
+let mockPathname = "/";
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+}));
+
+// auth0.getSession is async; PortalLayoutV3 awaits it. Return no session so
+// color falls back to undefined input (calculateColorFromString handles it).
+jest.mock("@/lib/auth0", () => ({
+  auth0: { getSession: jest.fn().mockResolvedValue(null) },
+}));
+
+jest.mock("@/scenes/Portal/layout/Header", () => ({
+  Header: () => <div data-testid="v2-header">header</div>,
+}));
+
+import LayoutScene from "@/app/(portal)/layout";
+
+const renderScene = async (children: React.ReactNode) => {
+  // The scene returns props => <C .../>; the v3 layout is an async server
+  // component, so await its element before rendering.
+  const element = (LayoutScene as any)({ children });
+  const resolved = await element.type(element.props);
+  return render(resolved);
+};
+
+describe("(portal) layout chooser [flag on]", () => {
+  it("keeps the v2 Header on a /kiosk route", async () => {
+    mockPathname = "/kiosk/app_00000000000000000000000000000000/action_x";
+    const { queryByTestId } = await renderScene(<div>child</div>);
+    expect(queryByTestId("v2-header")).toBeInTheDocument();
+  });
+
+  it("has no (portal) Header on /teams/<id>/apps/<id>", async () => {
+    mockPathname = "/teams/team_123/apps/app_00000000000000000000000000000000";
+    const { queryByTestId } = await renderScene(<div>child</div>);
+    expect(queryByTestId("v2-header")).not.toBeInTheDocument();
+  });
+});

--- a/web/tests/unit/portal-v3/profile-layout-v3.test.tsx
+++ b/web/tests/unit/portal-v3/profile-layout-v3.test.tsx
@@ -1,0 +1,25 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import { ProfileLayoutV3 } from "@/scenes/PortalV3/Profile/layout";
+
+describe("ProfileLayoutV3", () => {
+  it("renders the account page content with a close-X to the main app (no tabs)", () => {
+    render(
+      <ProfileLayoutV3>
+        <div data-testid="page-body">profile content</div>
+      </ProfileLayoutV3>,
+    );
+    // The v2 account page content renders as-is.
+    expect(screen.getByTestId("page-body")).toBeInTheDocument();
+    expect(screen.getByTestId("portal-v3-account-shell")).toBeInTheDocument();
+
+    // Close-X returns to the main app; "/" resolves to the team dashboard.
+    const close = screen.getByRole("link", { name: /back to/i });
+    expect(close).toHaveAttribute("href", "/");
+
+    // No v2 account tabs in this minimal chrome.
+    expect(screen.queryByText("Danger zone")).not.toBeInTheDocument();
+  });
+});

--- a/web/tests/unit/portal-v3/profile-layout-v3.test.tsx
+++ b/web/tests/unit/portal-v3/profile-layout-v3.test.tsx
@@ -1,19 +1,36 @@
 /** @jest-environment jsdom */
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
+import React from "react";
+
+jest.mock("@/lib/auth0", () => ({
+  auth0: {
+    getSession: jest
+      .fn()
+      .mockResolvedValue({ user: { name: "Ada", email: "ada@example.com" } }),
+  },
+}));
+jest.mock("@/scenes/PortalV3/Shell/UserPopup", () => ({
+  UserPopup: () => <div data-testid="user-popup" />,
+}));
+jest.mock("@/scenes/PortalV3/Shell/ColorInitializer", () => ({
+  ColorInitializer: () => null,
+}));
 
 import { ProfileLayoutV3 } from "@/scenes/PortalV3/Profile/layout";
 
 describe("ProfileLayoutV3", () => {
-  it("renders the account page content with a close-X to the main app (no tabs)", () => {
-    render(
-      <ProfileLayoutV3>
-        <div data-testid="page-body">profile content</div>
-      </ProfileLayoutV3>,
-    );
+  it("wraps account content with a close-X and the bottom user menu (no tabs)", async () => {
+    const element = await ProfileLayoutV3({
+      children: <div data-testid="page-body">profile content</div>,
+    });
+    render(element);
+
     // The v2 account page content renders as-is.
     expect(screen.getByTestId("page-body")).toBeInTheDocument();
     expect(screen.getByTestId("portal-v3-account-shell")).toBeInTheDocument();
+    // Bottom user menu now persists in the account chrome.
+    expect(screen.getByTestId("user-popup")).toBeInTheDocument();
 
     // Close-X returns to the main app; "/" resolves to the team dashboard.
     const close = screen.getByRole("link", { name: /back to/i });

--- a/web/tests/unit/portal-v3/shell.test.tsx
+++ b/web/tests/unit/portal-v3/shell.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import { ShellFrame } from "@/scenes/PortalV3/Shell/ShellFrame";
+import { SidebarNav } from "@/scenes/PortalV3/Shell/SidebarNav";
+
+// next/navigation hooks used by SidebarNav.
+const mockPathname = jest.fn<string, []>(() => "/teams/team_1/apps/app_1");
+const mockParams = jest.fn<Record<string, string | undefined>, []>(() => ({
+  teamId: "team_1",
+  appId: "app_1",
+}));
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockPathname(),
+  useParams: () => mockParams(),
+}));
+
+describe("ShellFrame", () => {
+  it("renders the portal-v3-shell test id, nav, header and children", () => {
+    render(
+      <ShellFrame
+        color={null}
+        user={{ name: "Ada", email: "ada@example.com" }}
+        topSlot={<div>team-switcher-slot</div>}
+        nav={<div>nav-slot</div>}
+        header={<div>header-slot</div>}
+      >
+        <div>page-body</div>
+      </ShellFrame>,
+    );
+
+    expect(screen.getByTestId("portal-v3-shell")).toBeInTheDocument();
+    expect(screen.getByText("team-switcher-slot")).toBeInTheDocument();
+    expect(screen.getByText("nav-slot")).toBeInTheDocument();
+    expect(screen.getByText("header-slot")).toBeInTheDocument();
+    expect(screen.getByText("page-body")).toBeInTheDocument();
+  });
+
+  it("omits the header element when no header prop is given", () => {
+    const { container } = render(
+      <ShellFrame color={null} user={null} nav={<div>nav-slot</div>}>
+        <div>page-body</div>
+      </ShellFrame>,
+    );
+    expect(container.querySelector("header")).toBeNull();
+    expect(screen.getByText("page-body")).toBeInTheDocument();
+  });
+});
+
+describe("SidebarNav legacy-link safety", () => {
+  it("renders app- and team-scope links and NO legacy surfaces", () => {
+    render(<SidebarNav canSeeApiKeys canSeeSettings />);
+
+    // Present, expected links.
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("World ID")).toBeInTheDocument();
+    expect(screen.getByText("Configuration")).toBeInTheDocument();
+    expect(screen.getByText("Mini App")).toBeInTheDocument();
+    expect(screen.getByText("Members")).toBeInTheDocument();
+    expect(screen.getByText("API Keys")).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+
+    // No legacy compatibility links anywhere in the nav.
+    const hrefs = Array.from(document.querySelectorAll("a[href]")).map(
+      (a) => a.getAttribute("href") ?? "",
+    );
+    for (const href of hrefs) {
+      expect(href).not.toContain("/actions");
+      expect(href).not.toContain("/sign-in-with-world-id");
+      expect(href).not.toContain("proof-debugging");
+    }
+    // World ID points at the v3 surface, not legacy actions.
+    expect(
+      screen.getByText("World ID").closest("a")?.getAttribute("href"),
+    ).toBe("/teams/team_1/apps/app_1/world-id-4-0");
+  });
+
+  it("role-gates API Keys and Settings (hidden without permission)", () => {
+    render(<SidebarNav />);
+    expect(screen.getByText("Members")).toBeInTheDocument();
+    expect(screen.queryByText("API Keys")).not.toBeInTheDocument();
+    expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+  });
+});

--- a/web/tests/unit/portal-v3/team-id-layout-v3.test.tsx
+++ b/web/tests/unit/portal-v3/team-id-layout-v3.test.tsx
@@ -1,0 +1,28 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import React from "react";
+
+// Stub V3Shell so we assert TeamIdLayoutV3 wiring, not shell internals.
+jest.mock("@/scenes/PortalV3/Shell", () => ({
+  V3Shell: (props: { teamId?: string; children: React.ReactNode }) => (
+    <div data-testid="v3-shell" data-team-id={props.teamId}>
+      {props.children}
+    </div>
+  ),
+}));
+
+import { TeamIdLayoutV3 } from "@/scenes/PortalV3/Teams/TeamId/layout";
+
+describe("TeamIdLayoutV3", () => {
+  it("awaits params and mounts V3Shell with the resolved teamId", async () => {
+    const element = await TeamIdLayoutV3({
+      params: Promise.resolve({ teamId: "team_123" }),
+      children: <div data-testid="page-body">body</div>,
+    });
+    const { getByTestId } = render(element);
+    const shell = getByTestId("v3-shell");
+    expect(shell).toHaveAttribute("data-team-id", "team_123");
+    expect(getByTestId("page-body")).toBeInTheDocument();
+  });
+});

--- a/web/tests/unit/portal-v3/tokens.test.ts
+++ b/web/tests/unit/portal-v3/tokens.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// web/ root: this test file lives at web/tests/unit/portal-v3/tokens.test.ts
+const webRoot = join(__dirname, "..", "..", "..");
+
+const globalsCss = readFileSync(join(webRoot, "styles/globals.css"), "utf8");
+const tailwindConfig = readFileSync(
+  join(webRoot, "tailwind.config.ts"),
+  "utf8",
+);
+
+// The 13 light-only CSS vars ported from the reference globals.css.
+const REQUIRED_CSS_VARS = [
+  "--v3-background",
+  "--v3-foreground",
+  "--v3-muted-foreground",
+  "--v3-faint-foreground",
+  "--v3-card",
+  "--v3-sidebar",
+  "--v3-sidebar-foreground",
+  "--v3-border",
+  "--v3-muted",
+  "--v3-accent",
+  "--v3-accent-foreground",
+  "--v3-accent-muted",
+  "--v3-ring",
+];
+
+// The semantic Tailwind color keys -> CSS var bindings.
+const REQUIRED_COLOR_BINDINGS: Array<[string, string]> = [
+  ["background", "--v3-background"],
+  ["foreground", "--v3-foreground"],
+  ["muted-foreground", "--v3-muted-foreground"],
+  ["faint-foreground", "--v3-faint-foreground"],
+  ["card", "--v3-card"],
+  ["sidebar", "--v3-sidebar"],
+  ["sidebar-foreground", "--v3-sidebar-foreground"],
+  ["border", "--v3-border"],
+  ["muted", "--v3-muted"],
+  ["accent", "--v3-accent"],
+  ["accent-foreground", "--v3-accent-foreground"],
+  ["accent-muted", "--v3-accent-muted"],
+  ["ring", "--v3-ring"],
+];
+
+describe("portal-v3 design tokens", () => {
+  it.each(REQUIRED_CSS_VARS)("globals.css declares %s", (cssVar) => {
+    // Match a declaration like `--v3-background:` (allowing whitespace).
+    const re = new RegExp(`${cssVar}\\s*:`);
+    expect(globalsCss).toMatch(re);
+  });
+
+  it.each(REQUIRED_COLOR_BINDINGS)(
+    "tailwind.config.ts maps `%s` -> var(%s)",
+    (key, cssVar) => {
+      // Match `key: "var(--v3-...)"` or `"key": "var(--v3-...)"`.
+      const re = new RegExp(
+        `["']?${key}["']?\\s*:\\s*["']var\\(${cssVar}\\)["']`,
+      );
+      expect(tailwindConfig).toMatch(re);
+    },
+  );
+});

--- a/web/tests/unit/portal-v3/v3-shell.test.tsx
+++ b/web/tests/unit/portal-v3/v3-shell.test.tsx
@@ -1,0 +1,99 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import React from "react";
+
+const getSession = jest.fn();
+jest.mock("@/lib/auth0", () => ({ auth0: { getSession: () => getSession() } }));
+
+const redirectMock = jest.fn((url: string) => {
+  throw new Error("REDIRECT:" + url);
+});
+jest.mock("next/navigation", () => ({
+  redirect: (url: string) => redirectMock(url),
+}));
+
+// Mock the leaf children so we test only V3Shell's data-shaping + wiring.
+jest.mock("@/scenes/PortalV3/Shell/ShellFrame", () => ({
+  ShellFrame: (props: {
+    user?: { name: string } | null;
+    topSlot?: React.ReactNode;
+    children?: React.ReactNode;
+  }) => (
+    <div
+      data-testid="shell-frame"
+      data-has-topslot={props.topSlot ? "yes" : "no"}
+      data-user={props.user?.name ?? "none"}
+    >
+      {props.children}
+    </div>
+  ),
+}));
+jest.mock("@/scenes/PortalV3/Shell/TeamSwitcher", () => ({
+  TeamSwitcher: () => <div data-testid="team-switcher" />,
+}));
+jest.mock("@/scenes/PortalV3/Shell/SidebarNav", () => ({
+  SidebarNav: () => <div data-testid="sidebar-nav" />,
+}));
+jest.mock("@/scenes/PortalV3/Shell/AppSwitcherContainer", () => ({
+  AppSwitcherContainer: () => <div data-testid="app-switcher" />,
+}));
+// Role_Enum lives in @/graphql/graphql, which pulls the GraphQL stack (needs
+// TextEncoder, absent in jsdom). Stub it + the pure permission helper — the
+// shell wiring under test doesn't depend on their real values (SidebarNav is mocked).
+jest.mock("@/graphql/graphql", () => ({
+  Role_Enum: { Owner: "OWNER", Admin: "ADMIN", Member: "MEMBER" },
+}));
+jest.mock("@/lib/utils", () => ({ checkUserPermissions: () => true }));
+
+import { V3Shell } from "@/scenes/PortalV3/Shell";
+
+const sessionWithTeams = (teams: Array<{ id: string; name: string }>) => ({
+  user: {
+    name: "Ada",
+    email: "ada@example.com",
+    hasura: { memberships: teams.map((team) => ({ team })) },
+  },
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("V3Shell", () => {
+  it("redirects to login when there is no session", async () => {
+    getSession.mockResolvedValue(null);
+    await expect(V3Shell({ teamId: "team_1", children: null })).rejects.toThrow(
+      /REDIRECT/,
+    );
+    expect(redirectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("mounts the shell + team switcher when teamId matches a membership", async () => {
+    getSession.mockResolvedValue(
+      sessionWithTeams([{ id: "team_1", name: "Acme" }]),
+    );
+    const element = await V3Shell({
+      teamId: "team_1",
+      children: <div data-testid="body">body</div>,
+    });
+    const { getByTestId } = render(element);
+    expect(getByTestId("shell-frame")).toHaveAttribute(
+      "data-has-topslot",
+      "yes",
+    );
+    expect(getByTestId("shell-frame")).toHaveAttribute("data-user", "Ada");
+    expect(getByTestId("body")).toBeInTheDocument();
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it("omits the team switcher when no membership matches the teamId", async () => {
+    getSession.mockResolvedValue(
+      sessionWithTeams([{ id: "other_team", name: "Other" }]),
+    );
+    const element = await V3Shell({ teamId: "team_1", children: null });
+    const { getByTestId } = render(element);
+    expect(getByTestId("shell-frame")).toHaveAttribute(
+      "data-has-topslot",
+      "no",
+    );
+  });
+});


### PR DESCRIPTION
First-slice shell for Developer Portal v3, switched by a local-only flag (`LOCAL_DEV_PORTAL_V3_ENABLED`). **Flag off → v2 unchanged.** First of a stacked series (A → B → C).

## What's here
- **Switching layer** — `isPortalV3Enabled` (server-only) + a pure, ordered route-mode classifier (`getPortalV3RouteMode` → typed modes, first-match rule table) + a sync `renderPortalScene`/`pickPortalComponent` chooser.
- **Design tokens** — additive `--v3-*` CSS vars + semantic Tailwind colors (light-only; 0 collisions with v2 utilities).
- **Shell** — `V3Shell` (server; user + teams resolved from the session) + presentational primitives (sidebar nav, team/app switchers, user popup, `ShellFrame`). Nav role-gates API Keys/Settings (Owner/Admin) via `checkUserPermissions`.
- **Structural mounting** — `(portal)` chooser + `PortalChromeGate`, `teams/[teamId]` mounts `V3Shell`, `apps/[appId]` access guard (drops chrome), minimal `/profile` X-chrome.
- **Proofs** — `/actions` renders the v2 body inside the v3 shell (compat); `/kiosk` is untouched (exempt).
