### PR TITLE
perf(portal-v3): faster app dashboard navigation

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/loading.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/loading.tsx
@@ -2,5 +2,5 @@ import { AppDashboardSkeleton } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/
 
 // Rendered as the Suspense fallback for this segment during navigation.
 export default function Loading() {
-    return <AppDashboardSkeleton />;
+  return <AppDashboardSkeleton />;
 }

--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/loading.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/loading.tsx
@@ -1,0 +1,6 @@
+import { AppDashboardSkeleton } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Loading";
+
+// Rendered as the Suspense fallback for this segment during navigation.
+export default function Loading() {
+    return <AppDashboardSkeleton />;
+}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Loading/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Loading/index.tsx
@@ -1,0 +1,28 @@
+import { SizingWrapper } from "@/components/SizingWrapper";
+import Skeleton from "react-loading-skeleton";
+
+/** Fallback shown the instant a user navigates to the app dashboard, while the
+ *  server render (auth + FetchAppEnv) resolves. Mirrors AppIdPage's layout so
+ *  the swap to real content doesn't shift. */
+export const AppDashboardSkeleton = () => (
+    <SizingWrapper className="flex flex-col gap-y-8 py-4">
+        {/* status rows (VerificationStatusSection + BanStatusSection) */}
+        <div className="grid gap-y-3">
+            <Skeleton height={64} borderRadius={12} />
+        </div>
+
+        {/* "Overview" header + TimePeriodSelector */}
+        <div className="flex items-center justify-between">
+            <Skeleton width={110} height={24} />
+            <Skeleton width={180} height={36} borderRadius={8} />
+        </div>
+
+        {/* AppStatsGraph — stat row + chart */}
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} height={88} borderRadius={12} />
+            ))}
+        </div>
+        <Skeleton height={320} borderRadius={12} />
+    </SizingWrapper>
+);

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Loading/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Loading/index.tsx
@@ -5,24 +5,24 @@ import Skeleton from "react-loading-skeleton";
  *  server render (auth + FetchAppEnv) resolves. Mirrors AppIdPage's layout so
  *  the swap to real content doesn't shift. */
 export const AppDashboardSkeleton = () => (
-    <SizingWrapper className="flex flex-col gap-y-8 py-4">
-        {/* status rows (VerificationStatusSection + BanStatusSection) */}
-        <div className="grid gap-y-3">
-            <Skeleton height={64} borderRadius={12} />
-        </div>
+  <SizingWrapper className="flex flex-col gap-y-8 py-4">
+    {/* status rows (VerificationStatusSection + BanStatusSection) */}
+    <div className="grid gap-y-3">
+      <Skeleton height={64} borderRadius={12} />
+    </div>
 
-        {/* "Overview" header + TimePeriodSelector */}
-        <div className="flex items-center justify-between">
-            <Skeleton width={110} height={24} />
-            <Skeleton width={180} height={36} borderRadius={8} />
-        </div>
+    {/* "Overview" header + TimePeriodSelector */}
+    <div className="flex items-center justify-between">
+      <Skeleton width={110} height={24} />
+      <Skeleton width={180} height={36} borderRadius={8} />
+    </div>
 
-        {/* AppStatsGraph — stat row + chart */}
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-            {Array.from({ length: 4 }).map((_, i) => (
-                <Skeleton key={i} height={88} borderRadius={12} />
-            ))}
-        </div>
-        <Skeleton height={320} borderRadius={12} />
-    </SizingWrapper>
+    {/* AppStatsGraph — stat row + chart */}
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Skeleton key={i} height={88} borderRadius={12} />
+      ))}
+    </div>
+    <Skeleton height={320} borderRadius={12} />
+  </SizingWrapper>
 );

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/AppIdChrome.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/AppIdChrome.tsx
@@ -8,8 +8,12 @@ import { ReactNode } from "react";
 
 type AppIdChromeProps = {
   params: { teamId?: string; appId?: string };
-  hasRpRegistration: boolean;
-  hasLegacyActions: boolean;
+  /**
+   * World ID section sub-tabs, provided as a server-rendered slot (see
+   * `AppWorldIdSubTabs`) so their app-env fetch streams in via <Suspense>
+   * without blocking this client chrome. Only mounted on World ID segments.
+   */
+  worldIdTabs: ReactNode;
   children: ReactNode;
 };
 
