### PR TITLE
feat(portal-v3): add World ID action detail

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id/actions/[actionId]/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id/actions/[actionId]/page.tsx
@@ -1,21 +1,33 @@
 import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
-import { urls } from "@/lib/urls";
+import { getIsUserAllowedToUpdateApp } from "@/lib/permissions";
+import { appendSearchParams, urls } from "@/lib/urls";
 import { WorldIdActionDetailPage } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page";
 import { redirect } from "next/navigation";
 
 export default async function Page(props: {
   params: Promise<Record<string, string>>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const params = await props.params;
+  const searchParams = await props.searchParams;
+
   return pickPortalVersion(
-    () => <WorldIdActionDetailPage params={params} />,
+    async () => (
+      <WorldIdActionDetailPage
+        params={params}
+        canDelete={await getIsUserAllowedToUpdateApp(params.appId)}
+      />
+    ),
     () =>
       redirect(
-        urls.worldIdAction({
-          team_id: params.teamId,
-          app_id: params.appId,
-          action_id: params.actionId,
-        }),
+        appendSearchParams(
+          urls.worldIdAction({
+            team_id: params.teamId,
+            app_id: params.appId,
+            action_id: params.actionId,
+          }),
+          searchParams,
+        ),
       ),
   );
 }

--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id/actions/[actionId]/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id/actions/[actionId]/page.tsx
@@ -1,0 +1,21 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
+import { urls } from "@/lib/urls";
+import { WorldIdActionDetailPage } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page";
+import { redirect } from "next/navigation";
+
+export default async function Page(props: {
+  params: Promise<Record<string, string>>;
+}) {
+  const params = await props.params;
+  return pickPortalVersion(
+    () => <WorldIdActionDetailPage params={params} />,
+    () =>
+      redirect(
+        urls.worldIdAction({
+          team_id: params.teamId,
+          app_id: params.appId,
+          action_id: params.actionId,
+        }),
+      ),
+  );
+}

--- a/web/lib/urls.ts
+++ b/web/lib/urls.ts
@@ -2,6 +2,27 @@ type SignupParams = {
   invite_id?: string;
 };
 
+/**
+ * Merge `searchParams` into `path`'s query string. Params already present in
+ * the path take precedence; an empty `searchParams` returns the path untouched.
+ * Used by the v3 route redirects so deep-link params survive uniformly.
+ */
+export const appendSearchParams = (
+  path: string,
+  searchParams: Record<string, string>,
+): string => {
+  if (Object.keys(searchParams).length === 0) {
+    return path;
+  }
+
+  const [basePath, existingQuery] = path.split("?", 2);
+  const merged = new URLSearchParams(searchParams);
+  for (const [key, value] of new URLSearchParams(existingQuery)) {
+    merged.set(key, value);
+  }
+  return `${basePath}?${merged.toString()}`;
+};
+
 export const urls = {
   app: (params: { team_id: string; app_id?: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id || ""}`,
@@ -35,6 +56,13 @@ export const urls = {
 
   enableWorldId4: (params: { team_id: string; app_id: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id}?enableWorldId4=true`,
+
+  worldId: (params: {
+    team_id: string;
+    app_id: string;
+    tab?: "world-id-4-0";
+  }): string =>
+    `/teams/${params.team_id}/apps/${params.app_id}/world-id${params.tab ? `?tab=${params.tab}` : ""}`,
 
   worldId40: (params: { team_id: string; app_id: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id}/world-id-4-0`,

--- a/web/lib/urls.ts
+++ b/web/lib/urls.ts
@@ -2,27 +2,6 @@ type SignupParams = {
   invite_id?: string;
 };
 
-/**
- * Merge `searchParams` into `path`'s query string. Params already present in
- * the path take precedence; an empty `searchParams` returns the path untouched.
- * Used by the v3 route redirects so deep-link params survive uniformly.
- */
-export const appendSearchParams = (
-  path: string,
-  searchParams: Record<string, string>,
-): string => {
-  if (Object.keys(searchParams).length === 0) {
-    return path;
-  }
-
-  const [basePath, existingQuery] = path.split("?", 2);
-  const merged = new URLSearchParams(searchParams);
-  for (const [key, value] of new URLSearchParams(existingQuery)) {
-    merged.set(key, value);
-  }
-  return `${basePath}?${merged.toString()}`;
-};
-
 export const urls = {
   app: (params: { team_id: string; app_id?: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id || ""}`,

--- a/web/lib/urls.ts
+++ b/web/lib/urls.ts
@@ -2,6 +2,34 @@ type SignupParams = {
   invite_id?: string;
 };
 
+/** Adds missing search params without overriding params already in the path. */
+export const appendSearchParams = (
+  path: string,
+  searchParams: Record<string, string | string[] | undefined>,
+): string => {
+  const merged = new URLSearchParams();
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    for (const entry of Array.isArray(value) ? value : [value]) {
+      merged.append(key, entry);
+    }
+  }
+
+  if (!merged.toString()) {
+    return path;
+  }
+
+  const [basePath, existingQuery] = path.split("?", 2);
+  for (const [key, value] of new URLSearchParams(existingQuery)) {
+    merged.set(key, value);
+  }
+
+  return `${basePath}?${merged.toString()}`;
+};
+
 export const urls = {
   app: (params: { team_id: string; app_id?: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id || ""}`,

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/SettingsCard/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/SettingsCard/index.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { ActionDangerZone } from "@/components/ActionDangerZone";
+import { urls } from "@/lib/urls";
+import { Icon } from "@/scenes/PortalV3/common/Icon";
+import { deleteActionV4ServerSide } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Danger/page/server";
+import { UpdateActionV4Form } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/UpdateActionV4Form";
+import { GetActionVerificationsFeedQuery } from "@/scenes/common/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/graphql/client/get-action-verifications.generated";
+import { useApolloClient } from "@apollo/client";
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+import { toast } from "react-toastify";
+
+type Action = GetActionVerificationsFeedQuery["action_v4"][number];
+
+export const SettingsCard = (props: {
+  action: Action;
+  teamId: string;
+  appId: string;
+  onDeleted?: () => void;
+}) => {
+  const { action, teamId, appId, onDeleted } = props;
+  const router = useRouter();
+  const apolloClient = useApolloClient();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      const result = await deleteActionV4ServerSide(action.id, appId);
+      if (!result.success) {
+        // Surface the failure so ActionDangerZone keeps the modal open + toasts.
+        throw new Error(result.message || "Failed to delete action");
+      }
+      // Flip the parent into its loading state before the evict so it never
+      // renders a 404 while navigation is pending.
+      onDeleted?.();
+      // Evict the action (and the app-level aggregates, which counted its
+      // nullifiers) from the client cache; the delete ran server-side, so the
+      // cached overview would otherwise still show it back on the landing.
+      const cacheId = apolloClient.cache.identify({
+        __typename: "action_v4",
+        id: action.id,
+      });
+      if (cacheId) {
+        apolloClient.cache.evict({ id: cacheId });
+      }
+      apolloClient.cache.evict({ fieldName: "nullifier_v4_aggregate" });
+      apolloClient.cache.gc();
+      toast.success("Action deleted successfully");
+      router.push(urls.worldId({ team_id: teamId, app_id: appId }));
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [action.id, appId, teamId, router, apolloClient, onDeleted]);
+
+  return (
+    <details className="setcard group flex flex-col overflow-hidden rounded-16 border border-portal-border bg-white shadow-portal-card">
+      <summary className="flex cursor-pointer select-none items-center gap-2.5 px-4 py-3.5">
+        <Icon
+          name="chevron-down"
+          className="size-3 -rotate-90 text-portal-muted transition-transform group-open:rotate-0"
+        />
+        <span className="font-world text-sm font-medium text-portal-heading">
+          Settings
+        </span>
+      </summary>
+      <div className="flex flex-col gap-8 border-t border-portal-border p-4 pt-6">
+        <UpdateActionV4Form action={action} appId={appId} />
+        <div className="border-t border-portal-border pt-6">
+          <ActionDangerZone
+            actionIdentifier={action.action}
+            onDelete={handleDelete}
+            isDeleting={isDeleting}
+            canDelete={true}
+          />
+        </div>
+      </div>
+    </details>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/SettingsCard/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/SettingsCard/index.tsx
@@ -17,9 +17,10 @@ export const SettingsCard = (props: {
   action: Action;
   teamId: string;
   appId: string;
+  canDelete: boolean;
   onDeleted?: () => void;
 }) => {
-  const { action, teamId, appId, onDeleted } = props;
+  const { action, teamId, appId, canDelete, onDeleted } = props;
   const router = useRouter();
   const apolloClient = useApolloClient();
   const [isDeleting, setIsDeleting] = useState(false);
@@ -29,15 +30,9 @@ export const SettingsCard = (props: {
     try {
       const result = await deleteActionV4ServerSide(action.id, appId);
       if (!result.success) {
-        // Surface the failure so ActionDangerZone keeps the modal open + toasts.
         throw new Error(result.message || "Failed to delete action");
       }
-      // Flip the parent into its loading state before the evict so it never
-      // renders a 404 while navigation is pending.
       onDeleted?.();
-      // Evict the action (and the app-level aggregates, which counted its
-      // nullifiers) from the client cache; the delete ran server-side, so the
-      // cached overview would otherwise still show it back on the landing.
       const cacheId = apolloClient.cache.identify({
         __typename: "action_v4",
         id: action.id,
@@ -55,8 +50,8 @@ export const SettingsCard = (props: {
   }, [action.id, appId, teamId, router, apolloClient, onDeleted]);
 
   return (
-    <details className="setcard group flex flex-col overflow-hidden rounded-16 border border-portal-border bg-white shadow-portal-card">
-      <summary className="flex cursor-pointer select-none items-center gap-2.5 px-4 py-3.5">
+    <details className="group flex flex-col overflow-hidden rounded-16 border border-portal-border bg-white shadow-portal-card">
+      <summary className="flex cursor-pointer items-center gap-2.5 px-4 py-3.5 select-none">
         <Icon
           name="chevron-down"
           className="size-3 -rotate-90 text-portal-muted transition-transform group-open:rotate-0"
@@ -67,14 +62,16 @@ export const SettingsCard = (props: {
       </summary>
       <div className="flex flex-col gap-8 border-t border-portal-border p-4 pt-6">
         <UpdateActionV4Form action={action} appId={appId} />
-        <div className="border-t border-portal-border pt-6">
-          <ActionDangerZone
-            actionIdentifier={action.action}
-            onDelete={handleDelete}
-            isDeleting={isDeleting}
-            canDelete={true}
-          />
-        </div>
+        {canDelete ? (
+          <div className="border-t border-portal-border pt-6">
+            <ActionDangerZone
+              actionIdentifier={action.action}
+              onDelete={handleDelete}
+              isDeleting={isDeleting}
+              canDelete
+            />
+          </div>
+        ) : null}
       </div>
     </details>
   );

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/VerificationsFeed/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/VerificationsFeed/index.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Pagination } from "@/components/Pagination";
+import { formatNullifierHex } from "@/lib/format-nullifier";
+import { relativeTimeShort } from "@/lib/relative-time-short";
+
+type NullifierRow = {
+  id: string;
+  created_at: string;
+  nullifier: string;
+};
+
+export const VerificationsFeed = (props: {
+  nullifiers: NullifierRow[];
+  total: number;
+  page: number;
+  rowsPerPage: number;
+  onPageChange: (page: number) => void;
+}) => {
+  const { nullifiers, total, page, rowsPerPage, onPageChange } = props;
+
+  return (
+    <div className="flex flex-col overflow-hidden rounded-16 border border-portal-border bg-white shadow-portal-card">
+      <div className="flex items-center gap-2 border-b border-portal-border px-4 py-3">
+        <span className="font-world text-sm font-medium text-portal-heading">
+          Verifications
+        </span>
+      </div>
+
+      {nullifiers.length === 0 ? (
+        <div className="px-4 py-12 text-center font-world text-13 text-portal-muted">
+          No verifications yet.
+        </div>
+      ) : (
+        <div className="flex flex-col">
+          {nullifiers.map((nullifier) => (
+            <div
+              key={nullifier.id}
+              className="flex items-center gap-3 border-b border-portal-border px-4 py-3"
+            >
+              <span className="font-ibm text-13 text-portal-ink">
+                {formatNullifierHex(nullifier.nullifier)}
+              </span>
+              <span className="flex-1" />
+              <span className="whitespace-nowrap font-world text-12 text-portal-subtle">
+                {relativeTimeShort(nullifier.created_at)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Pagination
+        totalResults={total}
+        currentPage={page}
+        rowsPerPage={rowsPerPage}
+        handlePageChange={onPageChange}
+        className="px-4"
+      />
+    </div>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/VerificationsFeed/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/VerificationsFeed/index.tsx
@@ -42,7 +42,7 @@ export const VerificationsFeed = (props: {
                 {formatNullifierHex(nullifier.nullifier)}
               </span>
               <span className="flex-1" />
-              <span className="whitespace-nowrap font-world text-12 text-portal-subtle">
+              <span className="font-world text-12 whitespace-nowrap text-portal-subtle">
                 {relativeTimeShort(nullifier.created_at)}
               </span>
             </div>
@@ -50,13 +50,15 @@ export const VerificationsFeed = (props: {
         </div>
       )}
 
-      <Pagination
-        totalResults={total}
-        currentPage={page}
-        rowsPerPage={rowsPerPage}
-        handlePageChange={onPageChange}
-        className="px-4"
-      />
+      {total > 0 ? (
+        <Pagination
+          totalResults={total}
+          currentPage={page}
+          rowsPerPage={rowsPerPage}
+          handlePageChange={onPageChange}
+          className="px-4"
+        />
+      ) : null}
     </div>
   );
 };

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/index.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { ErrorPage } from "@/components/ErrorPage";
+import { SizingWrapper } from "@/components/SizingWrapper";
+import { trendPoints, type TrendPeriod } from "@/lib/day-buckets";
+import { urls } from "@/lib/urls";
+import { PeriodSelector } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/common/PeriodSelector";
+import { TrendSparkline } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/common/TrendSparkline";
+import {
+  buildTrendState,
+  useTrendWindow,
+} from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/common/use-trend-window";
+import {
+  useGetActionStatsQuery,
+  useGetActionVerificationsFeedQuery,
+} from "@/scenes/common/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/graphql/client/get-action-verifications.generated";
+import { useGetWorldIdActionTrendQuery } from "@/scenes/common/Teams/TeamId/Apps/AppId/WorldId/graphql/client/get-world-id-trends.generated";
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import Skeleton from "react-loading-skeleton";
+import { SettingsCard } from "./SettingsCard";
+import { VerificationsFeed } from "./VerificationsFeed";
+
+const LIMIT = 6;
+// Live-total changes refresh the aggregate queries at most this often.
+const AGGREGATE_REFRESH_MS = 60_000;
+
+const Stat = (props: { label: string; value: number }) => (
+  <div className="flex flex-col gap-1.5">
+    <span className="font-world text-13 text-portal-muted">{props.label}</span>
+    <span className="font-twk text-[32px] font-medium leading-none tracking-[-0.01em] text-portal-heading">
+      {props.value.toLocaleString()}
+    </span>
+  </div>
+);
+
+export const WorldIdActionDetailPage = (props: {
+  params: Record<string, string>;
+}) => {
+  const { params } = props;
+  const teamId = params.teamId;
+  const appId = params.appId;
+  const actionId = params.actionId;
+
+  const [page, setPage] = useState(1);
+  const [timePeriod, setTimePeriod] = useState<TrendPeriod>("weekly");
+  const [deleted, setDeleted] = useState(false);
+  const offset = (page - 1) * LIMIT;
+
+  const { data, loading, error } = useGetActionVerificationsFeedQuery({
+    variables: {
+      action_id: actionId,
+      app_id: appId,
+      limit: LIMIT,
+      offset,
+    },
+    skip: !actionId,
+    // Poll only on page 1 so paging back through history isn't reset under us.
+    pollInterval: page === 1 ? 5000 : 0,
+    // Pause polling while the tab is hidden (`document` guard for SSR).
+    skipPollAttempt: () => typeof document !== "undefined" && document.hidden,
+  });
+
+  const action = data?.action_v4?.[0];
+  const total = action?.total.aggregate?.count;
+
+  const trend = useTrendWindow({
+    createdAt: action?.created_at,
+    timePeriod,
+  });
+
+  // Feed total + timestamp captured at each fetch of an aggregate query; used
+  // to throttle the live refreshes in the effect below.
+  const statsFetchRef = useRef<{ total: number; at: number } | undefined>(
+    undefined,
+  );
+  const trendFetchRef = useRef<{ total: number; at: number } | undefined>(
+    undefined,
+  );
+
+  const {
+    data: statsData,
+    loading: statsLoading,
+    error: statsError,
+    refetch: refetchStats,
+  } = useGetActionStatsQuery({
+    variables: {
+      action_id: actionId,
+      app_id: appId,
+      ...trend.weeklyVariables,
+    },
+    skip: !actionId,
+    onCompleted: () => {
+      statsFetchRef.current = { total: total ?? 0, at: Date.now() };
+    },
+  });
+
+  const {
+    data: actionTrendData,
+    loading: actionTrendLoading,
+    error: actionTrendError,
+    refetch: refetchActionTrend,
+  } = useGetWorldIdActionTrendQuery({
+    variables: {
+      app_id: appId,
+      action_id: actionId,
+      ...trend.allTimeVariables,
+    },
+    skip: timePeriod !== "all-time" || !appId || !action,
+    // Revalidate cached buckets whenever the all-time view is (re)entered.
+    fetchPolicy: "cache-and-network",
+    onCompleted: () => {
+      trendFetchRef.current = { total: total ?? 0, at: Date.now() };
+    },
+  });
+
+  // When the polled feed reports new verifications, refresh the aggregate
+  // queries — throttled so a busy action doesn't refetch on every 5s tick.
+  useEffect(() => {
+    if (total === undefined) {
+      return;
+    }
+    const now = Date.now();
+
+    const statsFetch = statsFetchRef.current;
+    if (
+      statsFetch &&
+      statsFetch.total !== total &&
+      now - statsFetch.at >= AGGREGATE_REFRESH_MS
+    ) {
+      statsFetchRef.current = { total, at: now };
+      void refetchStats();
+    }
+
+    const trendFetch = trendFetchRef.current;
+    if (
+      timePeriod === "all-time" &&
+      trendFetch &&
+      trendFetch.total !== total &&
+      now - trendFetch.at >= AGGREGATE_REFRESH_MS
+    ) {
+      trendFetchRef.current = { total, at: now };
+      void refetchActionTrend();
+    }
+  }, [refetchActionTrend, refetchStats, timePeriod, total]);
+
+  if (error) {
+    return (
+      <SizingWrapper gridClassName="order-1 md:order-2">
+        <ErrorPage statusCode={500} title="Failed to load action" />
+      </SizingWrapper>
+    );
+  }
+
+  // After a delete the action is evicted from the cache before navigation
+  // completes, so keep showing the skeletons instead of flashing a 404.
+  if (!loading && !action && !deleted) {
+    return (
+      <SizingWrapper gridClassName="order-1 md:order-2">
+        <ErrorPage statusCode={404} title="Action not found" />
+      </SizingWrapper>
+    );
+  }
+
+  // Total verifications === unique humans (one nullifier row per human per
+  // action), rendered as two cards per the design.
+  const totalCount = total ?? 0;
+  const stats = statsData?.action_v4?.[0];
+  const weekCount = stats?.week.aggregate?.count ?? 0;
+  const sparkPoints =
+    timePeriod === "all-time"
+      ? trendPoints(actionTrendData?.action_v4?.[0])
+      : trendPoints(stats);
+  const trendState = buildTrendState({
+    loading: timePeriod === "all-time" ? actionTrendLoading : statsLoading,
+    error:
+      timePeriod === "all-time"
+        ? Boolean(actionTrendError)
+        : Boolean(statsError),
+    points: sparkPoints,
+    labels: trend.labels,
+    onRetry: () =>
+      void (timePeriod === "all-time" ? refetchActionTrend() : refetchStats()),
+  });
+
+  return (
+    <SizingWrapper gridClassName="pb-6 pt-6 md:pb-10">
+      <div className="mx-auto flex w-full max-w-[900px] flex-col gap-4">
+        {/* Breadcrumb — items-baseline, not items-center: the world-font link
+            and the mono identifier have different vertical metrics, so center
+            alignment leaves the mono text visually sagging. */}
+        <div className="flex items-baseline gap-2.5">
+          <Link
+            href={urls.worldId({ team_id: teamId, app_id: appId })}
+            className="font-world text-13 text-portal-muted transition-colors hover:text-portal-text"
+          >
+            Actions
+          </Link>
+          <span className="font-world text-13 text-portal-subtle">/</span>
+          {loading || !action ? (
+            <Skeleton width={120} />
+          ) : (
+            <span className="font-ibm text-13 font-medium text-portal-heading">
+              {action.action}
+            </span>
+          )}
+        </div>
+
+        {/* Stats card */}
+        <div className="flex flex-col gap-7 rounded-16 border border-portal-border bg-white p-8 shadow-portal-card">
+          {loading || !action ? (
+            <Skeleton height={128} />
+          ) : (
+            <>
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+                <span className="font-ibm text-[20px] font-medium leading-none text-portal-heading">
+                  {action.action}
+                </span>
+                {action.description ? (
+                  // translate: optical correction — the mono heading's glyphs sit
+                  // low in their em box, so pure box-centering leaves the
+                  // description looking high against the mono ink.
+                  <span className="translate-y-[3px] font-world text-sm leading-none text-portal-muted">
+                    {action.description}
+                  </span>
+                ) : null}
+                <span className="ml-auto">
+                  <PeriodSelector
+                    timePeriod={timePeriod}
+                    onTimePeriodChange={setTimePeriod}
+                  />
+                </span>
+              </div>
+
+              <div className="flex flex-wrap items-end gap-x-14 gap-y-6">
+                <Stat label="Unique humans" value={totalCount} />
+                <Stat label="This week" value={weekCount} />
+                <div className="ml-auto">
+                  <TrendSparkline
+                    state={trendState}
+                    rangeLabel={trend.rangeLabel}
+                    variant="detail"
+                  />
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Verifications feed */}
+        {loading || !action ? (
+          <div className="rounded-16 border border-portal-border bg-white p-4 shadow-portal-card">
+            <Skeleton height={40} count={6} />
+          </div>
+        ) : (
+          <VerificationsFeed
+            nullifiers={action.nullifiers}
+            total={totalCount}
+            page={page}
+            rowsPerPage={LIMIT}
+            onPageChange={setPage}
+          />
+        )}
+
+        {/* Settings */}
+        {!loading && action ? (
+          <SettingsCard
+            action={action}
+            teamId={teamId}
+            appId={appId}
+            onDeleted={() => setDeleted(true)}
+          />
+        ) : null}
+      </div>
+    </SizingWrapper>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/index.tsx
@@ -162,9 +162,9 @@ export const WorldIdActionDetailPage = (props: {
     );
   }
 
-  // Total verifications === unique humans (one nullifier row per human per
-  // action), rendered as two cards per the design.
-  const totalCount = total ?? 0;
+  // Each stored nullifier is one unique verification for this action; replayed
+  // proofs do not add another row.
+  const uniqueVerificationCount = total ?? 0;
   const stats = statsData?.action_v4?.[0];
   const weekCount = stats?.week.aggregate?.count ?? 0;
   const sparkPoints =
@@ -233,7 +233,10 @@ export const WorldIdActionDetailPage = (props: {
               </div>
 
               <div className="flex flex-wrap items-end gap-x-14 gap-y-6">
-                <Stat label="Unique humans" value={totalCount} />
+                <Stat
+                  label="Unique verifications"
+                  value={uniqueVerificationCount}
+                />
                 <Stat label="This week" value={weekCount} />
                 <div className="ml-auto">
                   <TrendSparkline
@@ -255,7 +258,7 @@ export const WorldIdActionDetailPage = (props: {
         ) : (
           <VerificationsFeed
             nullifiers={action.nullifiers}
-            total={totalCount}
+            total={uniqueVerificationCount}
             page={page}
             rowsPerPage={LIMIT}
             onPageChange={setPage}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/index.tsx
@@ -15,6 +15,7 @@ import {
   useGetActionVerificationsFeedQuery,
 } from "@/scenes/common/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/graphql/client/get-action-verifications.generated";
 import { useGetWorldIdActionTrendQuery } from "@/scenes/common/Teams/TeamId/Apps/AppId/WorldId/graphql/client/get-world-id-trends.generated";
+import { NetworkStatus } from "@apollo/client";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import Skeleton from "react-loading-skeleton";
@@ -22,46 +23,55 @@ import { SettingsCard } from "./SettingsCard";
 import { VerificationsFeed } from "./VerificationsFeed";
 
 const LIMIT = 6;
-// Live-total changes refresh the aggregate queries at most this often.
 const AGGREGATE_REFRESH_MS = 60_000;
 
-const Stat = (props: { label: string; value: number }) => (
+const Stat = (props: { label: string; value?: number }) => (
   <div className="flex flex-col gap-1.5">
     <span className="font-world text-13 text-portal-muted">{props.label}</span>
-    <span className="font-twk text-[32px] font-medium leading-none tracking-[-0.01em] text-portal-heading">
-      {props.value.toLocaleString()}
+    <span className="font-twk text-[32px] leading-none font-medium tracking-[-0.01em] text-portal-heading">
+      {props.value === undefined ? "—" : props.value.toLocaleString()}
     </span>
   </div>
 );
 
 export const WorldIdActionDetailPage = (props: {
   params: Record<string, string>;
+  canDelete: boolean;
 }) => {
-  const { params } = props;
+  const { params, canDelete } = props;
   const teamId = params.teamId;
   const appId = params.appId;
   const actionId = params.actionId;
 
   const [page, setPage] = useState(1);
+  const [loadedPage, setLoadedPage] = useState<number>();
   const [timePeriod, setTimePeriod] = useState<TrendPeriod>("weekly");
   const [deleted, setDeleted] = useState(false);
   const offset = (page - 1) * LIMIT;
 
-  const { data, loading, error } = useGetActionVerificationsFeedQuery({
-    variables: {
-      action_id: actionId,
-      app_id: appId,
-      limit: LIMIT,
-      offset,
-    },
-    skip: !actionId,
-    // Poll only on page 1 so paging back through history isn't reset under us.
-    pollInterval: page === 1 ? 5000 : 0,
-    // Pause polling while the tab is hidden (`document` guard for SSR).
-    skipPollAttempt: () => typeof document !== "undefined" && document.hidden,
-  });
+  const { data, previousData, loading, error, networkStatus } =
+    useGetActionVerificationsFeedQuery({
+      variables: {
+        action_id: actionId,
+        app_id: appId,
+        limit: LIMIT,
+        offset,
+      },
+      skip: !actionId,
+      // Poll only on page 1 so paging back through history isn't reset under us.
+      pollInterval: page === 1 ? 5000 : 0,
+      // Pause polling while the tab is hidden (`document` guard for SSR).
+      skipPollAttempt: () => typeof document !== "undefined" && document.hidden,
+      onCompleted: () => setLoadedPage(page),
+    });
 
-  const action = data?.action_v4?.[0];
+  const queriedAction = data?.action_v4?.[0];
+  const previousAction = previousData?.action_v4?.[0];
+  const currentAction =
+    queriedAction?.id === actionId ? queriedAction : undefined;
+  const action =
+    currentAction ??
+    (previousAction?.id === actionId ? previousAction : undefined);
   const total = action?.total.aggregate?.count;
 
   const trend = useTrendWindow({
@@ -69,8 +79,6 @@ export const WorldIdActionDetailPage = (props: {
     timePeriod,
   });
 
-  // Feed total + timestamp captured at each fetch of an aggregate query; used
-  // to throttle the live refreshes in the effect below.
   const statsFetchRef = useRef<{ total: number; at: number } | undefined>(
     undefined,
   );
@@ -107,44 +115,62 @@ export const WorldIdActionDetailPage = (props: {
       ...trend.allTimeVariables,
     },
     skip: timePeriod !== "all-time" || !appId || !action,
-    // Revalidate cached buckets whenever the all-time view is (re)entered.
     fetchPolicy: "cache-and-network",
     onCompleted: () => {
       trendFetchRef.current = { total: total ?? 0, at: Date.now() };
     },
   });
 
-  // When the polled feed reports new verifications, refresh the aggregate
-  // queries — throttled so a busy action doesn't refetch on every 5s tick.
   useEffect(() => {
     if (total === undefined) {
       return;
     }
     const now = Date.now();
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const scheduleTrailingRefresh = (
+      fetchRef: typeof statsFetchRef,
+      refetch: () => Promise<unknown>,
+    ) => {
+      const fetched = fetchRef.current;
+      if (!fetched || fetched.total === total) {
+        return;
+      }
 
-    const statsFetch = statsFetchRef.current;
-    if (
-      statsFetch &&
-      statsFetch.total !== total &&
-      now - statsFetch.at >= AGGREGATE_REFRESH_MS
-    ) {
-      statsFetchRef.current = { total, at: now };
-      void refetchStats();
+      const refresh = () => {
+        if (fetchRef.current?.total === total) {
+          return;
+        }
+        // Keep the last successful total so failed refetches remain retryable.
+        fetchRef.current = { total: fetched.total, at: Date.now() };
+        void refetch();
+      };
+      const delay = AGGREGATE_REFRESH_MS - (now - fetched.at);
+      if (delay <= 0) {
+        refresh();
+      } else {
+        timers.push(setTimeout(refresh, delay));
+      }
+    };
+
+    // Avoid duplicate refreshes while an aggregate query is in flight.
+    if (!statsLoading) {
+      scheduleTrailingRefresh(statsFetchRef, refetchStats);
+    }
+    if (timePeriod === "all-time" && !actionTrendLoading) {
+      scheduleTrailingRefresh(trendFetchRef, refetchActionTrend);
     }
 
-    const trendFetch = trendFetchRef.current;
-    if (
-      timePeriod === "all-time" &&
-      trendFetch &&
-      trendFetch.total !== total &&
-      now - trendFetch.at >= AGGREGATE_REFRESH_MS
-    ) {
-      trendFetchRef.current = { total, at: now };
-      void refetchActionTrend();
-    }
-  }, [refetchActionTrend, refetchStats, timePeriod, total]);
+    return () => timers.forEach((timer) => clearTimeout(timer));
+  }, [
+    actionTrendLoading,
+    refetchActionTrend,
+    refetchStats,
+    statsLoading,
+    timePeriod,
+    total,
+  ]);
 
-  if (error) {
+  if (error && !action) {
     return (
       <SizingWrapper gridClassName="order-1 md:order-2">
         <ErrorPage statusCode={500} title="Failed to load action" />
@@ -152,8 +178,7 @@ export const WorldIdActionDetailPage = (props: {
     );
   }
 
-  // After a delete the action is evicted from the cache before navigation
-  // completes, so keep showing the skeletons instead of flashing a 404.
+  // Avoid flashing a 404 while deletion navigation completes.
   if (!loading && !action && !deleted) {
     return (
       <SizingWrapper gridClassName="order-1 md:order-2">
@@ -162,11 +187,9 @@ export const WorldIdActionDetailPage = (props: {
     );
   }
 
-  // Each stored nullifier is one unique verification for this action; replayed
-  // proofs do not add another row.
   const uniqueVerificationCount = total ?? 0;
   const stats = statsData?.action_v4?.[0];
-  const weekCount = stats?.week.aggregate?.count ?? 0;
+  const weekCount = stats?.week.aggregate?.count;
   const sparkPoints =
     timePeriod === "all-time"
       ? trendPoints(actionTrendData?.action_v4?.[0])
@@ -179,16 +202,16 @@ export const WorldIdActionDetailPage = (props: {
         : Boolean(statsError),
     points: sparkPoints,
     labels: trend.labels,
+    // Apollo exposes refetch failures through query error state.
     onRetry: () =>
-      void (timePeriod === "all-time" ? refetchActionTrend() : refetchStats()),
+      void (
+        timePeriod === "all-time" ? refetchActionTrend() : refetchStats()
+      ).catch(() => {}),
   });
 
   return (
     <SizingWrapper gridClassName="pb-6 pt-6 md:pb-10">
       <div className="mx-auto flex w-full max-w-[900px] flex-col gap-4">
-        {/* Breadcrumb — items-baseline, not items-center: the world-font link
-            and the mono identifier have different vertical metrics, so center
-            alignment leaves the mono text visually sagging. */}
         <div className="flex items-baseline gap-2.5">
           <Link
             href={urls.worldId({ team_id: teamId, app_id: appId })}
@@ -197,7 +220,7 @@ export const WorldIdActionDetailPage = (props: {
             Actions
           </Link>
           <span className="font-world text-13 text-portal-subtle">/</span>
-          {loading || !action ? (
+          {!action ? (
             <Skeleton width={120} />
           ) : (
             <span className="font-ibm text-13 font-medium text-portal-heading">
@@ -206,20 +229,16 @@ export const WorldIdActionDetailPage = (props: {
           )}
         </div>
 
-        {/* Stats card */}
         <div className="flex flex-col gap-7 rounded-16 border border-portal-border bg-white p-8 shadow-portal-card">
-          {loading || !action ? (
+          {!action ? (
             <Skeleton height={128} />
           ) : (
             <>
               <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-                <span className="font-ibm text-[20px] font-medium leading-none text-portal-heading">
+                <span className="font-ibm text-[20px] leading-none font-medium text-portal-heading">
                   {action.action}
                 </span>
                 {action.description ? (
-                  // translate: optical correction — the mono heading's glyphs sit
-                  // low in their em box, so pure box-centering leaves the
-                  // description looking high against the mono ink.
                   <span className="translate-y-[3px] font-world text-sm leading-none text-portal-muted">
                     {action.description}
                   </span>
@@ -250,27 +269,28 @@ export const WorldIdActionDetailPage = (props: {
           )}
         </div>
 
-        {/* Verifications feed */}
-        {loading || !action ? (
+        {networkStatus === NetworkStatus.setVariables ||
+        loadedPage !== page ||
+        !currentAction ? (
           <div className="rounded-16 border border-portal-border bg-white p-4 shadow-portal-card">
             <Skeleton height={40} count={6} />
           </div>
         ) : (
           <VerificationsFeed
-            nullifiers={action.nullifiers}
-            total={uniqueVerificationCount}
+            nullifiers={currentAction.nullifiers}
+            total={currentAction.total.aggregate?.count ?? 0}
             page={page}
             rowsPerPage={LIMIT}
             onPageChange={setPage}
           />
         )}
 
-        {/* Settings */}
-        {!loading && action ? (
+        {action ? (
           <SettingsCard
             action={action}
             teamId={teamId}
             appId={appId}
+            canDelete={canDelete}
             onDeleted={() => setDeleted(true)}
           />
         ) : null}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/UpdateActionV4Form/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/UpdateActionV4Form/index.tsx
@@ -17,7 +17,12 @@ import { GetSingleActionV4Query } from "@/scenes/common/Teams/TeamId/Apps/AppId/
 import { updateActionV4ServerSide } from "./server";
 
 type UpdateActionV4FormProps = {
-  action: NonNullable<GetSingleActionV4Query["action_v4_by_pk"]>;
+  // Only the fields the form reads, so callers with wider query shapes can
+  // pass their action straight through.
+  action: Pick<
+    NonNullable<GetSingleActionV4Query["action_v4_by_pk"]>,
+    "id" | "action" | "description"
+  >;
   appId: string;
 };
 

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/UpdateActionV4Form/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/Settings/UpdateActionV4Form/index.tsx
@@ -17,8 +17,6 @@ import { GetSingleActionV4Query } from "@/scenes/common/Teams/TeamId/Apps/AppId/
 import { updateActionV4ServerSide } from "./server";
 
 type UpdateActionV4FormProps = {
-  // Only the fields the form reads, so callers with wider query shapes can
-  // pass their action straight through.
   action: Pick<
     NonNullable<GetSingleActionV4Query["action_v4_by_pk"]>,
     "id" | "action" | "description"

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/graphql/client/get-action-verifications.generated.ts
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/graphql/client/get-action-verifications.generated.ts
@@ -1,0 +1,353 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { gql } from "@apollo/client";
+import { WorldIdActionTrendBucketsFragmentDoc } from "../../../../../graphql/client/get-world-id-trends.generated";
+import * as Apollo from "@apollo/client";
+const defaultOptions = {} as const;
+export type GetActionVerificationsFeedQueryVariables = Types.Exact<{
+  action_id: Types.Scalars["String"]["input"];
+  app_id: Types.Scalars["String"]["input"];
+  limit: Types.Scalars["Int"]["input"];
+  offset: Types.Scalars["Int"]["input"];
+}>;
+
+export type GetActionVerificationsFeedQuery = {
+  __typename?: "query_root";
+  action_v4: Array<{
+    __typename?: "action_v4";
+    id: string;
+    action: string;
+    description: string;
+    rp_id: string;
+    created_at: string;
+    rp_registration: { __typename?: "rp_registration"; app_id: string };
+    total: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    nullifiers: Array<{
+      __typename?: "nullifier_v4";
+      id: string;
+      created_at: string;
+      nullifier: string;
+    }>;
+  }>;
+};
+
+export type GetActionStatsQueryVariables = Types.Exact<{
+  action_id: Types.Scalars["String"]["input"];
+  app_id: Types.Scalars["String"]["input"];
+  d0: Types.Scalars["timestamptz"]["input"];
+  d1: Types.Scalars["timestamptz"]["input"];
+  d2: Types.Scalars["timestamptz"]["input"];
+  d3: Types.Scalars["timestamptz"]["input"];
+  d4: Types.Scalars["timestamptz"]["input"];
+  d5: Types.Scalars["timestamptz"]["input"];
+  d6: Types.Scalars["timestamptz"]["input"];
+  d7: Types.Scalars["timestamptz"]["input"];
+}>;
+
+export type GetActionStatsQuery = {
+  __typename?: "query_root";
+  action_v4: Array<{
+    __typename?: "action_v4";
+    id: string;
+    week: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b0: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b1: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b2: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b3: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b4: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b5: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b6: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+  }>;
+};
+
+export const GetActionVerificationsFeedDocument = gql`
+  query GetActionVerificationsFeed(
+    $action_id: String!
+    $app_id: String!
+    $limit: Int!
+    $offset: Int!
+  ) {
+    action_v4(
+      where: {
+        id: { _eq: $action_id }
+        environment: { _eq: "production" }
+        rp_registration: { app_id: { _eq: $app_id } }
+      }
+      limit: 1
+    ) {
+      id
+      action
+      description
+      rp_id
+      created_at
+      rp_registration {
+        app_id
+      }
+      total: nullifiers_aggregate {
+        aggregate {
+          count
+        }
+      }
+      nullifiers(
+        limit: $limit
+        offset: $offset
+        order_by: [{ created_at: desc }, { id: desc }]
+      ) {
+        id
+        created_at
+        nullifier
+      }
+    }
+  }
+`;
+
+/**
+ * __useGetActionVerificationsFeedQuery__
+ *
+ * To run a query within a React component, call `useGetActionVerificationsFeedQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetActionVerificationsFeedQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetActionVerificationsFeedQuery({
+ *   variables: {
+ *      action_id: // value for 'action_id'
+ *      app_id: // value for 'app_id'
+ *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
+ *   },
+ * });
+ */
+export function useGetActionVerificationsFeedQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetActionVerificationsFeedQuery,
+    GetActionVerificationsFeedQueryVariables
+  > &
+    (
+      | { variables: GetActionVerificationsFeedQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetActionVerificationsFeedQuery,
+    GetActionVerificationsFeedQueryVariables
+  >(GetActionVerificationsFeedDocument, options);
+}
+export function useGetActionVerificationsFeedLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetActionVerificationsFeedQuery,
+    GetActionVerificationsFeedQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetActionVerificationsFeedQuery,
+    GetActionVerificationsFeedQueryVariables
+  >(GetActionVerificationsFeedDocument, options);
+}
+export function useGetActionVerificationsFeedSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetActionVerificationsFeedQuery,
+        GetActionVerificationsFeedQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetActionVerificationsFeedQuery,
+    GetActionVerificationsFeedQueryVariables
+  >(GetActionVerificationsFeedDocument, options);
+}
+export type GetActionVerificationsFeedQueryHookResult = ReturnType<
+  typeof useGetActionVerificationsFeedQuery
+>;
+export type GetActionVerificationsFeedLazyQueryHookResult = ReturnType<
+  typeof useGetActionVerificationsFeedLazyQuery
+>;
+export type GetActionVerificationsFeedSuspenseQueryHookResult = ReturnType<
+  typeof useGetActionVerificationsFeedSuspenseQuery
+>;
+export type GetActionVerificationsFeedQueryResult = Apollo.QueryResult<
+  GetActionVerificationsFeedQuery,
+  GetActionVerificationsFeedQueryVariables
+>;
+export const GetActionStatsDocument = gql`
+  query GetActionStats(
+    $action_id: String!
+    $app_id: String!
+    $d0: timestamptz!
+    $d1: timestamptz!
+    $d2: timestamptz!
+    $d3: timestamptz!
+    $d4: timestamptz!
+    $d5: timestamptz!
+    $d6: timestamptz!
+    $d7: timestamptz!
+  ) {
+    action_v4(
+      where: {
+        id: { _eq: $action_id }
+        environment: { _eq: "production" }
+        rp_registration: { app_id: { _eq: $app_id } }
+      }
+      limit: 1
+    ) {
+      id
+      week: nullifiers_aggregate(
+        where: { created_at: { _gte: $d0, _lt: $d7 } }
+      ) {
+        aggregate {
+          count
+        }
+      }
+      ...WorldIdActionTrendBuckets
+    }
+  }
+  ${WorldIdActionTrendBucketsFragmentDoc}
+`;
+
+/**
+ * __useGetActionStatsQuery__
+ *
+ * To run a query within a React component, call `useGetActionStatsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetActionStatsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetActionStatsQuery({
+ *   variables: {
+ *      action_id: // value for 'action_id'
+ *      app_id: // value for 'app_id'
+ *      d0: // value for 'd0'
+ *      d1: // value for 'd1'
+ *      d2: // value for 'd2'
+ *      d3: // value for 'd3'
+ *      d4: // value for 'd4'
+ *      d5: // value for 'd5'
+ *      d6: // value for 'd6'
+ *      d7: // value for 'd7'
+ *   },
+ * });
+ */
+export function useGetActionStatsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetActionStatsQuery,
+    GetActionStatsQueryVariables
+  > &
+    (
+      | { variables: GetActionStatsQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetActionStatsQuery, GetActionStatsQueryVariables>(
+    GetActionStatsDocument,
+    options,
+  );
+}
+export function useGetActionStatsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetActionStatsQuery,
+    GetActionStatsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GetActionStatsQuery, GetActionStatsQueryVariables>(
+    GetActionStatsDocument,
+    options,
+  );
+}
+export function useGetActionStatsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetActionStatsQuery,
+        GetActionStatsQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetActionStatsQuery,
+    GetActionStatsQueryVariables
+  >(GetActionStatsDocument, options);
+}
+export type GetActionStatsQueryHookResult = ReturnType<
+  typeof useGetActionStatsQuery
+>;
+export type GetActionStatsLazyQueryHookResult = ReturnType<
+  typeof useGetActionStatsLazyQuery
+>;
+export type GetActionStatsSuspenseQueryHookResult = ReturnType<
+  typeof useGetActionStatsSuspenseQuery
+>;
+export type GetActionStatsQueryResult = Apollo.QueryResult<
+  GetActionStatsQuery,
+  GetActionStatsQueryVariables
+>;

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/graphql/client/get-action-verifications.graphql
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/graphql/client/get-action-verifications.graphql
@@ -1,0 +1,80 @@
+# Powers the action detail page. Split into two operations so the 5s live-feed
+# poll only re-runs the feed selection, not the stats aggregates.
+
+# Live verifications feed (`nullifiers`, polled every 5s while on page 1) plus
+# the fields the page needs fresh on every tick. There is one nullifier row per
+# human for a given action, so "Total verifications" == "Unique humans"; the
+# stat and pagination both use `total`.
+query GetActionVerificationsFeed(
+  $action_id: String!
+  $app_id: String!
+  $limit: Int!
+  $offset: Int!
+) {
+  action_v4(
+    where: {
+      id: { _eq: $action_id }
+      environment: { _eq: "production" }
+      rp_registration: { app_id: { _eq: $app_id } }
+    }
+    limit: 1
+  ) {
+    id
+    action
+    description
+    rp_id
+    created_at
+    rp_registration {
+      app_id
+    }
+    total: nullifiers_aggregate {
+      aggregate {
+        count
+      }
+    }
+    # id tie-breaker keeps the sort stable across pages when rows share a
+    # created_at timestamp.
+    nullifiers(
+      limit: $limit
+      offset: $offset
+      order_by: [{ created_at: desc }, { id: desc }]
+    ) {
+      id
+      created_at
+      nullifier
+    }
+  }
+}
+
+# "This week" count plus the per-day sparkline (b0..b6 driven by local-midnight
+# bounds from `weekBucketBounds`). Fetched once per view, not polled. `week` is
+# bounded to [d0, d7) so it matches the b0..b6 buckets exactly.
+query GetActionStats(
+  $action_id: String!
+  $app_id: String!
+  $d0: timestamptz!
+  $d1: timestamptz!
+  $d2: timestamptz!
+  $d3: timestamptz!
+  $d4: timestamptz!
+  $d5: timestamptz!
+  $d6: timestamptz!
+  $d7: timestamptz!
+) {
+  action_v4(
+    where: {
+      id: { _eq: $action_id }
+      environment: { _eq: "production" }
+      rp_registration: { app_id: { _eq: $app_id } }
+    }
+    limit: 1
+  ) {
+    id
+    week: nullifiers_aggregate(where: { created_at: { _gte: $d0, _lt: $d7 } }) {
+      aggregate {
+        count
+      }
+    }
+    ...WorldIdActionTrendBuckets
+  }
+}

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/graphql/client/get-action-verifications.graphql
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/graphql/client/get-action-verifications.graphql
@@ -1,10 +1,4 @@
-# Powers the action detail page. Split into two operations so the 5s live-feed
-# poll only re-runs the feed selection, not the stats aggregates.
-
-# Live verifications feed (`nullifiers`, polled every 5s while on page 1) plus
-# the fields the page needs fresh on every tick. Each stored nullifier is one
-# unique verification for this action; replayed proofs do not add another row.
-# The headline stat and pagination both use `total`.
+# Split so the 5s feed poll does not refetch aggregates.
 query GetActionVerificationsFeed(
   $action_id: String!
   $app_id: String!
@@ -32,8 +26,7 @@ query GetActionVerificationsFeed(
         count
       }
     }
-    # id tie-breaker keeps the sort stable across pages when rows share a
-    # created_at timestamp.
+    # Stable tie-breaker for rows sharing a timestamp.
     nullifiers(
       limit: $limit
       offset: $offset
@@ -46,9 +39,6 @@ query GetActionVerificationsFeed(
   }
 }
 
-# "This week" count plus the per-day sparkline (b0..b6 driven by local-midnight
-# bounds from `weekBucketBounds`). Fetched once per view, not polled. `week` is
-# bounded to [d0, d7) so it matches the b0..b6 buckets exactly.
 query GetActionStats(
   $action_id: String!
   $app_id: String!

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/graphql/client/get-action-verifications.graphql
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page/graphql/client/get-action-verifications.graphql
@@ -2,9 +2,9 @@
 # poll only re-runs the feed selection, not the stats aggregates.
 
 # Live verifications feed (`nullifiers`, polled every 5s while on page 1) plus
-# the fields the page needs fresh on every tick. There is one nullifier row per
-# human for a given action, so "Total verifications" == "Unique humans"; the
-# stat and pagination both use `total`.
+# the fields the page needs fresh on every tick. Each stored nullifier is one
+# unique verification for this action; replayed proofs do not add another row.
+# The headline stat and pagination both use `total`.
 query GetActionVerificationsFeed(
   $action_id: String!
   $app_id: String!

--- a/web/tests/unit/pv3-r-world-id-action.test.tsx
+++ b/web/tests/unit/pv3-r-world-id-action.test.tsx
@@ -3,26 +3,70 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 
+const mockGetIsUserAllowedToUpdateApp = jest.fn();
+const mockRedirect = jest.fn();
+let mockPortalV3Enabled = true;
+
 jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
-  pickPortalVersion: async (v3: () => unknown) => v3(),
+  pickPortalVersion: async (v3: () => unknown, v2: () => unknown) =>
+    mockPortalV3Enabled ? v3() : v2(),
+}));
+jest.mock("@/lib/permissions", () => ({
+  getIsUserAllowedToUpdateApp: (...args: unknown[]) =>
+    mockGetIsUserAllowedToUpdateApp(...args),
+}));
+jest.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => mockRedirect(...args),
 }));
 jest.mock(
   "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page",
   () => ({
-    WorldIdActionDetailPage: () => <div data-testid="v3-world-id-action" />,
+    WorldIdActionDetailPage: (props: { canDelete: boolean }) => (
+      <div
+        data-testid="v3-world-id-action"
+        data-can-delete={String(props.canDelete)}
+      />
+    ),
   }),
 );
 import Page from "../../app/(portal)/teams/[teamId]/apps/[appId]/world-id/actions/[actionId]/page";
 
