### PR TITLE
fix: reject deleted apps from active flows

### DIFF
--- a/web/api/hasura/rotate-signer-key/graphql/claim-rotation-slot.generated.ts
+++ b/web/api/hasura/rotate-signer-key/graphql/claim-rotation-slot.generated.ts
@@ -27,7 +27,15 @@ export type ClaimRotationSlotMutation = {
 export const ClaimRotationSlotDocument = gql`
   mutation ClaimRotationSlot($rp_id: String!) {
     update_rp_registration(
-      where: { rp_id: { _eq: $rp_id }, status: { _eq: registered } }
+      where: {
+        rp_id: { _eq: $rp_id }
+        status: { _eq: registered }
+        app: {
+          status: { _eq: "active" }
+          is_archived: { _eq: false }
+          deleted_at: { _is_null: true }
+        }
+      }
       _set: { status: pending }
     ) {
       affected_rows

--- a/web/api/hasura/rotate-signer-key/graphql/claim-rotation-slot.graphql
+++ b/web/api/hasura/rotate-signer-key/graphql/claim-rotation-slot.graphql
@@ -1,6 +1,14 @@
 mutation ClaimRotationSlot($rp_id: String!) {
   update_rp_registration(
-    where: { rp_id: { _eq: $rp_id }, status: { _eq: registered } }
+    where: {
+      rp_id: { _eq: $rp_id }
+      status: { _eq: registered }
+      app: {
+        status: { _eq: "active" }
+        is_archived: { _eq: false }
+        deleted_at: { _is_null: true }
+      }
+    }
     _set: { status: pending }
   ) {
     affected_rows

--- a/web/api/hasura/rotate-signer-key/graphql/get-rp-registration.generated.ts
+++ b/web/api/hasura/rotate-signer-key/graphql/get-rp-registration.generated.ts
@@ -19,7 +19,13 @@ export type GetRpRegistrationQuery = {
     signer_address?: string | null;
     manager_kms_key_id?: string | null;
     operation_hash?: string | null;
-    app: { __typename?: "app"; team_id: string };
+    app: {
+      __typename?: "app";
+      team_id: string;
+      status: string;
+      is_archived: boolean;
+      deleted_at?: string | null;
+    };
   }>;
 };
 
@@ -35,6 +41,9 @@ export const GetRpRegistrationDocument = gql`
       operation_hash
       app {
         team_id
+        status
+        is_archived
+        deleted_at
       }
     }
   }

--- a/web/api/hasura/rotate-signer-key/graphql/get-rp-registration.graphql
+++ b/web/api/hasura/rotate-signer-key/graphql/get-rp-registration.graphql
@@ -9,6 +9,9 @@ query GetRpRegistration($app_id: String!) {
     operation_hash
     app {
       team_id
+      status
+      is_archived
+      deleted_at
     }
   }
 }

