### PR TITLE
feat(portal-v3): flip /teams/[teamId]/apps/[appId]/configuration/danger to v3

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/configuration/danger/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/configuration/danger/page.tsx
@@ -1,13 +1,10 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { generateMetaTitle } from "@/lib/genarate-title";
 import { AppProfileDangerPage } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Danger/page";
+import { AppProfileDangerPage as AppProfileDangerPageV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/page";
 import { Metadata } from "next";
 
-type Props = {
-  params: Promise<{
-    teamId: string;
-    appId: string;
-  }>;
-};
+type Props = { params: Promise<{ teamId: string; appId: string }> };
 
 export const metadata: Metadata = {
   title: generateMetaTitle({ left: "Danger zone" }),
@@ -15,5 +12,8 @@ export const metadata: Metadata = {
 
 export default async function Page(props: Props) {
   const params = await props.params;
-  return <AppProfileDangerPage params={params} />;
+  return pickPortalVersion(
+    () => <AppProfileDangerPageV3 params={params} />,
+    () => <AppProfileDangerPage params={params} />,
+  );
 }

--- a/web/tests/unit/pv3-r-configuration-danger.test.tsx
+++ b/web/tests/unit/pv3-r-configuration-danger.test.tsx
@@ -1,0 +1,31 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Danger/page",
+  () => ({
+    AppProfileDangerPage: () => <div data-testid="v2-configuration-danger" />,
+  }),
+);
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/page",
+  () => ({
+    AppProfileDangerPage: () => <div data-testid="v3-configuration-danger" />,
+  }),
+);
+import RoutePage from "../../app/(portal)/teams/[teamId]/apps/[appId]/configuration/danger/page";
+it("renders v3 configuration-danger", async () => {
+  render(
+    await RoutePage({
+      params: Promise.resolve({ teamId: "team_1", appId: "app_1" }),
+    }),
+  );
+  expect(screen.getByTestId("v3-configuration-danger")).toBeInTheDocument();
+  expect(
+    screen.queryByTestId("v2-configuration-danger"),
+  ).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Flips **`/teams/[teamId]/apps/[appId]/configuration/danger`** to portal v3: the route file becomes a `pickPortalVersion` chooser — allow-listed (v3) sessions render the forked `PortalV3` version, everyone else keeps v2. Behavior-preserving: the fork is byte-identical to v2 today.

- route file: bare re-export → chooser (metadata export unchanged; params forwarded in the exact shape the scene component expects)
- one chooser test (mocks activation to v3, asserts the v3 component renders and v2 doesn't)

## Footprint / verification

- 2 files, minimal diff. `npx tsc --noEmit` → 0 · chooser test passes · full `tests/unit/` green on the stack.

## Stack

Stacked on #2019 (Configuration foundation). Same pattern as #2018. Retarget as parents merge.