### PR TITLE
feat(portal-v3): flip /teams/[teamId]/apps/[appId]/world-id-actions/[actionId]/settings to v3

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id-actions/[actionId]/settings/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id-actions/[actionId]/settings/page.tsx
@@ -1,3 +1,12 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { WorldIdActionIdSettingsPage } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/page";
+import { WorldIdActionIdSettingsPage as WorldIdActionIdSettingsPageV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/page";
 
-export default WorldIdActionIdSettingsPage;
+export default async function Page(props: {
+  params: Promise<Record<string, string>>;
+}) {
+  return pickPortalVersion(
+    () => <WorldIdActionIdSettingsPageV3 params={props.params} />,
+    () => <WorldIdActionIdSettingsPage params={props.params} />,
+  );
+}

--- a/web/tests/unit/pv3-r-wia-settings.test.tsx
+++ b/web/tests/unit/pv3-r-wia-settings.test.tsx
@@ -1,0 +1,29 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/page",
+  () => ({
+    WorldIdActionIdSettingsPage: () => <div data-testid="v2-wia-settings" />,
+  }),
+);
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/page",
+  () => ({
+    WorldIdActionIdSettingsPage: () => <div data-testid="v3-wia-settings" />,
+  }),
+);
+import RoutePage from "../../app/(portal)/teams/[teamId]/apps/[appId]/world-id-actions/[actionId]/settings/page";
+it("renders v3 wia-settings", async () => {
+  render(
+    await RoutePage({
+      params: Promise.resolve({ teamId: "t", appId: "a", actionId: "x" }),
+    }),
+  );
+  expect(screen.getByTestId("v3-wia-settings")).toBeInTheDocument();
+  expect(screen.queryByTestId("v2-wia-settings")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Flips **`/teams/[teamId]/apps/[appId]/world-id-actions/[actionId]/settings`** to portal v3: the route file becomes a `pickPortalVersion` chooser — allow-listed (v3) sessions render the forked `PortalV3` version, everyone else keeps v2. Behavior-preserving: the fork is byte-identical to v2 today.

- route file: bare re-export → chooser (metadata export unchanged; params forwarded in the exact shape the scene component expects)
- one chooser test (mocks activation to v3, asserts the v3 component renders and v2 doesn't)

## Footprint / verification

- 2 files, minimal diff. `npx tsc --noEmit` → 0 · chooser test passes · full `tests/unit/` green on the stack.

## Stack

Stacked on #2027 (World ID Actions foundation). Same pattern as #2018. Retarget as parents merge.