### PR TITLE
feat(portal-v3): flip /teams/[teamId]/apps/[appId]/mini-app/transactions to v3

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/mini-app/transactions/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/mini-app/transactions/page.tsx
@@ -1,14 +1,19 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { generateMetaTitle } from "@/lib/genarate-title";
 import { TransactionsPage } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page";
+import { TransactionsPage as TransactionsPageV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: generateMetaTitle({ left: "Transactions" }),
 };
 
-// Next 16: params is a Promise — resolve it before handing it to the scene component.
 export default async function Page(props: {
   params: Promise<Record<string, string>>;
 }) {
-  return <TransactionsPage params={await props.params} />;
+  const params = await props.params;
+  return pickPortalVersion(
+    () => <TransactionsPageV3 params={params} />,
+    () => <TransactionsPage params={params} />,
+  );
 }

--- a/web/tests/unit/pv3-r-mini-app-transactions.test.tsx
+++ b/web/tests/unit/pv3-r-mini-app-transactions.test.tsx
@@ -1,0 +1,29 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page",
+  () => ({
+    TransactionsPage: () => <div data-testid="v2-mini-app-transactions" />,
+  }),
+);
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page",
+  () => ({
+    TransactionsPage: () => <div data-testid="v3-mini-app-transactions" />,
+  }),
+);
+import RoutePage from "../../app/(portal)/teams/[teamId]/apps/[appId]/mini-app/transactions/page";
+it("renders v3 mini-app-transactions", async () => {
+  render(
+    await RoutePage({ params: Promise.resolve({ teamId: "t", appId: "a" }) }),
+  );
+  expect(screen.getByTestId("v3-mini-app-transactions")).toBeInTheDocument();
+  expect(
+    screen.queryByTestId("v2-mini-app-transactions"),
+  ).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Flips **`/teams/[teamId]/apps/[appId]/mini-app/transactions`** to portal v3: the route file becomes a `pickPortalVersion` chooser — allow-listed (v3) sessions render the forked `PortalV3` version, everyone else keeps v2. Behavior-preserving: the fork is byte-identical to v2 today.

- route file: bare re-export → chooser (metadata export unchanged; params forwarded in the exact shape the scene component expects)
- one chooser test (mocks activation to v3, asserts the v3 component renders and v2 doesn't)

## Footprint / verification

- 2 files, minimal diff. `npx tsc --noEmit` → 0 · chooser test passes · full `tests/unit/` green on the stack.

## Stack

Stacked on #2025 (Mini App foundation). Same pattern as #2018. Retarget as parents merge.