### PR TITLE
feat(portal-v3): add World ID trend foundations

### DIFF
--- a/web/lib/day-buckets.ts
+++ b/web/lib/day-buckets.ts
@@ -1,0 +1,110 @@
+import { addDays, startOfDay } from "date-fns";
+
+/** Seven trailing-day buckets aligned to the viewer's local midnight. */
+export const weekBucketBounds = (now: Date): string[] => {
+  const todayMidnight = startOfDay(now);
+
+  const bounds: string[] = [];
+  for (let k = 0; k <= 7; k++) {
+    bounds.push(addDays(todayMidnight, k - 6).toISOString());
+  }
+  return bounds;
+};
+
+/** Seven equal-width buckets from creation through tomorrow's local midnight. */
+export const lifetimeBucketBounds = (createdAt: Date, now: Date): string[] => {
+  const end = addDays(startOfDay(now), 1).getTime();
+  const requestedStart = createdAt.getTime();
+  const start =
+    Number.isFinite(requestedStart) && requestedStart < end
+      ? requestedStart
+      : startOfDay(now).getTime();
+  const span = end - start;
+
+  return Array.from({ length: 8 }, (_, index) =>
+    new Date(start + Math.round((span * index) / 7)).toISOString(),
+  );
+};
+
+export type TrendPeriod = "weekly" | "all-time";
+
+const TREND_BUCKET_KEYS = ["b0", "b1", "b2", "b3", "b4", "b5", "b6"] as const;
+
+type TrendBucket = {
+  aggregate?: { count: number } | null;
+} | null;
+
+type TrendBuckets = Partial<
+  Record<(typeof TREND_BUCKET_KEYS)[number], TrendBucket>
+>;
+
+export const trendPoints = (trend?: TrendBuckets | null): number[] =>
+  trend
+    ? TREND_BUCKET_KEYS.map((key) => trend[key]?.aggregate?.count ?? 0)
+    : [];
+
+export const trendBucketVariables = (bounds: string[]) => ({
+  d0: bounds[0],
+  d1: bounds[1],
+  d2: bounds[2],
+  d3: bounds[3],
+  d4: bounds[4],
+  d5: bounds[5],
+  d6: bounds[6],
+  d7: bounds[7],
+});
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const YEAR_MS = 365 * DAY_MS;
+
+const bucketLabelOptions = (
+  bucketDuration: number,
+): Intl.DateTimeFormatOptions => {
+  if (bucketDuration < DAY_MS) {
+    return { month: "short", day: "numeric", hour: "numeric" };
+  }
+  if (bucketDuration < YEAR_MS) {
+    return { month: "short", day: "numeric" };
+  }
+  return { month: "short", year: "numeric" };
+};
+
+export const trendBucketLabels = (
+  bounds: string[],
+  period: TrendPeriod,
+): string[] => {
+  if (period === "weekly") {
+    return bounds.slice(0, 7).map((bound) => {
+      const day = new Date(bound);
+      return `${day.toLocaleDateString(undefined, { weekday: "short" })} · ${day.toLocaleDateString(undefined, { month: "short", day: "numeric" })}`;
+    });
+  }
+
+  return bounds.slice(0, 7).map((bound, index) => {
+    const start = new Date(bound);
+    const end = new Date(new Date(bounds[index + 1]).getTime() - 1);
+    const bucketDuration = end.getTime() - start.getTime();
+    const options = bucketLabelOptions(bucketDuration);
+
+    return `${start.toLocaleDateString(undefined, options)} - ${end.toLocaleDateString(undefined, options)}`;
+  });
+};
+
+export const trendRangeLabel = (
+  period: TrendPeriod,
+  createdAt?: string,
+): string => {
+  if (period === "weekly") {
+    return "Last 7 days";
+  }
+
+  if (!createdAt) {
+    return "All time";
+  }
+
+  return `All time · since ${new Date(createdAt).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })}`;
+};

--- a/web/lib/format-nullifier.ts
+++ b/web/lib/format-nullifier.ts
@@ -1,0 +1,19 @@
+/** Formats a decimal nullifier as compact hexadecimal. */
+export const formatNullifierHex = (nullifier: string): string => {
+  if (!nullifier?.trim() || nullifier.trim().startsWith("-")) {
+    return nullifier;
+  }
+
+  let hex: string;
+  try {
+    hex = BigInt(nullifier).toString(16);
+  } catch {
+    return nullifier;
+  }
+
+  if (hex.length <= 12) {
+    return `0x${hex}`;
+  }
+
+  return `0x${hex.slice(0, 8)}…${hex.slice(-4)}`;
+};

