### PR TITLE
fix(portal-v3): Change undefined tailwind elements that resulted in broken hover effect

### DIFF
--- a/web/scenes/PortalV3/layout/Shell/NavItem.tsx
+++ b/web/scenes/PortalV3/layout/Shell/NavItem.tsx
@@ -15,8 +15,8 @@ export const NavItem = (props: {
     "flex min-w-0 items-center gap-2.5 rounded-8 px-2.5 py-1.5 font-gta text-14 font-medium outline-none transition-colors",
     "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
     active
-      ? "bg-muted text-foreground"
-      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+      ? "bg-grey-100 text-foreground"
+      : "text-muted-foreground hover:bg-grey-100",
     dimmed && "opacity-40",
   );
 


### PR DESCRIPTION
## What
hover effects on the dashboard links were broken cause we used tailwind elements like `bg-muted` which aren't defined in vanilla tailwind (probably referenced from some shadcn inclusion prompt). 

## Fixed
Changed hover effect to `bg-grey-100`

## Before and After

https://github.com/user-attachments/assets/a5abff78-dd77-401e-bc2b-5db6a69bc542




https://github.com/user-attachments/assets/079e1542-7ebe-4811-a47a-9d842e05de55