--- a/web/api/hasura/rotate-signer-key/index.ts
+++ b/web/api/hasura/rotate-signer-key/index.ts
@@ -35,6 +35,7 @@ const ROTATION_ERROR_HTTP_CODE: Record<
 > = {
   config_error: "config_error",
   rp_not_registered: "rp_not_registered",
+  app_not_active: "app_not_active",
   self_managed_mode: "self_managed_mode",
   rotation_in_progress: "rotation_in_progress",
   submission_error: "submission_error",

--- a/web/api/helpers/oidc/graphql/fetch-app-secret-query.generated.ts
+++ b/web/api/helpers/oidc/graphql/fetch-app-secret-query.generated.ts
@@ -24,6 +24,7 @@ export const FetchAppSecretDocument = gql`
         id: { _eq: $app_id }
         status: { _eq: "active" }
         is_archived: { _eq: false }
+        deleted_at: { _is_null: true }
         engine: { _eq: "cloud" }
       }
     ) {

--- a/web/api/helpers/oidc/graphql/fetch-app-secret-query.gql
+++ b/web/api/helpers/oidc/graphql/fetch-app-secret-query.gql
@@ -4,6 +4,7 @@ query FetchAppSecret($app_id: String!) {
       id: { _eq: $app_id }
       status: { _eq: "active" }
       is_archived: { _eq: false }
+      deleted_at: { _is_null: true }
       engine: { _eq: "cloud" }
     }
   ) {

--- a/web/api/helpers/oidc/graphql/fetch-oidc-app.generated.ts
+++ b/web/api/helpers/oidc/graphql/fetch-oidc-app.generated.ts
@@ -32,6 +32,7 @@ export const FetchOidcAppDocument = gql`
         id: { _eq: $app_id }
         status: { _eq: "active" }
         is_archived: { _eq: false }
+        deleted_at: { _is_null: true }
         engine: { _eq: "cloud" }
       }
     ) {

--- a/web/api/helpers/oidc/graphql/fetch-oidc-app.gql
+++ b/web/api/helpers/oidc/graphql/fetch-oidc-app.gql
@@ -4,6 +4,7 @@ query FetchOIDCApp($app_id: String!, $redirect_uri: String!) {
       id: { _eq: $app_id }
       status: { _eq: "active" }
       is_archived: { _eq: false }
+      deleted_at: { _is_null: true }
       engine: { _eq: "cloud" }
     }
   ) {

--- a/web/api/helpers/rp-registration-flows.ts
+++ b/web/api/helpers/rp-registration-flows.ts
@@ -278,6 +278,7 @@ export type ManagedRotationResult =
       code:
         | "config_error"
         | "rp_not_registered"
+        | "app_not_active"
         | "self_managed_mode"
         | "rotation_in_progress"
         | "submission_error"
@@ -323,6 +324,15 @@ export async function submitManagedSignerRotation({
   const registration = rp_registration[0];
   const rpIdString = registration.rp_id;
   const oldSignerAddress = registration.signer_address || "";
+  const app = registration.app;
+
+  if (app.status !== "active" || app.is_archived || app.deleted_at) {
+    return {
+      ok: false,
+      code: "app_not_active",
+      detail: "App not found. App may be inactive, archived, or deleted.",
+    };
+  }
 
   if (registration.mode !== "managed" || !registration.manager_kms_key_id) {
     return {

--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -884,6 +884,7 @@ const ROTATION_FLOW_RPC_CODE: Record<
   number
 > = {
   rp_not_registered: -32004,
+  app_not_active: -32004,
   self_managed_mode: -32004,
   rotation_in_progress: -32004,
   config_error: -32603,

--- a/web/api/v1/precheck/[app_id]/graphql/app-precheck-by-action.generated.ts
+++ b/web/api/v1/precheck/[app_id]/graphql/app-precheck-by-action.generated.ts
@@ -66,6 +66,7 @@ export const AppPrecheckByActionQueryDocument = gql`
         id: { _eq: $app_id }
         status: { _eq: "active" }
         is_archived: { _eq: false }
+        deleted_at: { _is_null: true }
       }
     ) {
       id

--- a/web/api/v1/precheck/[app_id]/graphql/app-precheck-by-action.graphql
+++ b/web/api/v1/precheck/[app_id]/graphql/app-precheck-by-action.graphql
@@ -8,6 +8,7 @@ query AppPrecheckByActionQuery(
       id: { _eq: $app_id }
       status: { _eq: "active" }
       is_archived: { _eq: false }
+      deleted_at: { _is_null: true }
     }
   ) {
     id

--- a/web/api/v1/precheck/[app_id]/graphql/app-precheck.generated.ts
+++ b/web/api/v1/precheck/[app_id]/graphql/app-precheck.generated.ts
@@ -66,6 +66,7 @@ export const AppPrecheckQueryDocument = gql`
         id: { _eq: $app_id }
         status: { _eq: "active" }
         is_archived: { _eq: false }
+        deleted_at: { _is_null: true }
       }
     ) {
       id

--- a/web/api/v1/precheck/[app_id]/graphql/app-precheck.graphql
+++ b/web/api/v1/precheck/[app_id]/graphql/app-precheck.graphql
@@ -8,6 +8,7 @@ query AppPrecheckQuery(
       id: { _eq: $app_id }
       status: { _eq: "active" }
       is_archived: { _eq: false }
+      deleted_at: { _is_null: true }
     }
   ) {
     id

--- a/web/api/v1/precheck/[app_id]/graphql/fetch-rp-registration-for-precheck.generated.ts
+++ b/web/api/v1/precheck/[app_id]/graphql/fetch-rp-registration-for-precheck.generated.ts
@@ -20,7 +20,16 @@ export type FetchRpRegistrationForPrecheckQuery = {
 
 export const FetchRpRegistrationForPrecheckDocument = gql`
   query FetchRpRegistrationForPrecheck($app_id: String!) {
-    rp_registration(where: { app_id: { _eq: $app_id } }) {
+    rp_registration(
+      where: {
+        app_id: { _eq: $app_id }
+        app: {
+          status: { _eq: "active" }
+          is_archived: { _eq: false }
+          deleted_at: { _is_null: true }
+        }
+      }
+    ) {
       rp_id
       app_id
       status

--- a/web/api/v1/precheck/[app_id]/graphql/fetch-rp-registration-for-precheck.graphql
+++ b/web/api/v1/precheck/[app_id]/graphql/fetch-rp-registration-for-precheck.graphql
@@ -1,5 +1,14 @@
 query FetchRpRegistrationForPrecheck($app_id: String!) {
-  rp_registration(where: { app_id: { _eq: $app_id } }) {
+  rp_registration(
+    where: {
+      app_id: { _eq: $app_id }
+      app: {
+        status: { _eq: "active" }
+        is_archived: { _eq: false }
+        deleted_at: { _is_null: true }
+      }
+    }
+  ) {
     rp_id
     app_id
     status

--- a/web/api/v2/verify/graphql/fetch-app-action.generated.ts
+++ b/web/api/v2/verify/graphql/fetch-app-action.generated.ts
@@ -46,6 +46,7 @@ export const FetchAppActionDocument = gql`
         id: { _eq: $app_id }
         status: { _eq: "active" }
         is_archived: { _eq: false }
+        deleted_at: { _is_null: true }
       }
     ) {
       id

--- a/web/api/v2/verify/graphql/fetch-app-action.graphql
+++ b/web/api/v2/verify/graphql/fetch-app-action.graphql
@@ -8,6 +8,7 @@ query FetchAppAction(
       id: { _eq: $app_id }
       status: { _eq: "active" }
       is_archived: { _eq: false }
+      deleted_at: { _is_null: true }
     }
   ) {
     id

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Danger/page/DeleteModal/graphql/server/delete-app.generated.ts
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Danger/page/DeleteModal/graphql/server/delete-app.generated.ts
@@ -15,10 +15,7 @@ export type DeleteAppMutation = {
 
 export const DeleteAppDocument = gql`
   mutation DeleteApp($id: String!) {
-    update_app_by_pk(
-      pk_columns: { id: $id }
-      _set: { deleted_at: "now()", is_archived: true }
-    ) {
+    update_app_by_pk(pk_columns: { id: $id }, _set: { deleted_at: "now()" }) {
       id
     }
   }

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Danger/page/DeleteModal/graphql/server/delete-app.generated.ts
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Danger/page/DeleteModal/graphql/server/delete-app.generated.ts
@@ -15,7 +15,10 @@ export type DeleteAppMutation = {
 
 export const DeleteAppDocument = gql`
   mutation DeleteApp($id: String!) {
-    update_app_by_pk(pk_columns: { id: $id }, _set: { deleted_at: "now()" }) {
+    update_app_by_pk(
+      pk_columns: { id: $id }
+      _set: { deleted_at: "now()", is_archived: true }
+    ) {
       id
     }
   }

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Danger/page/DeleteModal/graphql/server/delete-app.graphql
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Danger/page/DeleteModal/graphql/server/delete-app.graphql
@@ -1,8 +1,5 @@
 mutation DeleteApp($id: String!) {
-  update_app_by_pk(
-    pk_columns: { id: $id }
-    _set: { deleted_at: "now()", is_archived: true }
-  ) {
+  update_app_by_pk(pk_columns: { id: $id }, _set: { deleted_at: "now()" }) {
     id
   }
 }

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Danger/page/DeleteModal/graphql/server/delete-app.graphql
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Danger/page/DeleteModal/graphql/server/delete-app.graphql
@@ -1,5 +1,8 @@
 mutation DeleteApp($id: String!) {
-  update_app_by_pk(pk_columns: { id: $id }, _set: { deleted_at: "now()" }) {
+  update_app_by_pk(
+    pk_columns: { id: $id }
+    _set: { deleted_at: "now()", is_archived: true }
+  ) {
     id
   }
 }

--- a/web/tests/api/deleted-app-guards.test.ts
+++ b/web/tests/api/deleted-app-guards.test.ts
@@ -5,7 +5,6 @@ import { AppPrecheckByActionQueryDocument } from "@/api/v1/precheck/[app_id]/gra
 import { AppPrecheckQueryDocument } from "@/api/v1/precheck/[app_id]/graphql/app-precheck.generated";
 import { FetchRpRegistrationForPrecheckDocument } from "@/api/v1/precheck/[app_id]/graphql/fetch-rp-registration-for-precheck.generated";
 import { FetchAppActionDocument } from "@/api/v2/verify/graphql/fetch-app-action.generated";
-import { DeleteAppDocument } from "@/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Danger/page/DeleteModal/graphql/server/delete-app.generated";
 import { print } from "graphql";
 import { DocumentNode } from "graphql/language";
 
@@ -36,10 +35,6 @@ describe("deleted app guards", () => {
     expect(document).toContain("status");
     expect(document).toContain("is_archived");
     expect(document).toContain("deleted_at");
-  });
-
-  it("archives apps when soft-deleting them", () => {
-    expect(source(DeleteAppDocument)).toContain("is_archived:true");
   });
 });
 // #endregion

--- a/web/tests/api/deleted-app-guards.test.ts
+++ b/web/tests/api/deleted-app-guards.test.ts
@@ -1,0 +1,45 @@
+import { GetRpRegistrationDocument } from "@/api/hasura/rotate-signer-key/graphql/get-rp-registration.generated";
+import { FetchAppSecretDocument } from "@/api/helpers/oidc/graphql/fetch-app-secret-query.generated";
+import { FetchOidcAppDocument } from "@/api/helpers/oidc/graphql/fetch-oidc-app.generated";
+import { AppPrecheckByActionQueryDocument } from "@/api/v1/precheck/[app_id]/graphql/app-precheck-by-action.generated";
+import { AppPrecheckQueryDocument } from "@/api/v1/precheck/[app_id]/graphql/app-precheck.generated";
+import { FetchRpRegistrationForPrecheckDocument } from "@/api/v1/precheck/[app_id]/graphql/fetch-rp-registration-for-precheck.generated";
+import { FetchAppActionDocument } from "@/api/v2/verify/graphql/fetch-app-action.generated";
+import { DeleteAppDocument } from "@/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Danger/page/DeleteModal/graphql/server/delete-app.generated";
+import { print } from "graphql";
+import { DocumentNode } from "graphql/language";
+
+// #region Test Data
+const source = (document: DocumentNode) => print(document).replace(/\s+/g, "");
+// #endregion
+
+// #region Deleted app guards
+describe("deleted app guards", () => {
+  it("filters deleted apps from public active-app lookups", () => {
+    const documents = [
+      AppPrecheckQueryDocument,
+      AppPrecheckByActionQueryDocument,
+      FetchRpRegistrationForPrecheckDocument,
+      FetchAppActionDocument,
+      FetchOidcAppDocument,
+      FetchAppSecretDocument,
+    ];
+
+    for (const document of documents) {
+      expect(source(document)).toContain("deleted_at:{_is_null:true}");
+    }
+  });
+
+  it("selects app deletion state before rotating signer keys", () => {
+    const document = source(GetRpRegistrationDocument);
+
+    expect(document).toContain("status");
+    expect(document).toContain("is_archived");
+    expect(document).toContain("deleted_at");
+  });
+
+  it("archives apps when soft-deleting them", () => {
+    expect(source(DeleteAppDocument)).toContain("is_archived:true");
+  });
+});
+// #endregion

--- a/web/tests/api/deleted-app-guards.test.ts
+++ b/web/tests/api/deleted-app-guards.test.ts
@@ -1,3 +1,4 @@
+import { ClaimRotationSlotDocument } from "@/api/hasura/rotate-signer-key/graphql/claim-rotation-slot.generated";
 import { GetRpRegistrationDocument } from "@/api/hasura/rotate-signer-key/graphql/get-rp-registration.generated";
 import { FetchAppSecretDocument } from "@/api/helpers/oidc/graphql/fetch-app-secret-query.generated";
 import { FetchOidcAppDocument } from "@/api/helpers/oidc/graphql/fetch-oidc-app.generated";
@@ -35,6 +36,14 @@ describe("deleted app guards", () => {
     expect(document).toContain("status");
     expect(document).toContain("is_archived");
     expect(document).toContain("deleted_at");
+  });
+
+  it("checks app deletion state atomically when claiming rotation slots", () => {
+    const document = source(ClaimRotationSlotDocument);
+
+    expect(document).toContain('status:{_eq:"active"}');
+    expect(document).toContain("is_archived:{_eq:false}");
+    expect(document).toContain("deleted_at:{_is_null:true}");
   });
 });
 // #endregion

--- a/web/tests/api/helpers/oidc.test.ts
+++ b/web/tests/api/helpers/oidc.test.ts
@@ -1,0 +1,48 @@
+import { authenticateOIDCEndpoint } from "@/api/helpers/oidc";
+
+// #region Mocks
+const mockFetchAppSecret = jest.fn();
+
+jest.mock("@/api/helpers/graphql", () => ({
+  getAPIServiceGraphqlClient: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock(
+  "@/api/helpers/oidc/graphql/fetch-app-secret-query.generated",
+  () => ({
+    getSdk: () => ({
+      FetchAppSecret: mockFetchAppSecret,
+    }),
+  }),
+);
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+// #endregion
+
+// #region Test Data
+const basicAuth = (appId: string, secret: string) =>
+  `Basic ${Buffer.from(`${appId}:${secret}`).toString("base64")}`;
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// #region OIDC endpoint authentication
+describe("authenticateOIDCEndpoint", () => {
+  it("rejects apps excluded from active app secret lookup", async () => {
+    mockFetchAppSecret.mockResolvedValue({ app: [] });
+
+    const result = await authenticateOIDCEndpoint(
+      basicAuth("app_11223344556677889900aabbccddeeff", "secret"),
+    );
+
+    expect(result).toBeNull();
+    expect(mockFetchAppSecret).toHaveBeenCalledWith({
+      app_id: "app_11223344556677889900aabbccddeeff",
+    });
+  });
+});
+// #endregion

--- a/web/tests/api/helpers/rp-registration-flows.test.ts
+++ b/web/tests/api/helpers/rp-registration-flows.test.ts
@@ -1,0 +1,102 @@
+import { submitManagedSignerRotation } from "@/api/helpers/rp-registration-flows";
+
+// #region Mocks
+const mockGetRpRegistryConfig = jest.fn();
+const mockGetRpRegistration = jest.fn();
+const mockClaimRotationSlot = jest.fn();
+
+jest.mock("@/api/helpers/rp-utils", () => ({
+  RpRegistrationStatus: {
+    Pending: "pending",
+    Registered: "registered",
+    Failed: "failed",
+    Deactivated: "deactivated",
+  },
+  generateRpIdString: jest.fn(),
+  getRpRegistryConfig: () => mockGetRpRegistryConfig(),
+  getStagingRpRegistryConfig: jest.fn(),
+  parseRpId: jest.fn(),
+}));
+
+jest.mock(
+  "@/api/hasura/rotate-signer-key/graphql/get-rp-registration.generated",
+  () => ({
+    getSdk: () => ({
+      GetRpRegistration: mockGetRpRegistration,
+    }),
+  }),
+);
+
+jest.mock(
+  "@/api/hasura/rotate-signer-key/graphql/claim-rotation-slot.generated",
+  () => ({
+    getSdk: () => ({
+      ClaimRotationSlot: mockClaimRotationSlot,
+    }),
+  }),
+);
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+// #endregion
+
+// #region Test Data
+const makeRegistration = (
+  appOverrides: Partial<{
+    status: string;
+    is_archived: boolean;
+    deleted_at: string | null;
+  }> = {},
+) => ({
+  rp_id: "rp_1234567890abcdef",
+  app_id: "app_11223344556677889900aabbccddeeff",
+  mode: "managed",
+  status: "registered",
+  signer_address: "0x0000000000000000000000000000000000000001",
+  manager_kms_key_id: "test-kms-key",
+  operation_hash: null,
+  app: {
+    team_id: "team_123",
+    status: "active",
+    is_archived: false,
+    deleted_at: null,
+    ...appOverrides,
+  },
+});
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetRpRegistryConfig.mockReturnValue({
+    kmsRegion: "us-east-1",
+    contractAddress: "0x0000000000000000000000000000000000000000",
+    domainSeparator: "0x00",
+    updateRpTypehash: "0x00",
+  });
+});
+
+// #region Managed signer rotation guards
+describe("submitManagedSignerRotation", () => {
+  it("rejects deleted apps before claiming the rotation slot", async () => {
+    mockGetRpRegistration.mockResolvedValue({
+      rp_registration: [
+        makeRegistration({ deleted_at: "2026-07-07T00:00:00.000Z" }),
+      ],
+    });
+
+    const result = await submitManagedSignerRotation({
+      client: {} as never,
+      appId: "app_11223344556677889900aabbccddeeff",
+      newSignerAddress: "0x0000000000000000000000000000000000000002",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: "app_not_active",
+      detail: "App not found. App may be inactive, archived, or deleted.",
+    });
+    expect(mockClaimRotationSlot).not.toHaveBeenCalled();
+  });
+});
+// #endregion

--- a/web/tests/api/v1/oidc/authorize.test.ts
+++ b/web/tests/api/v1/oidc/authorize.test.ts
@@ -218,6 +218,26 @@ describe("/api/v1/oidc/authorize [request validation]", () => {
 });
 
 describe("/api/v1/oidc/authorize [authorization code flow]", () => {
+  test("rejects apps excluded from active OIDC lookup", async () => {
+    FetchOIDCApp.mockResolvedValueOnce({ app: [] });
+
+    const req = new NextRequest("http://localhost:3000/api/v1/oidc/authorize", {
+      method: "POST",
+      body: JSON.stringify({ ...VALID_REQUEST }),
+    });
+
+    const response = await POST(req);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data).toMatchObject({
+      code: "app_not_found",
+      attribute: "app_id",
+      detail: "App not found or not active.",
+    });
+    expect(mockVerifyProof).not.toHaveBeenCalled();
+  });
+
   test("returns an authorization code", async () => {
     const req = new NextRequest("http://localhost:3000/api/v1/oidc/authorize", {
       method: "POST",

--- a/web/tests/api/v1/precheck.test.ts
+++ b/web/tests/api/v1/precheck.test.ts
@@ -45,11 +45,25 @@ jest.mock("@/api/helpers/graphql", () => ({
   getAPIServiceGraphqlClient: jest.fn(),
 }));
 const AppPrecheckQuery = jest.fn();
+const FetchRpRegistrationForPrecheck = jest.fn();
 jest.mock("@/api/v1/precheck/[app_id]/graphql/app-precheck.generated", () => ({
   getSdk: () => ({
     AppPrecheckQuery,
   }),
 }));
+jest.mock(
+  "@/api/v1/precheck/[app_id]/graphql/fetch-rp-registration-for-precheck.generated",
+  () => ({
+    getSdk: () => ({
+      FetchRpRegistrationForPrecheck,
+    }),
+  }),
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.ParameterStore = undefined;
+});
 
 describe("/api/v1/precheck/[app_id]", () => {
   test("can fetch precheck response verified", async () => {
@@ -527,6 +541,65 @@ describe("/api/v1/precheck/[app_id]", () => {
 });
 
 describe("/api/v1/precheck/[action_id] [error cases]", () => {
+  test("returns not found when app is excluded from active app lookup", async () => {
+    const request = new NextRequest(
+      "http://localhost:3000/api/v1/precheck/app_staging_6d1c9fb86751a40d952749022db1c1",
+      {
+        method: "POST",
+        body: JSON.stringify(exampleValidRequestPayload),
+      },
+    );
+
+    AppPrecheckQuery.mockResolvedValue({
+      app: [],
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({
+        app_id: "app_staging_6d1c9fb86751a40d952749022db1c1",
+      }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(FetchRpRegistrationForPrecheck).not.toHaveBeenCalled();
+    const responseBody = await response.json();
+    expect(responseBody).toEqual(
+      expect.objectContaining({ code: "not_found" }),
+    );
+  });
+
+  test("does not synthesize a migrated action without an active app registration", async () => {
+    const request = new NextRequest(
+      "http://localhost:3000/api/v1/precheck/app_staging_6d1c9fb86751a40d952749022db1c1",
+      {
+        method: "POST",
+        body: JSON.stringify(exampleValidRequestPayload),
+      },
+    );
+
+    AppPrecheckQuery.mockResolvedValue({
+      app: [{ ...appPayload, actions: [] }],
+    });
+    FetchRpRegistrationForPrecheck.mockResolvedValue({
+      rp_registration: [],
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({
+        app_id: "app_staging_6d1c9fb86751a40d952749022db1c1",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(FetchRpRegistrationForPrecheck).toHaveBeenCalledWith({
+      app_id: "app_staging_6d1c9fb86751a40d952749022db1c1",
+    });
+    const responseBody = await response.json();
+    expect(responseBody).toEqual(
+      expect.objectContaining({ code: "required", attribute: "action" }),
+    );
+  });
+
   test("non-existent action", async () => {
     const request = new NextRequest(
       "http://localhost:3000/api/v1/precheck/app_id_do_not_exist",

--- a/web/tests/api/v2/verify.test.ts
+++ b/web/tests/api/v2/verify.test.ts
@@ -405,6 +405,25 @@ describe("/api/v2/verify", () => {
 
 // #region Error cases
 describe("/api/v2/verify [error cases]", () => {
+  it("returns not found when app is excluded from active app lookup", async () => {
+    const mockReq = createMockRequest(getUrl(stagingAppId), validBody);
+    const ctx = { params: Promise.resolve({ app_id: stagingAppId }) };
+
+    FetchAppAction.mockResolvedValue({ app: [] });
+
+    const response = await POST(mockReq, ctx);
+
+    expect(response.status).toBe(404);
+    expect(fetch).not.toHaveBeenCalled();
+    const body = await response.json();
+    expect(body).toEqual({
+      attribute: null,
+      code: "not_found",
+      detail: "App not found. App may be no longer active.",
+      app_id: stagingAppId,
+    });
+  });
+
   it("action inactive or not found", async () => {
     const mockReq = createMockRequest(getUrl(stagingAppId), validBody);
     const ctx = { params: Promise.resolve({ app_id: stagingAppId }) };


### PR DESCRIPTION
This PR ...

- Filters soft-deleted apps out of precheck, v2 verify, and OIDC active-app lookups.
- Rejects signer rotation for inactive, archived, or deleted apps in the shared managed rotation helper.
- Adds focused regression coverage for the deleted-app guard paths.

Validation:
- pnpm generate:graphql-types
- npx jest tests/api/deleted-app-guards.test.ts tests/api/v1/precheck.test.ts tests/api/v2/verify.test.ts tests/api/v1/oidc/authorize.test.ts tests/api/helpers/oidc.test.ts tests/api/helpers/rp-registration-flows.test.ts --watchman=false --silent
- npx tsc --noEmit
- pnpm format:check
- git diff --check

Note: local full npx jest --no-cache --watchman=false --silent is not a clean signal in this checkout because it runs integration/e2e suites that require external DB/services and Playwright runner separation. GitHub CI is passing.