-it("renders the v3 action detail page", async () => {
-  render(
-    await Page({
-      params: Promise.resolve({
-        teamId: "team_1",
-        appId: "app_1",
-        actionId: "action_1",
-      }),
-    }),
-  );
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPortalV3Enabled = true;
+});
+
+const props = (
+  searchParams: Record<string, string | string[] | undefined> = {},
+) => ({
+  params: Promise.resolve({
+    teamId: "team_1",
+    appId: "app_1",
+    actionId: "action_1",
+  }),
+  searchParams: Promise.resolve(searchParams),
+});
+
+it("passes the current delete permission to the v3 detail page", async () => {
+  mockGetIsUserAllowedToUpdateApp.mockResolvedValue(false);
+
+  render(await Page(props()));
+
   expect(screen.getByTestId("v3-world-id-action")).toBeInTheDocument();
+  expect(screen.getByTestId("v3-world-id-action")).toHaveAttribute(
+    "data-can-delete",
+    "false",
+  );
+  expect(mockGetIsUserAllowedToUpdateApp).toHaveBeenCalledWith("app_1");
+});
+
+it("preserves legacy query params without querying the v3 permission", async () => {
+  mockPortalV3Enabled = false;
+
+  await Page(props({ foo: ["bar", "baz"], skipped: undefined }));
+
+  expect(mockRedirect).toHaveBeenCalledWith(
+    "/teams/team_1/apps/app_1/world-id-actions/action_1?foo=bar&foo=baz",
+  );
+  expect(mockGetIsUserAllowedToUpdateApp).not.toHaveBeenCalled();
 });

