### PR TITLE
feat(portal-v3): flip /teams/[teamId]/api-keys to v3

### DIFF
--- a/web/app/(portal)/teams/[teamId]/(team)/api-keys/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/(team)/api-keys/page.tsx
@@ -1,9 +1,18 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { generateMetaTitle } from "@/lib/genarate-title";
 import { TeamApiKeysPage } from "@/scenes/Portal/Teams/TeamId/Team/ApiKeys/page";
+import { TeamApiKeysPage as TeamApiKeysPageV3 } from "@/scenes/PortalV3/Teams/TeamId/Team/ApiKeys/page";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: generateMetaTitle({ left: "API keys" }),
 };
 
-export default TeamApiKeysPage;
+type Props = { params: Promise<Record<string, string>> };
+
+export default async function Page(props: Props) {
+  return pickPortalVersion(
+    () => <TeamApiKeysPageV3 params={props.params} />,
+    () => <TeamApiKeysPage params={props.params} />,
+  );
+}

--- a/web/tests/unit/pv3-r-api-keys.test.tsx
+++ b/web/tests/unit/pv3-r-api-keys.test.tsx
@@ -1,0 +1,23 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock("@/scenes/Portal/Teams/TeamId/Team/ApiKeys/page", () => ({
+  TeamApiKeysPage: () => <div data-testid="v2-api-keys" />,
+}));
+jest.mock("@/scenes/PortalV3/Teams/TeamId/Team/ApiKeys/page", () => ({
+  TeamApiKeysPage: () => <div data-testid="v3-api-keys" />,
+}));
+import RoutePage from "../../app/(portal)/teams/[teamId]/(team)/api-keys/page";
+it("renders v3 api-keys", async () => {
+  render(
+    await RoutePage({
+      params: Promise.resolve({ teamId: "team_1", appId: "app_1" }),
+    }),
+  );
+  expect(screen.getByTestId("v3-api-keys")).toBeInTheDocument();
+  expect(screen.queryByTestId("v2-api-keys")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Flips the single **`/teams/[teamId]/api-keys`** route to portal v3: the route file becomes a `pickPortalVersion` chooser — allow-listed (v3) sessions render the forked `PortalV3` page, everyone else keeps the v2 page. Behavior-preserving: the v3 fork is byte-identical to v2 today, so v3 users see the same page inside the v3 shell.

- `app/(portal)/teams/[teamId]/(team)/api-keys/page.tsx`: bare re-export → chooser (metadata export unchanged; forwards the `params` promise both branches expect).
- `tests/unit/pv3-r-api-keys.test.tsx`: chooser test (mocks activation to v3, asserts the v3 page renders and v2 doesn't).

## Why

Per-route flips keep the blast radius one route: reverting this PR (or removing an email from the allow-list) instantly restores v2 for that route with no other changes.

## Footprint / verification

- 2 files, +33/−1.
- `npx tsc --noEmit` → 0 · new chooser test passes · full `tests/unit/` green on the stack.

## Stack

Stacked on https://github.com/worldcoin/developer-portal/pull/2017 (API Keys foundation), which stacks on https://github.com/worldcoin/developer-portal/pull/2016. Retarget as parents merge.