### PR TITLE
feat(portal-v3): flip the sign-in-with-world-id layout to v3

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/sign-in-with-world-id/layout.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/sign-in-with-world-id/layout.tsx
@@ -1,2 +1,22 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { SignInWithWorldIdLayout } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/layout";
-export default SignInWithWorldIdLayout;
+import { SignInWithWorldIdLayout as SignInWithWorldIdLayoutV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/SignInWithWorldId/layout";
+import { ReactNode } from "react";
+
+export default async function Layout(props: {
+  params: Promise<Record<string, string>>;
+  children: ReactNode;
+}) {
+  return pickPortalVersion(
+    () => (
+      <SignInWithWorldIdLayoutV3 params={props.params}>
+        {props.children}
+      </SignInWithWorldIdLayoutV3>
+    ),
+    () => (
+      <SignInWithWorldIdLayout params={props.params}>
+        {props.children}
+      </SignInWithWorldIdLayout>
+    ),
+  );
+}

--- a/web/tests/unit/pv3-r-siwwi-layout.test.tsx
+++ b/web/tests/unit/pv3-r-siwwi-layout.test.tsx
@@ -1,0 +1,30 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/layout",
+  () => ({
+    SignInWithWorldIdLayout: () => <div data-testid="v2-siwwi-layout" />,
+  }),
+);
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/SignInWithWorldId/layout",
+  () => ({
+    SignInWithWorldIdLayout: () => <div data-testid="v3-siwwi-layout" />,
+  }),
+);
+import Layout from "../../app/(portal)/teams/[teamId]/apps/[appId]/sign-in-with-world-id/layout";
+it("renders v3 siwwi layout", async () => {
+  render(
+    await Layout({
+      params: Promise.resolve({ teamId: "team_1", appId: "app_1" }),
+      children: null,
+    }),
+  );
+  expect(screen.getByTestId("v3-siwwi-layout")).toBeInTheDocument();
+  expect(screen.queryByTestId("v2-siwwi-layout")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Flips **`the sign-in-with-world-id layout`** to portal v3: the route file becomes a `pickPortalVersion` chooser — allow-listed (v3) sessions render the forked `PortalV3` version, everyone else keeps v2. Behavior-preserving: the fork is byte-identical to v2 today.

- route file: bare re-export → chooser (metadata export unchanged; params forwarded in the exact shape the scene component expects)
- one chooser test (mocks activation to v3, asserts the v3 component renders and v2 doesn't)

## Footprint / verification

- 2 files, minimal diff. `npx tsc --noEmit` → 0 · chooser test passes · full `tests/unit/` green on the stack.

## Stack

Stacked on #2022 (Sign in with World ID foundation). Same pattern as #2018. Retarget as parents merge.