### PR TITLE
fix(permissions): reject empty/invalid ids before hitting GraphQL

### DIFF
--- a/web/lib/permissions/index.ts
+++ b/web/lib/permissions/index.ts
@@ -16,6 +16,12 @@ import { getSdk as getTeamUpdatePermissionsSdk } from "./graphql/server/get-team
 import { getSdk as getVerificationStatusUpdatePermissionsSdk } from "./graphql/server/get-verification-status-update-permissions.generated";
 
 const getIsIdValid = async (id: string) => {
+  // `entityIdSchema` is not `.required()`, so `validate(undefined)` resolves
+  // successfully. Guard explicitly so a missing/empty id is rejected here
+  // instead of being forwarded to GraphQL as a null non-nullable variable.
+  if (!id) {
+    return false;
+  }
   try {
     await entityIdSchema.validate(id);
     return true;
@@ -67,7 +73,7 @@ export const getIsUserAllowedToReadApp = async (appId: string) => {
 };
 
 export const getIsUserAllowedToUpdateApp = async (appId: string) => {
-  if (!getIsIdValid(appId)) {
+  if (!(await getIsIdValid(appId))) {
     return false;
   }
 
@@ -88,7 +94,7 @@ export const getIsUserAllowedToUpdateApp = async (appId: string) => {
 };
 
 export const getIsUserAllowedToDeleteApp = async (appId: string) => {
-  if (!getIsIdValid(appId)) {
+  if (!(await getIsIdValid(appId))) {
     return false;
   }
 
@@ -111,7 +117,7 @@ export const getIsUserAllowedToDeleteApp = async (appId: string) => {
 export const getIsUserAllowedToUpdateVerificationStatus = async (
   appMetadataId: string,
 ) => {
-  if (!getIsIdValid(appMetadataId)) {
+  if (!(await getIsIdValid(appMetadataId))) {
     return false;
   }
 
@@ -140,7 +146,7 @@ export const getIsUserAllowedToUpdateVerificationStatus = async (
 export const getIsUserAllowedToUpdateAppMetadata = async (
   appMetadataId: string,
 ) => {
-  if (!getIsIdValid(appMetadataId)) {
+  if (!(await getIsIdValid(appMetadataId))) {
     return false;
   }
 
@@ -188,7 +194,7 @@ export const getAppMetadataPermissionAndMode = async (
 };
 
 export const getIsUserAllowedToInsertLocalisation = async (appId: string) => {
-  if (!getIsIdValid(appId)) {
+  if (!(await getIsIdValid(appId))) {
     return false;
   }
 
@@ -211,7 +217,7 @@ export const getIsUserAllowedToInsertLocalisation = async (appId: string) => {
 export const getIsUserAllowedToUpdateLocalisation = async (
   localisationId: string,
 ) => {
-  if (!getIsIdValid(localisationId)) {
+  if (!(await getIsIdValid(localisationId))) {
     return false;
   }
   const session = await auth0.getSession();
@@ -234,7 +240,7 @@ export const getIsUserAllowedToDeleteLocalisation = async (
   appMetadataId: string,
   locale: string,
 ) => {
-  if (!getIsIdValid(appMetadataId)) {
+  if (!(await getIsIdValid(appMetadataId))) {
     return false;
   }
 
@@ -259,7 +265,7 @@ export const getIsUserAllowedToDeleteLocalisation = async (
 };
 
 export const getIsUserAllowedToUpdateTeam = async (teamId: string) => {
-  if (!getIsIdValid(teamId)) {
+  if (!(await getIsIdValid(teamId))) {
     return false;
   }
 
@@ -280,7 +286,7 @@ export const getIsUserAllowedToUpdateTeam = async (teamId: string) => {
 };
 
 export const getIsUserAllowedToDeleteTeam = async (teamId: string) => {
-  if (!getIsIdValid(teamId)) {
+  if (!(await getIsIdValid(teamId))) {
     return false;
   }
 

--- a/web/tests/unit/permissions-id-validation.test.ts
+++ b/web/tests/unit/permissions-id-validation.test.ts
@@ -1,0 +1,71 @@
+// Regression tests for the permission-layer id validation guard.
+//
+// Two related bugs let malformed/empty ids reach the GraphQL backend:
+//   1. `getIsIdValid` validated against a schema that is NOT `.required()`,
+//      so `validate(undefined)` resolved successfully and the function
+//      returned `true` for a missing id — producing Hasura "expecting a value
+//      for non-nullable variable" errors.
+//   2. Most callers invoked `getIsIdValid(...)` WITHOUT `await`, so the guard
+//      (a Promise, always truthy) never actually rejected anything.
+//
+// These tests assert that an invalid id is rejected in the handler itself,
+// BEFORE the GraphQL client is ever constructed.
+
+// #region Mocks
+const getSessionMock = jest.fn();
+jest.mock("@/lib/auth0", () => ({
+  auth0: { getSession: (...args: unknown[]) => getSessionMock(...args) },
+}));
+
+// I/O boundary: if a guard fails to short-circuit, the handler reaches this.
+// We assert it is NOT called for invalid ids.
+const getAPIServiceGraphqlClient = jest.fn();
+jest.mock("@/api/helpers/graphql", () => ({
+  getAPIServiceGraphqlClient: (...args: unknown[]) =>
+    getAPIServiceGraphqlClient(...args),
+}));
+
+import {
+  getIsUserAllowedToInsertApp,
+  getIsUserAllowedToUpdateApp,
+} from "@/lib/permissions";
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // A valid session is present, so the ONLY thing that can reject these calls
+  // is the id-format guard under test (not a missing session).
+  getSessionMock.mockResolvedValue({ user: { hasura: { id: "usr_123" } } });
+});
+
+// #region invalid id is rejected before any GraphQL call
+describe("permission guards reject invalid ids before hitting GraphQL", () => {
+  it.each([
+    ["empty string", ""],
+    ["undefined", undefined as unknown as string],
+    ["malformed id", "not-a-valid-id"],
+  ])(
+    "getIsUserAllowedToInsertApp returns false for %s without calling the client",
+    async (_label, teamId) => {
+      const result = await getIsUserAllowedToInsertApp(teamId);
+      expect(result).toBe(false);
+      expect(getAPIServiceGraphqlClient).not.toHaveBeenCalled();
+    },
+  );
+
+  // This handler previously called `getIsIdValid` without `await`, so the
+  // guard never fired. It must now reject an invalid id too.
+  it.each([
+    ["empty string", ""],
+    ["undefined", undefined as unknown as string],
+    ["malformed id", "not-a-valid-id"],
+  ])(
+    "getIsUserAllowedToUpdateApp returns false for %s without calling the client",
+    async (_label, appId) => {
+      const result = await getIsUserAllowedToUpdateApp(appId);
+      expect(result).toBe(false);
+      expect(getAPIServiceGraphqlClient).not.toHaveBeenCalled();
+    },
+  );
+});
+// #endregion


### PR DESCRIPTION
**NEEDS CAREFUL REVIEW** — this changes the input-validation guard in the team/app **permission layer** (`lib/permissions`). The change makes the guards *stricter* (it does not loosen any authorization check), but because it touches authz code paths a human should confirm the behavior on valid inputs is unchanged.

## Datadog issue
[Error: expecting a value for non-nullable variable: "teamId"](https://app.datadoghq.com/error-tracking/issue/e8ef415c-5ff5-11f1-bc4c-da7ad0900002) — `service:developer-portal env:production` (also addresses a latent, currently-silent correctness bug; see below).

## Root cause (with evidence)
The error sample shows the GraphQL operation `GetIsUserPermittedToInsertApp($userId: String!, $teamId: String!)` being sent with **only** `userId` — `teamId` is absent — so Hasura rejects it with `expecting a value for non-nullable variable: "teamId"`.

Two related defects in `web/lib/permissions/index.ts`:

1. **`getIsIdValid` accepts `undefined`.** It validates against `entityIdSchema` (`web/lib/schema/index.ts:7`), which is **not** `.required()`:
   ```ts
   export const entityIdSchema = yup.string().matches(/^[a-zA-Z0-9]+_[a-zA-Z0-9]{32}$/, "Invalid id format");
   ```
   `yup` string schemas resolve for `undefined` when not required, so `getIsIdValid(undefined)` returned `true`. The `undefined` id was then passed straight through as a non-nullable GraphQL variable → the triaged error.

2. **Missing `await` on the guard (latent bug).** Nine callers used `if (!getIsIdValid(id))`. `getIsIdValid` is `async`, so the expression is `!<Promise>` — always `false` — meaning the id-format guard **never ran** for `getIsUserAllowedToUpdateApp`, `...DeleteApp`, `...UpdateVerificationStatus`, `...UpdateAppMetadata`, `...InsertLocalisation`, `...UpdateLocalisation`, `...DeleteLocalisation`, `...UpdateTeam`, `...DeleteTeam`. Only `InsertApp`, `ReadApp`, and `getAppMetadataPermissionAndMode` awaited correctly.

## Fix
- Add an explicit `if (!id) return false;` guard inside `getIsIdValid` so missing/empty ids are rejected locally instead of being forwarded to GraphQL.
- `await getIsIdValid(...)` at all 12 call sites (9 were missing it).

Scope is limited to `lib/permissions/index.ts`; the shared `entityIdSchema` is intentionally left untouched to avoid affecting other consumers.

## Confidence: 80%
Root cause for the `teamId` error is well-evidenced from the error sample, and the missing-`await` bug is unambiguous in the source. The 20% reflects that I could not reproduce the exact upstream caller that passes an `undefined` `teamId` (likely a client/bot edge case), and this is authz-adjacent code that merits human eyes.

## Test plan
- `npx tsc --noEmit` — passes.
- `pnpm format:check` — passes.
- New unit test `tests/unit/permissions-id-validation.test.ts` (6 cases) asserts `getIsUserAllowedToInsertApp` and `getIsUserAllowedToUpdateApp` return `false` for empty/`undefined`/malformed ids **without constructing the GraphQL client**. All pass.
- Note: the guards still perform the same session + membership checks for valid ids; only the early-reject path for invalid ids changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164G7Eb4mRxeW2ft3JQ2ZUi)_