### PR TITLE
feat(portal-v3): flip /teams/[teamId]/apps/[appId]/sign-in-with-world-id to v3

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/sign-in-with-world-id/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/sign-in-with-world-id/page.tsx
@@ -1,14 +1,19 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { generateMetaTitle } from "@/lib/genarate-title";
 import { SignInWithWorldIdPage } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page";
+import { SignInWithWorldIdPage as SignInWithWorldIdPageV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/SignInWithWorldId/page";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: generateMetaTitle({ left: "Sign in with World ID" }),
 };
 
-// Next 16: params is a Promise — resolve it before handing it to the scene component.
 export default async function Page(props: {
   params: Promise<Record<string, string>>;
 }) {
-  return <SignInWithWorldIdPage params={await props.params} />;
+  const params = await props.params;
+  return pickPortalVersion(
+    () => <SignInWithWorldIdPageV3 params={params} />,
+    () => <SignInWithWorldIdPage params={params} />,
+  );
 }

--- a/web/tests/unit/pv3-r-siwwi.test.tsx
+++ b/web/tests/unit/pv3-r-siwwi.test.tsx
@@ -1,0 +1,25 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page",
+  () => ({ SignInWithWorldIdPage: () => <div data-testid="v2-siwwi" /> }),
+);
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/SignInWithWorldId/page",
+  () => ({ SignInWithWorldIdPage: () => <div data-testid="v3-siwwi" /> }),
+);
+import RoutePage from "../../app/(portal)/teams/[teamId]/apps/[appId]/sign-in-with-world-id/page";
+it("renders v3 siwwi", async () => {
+  render(
+    await RoutePage({
+      params: Promise.resolve({ teamId: "team_1", appId: "app_1" }),
+    }),
+  );
+  expect(screen.getByTestId("v3-siwwi")).toBeInTheDocument();
+  expect(screen.queryByTestId("v2-siwwi")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Flips **`/teams/[teamId]/apps/[appId]/sign-in-with-world-id`** to portal v3: the route file becomes a `pickPortalVersion` chooser — allow-listed (v3) sessions render the forked `PortalV3` version, everyone else keeps v2. Behavior-preserving: the fork is byte-identical to v2 today.

- route file: bare re-export → chooser (metadata export unchanged; params forwarded in the exact shape the scene component expects)
- one chooser test (mocks activation to v3, asserts the v3 component renders and v2 doesn't)

## Footprint / verification

- 2 files, minimal diff. `npx tsc --noEmit` → 0 · chooser test passes · full `tests/unit/` green on the stack.

## Stack

Stacked on #2022 (Sign in with World ID foundation). Same pattern as #2018. Retarget as parents merge.