### PR TITLE
fix(portal) Make all portal pages remmeber AppID based on what's selected in AppDropdown

### DIFF
--- a/web/scenes/PortalV3/layout/Shell/AppsDropdown.tsx
+++ b/web/scenes/PortalV3/layout/Shell/AppsDropdown.tsx
@@ -13,10 +13,43 @@ import { CreateAppDialogV4 } from "@/scenes/Portal/layout/CreateAppDialog/index-
 import { useUser } from "@auth0/nextjs-auth0/client";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import clsx from "clsx";
+import { atom, useAtomValue, useSetAtom } from "jotai";
 import { useParams, useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 type DropdownApp = { id: string; name: string };
+
+// Which app is "selected": the URL on app routes, otherwise the last app
+// visited under this team — remembered so team-scoped routes (Members /
+// API Keys / Settings, no appId in the URL) keep their app context. Keyed by
+// team so an app remembered under one team is never used under another.
+// SidebarNav reads this too, so its deep links always match the app name
+// shown in the dropdown trigger.
+const lastAppAtom = atom<{ teamId: string; appId: string } | undefined>(
+  undefined,
+);
+
+export const useCurrentAppId = (): string | undefined => {
+  const params = useParams<{ teamId?: string; appId?: string }>();
+  const teamId = params?.teamId;
+  const appId = params?.appId;
+  const setLastApp = useSetAtom(lastAppAtom);
+  const lastApp = useAtomValue(lastAppAtom);
+
+  // Updated in an effect, not during render; identity-guarded because every
+  // shell component using this hook runs the same sync.
+  useEffect(() => {
+    if (!teamId || !appId) return;
+    setLastApp((prev) =>
+      prev?.teamId === teamId && prev?.appId === appId
+        ? prev
+        : { teamId, appId },
+    );
+  }, [teamId, appId, setLastApp]);
+
+  if (appId) return appId;
+  return lastApp && lastApp.teamId === teamId ? lastApp.appId : undefined;
+};
 
 const appName = (app: FetchAppsQuery["app"][number]) =>
   app.app_metadata?.[0]?.name ?? "Untitled app";
@@ -39,22 +72,14 @@ const AppsDropdownRow = (props: {
 
 export const AppsDropdown = () => {
   const router = useRouter();
-  const { teamId, appId } = useParams() as { teamId?: string; appId?: string };
+  const { teamId } = useParams() as { teamId?: string };
   const { user } = useUser() as Auth0SessionUser;
   const canCreateApp = checkUserPermissions(user, teamId ?? "", [
     Role_Enum.Owner,
     Role_Enum.Admin,
   ]);
   const [dialogOpen, setDialogOpen] = useState(false);
-
-  // Remember the last selected app so its name still shows in the trigger on
-  // team-scoped routes (Members / API Keys / Settings) that have no appId in
-  // the URL. Updated in an effect, not during render.
-  const lastAppIdRef = useRef<string | undefined>(undefined);
-  useEffect(() => {
-    if (appId) lastAppIdRef.current = appId;
-  }, [appId]);
-  const currentAppId = appId ?? lastAppIdRef.current;
+  const currentAppId = useCurrentAppId();
 
   const { data, loading, error } = useFetchAppsQuery({
     variables: { teamId: teamId! },

--- a/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
@@ -6,14 +6,15 @@ import { urls } from "@/lib/urls";
 import { checkUserPermissions } from "@/lib/utils";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { useParams, usePathname } from "next/navigation";
+import { useCurrentAppId } from "./AppsDropdown";
 import { NavItem } from "./NavItem";
 
 export const SidebarNav = () => {
   const { user } = useUser() as Auth0SessionUser;
   const pathname = usePathname() ?? "";
-  const params = useParams<{ teamId?: string; appId?: string }>();
+  const params = useParams<{ teamId?: string }>();
   const teamId = params?.teamId;
-  const appId = params?.appId;
+  const appId = useCurrentAppId();
 
   const canSeeApiKeys = checkUserPermissions(user, teamId ?? "", [
     Role_Enum.Owner,
@@ -26,8 +27,10 @@ export const SidebarNav = () => {
   const appBase =
     teamId && appId ? urls.app({ team_id: teamId, app_id: appId }) : undefined;
 
-  // When no app is selected, app items still render but link to the apps
-  // resolver (urls.apps) so clicking them prompts the user to pick an app.
+  // Fallback for when no app has been visited yet this session (appId comes
+  // from useCurrentAppId, which remembers the last app opened under this
+  // team). The apps resolver redirects to an arbitrary app's dashboard, so it
+  // must only ever be the last resort.
   const appsListHref = teamId ? urls.apps({ team_id: teamId }) : undefined;
 
   const appItems = teamId


### PR DESCRIPTION
## What

Pages used useparams? to remember current appID. `Members`, `API Keys` etc. had **no app id** in the URL, so they would send back to dashboard /apps when clicking to /configuration from one of those pages in the sidebarnav

## Fix
export the lastAppID as a jotai atom from app dropdown, remember it in sidebarnav

## Before & After

https://github.com/user-attachments/assets/dfd036e4-e230-4a8a-92f3-5692cd9d66b8


https://github.com/user-attachments/assets/a46824de-7f84-47ac-b308-ecbdec46a08b

