### PR TITLE
feat(portal-v3): flip /teams/[teamId]/apps/[appId]/world-id-4-0 to v3

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id-4-0/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id-4-0/page.tsx
@@ -1,13 +1,13 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { WorldId40Page } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page";
+import { WorldId40Page as WorldId40PageV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId40/page";
 
-type Props = {
-  params: Promise<{
-    teamId: string;
-    appId: string;
-  }>;
-};
+type Props = { params: Promise<{ teamId: string; appId: string }> };
 
 export default async function Page(props: Props) {
   const params = await props.params;
-  return <WorldId40Page params={params} />;
+  return pickPortalVersion(
+    () => <WorldId40PageV3 params={params} />,
+    () => <WorldId40Page params={params} />,
+  );
 }

--- a/web/tests/unit/pv3-r-world-id-40.test.tsx
+++ b/web/tests/unit/pv3-r-world-id-40.test.tsx
@@ -1,0 +1,23 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock("@/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page", () => ({
+  WorldId40Page: () => <div data-testid="v2-world-id-40" />,
+}));
+jest.mock("@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId40/page", () => ({
+  WorldId40Page: () => <div data-testid="v3-world-id-40" />,
+}));
+import RoutePage from "../../app/(portal)/teams/[teamId]/apps/[appId]/world-id-4-0/page";
+it("renders v3 world-id-40", async () => {
+  render(
+    await RoutePage({
+      params: Promise.resolve({ teamId: "team_1", appId: "app_1" }),
+    }),
+  );
+  expect(screen.getByTestId("v3-world-id-40")).toBeInTheDocument();
+  expect(screen.queryByTestId("v2-world-id-40")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Flips **`/teams/[teamId]/apps/[appId]/world-id-4-0`** to portal v3: the route file becomes a `pickPortalVersion` chooser — allow-listed (v3) sessions render the forked `PortalV3` version, everyone else keeps v2. Behavior-preserving: the fork is byte-identical to v2 today.

- route file: bare re-export → chooser (metadata export unchanged; params forwarded in the exact shape the scene component expects)
- one chooser test (mocks activation to v3, asserts the v3 component renders and v2 doesn't)

## Footprint / verification

- 2 files, minimal diff. `npx tsc --noEmit` → 0 · chooser test passes · full `tests/unit/` green on the stack.

## Stack

Stacked on #2021 (World ID 4.0 foundation). Same pattern as #2018. Retarget as parents merge.