@@ -22,8 +26,7 @@ type AppIdChromeProps = {
  */
 export const AppIdChrome = ({
   params,
-  hasRpRegistration,
-  hasLegacyActions,
+  worldIdTabs,
   children,
 }: AppIdChromeProps) => {
   const pathname = usePathname();
@@ -58,34 +61,7 @@ export const AppIdChrome = ({
 
   return (
     <>
-      {isWorldIdSegment && (hasRpRegistration || hasLegacyActions) && (
-        <div className="md:border-b md:border-grey-100 md:bg-grey-50">
-          <SizingWrapper variant="nav">
-            <SectionSubTabs
-              items={[
-                {
-                  label: "World ID 4.0",
-                  href: `/teams/${teamId}/apps/${appId}/world-id-4-0`,
-                  segment: "world-id-4-0",
-                  hidden: !hasRpRegistration,
-                },
-                {
-                  label: "Actions",
-                  href: `/teams/${teamId}/apps/${appId}/world-id-actions`,
-                  segment: "world-id-actions",
-                  hidden: !hasRpRegistration,
-                },
-                {
-                  label: "World ID 3.0 Legacy",
-                  href: urls.actions({ team_id: teamId, app_id: appId }),
-                  segment: "actions",
-                  hidden: !hasLegacyActions,
-                },
-              ]}
-            />
-          </SizingWrapper>
-        </div>
-      )}
+      {isWorldIdSegment && worldIdTabs}
 
       {isMiniAppSegment && (
         <div className="md:border-b md:border-grey-100 md:bg-grey-50">

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/AppWorldIdSubTabs.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/AppWorldIdSubTabs.tsx
@@ -1,0 +1,75 @@
+import { SizingWrapper } from "@/components/SizingWrapper";
+import { logger } from "@/lib/logger";
+import { urls } from "@/lib/urls";
+import { SectionSubTabs } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/common/SectionSubTabs";
+import { fetchAppEnvCached } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout/server/fetch-app-env";
+
+/**
+ * World ID section sub-tabs (World ID 4.0 / Actions / World ID 3.0 Legacy).
+ *
+ * Server component so tab visibility is derived from the app's real state. It
+ * reads app-env through `fetchAppEnvCached`, which is React `cache()`-wrapped,
+ * so it shares the single FetchAppEnv round trip with the dashboard page within
+ * a request instead of adding a second one. `AppIdChrome` renders it inside a
+ * <Suspense> boundary, so it streams in without blocking the layout shell or
+ * the route's `loading.tsx` skeleton.
+ *
+ * The sub-tabs are non-critical chrome: if the app-env fetch fails we log and
+ * render nothing (degraded mode) rather than failing the whole app section —
+ * the page owns surfacing a hard error for its own data.
+ */
+export const AppWorldIdSubTabs = async (props: {
+  teamId: string;
+  appId: string;
+}) => {
+  const { teamId, appId } = props;
+
+  let hasRpRegistration = false;
+  let hasLegacyActions = false;
+
+  try {
+    const { app, action } = await fetchAppEnvCached(appId);
+    hasRpRegistration = (app?.[0]?.rp_registration?.length ?? 0) > 0;
+    hasLegacyActions = action.length > 0;
+  } catch (error) {
+    logger.warn("AppWorldIdSubTabs: FetchAppEnv failed, hiding sub-tabs", {
+      error,
+      appId,
+      teamId,
+    });
+    return null;
+  }
+
+  if (!hasRpRegistration && !hasLegacyActions) {
+    return null;
+  }
+
+  return (
+    <div className="md:border-b md:border-grey-100 md:bg-grey-50">
+      <SizingWrapper variant="nav">
+        <SectionSubTabs
+          items={[
+            {
+              label: "World ID 4.0",
+              href: `/teams/${teamId}/apps/${appId}/world-id-4-0`,
+              segment: "world-id-4-0",
+              hidden: !hasRpRegistration,
+            },
+            {
+              label: "Actions",
+              href: `/teams/${teamId}/apps/${appId}/world-id-actions`,
+              segment: "world-id-actions",
+              hidden: !hasRpRegistration,
+            },
+            {
+              label: "World ID 3.0 Legacy",
+              href: urls.actions({ team_id: teamId, app_id: appId }),
+              segment: "actions",
+              hidden: !hasLegacyActions,
+            },
+          ]}
+        />
+      </SizingWrapper>
+    </div>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/index.tsx
@@ -1,9 +1,8 @@
 import { ErrorPage } from "@/components/ErrorPage";
-import { logger } from "@/lib/logger";
 import { getIsUserAllowedToReadApp } from "@/lib/permissions";
-import { fetchAppEnvCached } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout/server/fetch-app-env";
-import { ReactNode } from "react";
+import { ReactNode, Suspense } from "react";
 import { AppIdChrome } from "./AppIdChrome";
+import { AppWorldIdSubTabs } from "./AppWorldIdSubTabs";
 
 type Params = {
   teamId?: string;
@@ -16,50 +15,37 @@ type AppIdLayoutProps = {
 };
 
 /**
- * v3 app layout. Mirrors the v2 auth/existence guard and app-env fetch (reusing
- * the same shared helpers) but renders the v3 chrome, which drops the primary
- * app nav in favor of the sidebar shell.
+ * v3 app layout. Authorizes against the database (the session cookie's
+ * `memberships` is not a trustworthy authorization source) and renders the v3
+ * chrome, which drops the primary app nav in favor of the sidebar shell.
+ *
+ * The layout deliberately does NOT fetch app-env: doing so here would block
+ * navigation on a GraphQL query before the route's `loading.tsx` skeleton could
+ * appear (the layout sits above that Suspense boundary). Instead the dashboard
+ * page owns the single `FetchAppEnv` round trip, and the World ID sub-tabs read
+ * the same `cache()`-deduped fetch via `AppWorldIdSubTabs`, streamed in through
+ * a <Suspense> boundary so it never blocks the shell.
  */
 export const AppIdLayout = async (props: AppIdLayoutProps) => {
   const params = props.params;
-  let hasLegacyActions = false;
-  let hasRpRegistration = false;
 
-  // Authorize against the database (the session cookie's `memberships` is not a
-  // trustworthy authorization source). Reading an app requires membership in
-  // the app's owning team.
+  // Authorize against the database. Reading an app requires membership in the
+  // app's owning team. A nonexistent app resolves to no permitted membership
+  // here too, so this also covers the existence check that the app-env fetch
+  // used to perform.
   if (!params.appId || !(await getIsUserAllowedToReadApp(params.appId))) {
     return <ErrorPage statusCode={404} title="App not found" />;
   }
 
-  try {
-    const { app, action } = await fetchAppEnvCached(params.appId);
-
-    if (app?.[0]) {
-      hasLegacyActions = action.length > 0;
-      hasRpRegistration = app[0].rp_registration.length > 0;
-    } else {
-      logger.warn("AppIdLayout (v3) could not resolve app from FetchAppEnv", {
-        appId: params.appId,
-        teamId: params.teamId,
-      });
-      return <ErrorPage statusCode={404} title="App not found" />;
-    }
-  } catch (error) {
-    logger.error("AppIdLayout (v3) FetchAppEnv failed", {
-      error,
-      appId: params.appId,
-      teamId: params.teamId,
-    });
-    return <ErrorPage statusCode={500} title="Failed to load app" />;
-  }
+  const worldIdTabs =
+    params.teamId && params.appId ? (
+      <Suspense fallback={null}>
+        <AppWorldIdSubTabs teamId={params.teamId} appId={params.appId} />
+      </Suspense>
+    ) : null;
 
   return (
-    <AppIdChrome
-      params={params}
-      hasRpRegistration={hasRpRegistration}
-      hasLegacyActions={hasLegacyActions}
-    >
+    <AppIdChrome params={params} worldIdTabs={worldIdTabs}>
       {props.children}
     </AppIdChrome>
   );

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/page/index.tsx
@@ -1,10 +1,12 @@
-import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { ErrorPage } from "@/components/ErrorPage";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { Role_Enum } from "@/graphql/graphql";
-import { Auth0SessionUser } from "@/lib/types";
 import { auth0 } from "@/lib/auth0";
+import { logger } from "@/lib/logger";
+import { Auth0SessionUser } from "@/lib/types";
 import { BanMessageDialog } from "@/scenes/Portal/Teams/TeamId/Apps/common/BanMessageDialog";
-import { getSdk as getAppEnvSdk } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout/graphql/server/fetch-app-env.generated";
+import { fetchAppEnvCached } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout/server/fetch-app-env";
+import { FetchAppEnvQuery } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout/graphql/server/fetch-app-env.generated";
 import { BanStatusSection } from "./BanStatusSection";
 import { DashboardWrapper } from "./DashboardWrapper";
 import { VerificationStatusSection } from "./VerificationStatusSection";
@@ -25,8 +27,19 @@ export const AppIdPage = async (props: {
 }) => {
   const { teamId, appId } = await props.params;
 
-  const client = await getAPIServiceGraphqlClient();
-  const appEnvData = await getAppEnvSdk(client).FetchAppEnv({ id: appId });
+  // Single source of app-env for this navigation. `fetchAppEnvCached` is
+  // React `cache()`-wrapped, so the World ID sub-tabs (AppWorldIdSubTabs) reuse
+  // this exact result rather than issuing a second FetchAppEnv. The layout no
+  // longer fetches app-env, so failures surface here — don't mask an upstream
+  // dependency failure as an empty dashboard.
+  let appEnvData: FetchAppEnvQuery;
+  try {
+    appEnvData = await fetchAppEnvCached(appId);
+  } catch (error) {
+    logger.error("AppIdPage (v3) FetchAppEnv failed", { error, appId, teamId });
+    return <ErrorPage statusCode={500} title="Failed to load app" />;
+  }
+
   const appInfo = appEnvData.app[0];
   const hasRpRegistration = (appInfo?.rp_registration?.length ?? 0) > 0;
 

--- a/web/tests/unit/pv3-appid-chrome.test.tsx
+++ b/web/tests/unit/pv3-appid-chrome.test.tsx
@@ -19,7 +19,7 @@ jest.mock("@/components/SizingWrapper", () => ({
 }));
 
 // Expose the (visible) items SectionSubTabs receives so tests can assert the
-// hidden-flag logic and active state without depending on Tab markup.
+// Mini App active state without depending on Tab markup.
 jest.mock(
   "@/scenes/Portal/Teams/TeamId/Apps/AppId/common/SectionSubTabs",
   () => ({
@@ -55,6 +55,10 @@ import { AppIdChrome } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/Ap
 
 // #region Test Data
 const params = { teamId: "team_1", appId: "app_1" };
+// The World ID sub-tabs are a server-rendered slot (AppWorldIdSubTabs); the
+// chrome's only job is to mount it on World ID segments. Its own visibility
+// logic is covered by pv3-appid-worldid-subtabs.test.tsx.
+const worldIdTabs = <div data-testid="world-id-tabs-slot" />;
 // #endregion
 
 beforeEach(() => {
@@ -68,56 +72,40 @@ describe("v3 AppIdChrome [missing team/app]", () => {
   it("renders only children when teamId/appId are absent", () => {
     useSelectedLayoutSegment.mockReturnValue("mini-app");
     render(
-      <AppIdChrome params={{}} hasRpRegistration hasLegacyActions>
+      <AppIdChrome params={{}} worldIdTabs={worldIdTabs}>
         <div data-testid="page" />
       </AppIdChrome>,
     );
     expect(screen.getByTestId("page")).toBeInTheDocument();
     expect(screen.queryByTestId("subtabs")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("world-id-tabs-slot")).not.toBeInTheDocument();
   });
 });
 // #endregion
 
-// #region World ID sub-tabs
-describe("v3 AppIdChrome [World ID sub-tabs]", () => {
-  it("shows World ID 4.0 + Actions and hides Legacy for an app with an RP registration only", () => {
-    useSelectedLayoutSegment.mockReturnValue("world-id-4-0");
+// #region World ID slot mounting
+describe("v3 AppIdChrome [World ID slot]", () => {
+  it.each(["world-id-4-0", "world-id-actions", "actions"])(
+    "mounts the World ID sub-tabs slot on the %s segment",
+    (segment) => {
+      useSelectedLayoutSegment.mockReturnValue(segment);
+      render(
+        <AppIdChrome params={params} worldIdTabs={worldIdTabs}>
+          <div />
+        </AppIdChrome>,
+      );
+      expect(screen.getByTestId("world-id-tabs-slot")).toBeInTheDocument();
+    },
+  );
+
+  it("does not mount the World ID slot on non-World-ID segments", () => {
+    useSelectedLayoutSegment.mockReturnValue("mini-app");
     render(
-      <AppIdChrome params={params} hasRpRegistration hasLegacyActions={false}>
+      <AppIdChrome params={params} worldIdTabs={worldIdTabs}>
         <div />
       </AppIdChrome>,
     );
-    expect(screen.getByTestId("subtabs")).toBeInTheDocument();
-    expect(screen.getByText("World ID 4.0")).toBeInTheDocument();
-    expect(screen.getByText("Actions")).toBeInTheDocument();
-    expect(screen.queryByText("World ID 3.0 Legacy")).not.toBeInTheDocument();
-  });
-
-  it("shows only Legacy for an app with legacy actions but no RP registration", () => {
-    useSelectedLayoutSegment.mockReturnValue("actions");
-    render(
-      <AppIdChrome params={params} hasRpRegistration={false} hasLegacyActions>
-        <div />
-      </AppIdChrome>,
-    );
-    expect(screen.getByText("World ID 3.0 Legacy")).toBeInTheDocument();
-    expect(screen.queryByText("World ID 4.0")).not.toBeInTheDocument();
-    expect(screen.queryByText("Actions")).not.toBeInTheDocument();
-  });
-
-  it("renders no sub-tab bar when the app has neither RP registration nor legacy actions", () => {
-    useSelectedLayoutSegment.mockReturnValue("world-id-4-0");
-    render(
-      <AppIdChrome
-        params={params}
-        hasRpRegistration={false}
-        hasLegacyActions={false}
-      >
-        <div data-testid="page" />
-      </AppIdChrome>,
-    );
-    expect(screen.queryByTestId("subtabs")).not.toBeInTheDocument();
-    expect(screen.getByTestId("page")).toBeInTheDocument();
+    expect(screen.queryByTestId("world-id-tabs-slot")).not.toBeInTheDocument();
   });
 });
 // #endregion
@@ -128,7 +116,7 @@ describe("v3 AppIdChrome [Mini App sub-tabs]", () => {
     useSelectedLayoutSegment.mockReturnValue("mini-app");
     usePathname.mockReturnValue("/mini/transactions");
     render(
-      <AppIdChrome params={params} hasRpRegistration hasLegacyActions>
+      <AppIdChrome params={params} worldIdTabs={worldIdTabs}>
         <div />
       </AppIdChrome>,
     );
@@ -150,12 +138,13 @@ describe("v3 AppIdChrome [Configuration]", () => {
   it("renders no sub-tabs and no primary app-nav tabs (sidebar owns nav; Danger zone moved into the page)", () => {
     useSelectedLayoutSegment.mockReturnValue("configuration");
     render(
-      <AppIdChrome params={params} hasRpRegistration hasLegacyActions>
+      <AppIdChrome params={params} worldIdTabs={worldIdTabs}>
         <div data-testid="page" />
       </AppIdChrome>,
     );
     expect(screen.getByTestId("page")).toBeInTheDocument();
     expect(screen.queryByTestId("subtabs")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("world-id-tabs-slot")).not.toBeInTheDocument();
     // The main nav (Dashboard / World ID / Configuration / Mini App) is never
     // rendered by the v3 chrome — it lives in the sidebar shell.
     expect(screen.queryByText("Dashboard")).not.toBeInTheDocument();

--- a/web/tests/unit/pv3-appid-layout.test.tsx
+++ b/web/tests/unit/pv3-appid-layout.test.tsx
@@ -2,7 +2,6 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import { FetchAppEnvQuery } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout/graphql/server/fetch-app-env.generated";
 
 // #region Mocks
 const getIsUserAllowedToReadApp = jest.fn();
@@ -11,39 +10,40 @@ jest.mock("@/lib/permissions", () => ({
     getIsUserAllowedToReadApp(...args),
 }));
 
-const fetchAppEnvCached = jest.fn();
-jest.mock(
-  "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout/server/fetch-app-env",
-  () => ({
-    fetchAppEnvCached: (...args: unknown[]) => fetchAppEnvCached(...args),
-  }),
-);
-
-jest.mock("@/lib/logger", () => ({
-  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
-}));
-
 jest.mock("@/components/ErrorPage", () => ({
   ErrorPage: ({ statusCode }: { statusCode: number }) => (
     <div data-testid="error" data-status={statusCode} />
   ),
 }));
 
+// The World ID sub-tabs are a server component fetched behind <Suspense>; stub
+// it so the layout test stays focused on the auth/existence guard and the slot
+// wiring. Its own behavior lives in pv3-appid-worldid-subtabs.test.tsx.
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/AppWorldIdSubTabs",
+  () => ({
+    AppWorldIdSubTabs: () => <div data-testid="world-id-tabs" />,
+  }),
+);
+
+// Assert what the layout hands the chrome: the page children and a worldIdTabs
+// slot (never the removed hasRpRegistration/hasLegacyActions flags).
 jest.mock(
   "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/AppIdChrome",
   () => ({
     AppIdChrome: ({
-      hasRpRegistration,
-      hasLegacyActions,
+      worldIdTabs,
+      children,
     }: {
-      hasRpRegistration: boolean;
-      hasLegacyActions: boolean;
+      worldIdTabs: React.ReactNode;
+      children: React.ReactNode;
     }) => (
       <div
         data-testid="chrome"
-        data-rp={String(hasRpRegistration)}
-        data-legacy={String(hasLegacyActions)}
-      />
+        data-has-worldid-tabs={worldIdTabs ? "true" : "false"}
+      >
+        {children}
+      </div>
     ),
   }),
 );
@@ -55,22 +55,6 @@ import { AppIdLayout } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout";
 const teamId = "team_1";
 const appId = "app_9cdd0a714aec9ed17dca660bc9ffe72a";
 
-const makeAppEnv = (overrides: {
-  rpRegistrations?: Array<{ rp_id: string }>;
-  actions?: unknown[];
-}): FetchAppEnvQuery =>
-  ({
-    app: [
-      {
-        id: appId,
-        engine: "cloud",
-        is_staging: false,
-        rp_registration: overrides.rpRegistrations ?? [],
-      },
-    ],
-    action: (overrides.actions ?? []) as FetchAppEnvQuery["action"],
-  }) as FetchAppEnvQuery;
-
 const renderLayout = async (params: { teamId?: string; appId?: string }) =>
   render(await AppIdLayout({ params, children: <div data-testid="page" /> }));
 
@@ -79,74 +63,39 @@ const status = () => screen.getByTestId("error").getAttribute("data-status");
 
 beforeEach(() => {
   jest.clearAllMocks();
-  // clearAllMocks clears call data but not implementations, so reset the
-  // resolved/rejected value between tests to avoid leakage.
-  fetchAppEnvCached.mockReset();
   getIsUserAllowedToReadApp.mockResolvedValue(true);
 });
 
 // #region auth / existence guard
 describe("v3 AppIdLayout [guard]", () => {
-  it("returns 404 when the user is not allowed to read the app (and never fetches app-env)", async () => {
+  it("returns 404 when the user is not allowed to read the app", async () => {
     getIsUserAllowedToReadApp.mockResolvedValue(false);
-    await renderLayout({ teamId, appId });
-    expect(status()).toBe("404");
-    expect(fetchAppEnvCached).not.toHaveBeenCalled();
-  });
-
-  it("returns 404 when appId is missing, short-circuiting the DB check and fetch", async () => {
-    await renderLayout({ teamId });
-    expect(status()).toBe("404");
-    expect(getIsUserAllowedToReadApp).not.toHaveBeenCalled();
-    expect(fetchAppEnvCached).not.toHaveBeenCalled();
-  });
-
-  it("returns 404 when the app cannot be resolved from FetchAppEnv", async () => {
-    fetchAppEnvCached.mockResolvedValue({
-      app: [],
-      action: [],
-    } as unknown as FetchAppEnvQuery);
     await renderLayout({ teamId, appId });
     expect(status()).toBe("404");
     expect(screen.queryByTestId("chrome")).not.toBeInTheDocument();
   });
 
-  it("returns 500 when FetchAppEnv throws — a dependency failure is not masked as 404", async () => {
-    fetchAppEnvCached.mockRejectedValue(new Error("upstream down"));
-    await renderLayout({ teamId, appId });
-    expect(status()).toBe("500");
+  it("returns 404 when appId is missing, short-circuiting the DB check", async () => {
+    await renderLayout({ teamId });
+    expect(status()).toBe("404");
+    expect(getIsUserAllowedToReadApp).not.toHaveBeenCalled();
   });
 });
 // #endregion
 
-// #region success → chrome flags
+// #region success → chrome + world-id tabs slot
 describe("v3 AppIdLayout [renders chrome]", () => {
-  it("passes hasRpRegistration=true when the app has an RP registration", async () => {
-    fetchAppEnvCached.mockResolvedValue(
-      makeAppEnv({ rpRegistrations: [{ rp_id: "rp_abc" }] }),
-    );
+  it("renders the chrome with the page children when authorized", async () => {
     await renderLayout({ teamId, appId });
-    const chrome = screen.getByTestId("chrome");
-    expect(chrome.getAttribute("data-rp")).toBe("true");
-    expect(chrome.getAttribute("data-legacy")).toBe("false");
+    expect(screen.getByTestId("chrome")).toBeInTheDocument();
+    expect(screen.getByTestId("page")).toBeInTheDocument();
   });
 
-  it("passes hasLegacyActions=true when the app has legacy actions", async () => {
-    fetchAppEnvCached.mockResolvedValue(
-      makeAppEnv({ actions: [{ id: "a_1" }] }),
-    );
+  it("passes a World ID sub-tabs slot to the chrome (does not fetch app-env itself)", async () => {
     await renderLayout({ teamId, appId });
-    const chrome = screen.getByTestId("chrome");
-    expect(chrome.getAttribute("data-legacy")).toBe("true");
-    expect(chrome.getAttribute("data-rp")).toBe("false");
-  });
-
-  it("passes both flags false for an app with no RP registration and no legacy actions", async () => {
-    fetchAppEnvCached.mockResolvedValue(makeAppEnv({}));
-    await renderLayout({ teamId, appId });
-    const chrome = screen.getByTestId("chrome");
-    expect(chrome.getAttribute("data-rp")).toBe("false");
-    expect(chrome.getAttribute("data-legacy")).toBe("false");
+    expect(
+      screen.getByTestId("chrome").getAttribute("data-has-worldid-tabs"),
+    ).toBe("true");
   });
 });
 // #endregion

--- a/web/tests/unit/pv3-appid-worldid-subtabs.test.tsx
+++ b/web/tests/unit/pv3-appid-worldid-subtabs.test.tsx
@@ -1,0 +1,123 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { FetchAppEnvQuery } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout/graphql/server/fetch-app-env.generated";
+
+// #region Mocks
+const fetchAppEnvCached = jest.fn();
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/AppId/layout/server/fetch-app-env",
+  () => ({
+    fetchAppEnvCached: (...args: unknown[]) => fetchAppEnvCached(...args),
+  }),
+);
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("@/components/SizingWrapper", () => ({
+  SizingWrapper: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+// Expose the visible items so we can assert the hidden-flag logic without
+// depending on Tab markup.
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/AppId/common/SectionSubTabs",
+  () => ({
+    SectionSubTabs: ({
+      items,
+    }: {
+      items: Array<{ label: string; hidden?: boolean }>;
+    }) => (
+      <ul data-testid="subtabs">
+        {items
+          .filter((i) => !i.hidden)
+          .map((i) => (
+            <li key={i.label}>{i.label}</li>
+          ))}
+      </ul>
+    ),
+  }),
+);
+
+jest.mock("@/lib/urls", () => ({
+  urls: { actions: () => "/actions-legacy" },
+}));
+
+import { AppWorldIdSubTabs } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/layout/AppWorldIdSubTabs";
+// #endregion
+
+// #region Test Data
+const teamId = "team_1";
+const appId = "app_9cdd0a714aec9ed17dca660bc9ffe72a";
+
+const makeAppEnv = (overrides: {
+  rpRegistrations?: Array<{ rp_id: string }>;
+  actions?: unknown[];
+}): FetchAppEnvQuery =>
+  ({
+    app: [
+      {
+        id: appId,
+        engine: "cloud",
+        is_staging: false,
+        rp_registration: overrides.rpRegistrations ?? [],
+      },
+    ],
+    action: (overrides.actions ?? []) as FetchAppEnvQuery["action"],
+  }) as FetchAppEnvQuery;
+
+const renderSubTabs = async () =>
+  render(await AppWorldIdSubTabs({ teamId, appId }));
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchAppEnvCached.mockReset();
+});
+
+// #region visibility from app state
+describe("AppWorldIdSubTabs [visibility]", () => {
+  it("shows World ID 4.0 + Actions and hides Legacy for an app with an RP registration only", async () => {
+    fetchAppEnvCached.mockResolvedValue(
+      makeAppEnv({ rpRegistrations: [{ rp_id: "rp_abc" }] }),
+    );
+    await renderSubTabs();
+    expect(screen.getByText("World ID 4.0")).toBeInTheDocument();
+    expect(screen.getByText("Actions")).toBeInTheDocument();
+    expect(screen.queryByText("World ID 3.0 Legacy")).not.toBeInTheDocument();
+  });
+
+  it("shows only Legacy for an app with legacy actions but no RP registration", async () => {
+    fetchAppEnvCached.mockResolvedValue(
+      makeAppEnv({ actions: [{ id: "a_1" }] }),
+    );
+    await renderSubTabs();
+    expect(screen.getByText("World ID 3.0 Legacy")).toBeInTheDocument();
+    expect(screen.queryByText("World ID 4.0")).not.toBeInTheDocument();
+    expect(screen.queryByText("Actions")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the app has neither RP registration nor legacy actions", async () => {
+    fetchAppEnvCached.mockResolvedValue(makeAppEnv({}));
+    const { container } = await renderSubTabs();
+    expect(screen.queryByTestId("subtabs")).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+// #endregion
+
+// #region degraded mode
+describe("AppWorldIdSubTabs [degraded mode]", () => {
+  it("renders nothing (and does not throw) when the app-env fetch fails", async () => {
+    fetchAppEnvCached.mockRejectedValue(new Error("upstream down"));
+    const { container } = await renderSubTabs();
+    expect(screen.queryByTestId("subtabs")).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+// #endregion


### PR DESCRIPTION
The app dashboard layout blocked navigation on two sequential GraphQL
queries (auth guard + FetchAppEnv) before its loading.tsx Suspense
boundary could paint, and the page then re-fetched FetchAppEnv a second
time. Collapse to a single cache()-deduped fetch owned by the page, and
stream the World ID sub-tabs so the layout no longer blocks on app-env.

- add loading.tsx skeleton for the app dashboard route
- page reads FetchAppEnv via fetchAppEnvCached (one request per nav)
- new AppWorldIdSubTabs server component renders the World ID sub-tabs
  from the same cached fetch, streamed via <Suspense>
- AppIdChrome takes a worldIdTabs slot instead of flag props
- page surfaces upstream FetchAppEnv failure as 500 (not masked)