--- a/web/tests/unit/pv3-r-world-id-action.test.tsx
+++ b/web/tests/unit/pv3-r-world-id-action.test.tsx
@@ -1,0 +1,28 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/Actions/ActionId/page",
+  () => ({
+    WorldIdActionDetailPage: () => <div data-testid="v3-world-id-action" />,
+  }),
+);
+import Page from "../../app/(portal)/teams/[teamId]/apps/[appId]/world-id/actions/[actionId]/page";
+
+it("renders the v3 action detail page", async () => {
+  render(
+    await Page({
+      params: Promise.resolve({
+        teamId: "team_1",
+        appId: "app_1",
+        actionId: "action_1",
+      }),
+    }),
+  );
+  expect(screen.getByTestId("v3-world-id-action")).toBeInTheDocument();
+});


### PR DESCRIPTION
## What this PR does

- Adds the Portal v3 `/world-id/actions/[actionId]` detail route while preserving query parameters when Portal v2 falls back to the legacy route.
- Shows unique-verification totals, this-week totals, and weekly/all-time trends for an action.
- Polls the first verification-feed page every five seconds and keeps pagination stable with an ID tie-breaker.
- Keeps the stats and settings shell mounted while another feed page loads, so changing pages does not discard an in-progress settings edit.
- Preserves cached action content when polling or refetching fails and shows an unknown weekly value as `—` instead of a real zero.
- Schedules a trailing aggregate refresh when a feed update arrives inside the 60-second throttle window.
- Adds inline action settings and only renders deletion controls when the current user has server-backed update permission.
- Hides pagination for an empty feed and preserves the loading state during deletion navigation.
- Splits feed polling from aggregate GraphQL queries so five-second polls do not refetch trend statistics.

## Stack

#2096 → #2097 → **3/4 (this PR)** → #2099

## Validation

- `pnpm generate:graphql-types`
- `pnpm format:check`
- `pnpm typecheck --noEmit`
- `pnpm lint`
- Action-detail route unit tests
- Next.js production build on Tailwind 4
