### PR TITLE
feat: Restore account with your World ID (Part 2/2)

### DIFF
--- a/hasura/metadata/databases/default/functions/functions.yaml
+++ b/hasura/metadata/databases/default/functions/functions.yaml
@@ -1,2 +1,3 @@
 - "!include public_action_stats.yaml"
+- "!include public_merge_world_id_accounts.yaml"
 - "!include public_rollup_app_stats.yaml"

--- a/hasura/metadata/databases/default/functions/public_merge_world_id_accounts.yaml
+++ b/hasura/metadata/databases/default/functions/public_merge_world_id_accounts.yaml
@@ -1,0 +1,8 @@
+function:
+  name: merge_world_id_accounts
+  schema: public
+configuration:
+  custom_root_fields: {}
+  exposed_as: mutation
+permissions:
+  - role: service

--- a/hasura/migrations/default/1782936294064_merge_world_id_accounts_function/down.sql
+++ b/hasura/migrations/default/1782936294064_merge_world_id_accounts_function/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS public.merge_world_id_accounts(TEXT, TEXT, TEXT);

--- a/hasura/migrations/default/1782936294064_merge_world_id_accounts_function/up.sql
+++ b/hasura/migrations/default/1782936294064_merge_world_id_accounts_function/up.sql
@@ -1,0 +1,144 @@
+-- Merges a legacy Sign in with World ID account into another (current) user's
+-- account, atomically:
+--   * the legacy account's team memberships move to the current user, deduping
+--     shared teams and keeping the highest role per team,
+--   * the legacy row's world_id_nullifier moves to the current user verbatim
+--     (login does an exact match against it),
+--   * the legacy row loses both login identifiers (world_id_nullifier and
+--     auth0Id) so World ID login resolves to exactly one user afterwards.
+-- Apps, api keys and invites are team-scoped, so they follow the memberships.
+--
+-- _world_id_nullifier is the World ID the caller verified a proof for; the
+-- merge aborts unless the legacy row still holds it. Nullifiers are compared
+-- case- and 0x-prefix-insensitively, matching the application's normalization.
+CREATE OR REPLACE FUNCTION public.merge_world_id_accounts(
+  _current_user_id TEXT,
+  _legacy_user_id TEXT,
+  _world_id_nullifier TEXT
+)
+RETURNS SETOF public."user"
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+DECLARE
+  _current_nullifier TEXT;
+  _legacy_nullifier TEXT;
+BEGIN
+  IF _legacy_user_id IS NULL OR _legacy_user_id = '' THEN
+    RAISE EXCEPTION 'merge_world_id_accounts: _legacy_user_id is required';
+  END IF;
+
+  IF _world_id_nullifier IS NULL OR _world_id_nullifier = '' THEN
+    RAISE EXCEPTION 'merge_world_id_accounts: _world_id_nullifier is required';
+  END IF;
+
+  IF _current_user_id = _legacy_user_id THEN
+    RAISE EXCEPTION 'merge_world_id_accounts: cannot merge user % into itself',
+      _current_user_id;
+  END IF;
+
+  -- Lock both user rows in a consistent order so concurrent calls touching
+  -- the same accounts serialize instead of deadlocking.
+  PERFORM 1 FROM public."user"
+  WHERE id = LEAST(_current_user_id, _legacy_user_id)
+  FOR UPDATE;
+
+  PERFORM 1 FROM public."user"
+  WHERE id = GREATEST(_current_user_id, _legacy_user_id)
+  FOR UPDATE;
+
+  SELECT world_id_nullifier INTO _current_nullifier
+  FROM public."user" WHERE id = _current_user_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'merge_world_id_accounts: current user % not found',
+      _current_user_id;
+  END IF;
+
+  SELECT world_id_nullifier INTO _legacy_nullifier
+  FROM public."user" WHERE id = _legacy_user_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'merge_world_id_accounts: legacy user % not found',
+      _legacy_user_id;
+  END IF;
+
+  IF _legacy_nullifier IS NULL THEN
+    RAISE EXCEPTION 'merge_world_id_accounts: legacy user % has no world_id_nullifier',
+      _legacy_user_id;
+  END IF;
+
+  -- The claimed World ID must be the one the legacy account holds (protects
+  -- against the caller's lookup racing a concurrent change).
+  IF regexp_replace(lower(_legacy_nullifier), '^0x', '')
+    <> regexp_replace(lower(_world_id_nullifier), '^0x', '') THEN
+    RAISE EXCEPTION 'merge_world_id_accounts: legacy user % holds a different World ID than the one being claimed',
+      _legacy_user_id;
+  END IF;
+
+  -- Never silently replace a different World ID already linked to the
+  -- current user.
+  IF _current_nullifier IS NOT NULL
+    AND regexp_replace(lower(_current_nullifier), '^0x', '')
+      <> regexp_replace(lower(_world_id_nullifier), '^0x', '') THEN
+    RAISE EXCEPTION 'merge_world_id_accounts: current user % is already linked to a different World ID',
+      _current_user_id;
+  END IF;
+
+  -- Bump the current user's role in shared teams where the legacy account
+  -- holds a higher role.
+  UPDATE public.membership AS cm
+  SET role = lm.role
+  FROM (
+    SELECT DISTINCT ON (team_id) team_id, role
+    FROM public.membership
+    WHERE user_id = _legacy_user_id
+    ORDER BY team_id,
+      CASE role WHEN 'OWNER' THEN 3 WHEN 'ADMIN' THEN 2 ELSE 1 END DESC
+  ) AS lm
+  WHERE cm.user_id = _current_user_id
+    AND cm.team_id = lm.team_id
+    AND (CASE cm.role WHEN 'OWNER' THEN 3 WHEN 'ADMIN' THEN 2 ELSE 1 END)
+      < (CASE lm.role WHEN 'OWNER' THEN 3 WHEN 'ADMIN' THEN 2 ELSE 1 END);
+
+  -- Drop legacy memberships in teams the current user is already in. There is
+  -- no unique (user_id, team_id) constraint, so this is the dedupe step.
+  DELETE FROM public.membership AS lm
+  WHERE lm.user_id = _legacy_user_id
+    AND EXISTS (
+      SELECT 1 FROM public.membership AS cm
+      WHERE cm.user_id = _current_user_id
+        AND cm.team_id = lm.team_id
+    );
+
+  -- Dedupe the legacy account's own per-team duplicates (keep the highest
+  -- role), then move what remains onto the current user.
+  DELETE FROM public.membership AS lm
+  WHERE lm.user_id = _legacy_user_id
+    AND lm.id NOT IN (
+      SELECT DISTINCT ON (team_id) id
+      FROM public.membership
+      WHERE user_id = _legacy_user_id
+      ORDER BY team_id,
+        CASE role WHEN 'OWNER' THEN 3 WHEN 'ADMIN' THEN 2 ELSE 1 END DESC
+    );
+
+  UPDATE public.membership
+  SET user_id = _current_user_id
+  WHERE user_id = _legacy_user_id;
+
+  -- Neutralize the legacy account's login identifiers first, then move the
+  -- nullifier, so the nullifier is never held by two rows. The legacy row's
+  -- stored value is copied verbatim for login parity.
+  UPDATE public."user"
+  SET world_id_nullifier = NULL, "auth0Id" = NULL
+  WHERE id = _legacy_user_id;
+
+  UPDATE public."user"
+  SET world_id_nullifier = _legacy_nullifier
+  WHERE id = _current_user_id;
+
+  RETURN QUERY
+  SELECT * FROM public."user" WHERE id = _current_user_id;
+END;
+$$;

