### PR TITLE
feat(portal-v3): flip /teams/[teamId]/apps/[appId]/actions/[actionId]/kiosk to v3

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/[actionId]/kiosk/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/actions/[actionId]/kiosk/page.tsx
@@ -1,9 +1,18 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { generateMetaTitle } from "@/lib/genarate-title";
 import { ActionIdKioskPage } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk";
+import { ActionIdKioskPage as ActionIdKioskPageV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: generateMetaTitle({ left: "Kiosk" }),
 };
 
-export default ActionIdKioskPage;
+export default async function Page(props: {
+  params: Promise<Record<string, string>>;
+}) {
+  return pickPortalVersion(
+    () => <ActionIdKioskPageV3 params={props.params} />,
+    () => <ActionIdKioskPage params={props.params} />,
+  );
+}

--- a/web/tests/unit/pv3-r-actions-kiosk.test.tsx
+++ b/web/tests/unit/pv3-r-actions-kiosk.test.tsx
@@ -1,0 +1,29 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk",
+  () => ({ ActionIdKioskPage: () => <div data-testid="v2-actions-kiosk" /> }),
+);
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk",
+  () => ({ ActionIdKioskPage: () => <div data-testid="v3-actions-kiosk" /> }),
+);
+import RoutePage from "../../app/(portal)/teams/[teamId]/apps/[appId]/actions/[actionId]/kiosk/page";
+it("renders v3 actions-kiosk", async () => {
+  render(
+    await RoutePage({
+      params: Promise.resolve({
+        teamId: "team_1",
+        appId: "app_1",
+        actionId: "a_1",
+      }),
+    }),
+  );
+  expect(screen.getByTestId("v3-actions-kiosk")).toBeInTheDocument();
+  expect(screen.queryByTestId("v2-actions-kiosk")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Flips **`/teams/[teamId]/apps/[appId]/actions/[actionId]/kiosk`** to portal v3: the route file becomes a `pickPortalVersion` chooser — allow-listed (v3) sessions render the forked `PortalV3` version, everyone else keeps v2. Behavior-preserving: the fork is byte-identical to v2 today.

- route file: bare re-export → chooser (metadata export unchanged; params forwarded in the exact shape the scene component expects)
- one chooser test (mocks activation to v3, asserts the v3 component renders and v2 doesn't)

## Footprint / verification

- 2 files, minimal diff. `npx tsc --noEmit` → 0 · chooser test passes · full `tests/unit/` green on the stack.

## Stack

Stacked on #2020 (Incognito Actions foundation). Same pattern as #2018. Retarget as parents merge.