--- a/web/lib/relative-time-short.ts
+++ b/web/lib/relative-time-short.ts
@@ -1,0 +1,31 @@
+export const relativeTimeShort = (
+  input: string | Date,
+  now: Date = new Date(),
+): string => {
+  const then = input instanceof Date ? input : new Date(input);
+  const seconds = Math.floor((now.getTime() - then.getTime()) / 1000);
+
+  if (seconds < 10) {
+    return "just now";
+  }
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+
+  const days = Math.floor(hours / 24);
+  if (days < 7) {
+    return `${days}d ago`;
+  }
+
+  return then.toLocaleDateString();
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/common/PeriodSelector/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/common/PeriodSelector/index.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import {
+  Select,
+  SelectButton,
+  SelectOption,
+  SelectOptions,
+} from "@/components/Select";
+import type { TrendPeriod } from "@/lib/day-buckets";
+import { Icon } from "@/scenes/PortalV3/common/Icon";
+
+const timePeriodOptions = [
+  { value: "all-time", label: "All time" },
+  { value: "weekly", label: "Weekly" },
+] satisfies Array<{ value: TrendPeriod; label: string }>;
+
+export const PeriodSelector = (props: {
+  timePeriod: TrendPeriod;
+  onTimePeriodChange: (period: TrendPeriod) => void;
+}) => (
+  <Select value={props.timePeriod} onChange={props.onTimePeriodChange}>
+    <SelectButton
+      aria-label="Trend period"
+      className="flex h-10 items-center justify-center gap-2 rounded-8 border border-portal-border bg-white py-2.5 pr-3 pl-4 font-world text-13 leading-none text-portal-ink transition-colors outline-none hover:bg-portal-canvas focus-visible:ring-2 focus-visible:ring-grey-300"
+    >
+      <span>
+        {timePeriodOptions.find((option) => option.value === props.timePeriod)
+          ?.label ?? "All time"}
+      </span>
+      <Icon name="chevron-down" className="size-4" />
+    </SelectButton>
+    <SelectOptions>
+      {timePeriodOptions.map((option) => (
+        <SelectOption
+          key={option.value}
+          value={option.value}
+          className="font-world text-13 text-portal-ink hover:bg-portal-canvas"
+        >
+          {option.label}
+        </SelectOption>
+      ))}
+    </SelectOptions>
+  </Select>
+);

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/common/Sparkline/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/common/Sparkline/index.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+type SparklineProps = {
+  points: number[];
+  labels?: string[];
+  className?: string;
+  ariaLabel?: string;
+};
+
+const VIEW_W = 240;
+const VIEW_H = 56;
+const PAD = 3;
+
+export const Sparkline = ({
+  points,
+  labels,
+  className,
+  ariaLabel,
+}: SparklineProps) => {
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+
+  const interactive = Boolean(labels?.length);
+
+  const handleMouseMove = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!interactive || points.length < 2) return;
+      const rect = event.currentTarget.getBoundingClientRect();
+      const fraction = (event.clientX - rect.left) / rect.width;
+      const idx = Math.round(fraction * (points.length - 1));
+      setHoverIdx(Math.max(0, Math.min(points.length - 1, idx)));
+    },
+    [interactive, points.length],
+  );
+
+  if (points.length === 0) {
+    return null;
+  }
+
+  const max = Math.max(...points, 1);
+  const stepX =
+    points.length > 1 ? (VIEW_W - PAD * 2) / (points.length - 1) : 0;
+
+  const coords = points.map((value, i) => {
+    const x = PAD + i * stepX;
+    const y = VIEW_H - PAD - (value / max) * (VIEW_H - PAD * 2);
+    return { x, y };
+  });
+
+  const polyline = coords
+    .map((c) => `${c.x.toFixed(1)},${c.y.toFixed(1)}`)
+    .join(" ");
+
+  const hover = hoverIdx !== null ? hoverIdx : null;
+  const hoverLeftPct = hover !== null ? (coords[hover].x / VIEW_W) * 100 : 0;
+  const tooltipShift =
+    hover === null
+      ? "-50%"
+      : hover === 0
+        ? "-10%"
+        : hover === points.length - 1
+          ? "-90%"
+          : "-50%";
+
+  return (
+    <div
+      className={`relative ${className ?? ""}`}
+      onMouseMove={interactive ? handleMouseMove : undefined}
+      onMouseLeave={interactive ? () => setHoverIdx(null) : undefined}
+    >
+      <svg
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        preserveAspectRatio="none"
+        className="size-full"
+        role="img"
+        aria-label={ariaLabel}
+      >
+        <polyline
+          points={polyline}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+
+      {interactive && hover !== null ? (
+        <>
+          <div
+            className="pointer-events-none absolute inset-y-0 border-l border-dashed border-portal-subtle"
+            style={{ left: `${hoverLeftPct}%` }}
+          />
+          <div
+            className="pointer-events-none absolute bottom-full z-20 mb-2 flex flex-col gap-0.5 rounded-8 border border-portal-border bg-white px-2.5 py-1.5 whitespace-nowrap shadow-portal-card"
+            style={{
+              left: `${hoverLeftPct}%`,
+              transform: `translateX(${tooltipShift})`,
+            }}
+          >
+            <span className="font-world text-13 font-medium text-portal-heading">
+              {points[hover].toLocaleString()}{" "}
+              {points[hover] === 1 ? "verification" : "verifications"}
+            </span>
+            <span className="font-world text-12 text-portal-muted">
+              {labels?.[hover]}
+            </span>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/common/TrendSparkline/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/common/TrendSparkline/index.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Skeleton from "react-loading-skeleton";
+import { Sparkline } from "../Sparkline";
+
+export type TrendSparklineState =
+  | { status: "loading" }
+  | { status: "error"; onRetry: () => void }
+  | { status: "ready"; points: number[]; labels: string[] };
+
+const variants = {
+  hero: {
+    wrapper: "min-h-16",
+    sparkline: "h-14 w-full text-portal-heading sm:w-[240px]",
+    skeleton: { width: 240, height: 56 },
+  },
+  detail: {
+    wrapper: "min-h-[52px]",
+    sparkline: "h-[52px] w-[200px] text-portal-heading",
+    skeleton: { width: 200, height: 52 },
+  },
+} as const;
+
+export const TrendSparkline = (props: {
+  state: TrendSparklineState;
+  rangeLabel: string;
+  variant: keyof typeof variants;
+}) => {
+  const variant = variants[props.variant];
+
+  return (
+    <div
+      className={`flex ${variant.wrapper} flex-col items-end justify-end gap-1`}
+      aria-busy={props.state.status === "loading"}
+      aria-live="polite"
+    >
+      {props.state.status === "loading" ? (
+        <Skeleton {...variant.skeleton} />
+      ) : props.state.status === "error" ? (
+        <div className="flex h-[52px] items-center gap-2 font-world text-12 text-portal-muted">
+          <span>Trend unavailable.</span>
+          <button
+            type="button"
+            className="underline hover:text-portal-ink"
+            onClick={props.state.onRetry}
+          >
+            Try again
+          </button>
+        </div>
+      ) : (
+        <Sparkline
+          points={props.state.points}
+          labels={props.state.labels}
+          className={variant.sparkline}
+          ariaLabel={`Verifications, ${props.rangeLabel.toLowerCase()}`}
+        />
+      )}
+      {props.state.status !== "error" ? (
+        <span className="font-world text-11 text-portal-subtle">
+          {props.rangeLabel}
+        </span>
+      ) : null}
+    </div>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/common/use-trend-window.ts
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/common/use-trend-window.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import {
+  lifetimeBucketBounds,
+  trendBucketLabels,
+  trendBucketVariables,
+  trendRangeLabel,
+  type TrendPeriod,
+  weekBucketBounds,
+} from "@/lib/day-buckets";
+import { useMemo, useState } from "react";
+import type { TrendSparklineState } from "./TrendSparkline";
+
+export type TrendWindow = {
+  weeklyBounds: string[];
+  allTimeBounds: string[];
+  selectedBounds: string[];
+  labels: string[];
+  rangeLabel: string;
+  weeklyVariables: Record<string, string>;
+  allTimeVariables: Record<string, string>;
+};
+
+type TrendBucketVariables = ReturnType<typeof trendBucketVariables>;
+
+/** Freezes time bounds at mount to keep Apollo cache keys stable. */
+export const useTrendWindow = (opts: {
+  createdAt?: string | null;
+  timePeriod: TrendPeriod;
+}): TrendWindow & {
+  weeklyVariables: TrendBucketVariables;
+  allTimeVariables: TrendBucketVariables;
+} => {
+  const { createdAt, timePeriod } = opts;
+
+  const [now] = useState(() => new Date());
+  const weeklyBounds = useMemo(() => weekBucketBounds(now), [now]);
+  const allTimeBounds = useMemo(
+    () =>
+      createdAt ? lifetimeBucketBounds(new Date(createdAt), now) : weeklyBounds,
+    [createdAt, now, weeklyBounds],
+  );
+  const selectedBounds =
+    timePeriod === "all-time" ? allTimeBounds : weeklyBounds;
+  const labels = useMemo(
+    () => trendBucketLabels(selectedBounds, timePeriod),
+    [selectedBounds, timePeriod],
+  );
+  const rangeLabel = useMemo(
+    () => trendRangeLabel(timePeriod, createdAt ?? undefined),
+    [createdAt, timePeriod],
+  );
+  const weeklyVariables = useMemo(
+    () => trendBucketVariables(weeklyBounds),
+    [weeklyBounds],
+  );
+  const allTimeVariables = useMemo(
+    () => trendBucketVariables(allTimeBounds),
+    [allTimeBounds],
+  );
+
+  return {
+    weeklyBounds,
+    allTimeBounds,
+    selectedBounds,
+    labels,
+    rangeLabel,
+    weeklyVariables,
+    allTimeVariables,
+  };
+};
+
+export const buildTrendState = (opts: {
+  loading: boolean;
+  error: boolean;
+  points: number[];
+  labels: string[];
+  onRetry: () => void;
+}): TrendSparklineState => {
+  if (opts.loading) {
+    return { status: "loading" };
+  }
+  if (opts.error) {
+    return { status: "error", onRetry: opts.onRetry };
+  }
+  return { status: "ready", points: opts.points, labels: opts.labels };
+};

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/graphql/client/get-world-id-trends.generated.ts
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/graphql/client/get-world-id-trends.generated.ts
@@ -1,0 +1,519 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { gql } from "@apollo/client";
+import * as Apollo from "@apollo/client";
+const defaultOptions = {} as const;
+export type GetWorldIdAppTrendQueryVariables = Types.Exact<{
+  app_id: Types.Scalars["String"]["input"];
+  d0: Types.Scalars["timestamptz"]["input"];
+  d1: Types.Scalars["timestamptz"]["input"];
+  d2: Types.Scalars["timestamptz"]["input"];
+  d3: Types.Scalars["timestamptz"]["input"];
+  d4: Types.Scalars["timestamptz"]["input"];
+  d5: Types.Scalars["timestamptz"]["input"];
+  d6: Types.Scalars["timestamptz"]["input"];
+  d7: Types.Scalars["timestamptz"]["input"];
+}>;
+
+export type GetWorldIdAppTrendQuery = {
+  __typename?: "query_root";
+  b0: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  b1: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  b2: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  b3: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  b4: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  b5: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  b6: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+};
+
+export type GetWorldIdActionTrendQueryVariables = Types.Exact<{
+  app_id: Types.Scalars["String"]["input"];
+  action_id: Types.Scalars["String"]["input"];
+  d0: Types.Scalars["timestamptz"]["input"];
+  d1: Types.Scalars["timestamptz"]["input"];
+  d2: Types.Scalars["timestamptz"]["input"];
+  d3: Types.Scalars["timestamptz"]["input"];
+  d4: Types.Scalars["timestamptz"]["input"];
+  d5: Types.Scalars["timestamptz"]["input"];
+  d6: Types.Scalars["timestamptz"]["input"];
+  d7: Types.Scalars["timestamptz"]["input"];
+}>;
+
+export type GetWorldIdActionTrendQuery = {
+  __typename?: "query_root";
+  action_v4: Array<{
+    __typename?: "action_v4";
+    b0: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b1: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b2: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b3: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b4: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b5: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b6: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+  }>;
+};
+
+export type WorldIdActionTrendBucketsFragment = {
+  __typename?: "action_v4";
+  b0: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  b1: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  b2: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  b3: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  b4: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  b5: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  b6: {
+    __typename?: "nullifier_v4_aggregate";
+    aggregate?: {
+      __typename?: "nullifier_v4_aggregate_fields";
+      count: number;
+    } | null;
+  };
+};
+
+export type WorldIdTrendCountFragment = {
+  __typename?: "nullifier_v4_aggregate";
+  aggregate?: {
+    __typename?: "nullifier_v4_aggregate_fields";
+    count: number;
+  } | null;
+};
+
+export const WorldIdTrendCountFragmentDoc = gql`
+  fragment WorldIdTrendCount on nullifier_v4_aggregate {
+    aggregate {
+      count
+    }
+  }
+`;
+export const WorldIdActionTrendBucketsFragmentDoc = gql`
+  fragment WorldIdActionTrendBuckets on action_v4 {
+    b0: nullifiers_aggregate(where: { created_at: { _gte: $d0, _lt: $d1 } }) {
+      ...WorldIdTrendCount
+    }
+    b1: nullifiers_aggregate(where: { created_at: { _gte: $d1, _lt: $d2 } }) {
+      ...WorldIdTrendCount
+    }
+    b2: nullifiers_aggregate(where: { created_at: { _gte: $d2, _lt: $d3 } }) {
+      ...WorldIdTrendCount
+    }
+    b3: nullifiers_aggregate(where: { created_at: { _gte: $d3, _lt: $d4 } }) {
+      ...WorldIdTrendCount
+    }
+    b4: nullifiers_aggregate(where: { created_at: { _gte: $d4, _lt: $d5 } }) {
+      ...WorldIdTrendCount
+    }
+    b5: nullifiers_aggregate(where: { created_at: { _gte: $d5, _lt: $d6 } }) {
+      ...WorldIdTrendCount
+    }
+    b6: nullifiers_aggregate(where: { created_at: { _gte: $d6, _lt: $d7 } }) {
+      ...WorldIdTrendCount
+    }
+  }
+  ${WorldIdTrendCountFragmentDoc}
+`;
+export const GetWorldIdAppTrendDocument = gql`
+  query GetWorldIdAppTrend(
+    $app_id: String!
+    $d0: timestamptz!
+    $d1: timestamptz!
+    $d2: timestamptz!
+    $d3: timestamptz!
+    $d4: timestamptz!
+    $d5: timestamptz!
+    $d6: timestamptz!
+    $d7: timestamptz!
+  ) {
+    b0: nullifier_v4_aggregate(
+      where: {
+        created_at: { _gte: $d0, _lt: $d1 }
+        action_v4: {
+          environment: { _eq: "production" }
+          rp_registration: { app_id: { _eq: $app_id } }
+        }
+      }
+    ) {
+      ...WorldIdTrendCount
+    }
+    b1: nullifier_v4_aggregate(
+      where: {
+        created_at: { _gte: $d1, _lt: $d2 }
+        action_v4: {
+          environment: { _eq: "production" }
+          rp_registration: { app_id: { _eq: $app_id } }
+        }
+      }
+    ) {
+      ...WorldIdTrendCount
+    }
+    b2: nullifier_v4_aggregate(
+      where: {
+        created_at: { _gte: $d2, _lt: $d3 }
+        action_v4: {
+          environment: { _eq: "production" }
+          rp_registration: { app_id: { _eq: $app_id } }
+        }
+      }
+    ) {
+      ...WorldIdTrendCount
+    }
+    b3: nullifier_v4_aggregate(
+      where: {
+        created_at: { _gte: $d3, _lt: $d4 }
+        action_v4: {
+          environment: { _eq: "production" }
+          rp_registration: { app_id: { _eq: $app_id } }
+        }
+      }
+    ) {
+      ...WorldIdTrendCount
+    }
+    b4: nullifier_v4_aggregate(
+      where: {
+        created_at: { _gte: $d4, _lt: $d5 }
+        action_v4: {
+          environment: { _eq: "production" }
+          rp_registration: { app_id: { _eq: $app_id } }
+        }
+      }
+    ) {
+      ...WorldIdTrendCount
+    }
+    b5: nullifier_v4_aggregate(
+      where: {
+        created_at: { _gte: $d5, _lt: $d6 }
+        action_v4: {
+          environment: { _eq: "production" }
+          rp_registration: { app_id: { _eq: $app_id } }
+        }
+      }
+    ) {
+      ...WorldIdTrendCount
+    }
+    b6: nullifier_v4_aggregate(
+      where: {
+        created_at: { _gte: $d6, _lt: $d7 }
+        action_v4: {
+          environment: { _eq: "production" }
+          rp_registration: { app_id: { _eq: $app_id } }
+        }
+      }
+    ) {
+      ...WorldIdTrendCount
+    }
+  }
+  ${WorldIdTrendCountFragmentDoc}
+`;
+
+/**
+ * __useGetWorldIdAppTrendQuery__
+ *
+ * To run a query within a React component, call `useGetWorldIdAppTrendQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetWorldIdAppTrendQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetWorldIdAppTrendQuery({
+ *   variables: {
+ *      app_id: // value for 'app_id'
+ *      d0: // value for 'd0'
+ *      d1: // value for 'd1'
+ *      d2: // value for 'd2'
+ *      d3: // value for 'd3'
+ *      d4: // value for 'd4'
+ *      d5: // value for 'd5'
+ *      d6: // value for 'd6'
+ *      d7: // value for 'd7'
+ *   },
+ * });
+ */
+export function useGetWorldIdAppTrendQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetWorldIdAppTrendQuery,
+    GetWorldIdAppTrendQueryVariables
+  > &
+    (
+      | { variables: GetWorldIdAppTrendQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetWorldIdAppTrendQuery,
+    GetWorldIdAppTrendQueryVariables
+  >(GetWorldIdAppTrendDocument, options);
+}
+export function useGetWorldIdAppTrendLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetWorldIdAppTrendQuery,
+    GetWorldIdAppTrendQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetWorldIdAppTrendQuery,
+    GetWorldIdAppTrendQueryVariables
+  >(GetWorldIdAppTrendDocument, options);
+}
+export function useGetWorldIdAppTrendSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetWorldIdAppTrendQuery,
+        GetWorldIdAppTrendQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetWorldIdAppTrendQuery,
+    GetWorldIdAppTrendQueryVariables
+  >(GetWorldIdAppTrendDocument, options);
+}
+export type GetWorldIdAppTrendQueryHookResult = ReturnType<
+  typeof useGetWorldIdAppTrendQuery
+>;
+export type GetWorldIdAppTrendLazyQueryHookResult = ReturnType<
+  typeof useGetWorldIdAppTrendLazyQuery
+>;
+export type GetWorldIdAppTrendSuspenseQueryHookResult = ReturnType<
+  typeof useGetWorldIdAppTrendSuspenseQuery
+>;
+export type GetWorldIdAppTrendQueryResult = Apollo.QueryResult<
+  GetWorldIdAppTrendQuery,
+  GetWorldIdAppTrendQueryVariables
+>;
+export const GetWorldIdActionTrendDocument = gql`
+  query GetWorldIdActionTrend(
+    $app_id: String!
+    $action_id: String!
+    $d0: timestamptz!
+    $d1: timestamptz!
+    $d2: timestamptz!
+    $d3: timestamptz!
+    $d4: timestamptz!
+    $d5: timestamptz!
+    $d6: timestamptz!
+    $d7: timestamptz!
+  ) {
+    action_v4(
+      where: {
+        id: { _eq: $action_id }
+        environment: { _eq: "production" }
+        rp_registration: { app_id: { _eq: $app_id } }
+      }
+      limit: 1
+    ) {
+      ...WorldIdActionTrendBuckets
+    }
+  }
+  ${WorldIdActionTrendBucketsFragmentDoc}
+`;
+
+/**
+ * __useGetWorldIdActionTrendQuery__
+ *
+ * To run a query within a React component, call `useGetWorldIdActionTrendQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetWorldIdActionTrendQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetWorldIdActionTrendQuery({
+ *   variables: {
+ *      app_id: // value for 'app_id'
+ *      action_id: // value for 'action_id'
+ *      d0: // value for 'd0'
+ *      d1: // value for 'd1'
+ *      d2: // value for 'd2'
+ *      d3: // value for 'd3'
+ *      d4: // value for 'd4'
+ *      d5: // value for 'd5'
+ *      d6: // value for 'd6'
+ *      d7: // value for 'd7'
+ *   },
+ * });
+ */
+export function useGetWorldIdActionTrendQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetWorldIdActionTrendQuery,
+    GetWorldIdActionTrendQueryVariables
+  > &
+    (
+      | { variables: GetWorldIdActionTrendQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetWorldIdActionTrendQuery,
+    GetWorldIdActionTrendQueryVariables
+  >(GetWorldIdActionTrendDocument, options);
+}
+export function useGetWorldIdActionTrendLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetWorldIdActionTrendQuery,
+    GetWorldIdActionTrendQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetWorldIdActionTrendQuery,
+    GetWorldIdActionTrendQueryVariables
+  >(GetWorldIdActionTrendDocument, options);
+}
+export function useGetWorldIdActionTrendSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetWorldIdActionTrendQuery,
+        GetWorldIdActionTrendQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetWorldIdActionTrendQuery,
+    GetWorldIdActionTrendQueryVariables
+  >(GetWorldIdActionTrendDocument, options);
+}
+export type GetWorldIdActionTrendQueryHookResult = ReturnType<
+  typeof useGetWorldIdActionTrendQuery
+>;
+export type GetWorldIdActionTrendLazyQueryHookResult = ReturnType<
+  typeof useGetWorldIdActionTrendLazyQuery
+>;
+export type GetWorldIdActionTrendSuspenseQueryHookResult = ReturnType<
+  typeof useGetWorldIdActionTrendSuspenseQuery
+>;
+export type GetWorldIdActionTrendQueryResult = Apollo.QueryResult<
+  GetWorldIdActionTrendQuery,
+  GetWorldIdActionTrendQueryVariables
+>;

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/graphql/client/get-world-id-trends.graphql
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/graphql/client/get-world-id-trends.graphql
@@ -1,0 +1,146 @@
+# Period-specific sparkline data. These operations are separate from the main
+# landing/detail queries so selecting All time does not change action-card
+# charts, weekly stats, or the live verification feed.
+query GetWorldIdAppTrend(
+  $app_id: String!
+  $d0: timestamptz!
+  $d1: timestamptz!
+  $d2: timestamptz!
+  $d3: timestamptz!
+  $d4: timestamptz!
+  $d5: timestamptz!
+  $d6: timestamptz!
+  $d7: timestamptz!
+) {
+  b0: nullifier_v4_aggregate(
+    where: {
+      created_at: { _gte: $d0, _lt: $d1 }
+      action_v4: {
+        environment: { _eq: "production" }
+        rp_registration: { app_id: { _eq: $app_id } }
+      }
+    }
+  ) {
+    ...WorldIdTrendCount
+  }
+  b1: nullifier_v4_aggregate(
+    where: {
+      created_at: { _gte: $d1, _lt: $d2 }
+      action_v4: {
+        environment: { _eq: "production" }
+        rp_registration: { app_id: { _eq: $app_id } }
+      }
+    }
+  ) {
+    ...WorldIdTrendCount
+  }
+  b2: nullifier_v4_aggregate(
+    where: {
+      created_at: { _gte: $d2, _lt: $d3 }
+      action_v4: {
+        environment: { _eq: "production" }
+        rp_registration: { app_id: { _eq: $app_id } }
+      }
+    }
+  ) {
+    ...WorldIdTrendCount
+  }
+  b3: nullifier_v4_aggregate(
+    where: {
+      created_at: { _gte: $d3, _lt: $d4 }
+      action_v4: {
+        environment: { _eq: "production" }
+        rp_registration: { app_id: { _eq: $app_id } }
+      }
+    }
+  ) {
+    ...WorldIdTrendCount
+  }
+  b4: nullifier_v4_aggregate(
+    where: {
+      created_at: { _gte: $d4, _lt: $d5 }
+      action_v4: {
+        environment: { _eq: "production" }
+        rp_registration: { app_id: { _eq: $app_id } }
+      }
+    }
+  ) {
+    ...WorldIdTrendCount
+  }
+  b5: nullifier_v4_aggregate(
+    where: {
+      created_at: { _gte: $d5, _lt: $d6 }
+      action_v4: {
+        environment: { _eq: "production" }
+        rp_registration: { app_id: { _eq: $app_id } }
+      }
+    }
+  ) {
+    ...WorldIdTrendCount
+  }
+  b6: nullifier_v4_aggregate(
+    where: {
+      created_at: { _gte: $d6, _lt: $d7 }
+      action_v4: {
+        environment: { _eq: "production" }
+        rp_registration: { app_id: { _eq: $app_id } }
+      }
+    }
+  ) {
+    ...WorldIdTrendCount
+  }
+}
+
+query GetWorldIdActionTrend(
+  $app_id: String!
+  $action_id: String!
+  $d0: timestamptz!
+  $d1: timestamptz!
+  $d2: timestamptz!
+  $d3: timestamptz!
+  $d4: timestamptz!
+  $d5: timestamptz!
+  $d6: timestamptz!
+  $d7: timestamptz!
+) {
+  action_v4(
+    where: {
+      id: { _eq: $action_id }
+      environment: { _eq: "production" }
+      rp_registration: { app_id: { _eq: $app_id } }
+    }
+    limit: 1
+  ) {
+    ...WorldIdActionTrendBuckets
+  }
+}
+
+fragment WorldIdActionTrendBuckets on action_v4 {
+  b0: nullifiers_aggregate(where: { created_at: { _gte: $d0, _lt: $d1 } }) {
+    ...WorldIdTrendCount
+  }
+  b1: nullifiers_aggregate(where: { created_at: { _gte: $d1, _lt: $d2 } }) {
+    ...WorldIdTrendCount
+  }
+  b2: nullifiers_aggregate(where: { created_at: { _gte: $d2, _lt: $d3 } }) {
+    ...WorldIdTrendCount
+  }
+  b3: nullifiers_aggregate(where: { created_at: { _gte: $d3, _lt: $d4 } }) {
+    ...WorldIdTrendCount
+  }
+  b4: nullifiers_aggregate(where: { created_at: { _gte: $d4, _lt: $d5 } }) {
+    ...WorldIdTrendCount
+  }
+  b5: nullifiers_aggregate(where: { created_at: { _gte: $d5, _lt: $d6 } }) {
+    ...WorldIdTrendCount
+  }
+  b6: nullifiers_aggregate(where: { created_at: { _gte: $d6, _lt: $d7 } }) {
+    ...WorldIdTrendCount
+  }
+}
+
+fragment WorldIdTrendCount on nullifier_v4_aggregate {
+  aggregate {
+    count
+  }
+}

--- a/web/tests/unit/day-buckets.test.tsx
+++ b/web/tests/unit/day-buckets.test.tsx
@@ -1,0 +1,23 @@
+import { lifetimeBucketBounds, weekBucketBounds } from "@/lib/day-buckets";
+
+it("returns 8 local-midnight bounds ending at today and tomorrow", () => {
+  const bounds = weekBucketBounds(new Date(2026, 5, 15, 9, 30, 0));
+
+  expect(bounds).toHaveLength(8);
+  expect(bounds[6]).toBe(new Date(2026, 5, 15).toISOString());
+  expect(bounds[7]).toBe(new Date(2026, 5, 16).toISOString());
+});
+
+it("splits an entity lifetime into 7 equal buckets ending tomorrow", () => {
+  const createdAt = new Date(2026, 0, 1, 12);
+  const bounds = lifetimeBucketBounds(createdAt, new Date(2026, 0, 8, 9, 30));
+
+  expect(bounds).toHaveLength(8);
+  expect(bounds[0]).toBe(createdAt.toISOString());
+  expect(bounds[7]).toBe(new Date(2026, 0, 9).toISOString());
+
+  const widths = bounds.slice(1).map((bound, index) => {
+    return new Date(bound).getTime() - new Date(bounds[index]).getTime();
+  });
+  expect(Math.max(...widths) - Math.min(...widths)).toBeLessThanOrEqual(1);
+});

--- a/web/tests/unit/format-nullifier.test.tsx
+++ b/web/tests/unit/format-nullifier.test.tsx
@@ -1,0 +1,9 @@
+import { formatNullifierHex } from "@/lib/format-nullifier";
+
+it("renders a decimal nullifier as truncated 0x hex and passes invalid input through", () => {
+  expect(formatNullifierHex(BigInt("0x1f9a4c7e0000b8e2").toString(10))).toBe(
+    "0x1f9a4c7e…b8e2",
+  );
+  expect(formatNullifierHex("255")).toBe("0xff");
+  expect(formatNullifierHex("not-a-number")).toBe("not-a-number");
+});

--- a/web/tests/unit/relative-time-short.test.tsx
+++ b/web/tests/unit/relative-time-short.test.tsx
@@ -1,0 +1,10 @@
+import { relativeTimeShort } from "@/lib/relative-time-short";
+
+it("formats abbreviated relative time across unit boundaries", () => {
+  const now = new Date("2026-06-15T12:00:00Z");
+  const ago = (ms: number) => new Date(now.getTime() - ms);
+
+  expect(relativeTimeShort(ago(5_000), now)).toBe("just now");
+  expect(relativeTimeShort(ago(90_000), now)).toBe("1m ago");
+  expect(relativeTimeShort(ago(3 * 86_400_000), now)).toBe("3d ago");
+});


### PR DESCRIPTION
## What this PR does

- Adds local-midnight weekly buckets and lifetime buckets for weekly and all-time analytics.
- Adds the shared period selector and interactive sparkline components used by the World ID overview and action-detail pages.
- Adds shared trend-query state handling for loading, error, retry, labels, and range text.
- Adds decimal-nullifier-to-hex formatting and compact relative timestamps for verification rows.
- Adds app-level and action-level GraphQL trend queries with generated Apollo hooks.
- Adds unit coverage for bucket calculation and both formatting helpers.

## Stack

**1/4 (this PR)** → #2097 → #2098 → #2099

## Validation

- `pnpm format:check`
- `pnpm typecheck --noEmit`
- `pnpm lint`
- Utility unit tests
- Next.js production build on Tailwind 4
