### PR TITLE
fix(hasura): return handled error from unimplemented delete-images route

### DIFF
--- a/web/api/hasura/delete-images/index.ts
+++ b/web/api/hasura/delete-images/index.ts
@@ -1,5 +1,15 @@
+import { errorHasuraQuery } from "@/api/helpers/errors";
 import { NextRequest } from "next/server";
 
 export const POST = async (req: NextRequest) => {
-  throw new Error("Not implemented yet.");
+  // This Hasura action handler has not been implemented yet. Returning a
+  // handled error response (logged at "warn") instead of throwing avoids
+  // surfacing an uncaught 500 and error-level noise in Error Tracking for an
+  // endpoint that is an intentional, not-yet-built stub.
+  return errorHasuraQuery({
+    req,
+    detail: "This endpoint is not implemented yet.",
+    code: "not_implemented",
+    logLevel: "warn",
+  });
 };


### PR DESCRIPTION
## Datadog issue
[Error: Not implemented yet.](https://app.datadoghq.com/error-tracking/issue/7e8584da-7304-11f1-b836-da7ad0900002) — `service:developer-portal env:production`

## Root cause (with evidence)
`web/api/hasura/delete-images/index.ts` was a stub whose `POST` handler threw `new Error("Not implemented yet.")` unconditionally:

```ts
export const POST = async (req: NextRequest) => {
  throw new Error("Not implemented yet.");
};
```

An uncaught throw inside a route handler surfaces as a 500 and is auto-captured by dd-trace as an **error-level** Error Tracking issue. Log-based onset (`"Not implemented yet"`, prod, last 5 weeks) confirms this is a genuinely **new** issue tied to the stub, not deploy re-fingerprinting:

| day | count |
|---|---|
| 2026-06-18 | 4 |
| 2026-06-28 | 15 |

So something in production is calling this Hasura action and getting a 500 each time.

## Fix
Replace the bare `throw` with a handled `errorHasuraQuery` response (`code: "not_implemented"`, `logLevel: "warn"`), mirroring the repo-wide `errorHasuraQuery` pattern used by sibling Hasura handlers. The caller's operation still fails cleanly, but the endpoint no longer emits an uncaught 500 / error-level telemetry for an intentional, not-yet-built stub.

## Confidence: 80%
The change is minimal and clearly removes an uncaught error path. The one open question is product-level: if `delete-images` is *supposed* to actually delete images, this endpoint still needs a real implementation — that is out of scope for error triage and called out below.

## Test plan
- `npx tsc --noEmit` — passes.
- `pnpm format:check` (prettier) — passes.
- No unit test added: the handler has no branching logic (single return), and repo conventions discourage heavy-SDK-mock handler tests for trivial handlers.
- Manual: POST to the `delete-images` Hasura action now returns a JSON `{ message, extensions: { code: "not_implemented" } }` body with status 400 and a `warn` log instead of a 500 + error log.

## Note for reviewer
This stops the error noise but does **not** implement deletion. If this action is on a live code path that expects images to be deleted, please file/track the real implementation separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164G7Eb4mRxeW2ft3JQ2ZUi)_