### PR TITLE
feat(portal-v3): flip /teams/[teamId]/apps/[appId]/world-id-actions to v3

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id-actions/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id-actions/page.tsx
@@ -1,4 +1,6 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { WorldIdActionsPage } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page";
+import { WorldIdActionsPage as WorldIdActionsPageV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/page";
 
 export default async function Page(props: {
   params: Promise<Record<string, string>>;
@@ -6,6 +8,8 @@ export default async function Page(props: {
 }) {
   const params = await props.params;
   const searchParams = await props.searchParams;
-
-  return <WorldIdActionsPage params={params} searchParams={searchParams} />;
+  return pickPortalVersion(
+    () => <WorldIdActionsPageV3 params={params} searchParams={searchParams} />,
+    () => <WorldIdActionsPage params={params} searchParams={searchParams} />,
+  );
 }

--- a/web/tests/unit/pv3-r-wia-list.test.tsx
+++ b/web/tests/unit/pv3-r-wia-list.test.tsx
@@ -1,0 +1,26 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/page",
+  () => ({ WorldIdActionsPage: () => <div data-testid="v2-wia-list" /> }),
+);
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/page",
+  () => ({ WorldIdActionsPage: () => <div data-testid="v3-wia-list" /> }),
+);
+import RoutePage from "../../app/(portal)/teams/[teamId]/apps/[appId]/world-id-actions/page";
+it("renders v3 wia-list", async () => {
+  render(
+    await RoutePage({
+      params: Promise.resolve({ teamId: "t", appId: "a" }),
+      searchParams: Promise.resolve({}),
+    }),
+  );
+  expect(screen.getByTestId("v3-wia-list")).toBeInTheDocument();
+  expect(screen.queryByTestId("v2-wia-list")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Flips **`/teams/[teamId]/apps/[appId]/world-id-actions`** to portal v3: the route file becomes a `pickPortalVersion` chooser — allow-listed (v3) sessions render the forked `PortalV3` version, everyone else keeps v2. Behavior-preserving: the fork is byte-identical to v2 today.

- route file: bare re-export → chooser (metadata export unchanged; params forwarded in the exact shape the scene component expects)
- one chooser test (mocks activation to v3, asserts the v3 component renders and v2 doesn't)

## Footprint / verification

- 2 files, minimal diff. `npx tsc --noEmit` → 0 · chooser test passes · full `tests/unit/` green on the stack.

## Stack

Stacked on #2027 (World ID Actions foundation). Same pattern as #2018. Retarget as parents merge.