### PR TITLE
fix(dashboard): stop showing unique_users as all-time New users

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/StatsRow/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/StatsRow/index.tsx
@@ -45,7 +45,9 @@ const StatItem = ({
   isLoading,
 }: StatItemProps) => {
   const formatValue = (val: number | undefined | null) => {
-    if (val === undefined || val === null) return "0";
+    // No data (missing feed field or failed fetch) is not the same as zero —
+    // show a dash instead of a fabricated "0".
+    if (val === undefined || val === null) return "—";
     return val.toLocaleString();
   };
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/index.tsx
@@ -44,7 +44,9 @@ export const AppStatsGraph = ({
       impressions: metrics.total_impressions ?? null,
       sessions: metrics.total_users ?? null,
       users: metrics.unique_users ?? null,
-      newUsers: metrics.unique_users ?? null, // No separate all-time new users
+      // The metrics feed has no all-time new-users field; render the tile's
+      // no-data state rather than repeating unique_users under a wrong label.
+      newUsers: null,
     };
   }, [metrics]);
 

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/page/AppStatsGraph/StatsRow/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/page/AppStatsGraph/StatsRow/index.tsx
@@ -45,7 +45,9 @@ const StatItem = ({
   isLoading,
 }: StatItemProps) => {
   const formatValue = (val: number | undefined | null) => {
-    if (val === undefined || val === null) return "0";
+    // No data (missing feed field or failed fetch) is not the same as zero —
+    // show a dash instead of a fabricated "0".
+    if (val === undefined || val === null) return "—";
     return val.toLocaleString();
   };
 

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/page/AppStatsGraph/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/page/AppStatsGraph/index.tsx
@@ -44,7 +44,9 @@ export const AppStatsGraph = ({
       impressions: metrics.total_impressions ?? null,
       sessions: metrics.total_users ?? null,
       users: metrics.unique_users ?? null,
-      newUsers: metrics.unique_users ?? null, // No separate all-time new users
+      // The metrics feed has no all-time new-users field; render the tile's
+      // no-data state rather than repeating unique_users under a wrong label.
+      newUsers: null,
     };
   }, [metrics]);
 

--- a/web/tests/unit/stats-row-no-data.test.tsx
+++ b/web/tests/unit/stats-row-no-data.test.tsx
@@ -1,0 +1,37 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { StatsRow } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/page/AppStatsGraph/StatsRow";
+
+// StatsRow renders a mobile grid and a desktop row (both present in the DOM,
+// toggled by CSS), so every value appears twice — use getAllByText.
+describe("StatsRow no-data rendering", () => {
+  it("renders a dash for metrics with no data instead of a fake zero", () => {
+    render(
+      <StatsRow
+        impressions={1234}
+        sessions={56}
+        users={7}
+        newUsers={null}
+        isLoading={false}
+      />,
+    );
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("1,234").length).toBeGreaterThan(0);
+    expect(screen.queryByText("0")).toBeNull();
+  });
+
+  it("still renders a genuine zero as 0", () => {
+    render(
+      <StatsRow
+        impressions={0}
+        sessions={0}
+        users={0}
+        newUsers={0}
+        isLoading={false}
+      />,
+    );
+    expect(screen.getAllByText("0").length).toBeGreaterThan(0);
+    expect(screen.queryByText("—")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

On the app dashboard's stats row, the **All time** view maps the **New users** tile to `unique_users` — the exact same number as the **Users** tile next to it. The miniapps metrics feed simply has no all-time new-users field, and the code papered over that with a duplicate value (`// No separate all-time new users`).

Additionally, `formatValue` rendered `null`/`undefined` as `"0"`, making a missing feed field — or a silently failed metrics fetch — visually indistinguishable from genuinely zero traffic.

## Fix

- All-time `newUsers` now maps to `null` instead of repeating `unique_users`.
- `StatsRow` renders `null`/`undefined` metric values as `—` instead of `"0"`, so no-data states are distinct from real zeros (this also applies to the fetch-failure path, which previously rendered as all-zeros).
- Applied to both the `Portal` (live v2) and `PortalV3` copies of `AppStatsGraph`.

## Tests

- New `web/tests/unit/stats-row-no-data.test.tsx`: null renders as dash, genuine 0 still renders as `0`.
- `npx tsc --noEmit` clean, prettier clean.