### PR TITLE
fix: allow world users to accept invites

### DIFF
--- a/web/api/login-callback/index.ts
+++ b/web/api/login-callback/index.ts
@@ -161,6 +161,8 @@ export const loginCallback = async (req: NextRequest) => {
   }
 
   let invite: InviteQuery["invite"][number] | null = null;
+  // If the user claims
+  let team_id_from_invite: string | null = null;
 
   if (invite_id) {
     try {
@@ -259,6 +261,7 @@ export const loginCallback = async (req: NextRequest) => {
       );
     }
 
+    team_id_from_invite = invite.team_id;
     user = membership.user;
 
     try {
@@ -321,7 +324,8 @@ export const loginCallback = async (req: NextRequest) => {
     }
   }
 
-  const teamId = user?.memberships[0]?.team.id;
+  // If a user just accepted an invite, redirect them to that teams page.
+  const teamId = team_id_from_invite ?? user?.memberships[0]?.team.id;
   let url: string = urls.profile();
   const rawReturnTo = req.nextUrl.searchParams.get("returnTo");
   let returnTo: string | null = null;

--- a/web/api/login-callback/index.ts
+++ b/web/api/login-callback/index.ts
@@ -198,6 +198,8 @@ export const loginCallback = async (req: NextRequest) => {
       );
     }
 
+    // Dont require email verification for World ID users, as they don't have an email address
+    // **for team invites**
     if (
       (isEmailUser(auth0User) || isPasswordUser(auth0User)) &&
       auth0User.email_verified &&

--- a/web/api/login-callback/index.ts
+++ b/web/api/login-callback/index.ts
@@ -257,6 +257,8 @@ export const loginCallback = async (req: NextRequest) => {
       );
     }
 
+    user = membership.user;
+
     try {
       const deleteInviteResult = await DeleteInviteSdk(client).DeleteInvite({
         invite_id,

--- a/web/api/login-callback/index.ts
+++ b/web/api/login-callback/index.ts
@@ -198,7 +198,12 @@ export const loginCallback = async (req: NextRequest) => {
       );
     }
 
-    if (invite.email !== auth0User.email) {
+    if (
+      (isEmailUser(auth0User) || isPasswordUser(auth0User)) &&
+      auth0User.email_verified &&
+      auth0User.email &&
+      invite.email.toLowerCase().trim() !== auth0User.email.toLowerCase().trim()
+    ) {
       logger.error("Invite email does not match logged in email", {
         team_id: invite.team_id,
       });

--- a/web/tests/integration/auth/login-callback.test.ts
+++ b/web/tests/integration/auth/login-callback.test.ts
@@ -353,4 +353,58 @@ describe("test /login-callback", () => {
     expect(getSession).toHaveReturned();
     expect(response.headers.get("location")?.endsWith("/apps")).toBeTruthy();
   });
+
+  it("Should add membership for the invited existing World ID user", async () => {
+    const inviteEmail = "invited-world-user@example.com";
+    const team_id = "team_2222214f17eda7e0ededba7ded6b4222";
+
+    const { rows: insertedInvite } = (await integrationDBExecuteQuery(
+      `INSERT INTO public.invite (team_id, expires_at, email) VALUES ('${team_id}', '2030-01-01 00:00:00+00', '${inviteEmail}') RETURNING  id, team_id, email`,
+    )) as { rows: { id: string; team_id: string; email: string }[] };
+
+    const url = new URL("/login-callback", "http://localhost:3000");
+    url.searchParams.append("invite_id", insertedInvite[0].id);
+
+    const mockReq = {
+      nextUrl: url,
+    } as unknown as NextRequest;
+
+    const mockSession = {
+      user: validNullifierSessionUser,
+    };
+
+    (getSession as jest.Mock).mockResolvedValue(mockSession);
+    const response = await loginCallback(mockReq);
+
+    const userQuery = gql`
+      query FetchUserByNullifier($world_id_nullifier: String!) {
+        user(where: { world_id_nullifier: { _eq: $world_id_nullifier } }) {
+          memberships {
+            team {
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const client = await getAPIServiceGraphqlClient();
+
+    const fetchUserRes = await client.request<{
+      user: Array<{
+        memberships: Array<{
+          team: {
+            id: string;
+          };
+        }>;
+      }>;
+    }>(userQuery, { world_id_nullifier: "0x123" });
+
+    expect(
+      fetchUserRes.user[0].memberships.some((m) => m.team.id === team_id),
+    ).toBeTruthy();
+
+    expect(getSession).toHaveReturned();
+    expect(response.headers.get("location")).not.toContain("/unauthorized");
+  });
 });

--- a/web/tests/integration/auth/login-callback.test.ts
+++ b/web/tests/integration/auth/login-callback.test.ts
@@ -358,6 +358,10 @@ describe("test /login-callback", () => {
     const inviteEmail = "invited-world-user@example.com";
     const team_id = "team_2222214f17eda7e0ededba7ded6b4222";
 
+    await integrationDBExecuteQuery(
+      `UPDATE public."user" SET "auth0Id" = '${validNullifierSessionUser.sub}', name = '${validNullifierSessionUser.name}' WHERE world_id_nullifier = '0x123'`,
+    );
+
     const { rows: insertedInvite } = (await integrationDBExecuteQuery(
       `INSERT INTO public.invite (team_id, expires_at, email) VALUES ('${team_id}', '2030-01-01 00:00:00+00', '${inviteEmail}') RETURNING  id, team_id, email`,
     )) as { rows: { id: string; team_id: string; email: string }[] };
@@ -405,6 +409,11 @@ describe("test /login-callback", () => {
     ).toBeTruthy();
 
     expect(getSession).toHaveReturned();
+    expect(
+      updateSession.mock.calls[0][2].user.hasura.memberships.some(
+        (m: { team: { id: string } }) => m.team.id === team_id,
+      ),
+    ).toBeTruthy();
     expect(response.headers.get("location")).not.toContain("/unauthorized");
   });
 });


### PR DESCRIPTION
This PR allows World ID logged in users that don't have an email accept team invites.