### PR TITLE
fix(hasura): remove partner-only columns from api_key action insert (H1 #3846290)

### DIFF
--- a/hasura/metadata/databases/default/tables/public_action.yaml
+++ b/hasura/metadata/databases/default/tables/public_action.yaml
@@ -47,11 +47,6 @@ insert_permissions:
         - max_accounts_per_user
         - max_verifications
         - name
-        - app_flow_on_complete
-        - webhook_pem
-        - webhook_uri
-        - post_action_deep_link_ios
-        - post_action_deep_link_android
   - role: service
     permission:
       check:

--- a/web/tests/integration/api-key-security.test.ts
+++ b/web/tests/integration/api-key-security.test.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client";
 import { integrationDBClean, integrationDBExecuteQuery } from "./setup";
-import { getAPIUserClient } from "./test-utils";
+import { getAPIClient, getAPIUserClient } from "./test-utils";
 
 /**
  * Integration tests for API key security
@@ -272,4 +272,112 @@ describe("API key security", () => {
     // Admin should not be able to update
     expect(updateResponse.data?.update_api_key_by_pk).toBeNull();
   });
+});
+
+/**
+ * Integration tests for the api_key role's action insert permission.
+ *
+ * H1 Report Reference: #3846290
+ *
+ * The partner-only action columns (webhook_uri, webhook_pem,
+ * app_flow_on_complete, post_action_deep_link_ios/android) are gated to partner
+ * teams in the UI create/update flows via checkIfPartnerTeam(). That check only
+ * runs in the Next.js server actions, but the public /api/v1/graphql proxy
+ * forwards raw mutations to Hasura with the api_key role, so a non-partner team
+ * could set these columns directly by calling insert_action_one. They are now
+ * removed from the api_key insert permission — partners set them through the
+ * service-role UI path — so Hasura rejects them regardless of the caller.
+ */
+describe("API key action insert permissions", () => {
+  // Each entry is [column, GraphQL literal] embedded inline in the insert input.
+  const PARTNER_ONLY_COLUMNS: Array<[string, string]> = [
+    ["webhook_uri", '"https://attacker.example.com/webhook"'],
+    ["webhook_pem", '"attacker-pem"'],
+    ["app_flow_on_complete", "VERIFY"],
+    ["post_action_deep_link_ios", '"worldapp://attacker-ios"'],
+    ["post_action_deep_link_android", '"worldapp://attacker-android"'],
+  ];
+
+  const getSeededApp = async () => {
+    const { rows } = (await integrationDBExecuteQuery(
+      `SELECT id AS app_id, team_id FROM "public"."app" WHERE team_id IS NOT NULL LIMIT 1`,
+    )) as { rows: Array<{ app_id: string; team_id: string }> };
+
+    expect(rows.length).toBe(1);
+    return rows[0];
+  };
+
+  test("api_key role can insert an action with the standard columns", async () => {
+    const { app_id, team_id } = await getSeededApp();
+    const client = await getAPIClient({ team_id });
+
+    const mutation = gql`
+      mutation InsertAction($object: action_insert_input!) {
+        insert_action_one(object: $object) {
+          id
+          action
+          name
+        }
+      }
+    `;
+
+    const response = await client.mutate({
+      mutation,
+      variables: {
+        object: {
+          app_id,
+          action: "regression_standard_action",
+          name: "Standard Action",
+          description: "created via api_key role",
+          max_verifications: 3,
+        },
+      },
+    });
+
+    expect(response.data?.insert_action_one?.id).toEqual(
+      expect.stringContaining("action_"),
+    );
+  });
+
+  test.each(PARTNER_ONLY_COLUMNS)(
+    "api_key role cannot set partner-only column '%s' on insert",
+    async (column, literal) => {
+      const { app_id, team_id } = await getSeededApp();
+      const client = await getAPIClient({ team_id });
+
+      // The forbidden field is placed inline in the insert input so it is
+      // validated against the api_key role's action_insert_input type.
+      const mutation = gql`
+        mutation InsertActionWithPartnerColumn($app_id: String!) {
+          insert_action_one(
+            object: {
+              app_id: $app_id
+              action: "regression_${column}"
+              ${column}: ${literal}
+            }
+          ) {
+            id
+          }
+        }
+      `;
+
+      let error: any;
+      try {
+        await client.mutate({ mutation, variables: { app_id } });
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeDefined();
+      expect(error.graphQLErrors?.[0]?.message).toContain(
+        `field '${column}' not found in type: 'action_insert_input'`,
+      );
+
+      // The mutation is rejected at validation, so nothing is inserted.
+      const { rows } = (await integrationDBExecuteQuery(
+        `SELECT COUNT(*)::int AS count FROM "public"."action" WHERE action = 'regression_${column}'`,
+      )) as { rows: Array<{ count: number }> };
+      expect(rows[0].count).toBe(0);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Fixes a data-layer authorization gap reported in **HackerOne #3846290**.

The action columns `webhook_uri`, `webhook_pem`, `app_flow_on_complete`, `post_action_deep_link_ios` and `post_action_deep_link_android` are **partner-only**. The gate that enforces this — `checkIfPartnerTeam()` — runs **only** in the Next.js `"use server"` create/update action flows. The public `/api/v1/graphql` proxy authenticates an API key and forwards **arbitrary GraphQL** to Hasura with the `api_key` role, so a non-partner team could bypass the UI gate entirely and set these columns directly via `insert_action_one`. Public `precheck` then echoes them back.

**Fix:** remove the five partner-only columns from the `api_key` **insert** permission so the data layer enforces the same restriction the UI does. This also makes INSERT consistent with the `api_key` **update** permission, which already excludes these columns (the columns were effectively an accidental inclusion — likely copied from the `service` role).

## Why this is the right shape

- The partner gate is **dynamic per-team** (`checkIfPartnerTeam` / `PARTNER_TEAM_IDS`), which a single static Hasura role can't express at the column level. A role split (`api_key_partner`) was considered but rejected: `api_key` spans 6 tables, so it would mean duplicating all permissions to grant a capability that isn't actually used.
- **Partners are unaffected** — they set these fields through the portal UI, which runs as the `service` role (unchanged here).
- **`/api/v2/create-action` is unaffected** — it uses a strict `.noUnknown()` schema (`action`/`name`/`description`/`max_verifications` only) and never touches webhook columns.
- **`precheck` is unaffected** — it reads via the `service` role.

## Severity

Low (matches the report): confined to the caller's own apps (row-level `team_id` check), no cross-tenant read/write, and the columns are inert within this repo (only stored + echoed; the webhook/deep-link consumer is the World App / app-backend). This is a defense-in-depth / consistent-enforcement fix.

## Scope note

`api_key` **select** permission is intentionally left as-is: after this change a non-partner can't populate these columns, so reads only ever return their own (empty) values — no cross-tenant leak.

## Tests

Added to `web/tests/integration/api-key-security.test.ts` (runs against the real `hasura_test` container with this metadata applied):

- `api_key` role can still insert an action with the standard columns ✅
- `api_key` role is rejected when setting **each** of the 5 partner-only columns ✅ (`field '<col>' not found in type: 'action_insert_input'`, and no row inserted)

Verified locally against the `hasura_test` stack: **9/9 pass** in the file; `action.test.ts` + `graphql-proxy.test.ts` regression **11/11 pass**; `tsc --noEmit` clean. Introspection confirms the `api_key` `action_insert_input` no longer exposes any partner column.

## Rollout / rollback

Metadata-only permission change (no schema migration, no data change). Applied via `hasura metadata apply` on deploy; rollback = revert this commit and re-apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
