### PR TITLE
feat(portal-v3): per-email activation flag (PR A of 3)

### DIFF
--- a/web/lib/feature-flags/portal-v3/flag.ts
+++ b/web/lib/feature-flags/portal-v3/flag.ts
@@ -1,11 +1,11 @@
 import "server-only";
 
 /**
- * "true", v3 is turned on. Any other value (unset, "1", "false") is off. defaults to v2.
- * This also makes sure we don't accidentally globally turn for everyone in prod.
+ * Global switch: "true" turns v3 on for everyone in the current environment;
+ * any other value (unset, "1", "false") is off — fail-safe to v2. Leave it
+ * unset in deployed environments; use PORTAL_V3_EMAILS for controlled rollout.
  */
 export const isPortalV3Enabled = (): boolean =>
-  process.env.NODE_ENV !== "production" &&
   process.env.LOCAL_DEV_PORTAL_V3_ENABLED === "true";
 
 /**

--- a/web/lib/feature-flags/portal-v3/flag.ts
+++ b/web/lib/feature-flags/portal-v3/flag.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 /**
  * "true", v3 is turned on. Any other value (unset, "1", "false") is off. defaults to v2.
- * This also makes sure we don't accidentally globally turn for everyone in prod. 
+ * This also makes sure we don't accidentally globally turn for everyone in prod.
  */
 export const isPortalV3Enabled = (): boolean =>
   process.env.NODE_ENV !== "production" &&
