### PR TITLE
feat(portal-v3): flip the actions [actionId] layout to v3

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/[actionId]/layout.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/[actionId]/layout.tsx
@@ -1,2 +1,20 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { ActionIdLayout } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/layout";
-export default ActionIdLayout;
+import { ActionIdLayout as ActionIdLayoutV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/ActionId/layout";
+import { ReactNode } from "react";
+
+export default async function Layout(props: {
+  params: Promise<Record<string, string>>;
+  children: ReactNode;
+}) {
+  return pickPortalVersion(
+    () => (
+      <ActionIdLayoutV3 params={props.params}>
+        {props.children}
+      </ActionIdLayoutV3>
+    ),
+    () => (
+      <ActionIdLayout params={props.params}>{props.children}</ActionIdLayout>
+    ),
+  );
+}

--- a/web/tests/unit/pv3-r-actions-actionid-layout.test.tsx
+++ b/web/tests/unit/pv3-r-actions-actionid-layout.test.tsx
@@ -1,0 +1,36 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/layout",
+  () => ({
+    ActionIdLayout: () => <div data-testid="v2-actions-actionid-layout" />,
+  }),
+);
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/ActionId/layout",
+  () => ({
+    ActionIdLayout: () => <div data-testid="v3-actions-actionid-layout" />,
+  }),
+);
+import Layout from "../../app/(portal)/teams/[teamId]/apps/[appId]/actions/[actionId]/layout";
+it("renders v3 actions actionId layout", async () => {
+  render(
+    await Layout({
+      params: Promise.resolve({
+        teamId: "team_1",
+        appId: "app_1",
+        actionId: "a_1",
+      }),
+      children: null,
+    }),
+  );
+  expect(screen.getByTestId("v3-actions-actionid-layout")).toBeInTheDocument();
+  expect(
+    screen.queryByTestId("v2-actions-actionid-layout"),
+  ).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Flips **`the actions [actionId] layout`** to portal v3: the route file becomes a `pickPortalVersion` chooser — allow-listed (v3) sessions render the forked `PortalV3` version, everyone else keeps v2. Behavior-preserving: the fork is byte-identical to v2 today.

- route file: bare re-export → chooser (metadata export unchanged; params forwarded in the exact shape the scene component expects)
- one chooser test (mocks activation to v3, asserts the v3 component renders and v2 doesn't)

## Footprint / verification

- 2 files, minimal diff. `npx tsc --noEmit` → 0 · chooser test passes · full `tests/unit/` green on the stack.

## Stack

Stacked on #2020 (Incognito Actions foundation). Same pattern as #2018. Retarget as parents merge.