### PR TITLE
feat(portal-v3): flip /teams/[teamId]/apps/[appId]/actions to v3

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/page.tsx
@@ -1,9 +1,23 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { generateMetaTitle } from "@/lib/genarate-title";
 import { ActionsPage } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page";
+import { ActionsPage as ActionsPageV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/page";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: generateMetaTitle({ left: "Incognito actions" }),
 };
 
-export default ActionsPage;
+export default async function Page(props: {
+  params: Promise<Record<string, string>>;
+  searchParams: Promise<Record<string, string>>;
+}) {
+  return pickPortalVersion(
+    () => (
+      <ActionsPageV3 params={props.params} searchParams={props.searchParams} />
+    ),
+    () => (
+      <ActionsPage params={props.params} searchParams={props.searchParams} />
+    ),
+  );
+}

--- a/web/tests/unit/pv3-r-actions.test.tsx
+++ b/web/tests/unit/pv3-r-actions.test.tsx
@@ -1,0 +1,24 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock("@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page", () => ({
+  ActionsPage: () => <div data-testid="v2-actions" />,
+}));
+jest.mock("@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/page", () => ({
+  ActionsPage: () => <div data-testid="v3-actions" />,
+}));
+import RoutePage from "../../app/(portal)/teams/[teamId]/apps/[appId]/actions/page";
+it("renders v3 actions", async () => {
+  render(
+    await RoutePage({
+      params: Promise.resolve({ teamId: "team_1", appId: "app_1" }),
+      searchParams: Promise.resolve({}),
+    }),
+  );
+  expect(screen.getByTestId("v3-actions")).toBeInTheDocument();
+  expect(screen.queryByTestId("v2-actions")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Flips **`/teams/[teamId]/apps/[appId]/actions`** to portal v3: the route file becomes a `pickPortalVersion` chooser — allow-listed (v3) sessions render the forked `PortalV3` version, everyone else keeps v2. Behavior-preserving: the fork is byte-identical to v2 today.

- route file: bare re-export → chooser (metadata export unchanged; params forwarded in the exact shape the scene component expects)
- one chooser test (mocks activation to v3, asserts the v3 component renders and v2 doesn't)

## Footprint / verification

- 2 files, minimal diff. `npx tsc --noEmit` → 0 · chooser test passes · full `tests/unit/` green on the stack.

## Stack

Stacked on #2020 (Incognito Actions foundation). Same pattern as #2018. Retarget as parents merge.