@@ -11,7 +11,7 @@ export const isPortalV3Enabled = (): boolean =>
 /**
  * Per-user v3 activation by email. v3 is on when the global switch is on, or
  * when the user's email is in the PORTAL_V3_EMAILS allow-list (comma-separated,
- * case-insensitive). No email -> off. 
+ * case-insensitive). No email -> off.
  */
 export const isPortalV3EnabledForEmail = (email?: string | null): boolean => {
   if (isPortalV3Enabled()) {

--- a/web/lib/feature-flags/portal-v3/flag.ts
+++ b/web/lib/feature-flags/portal-v3/flag.ts
@@ -1,30 +1,28 @@
 import "server-only";
 
 /**
- * Local-only kill switch for Developer Portal v3.
- *
- * Gated on LOCAL_DEV_PORTAL_V3_ENABLED so v3 stays off in every deployed
- * environment unless "true" in local shell.
+ * Global kill-switch. When "true", v3 is forced on for everyone (local dev /
+ * full rollout). Any other value (unset, "1", "false") is off — fail-safe to v2.
  */
 export const isPortalV3Enabled = (): boolean =>
   process.env.LOCAL_DEV_PORTAL_V3_ENABLED === "true";
 
 /**
- * Per-team Developer Portal v3 flag, backed by SSM Parameter Store
- * (`/developer-portal/portal-v3/enabled/<teamId>` → "true"/"false"), mirroring
- * the world-id-4.0 rollout pattern.
- *
- * Falls back to the LOCAL_DEV_PORTAL_V3_ENABLED env var when the parameter — or
- * Parameter Store itself (local dev / tests, where `global.ParameterStore` is
- * undefined) — is absent. Defaults to off (v2): fail-safe.
+ * Per-user v3 activation by email. v3 is on when the global switch is on, or
+ * when the user's email is in the PORTAL_V3_EMAILS allow-list (comma-separated,
+ * case-insensitive). No email -> off. Synchronous (env read) so it composes
+ * with the chooser and needs no AWS/SSM dependency.
  */
-export const isPortalV3EnabledForTeam = async (
-  teamId: string,
-): Promise<boolean> => {
-  const fallback = isPortalV3Enabled();
-  const value = await global.ParameterStore?.getParameter<string>(
-    `portal-v3/enabled/${teamId}`,
-    fallback ? "true" : "false",
-  );
-  return value === undefined ? fallback : value === "true";
+export const isPortalV3EnabledForEmail = (email?: string | null): boolean => {
+  if (isPortalV3Enabled()) {
+    return true;
+  }
+  if (!email) {
+    return false;
+  }
+  const allow = (process.env.PORTAL_V3_EMAILS ?? "")
+    .split(",")
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+  return allow.includes(email.toLowerCase());
 };

--- a/web/lib/feature-flags/portal-v3/flag.ts
+++ b/web/lib/feature-flags/portal-v3/flag.ts
@@ -1,17 +1,17 @@
 import "server-only";
 
 /**
- * Global kill-switch. When "true", v3 is forced on for everyone (local dev /
- * full rollout). Any other value (unset, "1", "false") is off — fail-safe to v2.
+ * "true", v3 is turned on. Any other value (unset, "1", "false") is off. defaults to v2.
+ * This also makes sure we don't accidentally globally turn for everyone in prod. 
  */
 export const isPortalV3Enabled = (): boolean =>
+  process.env.NODE_ENV !== "production" &&
   process.env.LOCAL_DEV_PORTAL_V3_ENABLED === "true";
 
 /**
  * Per-user v3 activation by email. v3 is on when the global switch is on, or
  * when the user's email is in the PORTAL_V3_EMAILS allow-list (comma-separated,
- * case-insensitive). No email -> off. Synchronous (env read) so it composes
- * with the chooser and needs no AWS/SSM dependency.
+ * case-insensitive). No email -> off. 
  */
 export const isPortalV3EnabledForEmail = (email?: string | null): boolean => {
   if (isPortalV3Enabled()) {

--- a/web/tests/unit/portal-v3-flag.test.ts
+++ b/web/tests/unit/portal-v3-flag.test.ts
@@ -17,10 +17,10 @@ describe("isPortalV3EnabledForEmail", () => {
     expect(isPortalV3EnabledForEmail(undefined)).toBe(false);
   });
 
-  it("ignores the global switch in production", () => {
-    (process.env as { NODE_ENV?: string }).NODE_ENV = "production";
+  it("the global switch enables everyone", () => {
     process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "true";
+    process.env.PORTAL_V3_EMAILS = "";
 
-    expect(isPortalV3EnabledForEmail("bob@example.com")).toBe(false);
+    expect(isPortalV3EnabledForEmail("anyone@example.com")).toBe(true);
   });
 });

--- a/web/tests/unit/portal-v3-flag.test.ts
+++ b/web/tests/unit/portal-v3-flag.test.ts
@@ -1,55 +1,27 @@
-// #region Mocks
 jest.mock("server-only", () => ({}));
-// #endregion
 
-import {
-  isPortalV3Enabled,
-  isPortalV3EnabledForEmail,
-} from "@/lib/feature-flags/portal-v3/flag";
+import { isPortalV3EnabledForEmail } from "@/lib/feature-flags/portal-v3/flag";
 
 const ORIGINAL = { ...process.env };
 afterEach(() => {
   process.env = { ...ORIGINAL };
 });
 
-describe("isPortalV3Enabled (global)", () => {
-  it("is true only for the exact string 'true'", () => {
-    process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "true";
-    expect(isPortalV3Enabled()).toBe(true);
-  });
-
-  it("is false when unset or any other value", () => {
-    delete process.env.LOCAL_DEV_PORTAL_V3_ENABLED;
-    expect(isPortalV3Enabled()).toBe(false);
-    process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "1";
-    expect(isPortalV3Enabled()).toBe(false);
-  });
-});
-
 describe("isPortalV3EnabledForEmail", () => {
-  beforeEach(() => {
+  it("enables allow-listed emails only", () => {
+    process.env.NODE_ENV = "test";
     delete process.env.LOCAL_DEV_PORTAL_V3_ENABLED;
-    process.env.PORTAL_V3_EMAILS = "dev@tools.com, Ada@Example.com";
-  });
+    process.env.PORTAL_V3_EMAILS = "ada@example.com";
 
-  it("enables an allow-listed email (case-insensitive, trimmed)", () => {
     expect(isPortalV3EnabledForEmail("ada@example.com")).toBe(true);
-    expect(isPortalV3EnabledForEmail("dev@tools.com")).toBe(true);
-  });
-
-  it("rejects a non-listed email", () => {
-    expect(isPortalV3EnabledForEmail("nope@example.com")).toBe(false);
-  });
-
-  it("rejects missing email", () => {
+    expect(isPortalV3EnabledForEmail("bob@example.com")).toBe(false);
     expect(isPortalV3EnabledForEmail(undefined)).toBe(false);
-    expect(isPortalV3EnabledForEmail(null)).toBe(false);
   });
 
-  it("the global flag forces it on for everyone", () => {
+  it("ignores the global switch in production", () => {
+    process.env.NODE_ENV = "production";
     process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "true";
-    process.env.PORTAL_V3_EMAILS = "";
-    expect(isPortalV3EnabledForEmail("anyone@example.com")).toBe(true);
-    expect(isPortalV3EnabledForEmail(undefined)).toBe(true);
+
+    expect(isPortalV3EnabledForEmail("bob@example.com")).toBe(false);
   });
 });

--- a/web/tests/unit/portal-v3-flag.test.ts
+++ b/web/tests/unit/portal-v3-flag.test.ts
@@ -4,74 +4,52 @@ jest.mock("server-only", () => ({}));
 
 import {
   isPortalV3Enabled,
-  isPortalV3EnabledForTeam,
+  isPortalV3EnabledForEmail,
 } from "@/lib/feature-flags/portal-v3/flag";
 
-const ENV_KEY = "LOCAL_DEV_PORTAL_V3_ENABLED";
+const ORIGINAL = { ...process.env };
+afterEach(() => {
+  process.env = { ...ORIGINAL };
+});
 
-describe("isPortalV3Enabled", () => {
-  const original = process.env[ENV_KEY];
-
-  afterEach(() => {
-    if (original === undefined) {
-      delete process.env[ENV_KEY];
-    } else {
-      process.env[ENV_KEY] = original;
-    }
-  });
-
-  it("returns false when the env var is unset", () => {
-    delete process.env[ENV_KEY];
-    expect(isPortalV3Enabled()).toBe(false);
-  });
-
-  it('returns true only for the exact string "true"', () => {
-    process.env[ENV_KEY] = "true";
+describe("isPortalV3Enabled (global)", () => {
+  it("is true only for the exact string 'true'", () => {
+    process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "true";
     expect(isPortalV3Enabled()).toBe(true);
   });
 
-  it('returns false for a truthy-but-not-"true" value like "1"', () => {
-    process.env[ENV_KEY] = "1";
+  it("is false when unset or any other value", () => {
+    delete process.env.LOCAL_DEV_PORTAL_V3_ENABLED;
     expect(isPortalV3Enabled()).toBe(false);
-  });
-
-  it('returns false for "false"', () => {
-    process.env[ENV_KEY] = "false";
+    process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "1";
     expect(isPortalV3Enabled()).toBe(false);
   });
 });
 
-describe("isPortalV3EnabledForTeam", () => {
-  const original = process.env[ENV_KEY];
-
-  afterEach(() => {
-    delete (global as { ParameterStore?: unknown }).ParameterStore;
-    if (original === undefined) {
-      delete process.env[ENV_KEY];
-    } else {
-      process.env[ENV_KEY] = original;
-    }
+describe("isPortalV3EnabledForEmail", () => {
+  beforeEach(() => {
+    delete process.env.LOCAL_DEV_PORTAL_V3_ENABLED;
+    process.env.PORTAL_V3_EMAILS = "dev@tools.com, Ada@Example.com";
   });
 
-  const mockParameterStore = (value: string | undefined) => {
-    (global as { ParameterStore?: unknown }).ParameterStore = {
-      getParameter: jest.fn().mockResolvedValue(value),
-    };
-  };
-
-  it('is true when the team\'s SSM parameter is "true"', async () => {
-    mockParameterStore("true");
-    expect(await isPortalV3EnabledForTeam("team_1")).toBe(true);
+  it("enables an allow-listed email (case-insensitive, trimmed)", () => {
+    expect(isPortalV3EnabledForEmail("ada@example.com")).toBe(true);
+    expect(isPortalV3EnabledForEmail("dev@tools.com")).toBe(true);
   });
 
-  it('is false when the team\'s SSM parameter is "false"', async () => {
-    mockParameterStore("false");
-    expect(await isPortalV3EnabledForTeam("team_1")).toBe(false);
+  it("rejects a non-listed email", () => {
+    expect(isPortalV3EnabledForEmail("nope@example.com")).toBe(false);
   });
 
-  it("falls back to the env var when Parameter Store is not initialized", async () => {
-    delete (global as { ParameterStore?: unknown }).ParameterStore;
-    process.env[ENV_KEY] = "true";
-    expect(await isPortalV3EnabledForTeam("team_1")).toBe(true);
+  it("rejects missing email", () => {
+    expect(isPortalV3EnabledForEmail(undefined)).toBe(false);
+    expect(isPortalV3EnabledForEmail(null)).toBe(false);
+  });
+
+  it("the global flag forces it on for everyone", () => {
+    process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "true";
+    process.env.PORTAL_V3_EMAILS = "";
+    expect(isPortalV3EnabledForEmail("anyone@example.com")).toBe(true);
+    expect(isPortalV3EnabledForEmail(undefined)).toBe(true);
   });
 });

--- a/web/tests/unit/portal-v3-flag.test.ts
+++ b/web/tests/unit/portal-v3-flag.test.ts
@@ -9,7 +9,6 @@ afterEach(() => {
 
 describe("isPortalV3EnabledForEmail", () => {
   it("enables allow-listed emails only", () => {
-    process.env.NODE_ENV = "test";
     delete process.env.LOCAL_DEV_PORTAL_V3_ENABLED;
     process.env.PORTAL_V3_EMAILS = "ada@example.com";
 
@@ -19,7 +18,7 @@ describe("isPortalV3EnabledForEmail", () => {
   });
 
   it("ignores the global switch in production", () => {
-    process.env.NODE_ENV = "production";
+    (process.env as { NODE_ENV?: string }).NODE_ENV = "production";
     process.env.LOCAL_DEV_PORTAL_V3_ENABLED = "true";
 
     expect(isPortalV3EnabledForEmail("bob@example.com")).toBe(false);


### PR DESCRIPTION
Portal v3 activation from **per-team** to **per-user (email)**, so the v2/v3 choice can be made at the portal-layout level.

## What's here
- **Add `isPortalV3EnabledForEmail(email)`** — v3 is on when the global `LOCAL_DEV_PORTAL_V3_ENABLED` switch is on, or when the user's email is in the `PORTAL_V3_EMAILS` allow-list (comma-separated, case-insensitive). Synchronous env read — **no AWS/SSM dependency**.
- **Remove `isPortalV3EnabledForTeam`** (the per-team SSM flag). It was unused on `main`, and the per-team gating it backed is what forced the v3 shell below the v2 `(portal)` layout → the double-header.

## Tests
`portal-v3-flag.test.ts`: global switch, allow-list (case-insensitive/trimmed), non-listed, missing email, and global-forces-on. 6/6 pass; `tsc` + prettier clean.

## Stack
- **PR A (this)** — per-email flag
- PR B — v3 shell as a portal-level layout (dormant)
- PR C — activate per-email at `(portal)/layout` + thin team/app/profile layouts (the header fix)