--- a/web/api/profile/world-id-account-migration/graphql/fetch-user-by-world-id-nullifier.generated.ts
+++ b/web/api/profile/world-id-account-migration/graphql/fetch-user-by-world-id-nullifier.generated.ts
@@ -1,0 +1,112 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type FetchUserByWorldIdNullifierQueryVariables = Types.Exact<{
+  world_id_nullifiers:
+    | Array<Types.Scalars["String"]["input"]>
+    | Types.Scalars["String"]["input"];
+  current_user_id: Types.Scalars["String"]["input"];
+}>;
+
+export type FetchUserByWorldIdNullifierQuery = {
+  __typename?: "query_root";
+  user: Array<{
+    __typename?: "user";
+    id: string;
+    email?: string | null;
+    name: string;
+    auth0Id?: string | null;
+    world_id_nullifier?: string | null;
+    memberships: Array<{
+      __typename?: "membership";
+      id: string;
+      team_id: string;
+      role: Types.Role_Enum;
+    }>;
+  }>;
+  current_user?: {
+    __typename?: "user";
+    id: string;
+    world_id_nullifier?: string | null;
+    memberships: Array<{
+      __typename?: "membership";
+      id: string;
+      team_id: string;
+      role: Types.Role_Enum;
+    }>;
+  } | null;
+};
+
+export const FetchUserByWorldIdNullifierDocument = gql`
+  query FetchUserByWorldIdNullifier(
+    $world_id_nullifiers: [String!]!
+    $current_user_id: String!
+  ) {
+    user(
+      where: { world_id_nullifier: { _in: $world_id_nullifiers } }
+      limit: 3
+    ) {
+      id
+      email
+      name
+      auth0Id
+      world_id_nullifier
+      memberships {
+        id
+        team_id
+        role
+      }
+    }
+    current_user: user_by_pk(id: $current_user_id) {
+      id
+      world_id_nullifier
+      memberships {
+        id
+        team_id
+        role
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchUserByWorldIdNullifier(
+      variables: FetchUserByWorldIdNullifierQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchUserByWorldIdNullifierQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchUserByWorldIdNullifierQuery>(
+            FetchUserByWorldIdNullifierDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchUserByWorldIdNullifier",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/profile/world-id-account-migration/graphql/fetch-user-by-world-id-nullifier.graphql
+++ b/web/api/profile/world-id-account-migration/graphql/fetch-user-by-world-id-nullifier.graphql
@@ -1,0 +1,33 @@
+query FetchUserByWorldIdNullifier(
+  $world_id_nullifiers: [String!]!
+  $current_user_id: String!
+) {
+  # limit 3 so the handler can distinguish "current user + one legacy account"
+  # (merge) from an ambiguous multi-account match (abort).
+  user(where: { world_id_nullifier: { _in: $world_id_nullifiers } }, limit: 3) {
+    id
+    email
+    name
+    auth0Id
+    world_id_nullifier
+    # Captured in the merge audit log: the legacy row is neutralized by the
+    # merge, so this is the only pre-merge record of what it held.
+    memberships {
+      id
+      team_id
+      role
+    }
+  }
+
+  # The current user's own nullifier, for the overwrite guard (never silently
+  # replace a different already-linked World ID); memberships for the audit log.
+  current_user: user_by_pk(id: $current_user_id) {
+    id
+    world_id_nullifier
+    memberships {
+      id
+      team_id
+      role
+    }
+  }
+}

--- a/web/api/profile/world-id-account-migration/graphql/merge-world-id-accounts.generated.ts
+++ b/web/api/profile/world-id-account-migration/graphql/merge-world-id-accounts.generated.ts
@@ -1,0 +1,78 @@
+/* eslint-disable import/no-relative-parent-imports -- auto generated file */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type MergeWorldIdAccountsMutationVariables = Types.Exact<{
+  current_user_id: Types.Scalars["String"]["input"];
+  legacy_user_id: Types.Scalars["String"]["input"];
+  world_id_nullifier: Types.Scalars["String"]["input"];
+}>;
+
+export type MergeWorldIdAccountsMutation = {
+  __typename?: "mutation_root";
+  merge_world_id_accounts: Array<{
+    __typename?: "user";
+    id: string;
+    world_id_nullifier?: string | null;
+  }>;
+};
+
+export const MergeWorldIdAccountsDocument = gql`
+  mutation MergeWorldIdAccounts(
+    $current_user_id: String!
+    $legacy_user_id: String!
+    $world_id_nullifier: String!
+  ) {
+    merge_world_id_accounts(
+      args: {
+        _current_user_id: $current_user_id
+        _legacy_user_id: $legacy_user_id
+        _world_id_nullifier: $world_id_nullifier
+      }
+    ) {
+      id
+      world_id_nullifier
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    MergeWorldIdAccounts(
+      variables: MergeWorldIdAccountsMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<MergeWorldIdAccountsMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<MergeWorldIdAccountsMutation>(
+            MergeWorldIdAccountsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "MergeWorldIdAccounts",
+        "mutation",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/api/profile/world-id-account-migration/graphql/merge-world-id-accounts.graphql
+++ b/web/api/profile/world-id-account-migration/graphql/merge-world-id-accounts.graphql
@@ -1,0 +1,20 @@
+# Calls the merge_world_id_accounts Postgres function (see the
+# merge_world_id_accounts_function Hasura migration), which owns all writes for
+# this endpoint in a single transaction: membership moves, dedupe, role bumps,
+# nullifier hand-over and legacy account neutralization.
+mutation MergeWorldIdAccounts(
+  $current_user_id: String!
+  $legacy_user_id: String!
+  $world_id_nullifier: String!
+) {
+  merge_world_id_accounts(
+    args: {
+      _current_user_id: $current_user_id
+      _legacy_user_id: $legacy_user_id
+      _world_id_nullifier: $world_id_nullifier
+    }
+  ) {
+    id
+    world_id_nullifier
+  }
+}

--- a/web/api/profile/world-id-account-migration/index.ts
+++ b/web/api/profile/world-id-account-migration/index.ts
@@ -1,0 +1,374 @@
+import { errorResponse, errorUnauthenticated } from "@/api/helpers/errors";
+import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { normalizeNullifierHash, verifyProof } from "@/api/helpers/verify";
+import { auth0, toSessionRequest } from "@/lib/auth0";
+import { WORLD_ID_MIGRATION_APP_IDS } from "@/lib/constants";
+import { generateExternalNullifier } from "@/lib/hashing";
+import { LegacyVerificationLevel } from "@/lib/idkit";
+import { isWorldUser } from "@/lib/is-world-user";
+import { logger } from "@/lib/logger";
+import { appIdRegex } from "@/lib/schema";
+import { Auth0SessionUser } from "@/lib/types";
+import { NextRequest, NextResponse } from "next/server";
+import { getSdk as getFetchUserByWorldIdNullifierSdk } from "./graphql/fetch-user-by-world-id-nullifier.generated";
+import { getSdk as getMergeWorldIdAccountsSdk } from "./graphql/merge-world-id-accounts.generated";
+
+// Sign in With World action defaults to ""
+const ACTION = "";
+const EMPTY_SIGNAL_HASH =
+  "0x00c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a4";
+
+// World ID 3.0 Proof type
+type ProofV3 = {
+  proof: string;
+  merkle_root: string;
+  nullifier: string;
+  signal_hash?: string;
+  verification_level: LegacyVerificationLevel;
+};
+
+// The World ID Migration `app_id` is the `client_id` used to configure the legacy Sign in
+// With World ID auth0 connection. It is a public identifier resolved from a per-env
+// dictionary (shared with the frontend) rather than a secret env var.
+function getWorldIdMigrationAppId(): `app_${string}` | null {
+  const appId =
+    WORLD_ID_MIGRATION_APP_IDS[process.env.NEXT_PUBLIC_APP_ENV ?? ""];
+
+  if (!appId || !appIdRegex.test(appId)) {
+    return null;
+  }
+
+  return appId;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function parseMigrationProof(
+  value: unknown,
+):
+  | { ok: true; response: ProofV3 }
+  | { ok: false; detail: string; attribute: string | null } {
+  const result = value as Partial<ProofV3> | null;
+
+  if (!result || typeof result !== "object") {
+    return {
+      ok: false,
+      detail: "Proof payload is missing.",
+      attribute: null,
+    };
+  }
+
+  for (const attribute of [
+    "proof",
+    "merkle_root",
+    "nullifier",
+    "verification_level",
+  ] as const) {
+    if (!isNonEmptyString(result[attribute])) {
+      return {
+        ok: false,
+        detail: `Proof is missing a valid "${attribute}".`,
+        attribute,
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    response: {
+      verification_level: result.verification_level as LegacyVerificationLevel,
+      proof: result.proof as string,
+      merkle_root: result.merkle_root as string,
+      nullifier: result.nullifier as string,
+      signal_hash: isNonEmptyString(result.signal_hash)
+        ? result.signal_hash
+        : EMPTY_SIGNAL_HASH,
+    },
+  };
+}
+
+function isLegacyWorldIdAccount(auth0Id: string | null | undefined): boolean {
+  return auth0Id?.startsWith("oauth2|worldcoin|") ?? false;
+}
+
+function getNullifierLookupValues(nullifier: string): string[] {
+  const normalized = normalizeNullifierHash(nullifier);
+  const withoutPrefix = normalized.replace(/^0x/, "");
+
+  return Array.from(new Set([nullifier, normalized, withoutPrefix]));
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth0.getSession(toSessionRequest(req));
+  if (!session) {
+    return errorUnauthenticated("You must be logged in.", req);
+  }
+
+  const auth0User = session.user as Auth0SessionUser["user"];
+  const currentUserId = auth0User?.hasura?.id;
+  if (!currentUserId) {
+    return errorUnauthenticated("You must be logged in.", req);
+  }
+
+  // A Sign in with World ID session IS a legacy account — there is nothing to
+  // migrate it into. The migration must run from the (email) account that
+  // should absorb the legacy one.
+  if (auth0User && isWorldUser(auth0User)) {
+    logger.warn(
+      "World ID account migration rejected for a Sign in with World ID session",
+      { currentUserId },
+    );
+    return errorResponse({
+      statusCode: 400,
+      code: "world_id_session",
+      detail:
+        "You are signed in with World ID. Log in with your email account to migrate this account into it.",
+      attribute: null,
+      req,
+    });
+  }
+
+  const appId = getWorldIdMigrationAppId();
+  if (!appId) {
+    return errorResponse({
+      statusCode: 500,
+      code: "missing_configuration",
+      detail: "World ID account migration is not configured.",
+      attribute: "NEXT_PUBLIC_APP_ENV",
+      req,
+    });
+  }
+
+  // Feature flag (opt-in): the restoration flow ships dark and is enabled
+  // per environment. The server reads this at runtime, so unsetting it also
+  // acts as the kill switch — the merge neutralizes legacy accounts, so we
+  // keep a way to stop it without a deploy. The same flag gates the UI
+  // (inlined client-side at build time).
+  if (process.env.NEXT_PUBLIC_ENABLE_WORLD_ID_RESTORATION !== "true") {
+    logger.warn("World ID account restoration is disabled", {
+      currentUserId,
+    });
+    return errorResponse({
+      statusCode: 503,
+      code: "restoration_disabled",
+      detail: "World ID account restoration is not available.",
+      attribute: null,
+      req,
+      app_id: appId,
+    });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch (error) {
+    logger.warn("Invalid JSON in World ID account migration request", {
+      error,
+    });
+    return errorResponse({
+      statusCode: 400,
+      code: "invalid_request",
+      detail: "Invalid JSON in request body.",
+      attribute: null,
+      req,
+      app_id: appId,
+    });
+  }
+
+  const parsed = parseMigrationProof(body);
+  if (!parsed.ok) {
+    return errorResponse({
+      statusCode: 400,
+      code: "invalid_request",
+      detail: parsed.detail,
+      attribute: parsed.attribute,
+      req,
+      app_id: appId,
+    });
+  }
+
+  const { response } = parsed;
+  const client = await getAPIServiceGraphqlClient();
+
+  // Sign in With World ID uses the empty action, so its external nullifier is
+  // derived from the app_id alone — no need to look up the app/action in the DB.
+  const externalNullifier = generateExternalNullifier(appId, ACTION).digest;
+
+  const verification = await verifyProof(
+    {
+      signal_hash: response.signal_hash ?? EMPTY_SIGNAL_HASH,
+      proof: response.proof,
+      merkle_root: response.merkle_root,
+      nullifier_hash: response.nullifier,
+      external_nullifier: externalNullifier,
+    },
+    {
+      // These migration apps are cloud, non-staging apps.
+      is_staging: false,
+      // The migration flow only ever requests device-legacy proofs
+      // (frontend uses the `deviceLegacy()` preset), so the verification
+      // level is fixed rather than read from the request.
+      verification_level:
+        response.verification_level as LegacyVerificationLevel,
+    },
+  );
+
+  if (verification.error || !verification.success) {
+    return errorResponse({
+      statusCode: verification.error?.statusCode || 400,
+      code: verification.error?.code || "verification_error",
+      detail:
+        verification.error?.message ||
+        "There was an error verifying this World ID proof.",
+      attribute: verification.error?.attribute || null,
+      req,
+      app_id: appId,
+    });
+  }
+
+  const nullifierLookupValues = getNullifierLookupValues(response.nullifier);
+  const userResponse = await getFetchUserByWorldIdNullifierSdk(
+    client,
+  ).FetchUserByWorldIdNullifier({
+    world_id_nullifiers: nullifierLookupValues,
+    current_user_id: currentUserId,
+  });
+
+  const matchingUsers = userResponse.user;
+  const linkedToCurrentUser = matchingUsers.some(
+    (user) => user.id === currentUserId,
+  );
+  const otherMatchedUsers = matchingUsers.filter(
+    (user) => user.id !== currentUserId,
+  );
+  const nonLegacyUsers = otherMatchedUsers.filter(
+    (user) => !isLegacyWorldIdAccount(user.auth0Id),
+  );
+  const legacyUsers = otherMatchedUsers.filter((user) =>
+    isLegacyWorldIdAccount(user.auth0Id),
+  );
+
+  if (nonLegacyUsers.length > 0) {
+    logger.warn("World ID account migration matched a non-legacy account", {
+      currentUserId,
+      matchedUserIds: nonLegacyUsers.map((user) => user.id),
+    });
+    return errorResponse({
+      statusCode: 409,
+      code: "non_legacy_account_match",
+      detail: "This World ID is already linked to another account.",
+      attribute: null,
+      req,
+      app_id: appId,
+    });
+  }
+
+  // This nullifier is already on the current user and nobody else — no-op.
+  if (linkedToCurrentUser && legacyUsers.length === 0) {
+    return NextResponse.json({ status: "already_linked" });
+  }
+
+  // There is no unique constraint on world_id_nullifier, so more than one
+  // other account holding this nullifier is possible in theory. Merging is
+  // ambiguous — abort without writing and leave a trail for manual handling.
+  if (legacyUsers.length > 1) {
+    logger.error(
+      "World ID account migration matched more than one legacy account",
+      {
+        currentUserId,
+        matchedUserIds: matchingUsers.map((user) => user.id),
+      },
+    );
+    return errorResponse({
+      statusCode: 500,
+      code: "migration_conflict",
+      detail:
+        "This World ID matches more than one account. Please contact support.",
+      attribute: null,
+      req,
+      app_id: appId,
+    });
+  }
+
+  const legacyUser = legacyUsers[0] ?? null;
+
+  // No legacy Sign in with World ID account holds this World ID — there is
+  // nothing to migrate, so tell the user and write nothing. This endpoint
+  // deliberately does NOT link the World ID to users without a legacy
+  // account; its only purpose is migrating old accounts.
+  if (!legacyUser) {
+    logger.info("World ID account migration found no legacy account", {
+      currentUserId,
+      status: "not_found",
+    });
+    return NextResponse.json({ status: "not_found" });
+  }
+
+  // Overwrite guard: never silently replace a different World ID that is
+  // already linked to this account. The merge function re-checks this inside
+  // the transaction; this pre-check exists to give a clean 409 (Hasura masks
+  // the function's exception message for non-admin roles).
+  const currentNullifier = userResponse.current_user?.world_id_nullifier;
+  if (
+    currentNullifier &&
+    normalizeNullifierHash(currentNullifier) !==
+      normalizeNullifierHash(response.nullifier)
+  ) {
+    logger.warn(
+      "World ID account migration blocked: user already linked to another World ID",
+      { currentUserId, legacyUserId: legacyUser.id },
+    );
+    return errorResponse({
+      statusCode: 409,
+      code: "already_linked_other",
+      detail: "This account is already linked to a different World ID.",
+      attribute: null,
+      req,
+      app_id: appId,
+    });
+  }
+
+  // All writes happen in the merge_world_id_accounts Postgres function, in
+  // one transaction: the legacy account's memberships move to the current
+  // user (teams and their apps ride along, they are team-scoped), the
+  // nullifier is handed over and the legacy row is neutralized so World ID
+  // login resolves to exactly one user.
+  try {
+    await getMergeWorldIdAccountsSdk(client).MergeWorldIdAccounts({
+      current_user_id: currentUserId,
+      legacy_user_id: legacyUser.id,
+      world_id_nullifier: normalizeNullifierHash(response.nullifier),
+    });
+  } catch (error) {
+    logger.error("World ID account migration merge failed", {
+      error,
+      currentUserId,
+      legacyUserId: legacyUser.id,
+    });
+    return errorResponse({
+      statusCode: 500,
+      code: "migration_failed",
+      detail: "There was an error merging this World ID account.",
+      attribute: null,
+      req,
+      app_id: appId,
+    });
+  }
+
+  // Audit record: the merge just neutralized the legacy row and moved its
+  // memberships, so this log is the only pre-merge record of what it held.
+  const currentTeamIds =
+    userResponse.current_user?.memberships.map(
+      (membership) => membership.team_id,
+    ) ?? [];
+  logger.info("Merged legacy World ID account", {
+    currentUserId,
+    legacyUserId: legacyUser.id,
+    legacyMemberships: legacyUser.memberships,
+    currentTeamIds,
+    status: "merged",
+  });
+  return NextResponse.json({ status: "merged" });
+}

--- a/web/app/api/profile/world-id-account-migration/route.ts
+++ b/web/app/api/profile/world-id-account-migration/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "@/api/profile/world-id-account-migration";

--- a/web/graphql/graphql.schema.json
+++ b/web/graphql/graphql.schema.json
@@ -45558,6 +45558,53 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "merge_world_id_accounts_args",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_current_user_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_legacy_user_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_world_id_nullifier",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "mutation_root",
         "description": "mutation root",
@@ -49976,6 +50023,123 @@
               "kind": "OBJECT",
               "name": "InviteTeamMembersOutput",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "merge_world_id_accounts",
+            "description": "execute VOLATILE function \"merge_world_id_accounts\" which returns \"user\"",
+            "args": [
+              {
+                "name": "args",
+                "description": "input parameters for function \"merge_world_id_accounts\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "merge_world_id_accounts_args",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "user_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "user_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "user_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "user",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/web/graphql/graphql.ts
+++ b/web/graphql/graphql.ts
@@ -6306,6 +6306,12 @@ export type Membership_Updates = {
   where: Membership_Bool_Exp;
 };
 
+export type Merge_World_Id_Accounts_Args = {
+  _current_user_id?: InputMaybe<Scalars["String"]["input"]>;
+  _legacy_user_id?: InputMaybe<Scalars["String"]["input"]>;
+  _world_id_nullifier?: InputMaybe<Scalars["String"]["input"]>;
+};
+
 /** mutation root */
 export type Mutation_Root = {
   __typename?: "mutation_root";
@@ -6544,6 +6550,8 @@ export type Mutation_Root = {
   invalidate_cache?: Maybe<InvalidateCacheOutput>;
   /** Create invites and send emails */
   invite_team_members?: Maybe<InviteTeamMembersOutput>;
+  /** execute VOLATILE function "merge_world_id_accounts" which returns "user" */
+  merge_world_id_accounts: Array<User>;
   /** Register an RP (Relying Party) for an app with managed mode */
   register_rp?: Maybe<RegisterRpOutput>;
   /** Reset the given API key for the developer portal */
@@ -7406,6 +7414,16 @@ export type Mutation_RootInsert_User_OneArgs = {
 export type Mutation_RootInvite_Team_MembersArgs = {
   emails?: InputMaybe<Array<Scalars["String"]["input"]>>;
   team_id: Scalars["String"]["input"];
+};
+
+/** mutation root */
+export type Mutation_RootMerge_World_Id_AccountsArgs = {
+  args: Merge_World_Id_Accounts_Args;
+  distinct_on?: InputMaybe<Array<User_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<User_Order_By>>;
+  where?: InputMaybe<User_Bool_Exp>;
 };
 
 /** mutation root */

--- a/web/lib/urls.ts
+++ b/web/lib/urls.ts
@@ -157,5 +157,9 @@ export const urls = {
 
     authDeleteAccount: (): "/api/auth/delete-account" =>
       "/api/auth/delete-account",
+
+    // API endpoint that helps recover an account created with "Sign in With World"
+    worldIdAccountMigration: (): "/api/profile/world-id-account-migration" =>
+      "/api/profile/world-id-account-migration",
   },
 };

--- a/web/scenes/Portal/Profile/page/index.tsx
+++ b/web/scenes/Portal/Profile/page/index.tsx
@@ -40,7 +40,7 @@ type FormValues = yup.InferType<typeof schema>;
 
 export const ProfilePage = () => {
   const { user: auth0User } = useUser() as Auth0SessionUser;
-  const { user, loading } = useMeQuery();
+  const { user, loading, refetch: refetchMe } = useMeQuery();
 
   const [updateUser] = useUpdateUserMutation({
     refetchQueries: [FetchMeDocument],
@@ -179,7 +179,11 @@ export const ProfilePage = () => {
               </div>
             </label>
 
-            <WorldIdAccountMigration auth0User={auth0User} />
+            <WorldIdAccountMigration
+              auth0User={auth0User}
+              isLinked={Boolean(user?.world_id_nullifier)}
+              onLinkSuccess={refetchMe}
+            />
 
             <DecoratedButton
               type="submit"

--- a/web/scenes/PortalV3/Profile/page/index.tsx
+++ b/web/scenes/PortalV3/Profile/page/index.tsx
@@ -40,7 +40,7 @@ type FormValues = yup.InferType<typeof schema>;
 
 export const ProfilePage = () => {
   const { user: auth0User } = useUser() as Auth0SessionUser;
-  const { user, loading } = useMeQuery();
+  const { user, loading, refetch: refetchMe } = useMeQuery();
 
   const [updateUser] = useUpdateUserMutation({
     refetchQueries: [FetchMeDocument],
@@ -179,7 +179,11 @@ export const ProfilePage = () => {
               </div>
             </label>
 
-            <WorldIdAccountMigration auth0User={auth0User} />
+            <WorldIdAccountMigration
+              auth0User={auth0User}
+              isLinked={Boolean(user?.world_id_nullifier)}
+              onLinkSuccess={refetchMe}
+            />
 
             <DecoratedButton
               type="submit"

--- a/web/scenes/common/Profile/page/WorldIdAccountMigration/index.tsx
+++ b/web/scenes/common/Profile/page/WorldIdAccountMigration/index.tsx
@@ -7,6 +7,7 @@ import { WORLD_ID_MIGRATION_APP_IDS } from "@/lib/constants";
 import { isWorldUser } from "@/lib/is-world-user";
 import { buildMockRpContext } from "@/lib/rp";
 import type { Auth0SessionUser } from "@/lib/types";
+import { urls } from "@/lib/urls";
 import {
   deviceLegacy,
   IDKitRequestWidget,
@@ -14,10 +15,12 @@ import {
 } from "@worldcoin/idkit";
 import clsx from "clsx";
 import { useCallback, useEffect, useState } from "react";
-import type { MigrationState } from "./types";
+import type { MigrationResponse, MigrationState } from "./types";
 
 type WorldIdAccountMigrationProps = {
   auth0User: Auth0SessionUser["user"] | undefined;
+  isLinked: boolean;
+  onLinkSuccess?: () => void;
 };
 
 const statusCopy: Record<
@@ -29,18 +32,40 @@ const statusCopy: Record<
       "Sign in With World ID method is deprecated. If you had a legacy account, link your account to continue using your teams and apps.",
     className: "text-grey-400",
   },
+  checking: {
+    description: "Verifying your World ID proof.",
+    className: "text-grey-400",
+  },
   error: {
     description: "Try again in a moment.",
     className: "text-system-error-600",
   },
+  already_linked: {
+    description: "This profile already has a World ID account.",
+    className: "text-grey-400",
+  },
+  merged: {
+    description:
+      "Your Sign in with World ID account was merged into this profile. Its teams and apps are now available here.",
+    className: "text-system-success-700",
+  },
+  not_found: {
+    description: "No existing account matched your World ID.",
+    className: "text-grey-400",
+  },
 };
+
+const isDoneState = (type: MigrationState["type"]) =>
+  type === "merged" || type === "already_linked";
 
 export const WorldIdAccountMigration = ({
   auth0User,
+  isLinked,
+  onLinkSuccess,
 }: WorldIdAccountMigrationProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [migrationState, setMigrationState] = useState<MigrationState>({
-    type: "idle",
+    type: isLinked ? "already_linked" : "idle",
   });
 
   const appId =
@@ -56,8 +81,17 @@ export const WorldIdAccountMigration = ({
         type: "error",
         message: "World ID account migration is not configured.",
       });
+      return;
     }
-  }, [appId]);
+
+    if (isLinked) {
+      // Don't clobber the richer "merged" success state when the
+      // me query refetch flips isLinked after a successful migration.
+      setMigrationState((state) =>
+        isDoneState(state.type) ? state : { type: "already_linked" },
+      );
+    }
+  }, [isLinked, appId]);
 
   const copy = statusCopy[migrationState.type];
   const description =
@@ -76,39 +110,76 @@ export const WorldIdAccountMigration = ({
     setIsOpen(true);
   }, [appId]);
 
-  const handleSuccess = useCallback(async (result: IDKitResult) => {
-    // The migration flow requests device-legacy proofs, so we expect a v3
-    // result whose first response carries the flat proof fields.
-    if (result.protocol_version !== "3.0") {
-      setMigrationState({
-        type: "error",
-        message: "Unsupported World ID proof for account migration.",
-      });
-      return;
-    }
+  const handleSuccess = useCallback(
+    async (result: IDKitResult) => {
+      // The migration flow requests device-legacy proofs, so we expect a v3
+      // result whose first response carries the flat proof fields.
+      if (result.protocol_version !== "3.0") {
+        setMigrationState({
+          type: "error",
+          message: "Unsupported World ID proof for account migration.",
+        });
+        return;
+      }
 
-    const response = result.responses[0];
-    if (!response) {
-      setMigrationState({
-        type: "error",
-        message: "World ID proof is missing.",
-      });
-      return;
-    }
+      const response = result.responses[0];
+      if (!response) {
+        setMigrationState({
+          type: "error",
+          message: "World ID proof is missing.",
+        });
+        return;
+      }
 
-    // Part 1 stops here: the verification + legacy account merge endpoint
-    // lands in the follow-up PR. Log the proof so the flow can be exercised
-    // end-to-end in the meantime.
-    console.log("World ID account migration proof", {
-      proof: response.proof,
-      merkle_root: response.merkle_root,
-      nullifier: response.nullifier,
-      signal_hash: response.signal_hash,
-      verification_level: response.identifier,
-    });
+      setMigrationState({ type: "checking" });
 
-    setMigrationState({ type: "idle" });
-  }, []);
+      try {
+        const migrationResponse = await fetch(
+          urls.api.worldIdAccountMigration(),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              proof: response.proof,
+              merkle_root: response.merkle_root,
+              nullifier: response.nullifier,
+              signal_hash: response.signal_hash,
+              verification_level: response.identifier,
+            }),
+          },
+        );
+
+        const payload = (await migrationResponse.json().catch(() => null)) as
+          | MigrationResponse
+          | { detail?: string }
+          | null;
+
+        if (!migrationResponse.ok || !payload || !("status" in payload)) {
+          throw new Error(
+            (payload && "detail" in payload && payload.detail) ||
+              "There was an error linking this World ID.",
+          );
+        }
+
+        setMigrationState({ type: payload.status });
+
+        if (payload.status === "merged") {
+          // Refresh the me query so world_id_nullifier (and any merged
+          // teams) are reflected across the portal.
+          onLinkSuccess?.();
+        }
+      } catch (error) {
+        setMigrationState({
+          type: "error",
+          message:
+            error instanceof Error
+              ? error.message
+              : "There was an error linking this World ID.",
+        });
+      }
+    },
+    [onLinkSuccess],
+  );
 
   // Feature-flagged (ships dark). A Sign in with World ID session IS a legacy
   // account, so migration only makes sense from an email account. Hide only on

--- a/web/scenes/common/Profile/page/WorldIdAccountMigration/types.ts
+++ b/web/scenes/common/Profile/page/WorldIdAccountMigration/types.ts
@@ -1,3 +1,19 @@
+import type { RpContext } from "@worldcoin/idkit";
+
+export type MigrationConfig = {
+  app_id: `app_${string}`;
+  action: "";
+  rp_context: RpContext;
+};
+
+export type MigrationStatus = "merged" | "already_linked" | "not_found";
+
+export type MigrationResponse = {
+  status: MigrationStatus;
+};
+
 export type MigrationState =
   | { type: "idle" }
-  | { type: "error"; message: string };
+  | { type: "checking" }
+  | { type: "error"; message: string }
+  | { type: MigrationStatus };

--- a/web/tests/api/profile/world-id-account-migration.test.ts
+++ b/web/tests/api/profile/world-id-account-migration.test.ts
@@ -1,0 +1,422 @@
+import { POST } from "@/api/profile/world-id-account-migration";
+import { NextRequest } from "next/server";
+
+// #region Mocks
+const getSessionMock = jest.fn();
+const FetchUserByWorldIdNullifier = jest.fn();
+const MergeWorldIdAccounts = jest.fn();
+const verifyProofMock = jest.fn();
+
+jest.mock("@/lib/auth0", () => ({
+  auth0: {
+    getSession: (...args: unknown[]) => getSessionMock(...args),
+  },
+  toSessionRequest: (req: NextRequest) => req,
+}));
+
+jest.mock("@/api/helpers/graphql", () => ({
+  getAPIServiceGraphqlClient: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock(
+  "@/api/profile/world-id-account-migration/graphql/fetch-user-by-world-id-nullifier.generated",
+  () => ({
+    getSdk: () => ({ FetchUserByWorldIdNullifier }),
+  }),
+);
+
+jest.mock(
+  "@/api/profile/world-id-account-migration/graphql/merge-world-id-accounts.generated",
+  () => ({
+    getSdk: () => ({ MergeWorldIdAccounts }),
+  }),
+);
+
+jest.mock("@/api/helpers/verify", () => ({
+  normalizeNullifierHash: jest.fn((value: string) => {
+    const normalized = value.toLowerCase().replace(/^0x/, "");
+    return `0x${normalized}`;
+  }),
+  verifyProof: (...args: unknown[]) => verifyProofMock(...args),
+}));
+
+jest.mock("@/lib/hashing", () => ({
+  generateExternalNullifier: jest.fn(() => ({ digest: "0xexternal" })),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+// #endregion
+
+// #region Test Data
+const currentUserId = "usr_current";
+const legacyUserId = "usr_legacy";
+const nullifier = "0xABC123";
+const normalizedNullifier = "0xabc123";
+const signalHash = "0xsignal";
+const emptySignalHash =
+  "0x00c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a4";
+
+const createRequest = (body?: unknown) =>
+  new NextRequest(
+    "http://localhost:3000/api/profile/world-id-account-migration",
+    {
+      method: body ? "POST" : "GET",
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    },
+  );
+
+const makeSession = () => ({
+  user: {
+    sub: "email|user@example.com",
+    email: "user@example.com",
+    email_verified: true,
+    hasura: {
+      id: currentUserId,
+    },
+  },
+});
+
+const makeProof = (overrides: Record<string, unknown> = {}) => ({
+  proof: "0xproof",
+  merkle_root: "0xroot",
+  nullifier,
+  signal_hash: signalHash,
+  verification_level: "device",
+  ...overrides,
+});
+
+const makeMatchedUser = (
+  id: string,
+  overrides: {
+    auth0Id?: string | null;
+    world_id_nullifier?: string;
+    memberships?: { id: string; team_id: string; role: string }[];
+  } = {},
+) => ({
+  id,
+  email: `${id}@test.dev`,
+  name: id,
+  auth0Id:
+    overrides.auth0Id === undefined
+      ? `oauth2|worldcoin|${normalizedNullifier}`
+      : overrides.auth0Id,
+  world_id_nullifier: overrides.world_id_nullifier ?? normalizedNullifier,
+  memberships: overrides.memberships ?? [],
+});
+
+const makeCurrentUser = (
+  overrides: {
+    world_id_nullifier?: string | null;
+    memberships?: { id: string; team_id: string; role: string }[];
+  } = {},
+) => ({
+  id: currentUserId,
+  world_id_nullifier: overrides.world_id_nullifier ?? null,
+  memberships: overrides.memberships ?? [],
+});
+
+const mockLookup = (
+  users: ReturnType<typeof makeMatchedUser>[],
+  current_user: ReturnType<typeof makeCurrentUser> | null = makeCurrentUser(),
+) => {
+  FetchUserByWorldIdNullifier.mockResolvedValue({ user: users, current_user });
+};
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_APP_ENV = "production";
+  process.env.NEXT_PUBLIC_ENABLE_WORLD_ID_RESTORATION = "true";
+
+  getSessionMock.mockResolvedValue(makeSession());
+  mockLookup([]);
+  MergeWorldIdAccounts.mockResolvedValue({
+    merge_world_id_accounts: [
+      { id: currentUserId, world_id_nullifier: normalizedNullifier },
+    ],
+  });
+  verifyProofMock.mockResolvedValue({ success: true });
+});
+
+// #region Request guards
+describe("/api/profile/world-id-account-migration [request guards]", () => {
+  it("rejects unauthenticated requests before verification", async () => {
+    getSessionMock.mockResolvedValue(null);
+
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.code).toBe("unauthenticated");
+    expect(verifyProofMock).not.toHaveBeenCalled();
+    expect(MergeWorldIdAccounts).not.toHaveBeenCalled();
+  });
+
+  it("rejects a payload missing a required proof field before verification", async () => {
+    const response = await POST(createRequest(makeProof({ proof: undefined })));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      code: "invalid_request",
+      attribute: "proof",
+    });
+    expect(verifyProofMock).not.toHaveBeenCalled();
+    expect(MergeWorldIdAccounts).not.toHaveBeenCalled();
+  });
+
+  it("rejects Sign in with World ID sessions before verification", async () => {
+    getSessionMock.mockResolvedValue({
+      user: {
+        ...makeSession().user,
+        sub: `oauth2|worldcoin|${normalizedNullifier}`,
+      },
+    });
+
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.code).toBe("world_id_session");
+    expect(verifyProofMock).not.toHaveBeenCalled();
+    expect(MergeWorldIdAccounts).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 without verifying or writing when the feature flag is off", async () => {
+    delete process.env.NEXT_PUBLIC_ENABLE_WORLD_ID_RESTORATION;
+
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.code).toBe("restoration_disabled");
+    expect(verifyProofMock).not.toHaveBeenCalled();
+    expect(MergeWorldIdAccounts).not.toHaveBeenCalled();
+  });
+
+  it("uses the empty signal hash fallback when signal_hash is omitted", async () => {
+    const response = await POST(
+      createRequest(makeProof({ signal_hash: undefined })),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ status: "not_found" });
+    expect(verifyProofMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signal_hash: emptySignalHash,
+      }),
+      expect.objectContaining({
+        verification_level: "device",
+      }),
+    );
+    expect(MergeWorldIdAccounts).not.toHaveBeenCalled();
+  });
+
+  it("returns the verification error without writing when the proof is invalid", async () => {
+    verifyProofMock.mockResolvedValue({
+      error: {
+        statusCode: 400,
+        code: "invalid_proof",
+        message: "Proof is invalid.",
+        attribute: null,
+      },
+    });
+
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.code).toBe("invalid_proof");
+    expect(FetchUserByWorldIdNullifier).not.toHaveBeenCalled();
+    expect(MergeWorldIdAccounts).not.toHaveBeenCalled();
+  });
+});
+// #endregion
+
+// #region No legacy account
+describe("/api/profile/world-id-account-migration [no legacy account]", () => {
+  it("verifies the proof as a device-legacy proof and returns not_found without writing", async () => {
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ status: "not_found" });
+
+    expect(verifyProofMock).toHaveBeenCalledWith(
+      {
+        signal_hash: signalHash,
+        proof: "0xproof",
+        merkle_root: "0xroot",
+        nullifier_hash: nullifier,
+        external_nullifier: "0xexternal",
+      },
+      {
+        is_staging: false,
+        verification_level: "device",
+      },
+    );
+    expect(FetchUserByWorldIdNullifier).toHaveBeenCalledWith({
+      world_id_nullifiers: [nullifier, normalizedNullifier, "abc123"],
+      current_user_id: currentUserId,
+    });
+    expect(MergeWorldIdAccounts).not.toHaveBeenCalled();
+  });
+
+  it("returns not_found without writing even when the current user holds a different World ID", async () => {
+    mockLookup([], makeCurrentUser({ world_id_nullifier: "0xother" }));
+
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ status: "not_found" });
+    expect(MergeWorldIdAccounts).not.toHaveBeenCalled();
+  });
+});
+// #endregion
+
+// #region Merge
+describe("/api/profile/world-id-account-migration [merge]", () => {
+  it("merges a legacy account through the merge_world_id_accounts function", async () => {
+    mockLookup([
+      makeMatchedUser(legacyUserId, {
+        memberships: [
+          { id: "memb_1", team_id: "team_shared", role: "OWNER" },
+          { id: "memb_2", team_id: "team_other", role: "MEMBER" },
+        ],
+      }),
+    ]);
+
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ status: "merged" });
+    expect(MergeWorldIdAccounts).toHaveBeenCalledWith({
+      current_user_id: currentUserId,
+      legacy_user_id: legacyUserId,
+      world_id_nullifier: normalizedNullifier,
+    });
+  });
+
+  it("merges even when the current user already holds the same nullifier", async () => {
+    mockLookup(
+      [
+        makeMatchedUser(currentUserId),
+        makeMatchedUser(legacyUserId, { world_id_nullifier: nullifier }),
+      ],
+      makeCurrentUser({ world_id_nullifier: normalizedNullifier }),
+    );
+
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ status: "merged" });
+    expect(MergeWorldIdAccounts).toHaveBeenCalledWith({
+      current_user_id: currentUserId,
+      legacy_user_id: legacyUserId,
+      world_id_nullifier: normalizedNullifier,
+    });
+  });
+
+  it("returns migration_failed when the merge function throws", async () => {
+    mockLookup([makeMatchedUser(legacyUserId)]);
+    MergeWorldIdAccounts.mockRejectedValue(new Error("merge failed"));
+
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.code).toBe("migration_failed");
+  });
+});
+// #endregion
+
+// #region No-op and conflict guards
+describe("/api/profile/world-id-account-migration [no-op and conflicts]", () => {
+  it("returns already_linked without writing when the nullifier is only on the current user", async () => {
+    mockLookup(
+      [makeMatchedUser(currentUserId)],
+      makeCurrentUser({ world_id_nullifier: normalizedNullifier }),
+    );
+
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ status: "already_linked" });
+    expect(MergeWorldIdAccounts).not.toHaveBeenCalled();
+  });
+
+  it("aborts with migration_conflict when more than one legacy account matches", async () => {
+    mockLookup([
+      makeMatchedUser("usr_legacy_1"),
+      makeMatchedUser("usr_legacy_2"),
+    ]);
+
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.code).toBe("migration_conflict");
+    expect(MergeWorldIdAccounts).not.toHaveBeenCalled();
+  });
+
+  it("aborts when the matched account is not a legacy World ID account", async () => {
+    mockLookup([
+      makeMatchedUser("usr_email_match", {
+        auth0Id: "email|matched@example.com",
+      }),
+    ]);
+
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("non_legacy_account_match");
+    expect(MergeWorldIdAccounts).not.toHaveBeenCalled();
+  });
+
+  it("aborts when a non-legacy account matches even if the current user is already linked", async () => {
+    mockLookup(
+      [
+        makeMatchedUser(currentUserId),
+        makeMatchedUser("usr_email_match", {
+          auth0Id: "auth0|matched",
+        }),
+      ],
+      makeCurrentUser({ world_id_nullifier: normalizedNullifier }),
+    );
+
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("non_legacy_account_match");
+    expect(MergeWorldIdAccounts).not.toHaveBeenCalled();
+  });
+
+  it("aborts with already_linked_other when the current user holds a different World ID", async () => {
+    mockLookup(
+      [makeMatchedUser(legacyUserId)],
+      makeCurrentUser({ world_id_nullifier: "0xother" }),
+    );
+
+    const response = await POST(createRequest(makeProof()));
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("already_linked_other");
+    expect(MergeWorldIdAccounts).not.toHaveBeenCalled();
+  });
+});
+// #endregion


### PR DESCRIPTION
Part 2 of #2059

This PR includes the migration logic, key files to review:
- API endpoint with restoration logic: `web/api/profile/world-id-account-migration/index.ts`
- PG transaction merging 2 accounts with nullifier: `hasura/migrations/default/1782936294064_merge_world_id_accounts_function/up.sql`

The rest of the changes are wiring and UI work. 