### PR TITLE
feat(portal-v3): flip the world-id-actions [actionId] layout to v3

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id-actions/[actionId]/layout.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id-actions/[actionId]/layout.tsx
@@ -1,3 +1,22 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { WorldIdActionIdLayout } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/layout";
+import { WorldIdActionIdLayout as WorldIdActionIdLayoutV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/layout";
+import { ReactNode } from "react";
 
-export default WorldIdActionIdLayout;
+export default async function Layout(props: {
+  params: Promise<Record<string, string>>;
+  children: ReactNode;
+}) {
+  return pickPortalVersion(
+    () => (
+      <WorldIdActionIdLayoutV3 params={props.params}>
+        {props.children}
+      </WorldIdActionIdLayoutV3>
+    ),
+    () => (
+      <WorldIdActionIdLayout params={props.params}>
+        {props.children}
+      </WorldIdActionIdLayout>
+    ),
+  );
+}

--- a/web/tests/unit/pv3-r-wia-actionid-layout.test.tsx
+++ b/web/tests/unit/pv3-r-wia-actionid-layout.test.tsx
@@ -1,0 +1,32 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/layout",
+  () => ({
+    WorldIdActionIdLayout: () => <div data-testid="v2-wia-actionid-layout" />,
+  }),
+);
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/layout",
+  () => ({
+    WorldIdActionIdLayout: () => <div data-testid="v3-wia-actionid-layout" />,
+  }),
+);
+import Layout from "../../app/(portal)/teams/[teamId]/apps/[appId]/world-id-actions/[actionId]/layout";
+it("renders v3 wia-actionid-layout", async () => {
+  render(
+    await Layout({
+      params: Promise.resolve({ teamId: "t", appId: "a", actionId: "x" }),
+      children: null,
+    }),
+  );
+  expect(screen.getByTestId("v3-wia-actionid-layout")).toBeInTheDocument();
+  expect(
+    screen.queryByTestId("v2-wia-actionid-layout"),
+  ).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Flips **`the world-id-actions [actionId] layout`** to portal v3: the route file becomes a `pickPortalVersion` chooser — allow-listed (v3) sessions render the forked `PortalV3` version, everyone else keeps v2. Behavior-preserving: the fork is byte-identical to v2 today.

- route file: bare re-export → chooser (metadata export unchanged; params forwarded in the exact shape the scene component expects)
- one chooser test (mocks activation to v3, asserts the v3 component renders and v2 doesn't)

## Footprint / verification

- 2 files, minimal diff. `npx tsc --noEmit` → 0 · chooser test passes · full `tests/unit/` green on the stack.

## Stack

Stacked on #2027 (World ID Actions foundation). Same pattern as #2018. Retarget as parents merge.