### PR TITLE
feat(portal-v3): flip the configuration layout to v3

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/configuration/layout.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/configuration/layout.tsx
@@ -1,16 +1,18 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { AppProfileLayout } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/layout";
+import { AppProfileLayout as AppProfileLayoutV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/layout";
 import { ReactNode } from "react";
 
 type Props = {
-  params: Promise<{
-    teamId: string;
-    appId: string;
-  }>;
+  params: Promise<{ teamId: string; appId: string }>;
   children: ReactNode;
 };
 
 export default async function Layout(props: Props) {
   const params = await props.params;
   const { children } = props;
-  return <AppProfileLayout params={params}>{children}</AppProfileLayout>;
+  return pickPortalVersion(
+    () => <AppProfileLayoutV3 params={params}>{children}</AppProfileLayoutV3>,
+    () => <AppProfileLayout params={params}>{children}</AppProfileLayout>,
+  );
 }

--- a/web/tests/unit/pv3-r-configuration-layout.test.tsx
+++ b/web/tests/unit/pv3-r-configuration-layout.test.tsx
@@ -1,0 +1,32 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/layout",
+  () => ({
+    AppProfileLayout: () => <div data-testid="v2-configuration-layout" />,
+  }),
+);
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/layout",
+  () => ({
+    AppProfileLayout: () => <div data-testid="v3-configuration-layout" />,
+  }),
+);
+import Layout from "../../app/(portal)/teams/[teamId]/apps/[appId]/configuration/layout";
+it("renders v3 configuration layout", async () => {
+  render(
+    await Layout({
+      params: Promise.resolve({ teamId: "team_1", appId: "app_1" }),
+      children: null,
+    }),
+  );
+  expect(screen.getByTestId("v3-configuration-layout")).toBeInTheDocument();
+  expect(
+    screen.queryByTestId("v2-configuration-layout"),
+  ).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Flips **`the configuration layout`** to portal v3: the route file becomes a `pickPortalVersion` chooser — allow-listed (v3) sessions render the forked `PortalV3` version, everyone else keeps v2. Behavior-preserving: the fork is byte-identical to v2 today.

- route file: bare re-export → chooser (metadata export unchanged; params forwarded in the exact shape the scene component expects)
- one chooser test (mocks activation to v3, asserts the v3 component renders and v2 doesn't)

## Footprint / verification

- 2 files, minimal diff. `npx tsc --noEmit` → 0 · chooser test passes · full `tests/unit/` green on the stack.

## Stack

Stacked on #2019 (Configuration foundation). Same pattern as #2018. Retarget as parents merge.