### PR TITLE
Fix Claude MCP setup command argument order

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
@@ -45,7 +45,7 @@ const getApiKeyPreview = (apiKey: string) => {
 };
 
 export const getClaudeMcpCommand = (apiKey: string) =>
-  `claude mcp add --transport http --scope project --header "Authorization: Bearer ${apiKey}" ${MCP_SERVER_NAME} ${MCP_ENDPOINT}`;
+  `claude mcp add ${MCP_SERVER_NAME} ${MCP_ENDPOINT} --transport http --scope project --header "Authorization: Bearer ${apiKey}"`;
 
 export const getCodexMcpCommand = (apiKey: string) =>
   `codex mcp add ${MCP_SERVER_NAME} --env ${MCP_API_KEY_ENV_VAR}=${shellQuote(apiKey)} -- npx -y mcp-remote ${MCP_ENDPOINT} --transport http-only --header 'Authorization:Bearer ${envReference(MCP_API_KEY_ENV_VAR)}'`;

--- a/web/scenes/PortalV3/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
@@ -45,7 +45,7 @@ const getApiKeyPreview = (apiKey: string) => {
 };
 
 export const getClaudeMcpCommand = (apiKey: string) =>
-  `claude mcp add --transport http --scope project --header "Authorization: Bearer ${apiKey}" ${MCP_SERVER_NAME} ${MCP_ENDPOINT}`;
+  `claude mcp add ${MCP_SERVER_NAME} ${MCP_ENDPOINT} --transport http --scope project --header "Authorization: Bearer ${apiKey}"`;
 
 export const getCodexMcpCommand = (apiKey: string) =>
   `codex mcp add ${MCP_SERVER_NAME} --env ${MCP_API_KEY_ENV_VAR}=${shellQuote(apiKey)} -- npx -y mcp-remote ${MCP_ENDPOINT} --transport http-only --header 'Authorization:Bearer ${envReference(MCP_API_KEY_ENV_VAR)}'`;


### PR DESCRIPTION
The Claude snippet on the API key screen fails with `error: missing required argument 'name'`: the `claude` CLI's `--header` flag is variadic, so the server name and URL placed after it are consumed as extra header values. This moves the positionals before the flags, in both Portal and PortalV3.

Verified the corrected command against claude CLI 2.1.202: registers the server and connects with a live key. The other provider snippets (Codex command + TOML, Cursor, Windsurf, ChatGPT, Zed) were checked against their current docs and are valid as-is.

Note for a possible follow-up: `--scope project` writes the raw API key into `.mcp.json`, which is designed to be committed; `--scope user` (or env-var expansion in the header) would keep the key out of repos.

Generated with [Claude Code](https://claude.com/claude-code)