### PR TITLE
feat(portal-v3): add the World ID overview

### DIFF
--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/world-id/page.tsx
@@ -1,0 +1,25 @@
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
+import { generateMetaTitle } from "@/lib/genarate-title";
+import { urls } from "@/lib/urls";
+import { WorldIdPage } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page";
+import { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+export const metadata: Metadata = {
+  title: generateMetaTitle({ left: "World ID" }),
+};
+
+export default async function Page(props: {
+  params: Promise<Record<string, string>>;
+  searchParams: Promise<Record<string, string>>;
+}) {
+  const params = await props.params;
+  const searchParams = await props.searchParams;
+  return pickPortalVersion(
+    () => <WorldIdPage params={params} searchParams={searchParams} />,
+    () =>
+      redirect(
+        urls.worldId40({ team_id: params.teamId, app_id: params.appId }),
+      ),
+  );
+}

--- a/web/lib/urls.ts
+++ b/web/lib/urls.ts
@@ -63,13 +63,6 @@ export const urls = {
   }): string =>
     `/teams/${params.team_id}/apps/${params.app_id}/world-id-actions/${params.action_id}/danger`,
 
-  worldIdActionDetail: (params: {
-    team_id: string;
-    app_id: string;
-    action_id: string;
-  }): string =>
-    `/teams/${params.team_id}/apps/${params.app_id}/world-id/actions/${params.action_id}`,
-
   createTeam: (): "/create-team" => "/create-team",
 
   signInWorldId: (params: { team_id: string; app_id?: string }): string =>

--- a/web/lib/urls.ts
+++ b/web/lib/urls.ts
@@ -2,27 +2,6 @@ type SignupParams = {
   invite_id?: string;
 };
 
-/**
- * Merge `searchParams` into `path`'s query string. Params already present in
- * the path take precedence; an empty `searchParams` returns the path untouched.
- * Used by the v3 route redirects so deep-link params survive uniformly.
- */
-export const appendSearchParams = (
-  path: string,
-  searchParams: Record<string, string>,
-): string => {
-  if (Object.keys(searchParams).length === 0) {
-    return path;
-  }
-
-  const [basePath, existingQuery] = path.split("?", 2);
-  const merged = new URLSearchParams(searchParams);
-  for (const [key, value] of new URLSearchParams(existingQuery)) {
-    merged.set(key, value);
-  }
-  return `${basePath}?${merged.toString()}`;
-};
-
 export const urls = {
   app: (params: { team_id: string; app_id?: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id || ""}`,
@@ -56,13 +35,6 @@ export const urls = {
 
   enableWorldId4: (params: { team_id: string; app_id: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id}?enableWorldId4=true`,
-
-  worldId: (params: {
-    team_id: string;
-    app_id: string;
-    tab?: "world-id-4-0";
-  }): string =>
-    `/teams/${params.team_id}/apps/${params.app_id}/world-id${params.tab ? `?tab=${params.tab}` : ""}`,
 
   worldId40: (params: { team_id: string; app_id: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id}/world-id-4-0`,

--- a/web/lib/urls.ts
+++ b/web/lib/urls.ts
@@ -2,6 +2,27 @@ type SignupParams = {
   invite_id?: string;
 };
 
+/**
+ * Merge `searchParams` into `path`'s query string. Params already present in
+ * the path take precedence; an empty `searchParams` returns the path untouched.
+ * Used by the v3 route redirects so deep-link params survive uniformly.
+ */
+export const appendSearchParams = (
+  path: string,
+  searchParams: Record<string, string>,
+): string => {
+  if (Object.keys(searchParams).length === 0) {
+    return path;
+  }
+
+  const [basePath, existingQuery] = path.split("?", 2);
+  const merged = new URLSearchParams(searchParams);
+  for (const [key, value] of new URLSearchParams(existingQuery)) {
+    merged.set(key, value);
+  }
+  return `${basePath}?${merged.toString()}`;
+};
+
 export const urls = {
   app: (params: { team_id: string; app_id?: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id || ""}`,
@@ -36,6 +57,13 @@ export const urls = {
   enableWorldId4: (params: { team_id: string; app_id: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id}?enableWorldId4=true`,
 
+  worldId: (params: {
+    team_id: string;
+    app_id: string;
+    tab?: "world-id-4-0";
+  }): string =>
+    `/teams/${params.team_id}/apps/${params.app_id}/world-id${params.tab ? `?tab=${params.tab}` : ""}`,
+
   worldId40: (params: { team_id: string; app_id: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id}/world-id-4-0`,
 
@@ -62,6 +90,13 @@ export const urls = {
     action_id: string;
   }): string =>
     `/teams/${params.team_id}/apps/${params.app_id}/world-id-actions/${params.action_id}/danger`,
+
+  worldIdActionDetail: (params: {
+    team_id: string;
+    app_id: string;
+    action_id: string;
+  }): string =>
+    `/teams/${params.team_id}/apps/${params.app_id}/world-id/actions/${params.action_id}`,
 
   createTeam: (): "/create-team" => "/create-team",
 

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionCard/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionCard/index.tsx
@@ -31,7 +31,7 @@ export const ActionCard = (props: {
 
   return (
     <Link
-      href={urls.worldIdActionDetail({
+      href={urls.worldIdAction({
         team_id: props.teamId,
         app_id: props.appId,
         action_id: action.id,

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionCard/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionCard/index.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { relativeTimeShort } from "@/lib/relative-time-short";
+import { urls } from "@/lib/urls";
+import Link from "next/link";
+import { Sparkline } from "../../common/Sparkline";
+
+export type ActionCardItem = {
+  id: string;
+  action: string;
+  description: string;
+  total: number;
+  latestAt: string | null;
+  points: number[];
+};
+
+export const ActionCard = (props: {
+  teamId: string;
+  appId: string;
+  action: ActionCardItem;
+}) => {
+  const { action } = props;
+  const footer =
+    action.total > 0 && action.latestAt
+      ? `${action.total.toLocaleString()} uses · last ${relativeTimeShort(
+          action.latestAt,
+        )}`
+      : `${action.total.toLocaleString()} uses`;
+
+  return (
+    <Link
+      href={urls.worldIdActionDetail({
+        team_id: props.teamId,
+        app_id: props.appId,
+        action_id: action.id,
+      })}
+      className="flex min-h-[220px] flex-col justify-between gap-4 rounded-[10px] border border-portal-border bg-white p-5 transition-shadow hover:shadow-portal-card"
+    >
+      <div className="flex flex-col gap-1">
+        <span className="font-ibm text-13 text-portal-heading">
+          {action.action}
+        </span>
+        {action.description ? (
+          <span className="font-world text-13 text-portal-muted">
+            {action.description}
+          </span>
+        ) : null}
+      </div>
+      <Sparkline
+        points={action.points}
+        className="h-12 w-full text-portal-heading"
+        ariaLabel={`Verifications for ${action.action}`}
+      />
+      <span className="font-world text-12 text-portal-muted">{footer}</span>
+    </Link>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionCard/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionCard/index.tsx
@@ -20,12 +20,14 @@ export const ActionCard = (props: {
   action: ActionCardItem;
 }) => {
   const { action } = props;
+  const verificationLabel =
+    action.total === 1 ? "unique verification" : "unique verifications";
   const footer =
     action.total > 0 && action.latestAt
-      ? `${action.total.toLocaleString()} uses · last ${relativeTimeShort(
+      ? `${action.total.toLocaleString()} ${verificationLabel} · last ${relativeTimeShort(
           action.latestAt,
         )}`
-      : `${action.total.toLocaleString()} uses`;
+      : `${action.total.toLocaleString()} ${verificationLabel}`;
 
   return (
     <Link

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionsGrid/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionsGrid/index.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { CreateActionDialogV4 } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/page/CreateActionDialogV4";
+import { useState } from "react";
+import { ActionCard, ActionCardItem } from "../ActionCard";
+
+export const ActionsGrid = (props: {
+  actions: ActionCardItem[];
+  teamId: string;
+  appId: string;
+  search: string;
+  initialDialogOpen?: boolean;
+  onActionsChanged: () => void;
+}) => {
+  const [dialogOpen, setDialogOpen] = useState(
+    props.initialDialogOpen ?? false,
+  );
+
+  const query = props.search.toLowerCase();
+  const filtered = props.actions.filter((action) =>
+    `${action.action} ${action.description}`.toLowerCase().includes(query),
+  );
+
+  const handleDialogClose = (success?: boolean) => {
+    setDialogOpen(false);
+    if (success) {
+      props.onActionsChanged();
+    }
+  };
+
+  return (
+    <>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {filtered.map((action) => (
+          <ActionCard
+            key={action.id}
+            teamId={props.teamId}
+            appId={props.appId}
+            action={action}
+          />
+        ))}
+
+        <button
+          type="button"
+          onClick={() => setDialogOpen(true)}
+          className="flex min-h-[220px] flex-col items-center justify-center gap-3 rounded-[10px] border border-dashed border-portal-border text-portal-muted transition-colors hover:border-portal-ink hover:text-portal-ink"
+          aria-label="Create action"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            className="size-6"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+          >
+            <path d="M12 5v14M5 12h14" strokeLinecap="round" />
+          </svg>
+          <span className="font-world text-13">Create action</span>
+        </button>
+      </div>
+
+      {dialogOpen ? (
+        <CreateActionDialogV4 open={dialogOpen} onClose={handleDialogClose} />
+      ) : null}
+    </>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/HeroCard/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/HeroCard/index.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { CopyButton } from "@/components/CopyButton";
+import type { TrendPeriod } from "@/lib/day-buckets";
+import { PeriodSelector } from "../../common/PeriodSelector";
+import { TrendSparkline } from "../../common/TrendSparkline";
+import type { TrendSparklineState } from "../../common/TrendSparkline";
+
+const HeroStat = (props: { label: string; value: number }) => (
+  <div className="flex flex-col gap-1">
+    <span className="font-world text-13 text-portal-muted">{props.label}</span>
+    <span className="font-world text-26 font-medium text-portal-heading">
+      {props.value.toLocaleString()}
+    </span>
+  </div>
+);
+
+export const HeroCard = (props: {
+  name: string;
+  appId: string;
+  unique: number;
+  week: number;
+  timePeriod: TrendPeriod;
+  onTimePeriodChange: (period: TrendPeriod) => void;
+  trendRangeLabel: string;
+  trendState: TrendSparklineState;
+}) => (
+  <div className="rounded-[10px] border border-portal-border bg-white p-6 shadow-portal-card">
+    <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-world text-19 font-medium text-portal-heading">
+          {props.name}
+        </span>
+        <span className="flex items-center gap-1 rounded-8 bg-portal-canvas px-2 py-1">
+          <span className="font-ibm text-12 text-portal-muted">
+            {props.appId}
+          </span>
+          <CopyButton
+            fieldName="App ID"
+            fieldValue={props.appId}
+            className="text-portal-muted"
+          />
+        </span>
+      </div>
+      <PeriodSelector
+        timePeriod={props.timePeriod}
+        onTimePeriodChange={props.onTimePeriodChange}
+      />
+    </div>
+
+    <div className="mt-6 flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+      <div className="flex flex-wrap gap-x-12 gap-y-6">
+        <HeroStat label="Unique humans" value={props.unique} />
+        <HeroStat label="This week" value={props.week} />
+      </div>
+      <TrendSparkline
+        state={props.trendState}
+        rangeLabel={props.trendRangeLabel}
+        variant="hero"
+      />
+    </div>
+  </div>
+);

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/HeroCard/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/HeroCard/index.tsx
@@ -18,7 +18,7 @@ const HeroStat = (props: { label: string; value: number }) => (
 export const HeroCard = (props: {
   name: string;
   appId: string;
-  unique: number;
+  uniqueVerifications: number;
   week: number;
   timePeriod: TrendPeriod;
   onTimePeriodChange: (period: TrendPeriod) => void;
@@ -50,7 +50,10 @@ export const HeroCard = (props: {
 
     <div className="mt-6 flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
       <div className="flex flex-wrap gap-x-12 gap-y-6">
-        <HeroStat label="Unique humans" value={props.unique} />
+        <HeroStat
+          label="Unique verifications"
+          value={props.uniqueVerifications}
+        />
         <HeroStat label="This week" value={props.week} />
       </div>
       <TrendSparkline

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/RegisterRpEmptyState/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/RegisterRpEmptyState/index.tsx
@@ -7,27 +7,16 @@ import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
-// Apps without an RP registration can't have v4 actions yet. Reuse the existing
-// create-app wizard opened at its enable step for this app (it supports
-// `initialStep` + `appId` for exactly this case) rather than rebuilding the
-// multi-step signer-key flow.
 export const RegisterRpEmptyState = (props: {
   appId: string;
   initialOpen?: boolean;
-  // The backend rejects staging registration with `staging_not_supported`, so
-  // the Enable CTA would be a guaranteed dead-end for staging apps.
   isStaging: boolean;
   onRegistered: () => void;
-  // RP-less apps can still have World ID 3.0 legacy actions; without this link
-  // they'd have no navigation to those pages at all.
   legacyActionsHref?: string;
 }) => {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  // Staging apps can't register an RP (the backend rejects them), so the enable
-  // flow is suppressed for them; everyone else can open it and the register_rp
-  // action enforces owner/admin server-side.
   const canEnable = !props.isStaging;
   const [open, setOpen] = useState(Boolean(props.initialOpen) && canEnable);
 
@@ -39,9 +28,6 @@ export const RegisterRpEmptyState = (props: {
     setOpen(false);
     props.onRegistered();
 
-    // Strip the `enableWorldId4` param so the World ID tab link returns to its
-    // clean state. Otherwise the URL keeps the param and clicking the tab again
-    // is a no-op (same URL), leaving the user unable to re-open the flow.
     if (searchParams.has("enableWorldId4")) {
       const params = new URLSearchParams(searchParams);
       params.delete("enableWorldId4");

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/RegisterRpEmptyState/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/RegisterRpEmptyState/index.tsx
@@ -14,9 +14,6 @@ import { useEffect, useState } from "react";
 export const RegisterRpEmptyState = (props: {
   appId: string;
   initialOpen?: boolean;
-  // The register_rp Hasura action rejects non-OWNER/ADMIN callers with
-  // `unauthorized`, so members get an explanation instead of a dead-end CTA.
-  canRegisterRp: boolean;
   // The backend rejects staging registration with `staging_not_supported`, so
   // the Enable CTA would be a guaranteed dead-end for staging apps.
   isStaging: boolean;
@@ -28,12 +25,12 @@ export const RegisterRpEmptyState = (props: {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const canEnable = props.canRegisterRp && !props.isStaging;
+  // Staging apps can't register an RP (the backend rejects them), so the enable
+  // flow is suppressed for them; everyone else can open it and the register_rp
+  // action enforces owner/admin server-side.
+  const canEnable = !props.isStaging;
   const [open, setOpen] = useState(Boolean(props.initialOpen) && canEnable);
 
-  // Auto-open only for users who can actually register (mirrors the old
-  // migration banner's gating). The effect covers the Auth0 user resolving
-  // after mount, which flips `canRegisterRp`.
   useEffect(() => {
     if (props.initialOpen && canEnable) setOpen(true);
   }, [props.initialOpen, canEnable]);
@@ -74,10 +71,6 @@ export const RegisterRpEmptyState = (props: {
         >
           Enable World ID 4.0
         </DecoratedButton>
-      ) : !props.isStaging ? (
-        <Typography variant={TYPOGRAPHY.R4} className="text-grey-400">
-          Ask a team owner or admin to enable World ID 4.0
-        </Typography>
       ) : null}
 
       {props.legacyActionsHref ? (

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/RegisterRpEmptyState/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/RegisterRpEmptyState/index.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { DecoratedButton } from "@/components/DecoratedButton";
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { CreateAppDialogV4 } from "@/scenes/PortalV3/layout/CreateAppDialog/index-v4";
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+// Apps without an RP registration can't have v4 actions yet. Reuse the existing
+// create-app wizard opened at its enable step for this app (it supports
+// `initialStep` + `appId` for exactly this case) rather than rebuilding the
+// multi-step signer-key flow.
+export const RegisterRpEmptyState = (props: {
+  appId: string;
+  initialOpen?: boolean;
+  // The register_rp Hasura action rejects non-OWNER/ADMIN callers with
+  // `unauthorized`, so members get an explanation instead of a dead-end CTA.
+  canRegisterRp: boolean;
+  // The backend rejects staging registration with `staging_not_supported`, so
+  // the Enable CTA would be a guaranteed dead-end for staging apps.
+  isStaging: boolean;
+  onRegistered: () => void;
+  // RP-less apps can still have World ID 3.0 legacy actions; without this link
+  // they'd have no navigation to those pages at all.
+  legacyActionsHref?: string;
+}) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const canEnable = props.canRegisterRp && !props.isStaging;
+  const [open, setOpen] = useState(Boolean(props.initialOpen) && canEnable);
+
+  // Auto-open only for users who can actually register (mirrors the old
+  // migration banner's gating). The effect covers the Auth0 user resolving
+  // after mount, which flips `canRegisterRp`.
+  useEffect(() => {
+    if (props.initialOpen && canEnable) setOpen(true);
+  }, [props.initialOpen, canEnable]);
+
+  const closeDialog = () => {
+    setOpen(false);
+    props.onRegistered();
+
+    // Strip the `enableWorldId4` param so the World ID tab link returns to its
+    // clean state. Otherwise the URL keeps the param and clicking the tab again
+    // is a no-op (same URL), leaving the user unable to re-open the flow.
+    if (searchParams.has("enableWorldId4")) {
+      const params = new URLSearchParams(searchParams);
+      params.delete("enableWorldId4");
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, {
+        scroll: false,
+      });
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-6 py-20 text-center">
+      <div className="flex flex-col items-center gap-2">
+        <Typography variant={TYPOGRAPHY.H6}>Set up World ID 4.0</Typography>
+        <Typography variant={TYPOGRAPHY.R4} className="max-w-md text-grey-500">
+          {props.isStaging
+            ? "World ID 4.0 isn't available for staging apps."
+            : "Register a Relying Party to start requesting World ID verifications for this app."}
+        </Typography>
+      </div>
+
+      {canEnable ? (
+        <DecoratedButton
+          type="button"
+          variant="primary"
+          onClick={() => setOpen(true)}
+        >
+          Enable World ID 4.0
+        </DecoratedButton>
+      ) : !props.isStaging ? (
+        <Typography variant={TYPOGRAPHY.R4} className="text-grey-400">
+          Ask a team owner or admin to enable World ID 4.0
+        </Typography>
+      ) : null}
+
+      {props.legacyActionsHref ? (
+        <Link
+          href={props.legacyActionsHref}
+          className="font-world text-13 text-portal-muted underline transition-colors hover:text-portal-ink"
+        >
+          Looking for your World ID 3.0 legacy actions?
+        </Link>
+      ) : null}
+
+      {open ? (
+        <CreateAppDialogV4
+          open={open}
+          initialStep="enable-world-id-4-0"
+          appId={props.appId}
+          onClose={closeDialog}
+        />
+      ) : null}
+    </div>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/WorldId40Pane/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/WorldId40Pane/index.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { CopyButton } from "@/components/CopyButton";
+import { DecoratedButton } from "@/components/DecoratedButton";
+import { Notification } from "@/components/Notification";
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { useRetryRpMutation } from "@/scenes/common/Teams/TeamId/Apps/AppId/WorldId40/page/graphql/client/retry-rp.generated";
+import { RotateSignerKeyDialog } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId40/page/RotateSignerKeyDialog";
+import { SwitchToSelfManagedDialog } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId40/page/SwitchToSelfManagedDialog";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "react-toastify";
+
+export type RpStatus = "pending" | "registered" | "failed" | "deactivated";
+
+const FieldRow = (props: { label: string; value: string; copy?: boolean }) => (
+  <div className="flex items-center justify-between">
+    <div className="flex flex-col gap-0.5">
+      <Typography variant={TYPOGRAPHY.B4} className="text-grey-500">
+        {props.label}
+      </Typography>
+      <Typography variant={TYPOGRAPHY.B3} className="text-grey-900">
+        {props.value}
+      </Typography>
+    </div>
+    {props.copy ? (
+      <CopyButton
+        fieldName={props.label}
+        fieldValue={props.value}
+        className="text-grey-500"
+      />
+    ) : null}
+  </div>
+);
+
+// The World ID 4.0 pane of the World ID page. Adapted from the standalone
+// WorldId40Content: the Production/Staging status rows are intentionally dropped
+// (they carry no actionable signal); a failed registration surfaces a banner +
+// Retry instead, and status is polled only while pending.
+export const WorldId40Pane = (props: {
+  appId: string;
+  rpId: string;
+  initialStatus: RpStatus;
+  initialStagingStatus: RpStatus | null;
+  mode: string;
+  createdAt: string;
+  // Re-runs the parent's Apollo overview query. `mode` comes from that query
+  // (client cache), so router.refresh() would NOT update it — a stale "managed"
+  // mode would re-enable the managed-only controls once polling settles.
+  onRpChanged?: () => void;
+}) => {
+  const [retryRpMutation] = useRetryRpMutation();
+  const [status, setStatus] = useState<RpStatus>(props.initialStatus);
+  const [stagingStatus, setStagingStatus] = useState<RpStatus | null>(
+    props.initialStagingStatus,
+  );
+  const [isRotateOpen, setIsRotateOpen] = useState(false);
+  const [isSwitchOpen, setIsSwitchOpen] = useState(false);
+  const [retryingEnvironment, setRetryingEnvironment] = useState<
+    "production" | "staging" | null
+  >(null);
+
+  // Guards against a slow status fetch piling up behind the 5s poll ticks.
+  const statusFetchInFlight = useRef(false);
+
+  const fetchStatus = useCallback(async () => {
+    if (statusFetchInFlight.current) {
+      return;
+    }
+    statusFetchInFlight.current = true;
+    try {
+      const response = await fetch(`/api/v4/rp-status/${props.rpId}`, {
+        signal: AbortSignal.timeout(4000),
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setStatus(data.production_status as RpStatus);
+        setStagingStatus(
+          data.staging_status == null
+            ? null
+            : (data.staging_status as RpStatus),
+        );
+      }
+    } catch {
+      // Keep the current status on error.
+    } finally {
+      statusFetchInFlight.current = false;
+    }
+  }, [props.rpId]);
+
+  // Poll every 5 seconds only while the registration is still settling; skip
+  // ticks while the tab is hidden.
+  useEffect(() => {
+    if (status === "pending" || stagingStatus === "pending") {
+      const interval = setInterval(() => {
+        if (!document.hidden) {
+          void fetchStatus();
+        }
+      }, 5000);
+      return () => clearInterval(interval);
+    }
+  }, [status, stagingStatus, fetchStatus]);
+
+  const handleRetry = async (environment: "production" | "staging") => {
+    setRetryingEnvironment(environment);
+    try {
+      const { data } = await retryRpMutation({
+        variables: { rp_id: props.rpId, environment },
+      });
+      if (data?.retry_rp?.success) {
+        if (environment === "production") {
+          setStatus("pending");
+        } else {
+          setStagingStatus("pending");
+        }
+      }
+    } catch {
+      toast.error("Failed to retry registration — please try again");
+    } finally {
+      setRetryingEnvironment(null);
+    }
+  };
+
+  const isActive = status === "registered";
+  const isSelfManaged = props.mode === "self_managed";
+  const modeLabel = props.mode === "managed" ? "Managed" : "Self-Managed";
+  const formattedDate = new Date(props.createdAt).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+  return (
+    <div className="flex max-w-[580px] flex-col gap-y-8 py-2">
+      <Typography variant={TYPOGRAPHY.B3} className="text-grey-500">
+        Registered {formattedDate}
+      </Typography>
+
+      {(["production", "staging"] as const).map((environment) => {
+        const environmentStatus =
+          environment === "production" ? status : stagingStatus;
+        if (environmentStatus !== "failed") {
+          return null;
+        }
+
+        const isRetrying = retryingEnvironment === environment;
+        return (
+          <Notification
+            key={environment}
+            variant="warning"
+            className="items-start"
+          >
+            <div className="flex w-full items-center justify-between gap-4">
+              <div>
+                <Typography as="p" variant={TYPOGRAPHY.S3}>
+                  {environment === "production" ? "Production" : "Staging"}{" "}
+                  registration failed
+                </Typography>
+                <Typography
+                  as="p"
+                  variant={TYPOGRAPHY.S4}
+                  className="mt-1 text-grey-500"
+                >
+                  Retry the on-chain registration for this RP.
+                </Typography>
+              </div>
+              <DecoratedButton
+                type="button"
+                variant="primary"
+                className="h-8 shrink-0 rounded-full px-4 py-0 text-xs"
+                disabled={isRetrying}
+                onClick={() => void handleRetry(environment)}
+              >
+                {isRetrying ? "Retrying..." : "Try again"}
+              </DecoratedButton>
+            </div>
+          </Notification>
+        );
+      })}
+
+      <FieldRow label="APP ID (Legacy)" value={props.appId} copy />
+      <FieldRow label="RP ID" value={props.rpId} copy />
+      <FieldRow label="Management Mode" value={modeLabel} />
+
+      <div className="mt-2 flex flex-col gap-4">
+        <Typography variant={TYPOGRAPHY.S2} className="text-gray-900">
+          Key
+        </Typography>
+        <div className="rounded-xl border border-grey-100 p-6">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex flex-col gap-1">
+              <Typography variant={TYPOGRAPHY.S2}>Reset signer key</Typography>
+              <Typography variant={TYPOGRAPHY.B3} className="text-grey-500">
+                This will create a new signer key and disable the existing key
+              </Typography>
+            </div>
+            <DecoratedButton
+              type="button"
+              variant="secondary"
+              disabled={!isActive || isSelfManaged}
+              className="h-8 rounded-full px-4 py-0 text-xs"
+              onClick={() => setIsRotateOpen(true)}
+            >
+              Reset
+            </DecoratedButton>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-2 flex flex-col gap-y-6">
+        <Typography variant={TYPOGRAPHY.S2} className="text-gray-900">
+          Danger zone
+        </Typography>
+        <div className="rounded-[10px] border border-grey-100 px-6 py-4">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex flex-col gap-1">
+              <Typography variant={TYPOGRAPHY.S2}>
+                Switch to Self-Managed
+              </Typography>
+              <Typography variant={TYPOGRAPHY.B3} className="text-grey-500">
+                Move this RP to a self-managed configuration
+              </Typography>
+            </div>
+            <DecoratedButton
+              type="button"
+              variant="danger"
+              disabled={!isActive || isSelfManaged}
+              className="h-8 shrink-0 rounded-full px-4 text-[13px] font-semibold"
+              onClick={() => setIsSwitchOpen(true)}
+            >
+              Switch
+            </DecoratedButton>
+          </div>
+        </div>
+      </div>
+
+      <RotateSignerKeyDialog
+        open={isRotateOpen}
+        onClose={() => setIsRotateOpen(false)}
+        appId={props.appId}
+        onSuccess={() => setStatus("pending")}
+      />
+
+      <SwitchToSelfManagedDialog
+        open={isSwitchOpen}
+        onClose={() => setIsSwitchOpen(false)}
+        appId={props.appId}
+        onSuccess={() => {
+          setStatus("pending");
+          props.onRpChanged?.();
+        }}
+      />
+    </div>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/WorldId40Pane/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/WorldId40Pane/index.tsx
@@ -32,10 +32,6 @@ const FieldRow = (props: { label: string; value: string; copy?: boolean }) => (
   </div>
 );
 
-// The World ID 4.0 pane of the World ID page. Adapted from the standalone
-// WorldId40Content: the Production/Staging status rows are intentionally dropped
-// (they carry no actionable signal); a failed registration surfaces a banner +
-// Retry instead, and status is polled only while pending.
 export const WorldId40Pane = (props: {
   appId: string;
   rpId: string;
@@ -43,9 +39,6 @@ export const WorldId40Pane = (props: {
   initialStagingStatus: RpStatus | null;
   mode: string;
   createdAt: string;
-  // Re-runs the parent's Apollo overview query. `mode` comes from that query
-  // (client cache), so router.refresh() would NOT update it — a stale "managed"
-  // mode would re-enable the managed-only controls once polling settles.
   onRpChanged?: () => void;
 }) => {
   const [retryRpMutation] = useRetryRpMutation();
@@ -59,7 +52,6 @@ export const WorldId40Pane = (props: {
     "production" | "staging" | null
   >(null);
 
-  // Guards against a slow status fetch piling up behind the 5s poll ticks.
   const statusFetchInFlight = useRef(false);
 
   const fetchStatus = useCallback(async () => {
@@ -73,22 +65,30 @@ export const WorldId40Pane = (props: {
       });
       if (response.ok) {
         const data = await response.json();
-        setStatus(data.production_status as RpStatus);
-        setStagingStatus(
+        const nextStatus = data.production_status as RpStatus;
+        const nextStagingStatus =
           data.staging_status == null
             ? null
-            : (data.staging_status as RpStatus),
-        );
+            : (data.staging_status as RpStatus);
+        setStatus(nextStatus);
+        setStagingStatus(nextStagingStatus);
+
+        // Sync the parent after reconciling DB status with the chain.
+        if (nextStatus !== props.initialStatus) {
+          props.onRpChanged?.();
+        }
       }
     } catch {
-      // Keep the current status on error.
     } finally {
       statusFetchInFlight.current = false;
     }
-  }, [props.rpId]);
+  }, [props.initialStatus, props.onRpChanged, props.rpId]);
 
-  // Poll every 5 seconds only while the registration is still settling; skip
-  // ticks while the tab is hidden.
+  // Reconcile stale DB status with the chain on mount.
+  useEffect(() => {
+    void fetchStatus();
+  }, [fetchStatus]);
+
   useEffect(() => {
     if (status === "pending" || stagingStatus === "pending") {
       const interval = setInterval(() => {

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/WorldIdTabs/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/WorldIdTabs/index.tsx
@@ -27,6 +27,7 @@ export const WorldIdTabs = (props: {
       <button
         type="button"
         className={tabClass(props.tab === "actions")}
+        aria-current={props.tab === "actions" ? "true" : undefined}
         onClick={() => props.onTabChange("actions")}
       >
         Actions
@@ -34,6 +35,7 @@ export const WorldIdTabs = (props: {
       <button
         type="button"
         className={tabClass(props.tab === "world-id-4-0")}
+        aria-current={props.tab === "world-id-4-0" ? "true" : undefined}
         onClick={() => props.onTabChange("world-id-4-0")}
       >
         World ID 4.0
@@ -51,8 +53,9 @@ export const WorldIdTabs = (props: {
           value={props.search}
           onChange={(e) => props.onSearchChange(e.target.value)}
           label=""
+          aria-label="Search actions"
           placeholder="Search actions"
-          className="w-full text-sm"
+          className="h-10 w-full py-0 text-sm"
           addOnLeft={<SearchIcon className="mx-2 text-grey-400" />}
         />
       </div>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/WorldIdTabs/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/WorldIdTabs/index.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { SearchIcon } from "@/components/Icons/SearchIcon";
+import { Input } from "@/components/Input";
+import clsx from "clsx";
+import Link from "next/link";
+
+export type WorldIdTab = "actions" | "world-id-4-0";
+
+const tabClass = (active: boolean) =>
+  clsx(
+    "border-b-2 px-1 pb-3 font-world text-13 transition-colors",
+    active
+      ? "border-portal-heading text-portal-heading"
+      : "border-transparent text-portal-muted hover:text-portal-ink",
+  );
+
+export const WorldIdTabs = (props: {
+  tab: WorldIdTab;
+  onTabChange: (tab: WorldIdTab) => void;
+  legacyActionsHref?: string;
+  search: string;
+  onSearchChange: (value: string) => void;
+}) => (
+  <div className="flex flex-wrap items-end justify-between gap-2 border-b border-portal-border">
+    <div className="flex items-center gap-6">
+      <button
+        type="button"
+        className={tabClass(props.tab === "actions")}
+        onClick={() => props.onTabChange("actions")}
+      >
+        Actions
+      </button>
+      <button
+        type="button"
+        className={tabClass(props.tab === "world-id-4-0")}
+        onClick={() => props.onTabChange("world-id-4-0")}
+      >
+        World ID 4.0
+      </button>
+      {props.legacyActionsHref ? (
+        <Link href={props.legacyActionsHref} className={tabClass(false)}>
+          World ID 3.0 Legacy
+        </Link>
+      ) : null}
+    </div>
+
+    {props.tab === "actions" ? (
+      <div className="w-full pb-2 sm:w-64">
+        <Input
+          value={props.search}
+          onChange={(e) => props.onSearchChange(e.target.value)}
+          label=""
+          placeholder="Search actions"
+          className="w-full text-sm"
+          addOnLeft={<SearchIcon className="mx-2 text-grey-400" />}
+        />
+      </div>
+    ) : null}
+  </div>
+);

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/index.tsx
@@ -178,7 +178,10 @@ export const WorldIdPage = (props: {
   // Hero totals are summed client-side from the per-action aggregates: the
   // per-action counts use the same filters an app-level aggregate would, and
   // every nullifier row belongs to exactly one action.
-  const total = actionItems.reduce((sum, action) => sum + action.total, 0);
+  const uniqueVerifications = actionItems.reduce(
+    (sum, action) => sum + action.total,
+    0,
+  );
   const week = weeklyHeroPoints.reduce((sum, count) => sum + count, 0);
 
   return (
@@ -188,7 +191,7 @@ export const WorldIdPage = (props: {
       <HeroCard
         name={name}
         appId={appId}
-        unique={total}
+        uniqueVerifications={uniqueVerifications}
         week={week}
         timePeriod={timePeriod}
         onTimePeriodChange={setTimePeriod}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/index.tsx
@@ -23,8 +23,6 @@ import { RegisterRpEmptyState } from "./RegisterRpEmptyState";
 import { WorldId40Pane, type RpStatus } from "./WorldId40Pane";
 import { WorldIdTab, WorldIdTabs } from "./WorldIdTabs";
 
-// Compact ban notice mirroring the old dashboard's BanStatusSection; opens the
-// shared BanMessageDialog (mounted alongside) via its jotai atom.
 const BanBanner = () => {
   const [, setIsOpened] = useAtom(banMessageDialogOpenedAtom);
 
@@ -63,10 +61,7 @@ export const WorldIdPage = (props: {
   const [search, setSearch] = useState("");
   const [timePeriod, setTimePeriod] = useState<TrendPeriod>("weekly");
 
-  // The overview query both consumes the weekly bucket variables and is the
-  // source of the RP's created_at (which drives the all-time window), so
-  // created_at is mirrored through state to break the cycle. The trend hook
-  // falls back to the weekly window until it's set.
+  // RP creation time determines the all-time query window.
   const [rpCreatedAt, setRpCreatedAt] = useState<string>();
   const trend = useTrendWindow({ createdAt: rpCreatedAt, timePeriod });
 
@@ -96,6 +91,9 @@ export const WorldIdPage = (props: {
     skip: timePeriod !== "all-time" || !appId || !rpCreatedAt,
   });
 
+  // Apollo exposes refetch failures through query error state.
+  const refetchOverview = () => void refetch().catch(() => {});
+
   if (loading) {
     return (
       <SizingWrapper className="flex flex-col gap-8 py-8">
@@ -107,8 +105,7 @@ export const WorldIdPage = (props: {
     );
   }
 
-  // Only hard-fail without cached data: a failed refetch (e.g. after closing
-  // the enable dialog) sets `error` while `data` is still valid.
+  // Preserve cached content when a refetch fails.
   if (error && !data) {
     return (
       <SizingWrapper className="py-8">
@@ -143,7 +140,7 @@ export const WorldIdPage = (props: {
           appId={appId}
           initialOpen={props.searchParams.enableWorldId4 === "true"}
           isStaging={app.is_staging}
-          onRegistered={() => refetch()}
+          onRegistered={refetchOverview}
           legacyActionsHref={legacyActionsHref}
         />
       </SizingWrapper>
@@ -159,8 +156,6 @@ export const WorldIdPage = (props: {
     points: trendPoints(action),
   }));
 
-  // The weekly hero trend reuses the per-action daily buckets. All time uses a
-  // separate app-level query so action-card sparklines remain weekly.
   const weeklyHeroPoints = Array.from({ length: 7 }, (_, day) =>
     actionItems.reduce((sum, action) => sum + (action.points[day] ?? 0), 0),
   );
@@ -172,12 +167,10 @@ export const WorldIdPage = (props: {
     error: timePeriod === "all-time" && Boolean(appTrendError),
     points: heroPoints,
     labels: trend.labels,
-    onRetry: () => void refetchAppTrend(),
+    onRetry: () => void refetchAppTrend().catch(() => {}),
   });
 
-  // Hero totals are summed client-side from the per-action aggregates: the
-  // per-action counts use the same filters an app-level aggregate would, and
-  // every nullifier row belongs to exactly one action.
+  // Each nullifier belongs to exactly one action.
   const uniqueVerifications = actionItems.reduce(
     (sum, action) => sum + action.total,
     0,
@@ -215,7 +208,7 @@ export const WorldIdPage = (props: {
             appId={appId}
             search={search}
             initialDialogOpen={props.searchParams.createAction === "true"}
-            onActionsChanged={() => refetch()}
+            onActionsChanged={refetchOverview}
           />
         ) : (
           <WorldId40Pane
@@ -227,7 +220,7 @@ export const WorldIdPage = (props: {
             }
             mode={rp.mode as string}
             createdAt={rp.created_at}
-            onRpChanged={() => refetch()}
+            onRpChanged={refetchOverview}
           />
         )}
       </div>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/index.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { Button } from "@/components/Button";
+import { ErrorPage } from "@/components/ErrorPage";
+import { AlertIcon } from "@/components/Icons/AlertIcon";
+import { SizingWrapper } from "@/components/SizingWrapper";
+import { Role_Enum } from "@/graphql/graphql";
+import { trendPoints, type TrendPeriod } from "@/lib/day-buckets";
+import { Auth0SessionUser } from "@/lib/types";
+import { urls } from "@/lib/urls";
+import { checkUserPermissions } from "@/lib/utils";
+import {
+  buildTrendState,
+  useTrendWindow,
+} from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/common/use-trend-window";
+import { BanMessageDialog } from "@/scenes/PortalV3/Teams/TeamId/Apps/common/BanMessageDialog";
+import { banMessageDialogOpenedAtom } from "@/scenes/common/Teams/TeamId/Apps/common/BanMessageDialog/atoms";
+import { useGetWorldIdAppTrendQuery } from "@/scenes/common/Teams/TeamId/Apps/AppId/WorldId/graphql/client/get-world-id-trends.generated";
+import { useGetWorldIdOverviewQuery } from "@/scenes/common/Teams/TeamId/Apps/AppId/WorldId/page/graphql/client/get-world-id-overview.generated";
+import { useUser } from "@auth0/nextjs-auth0/client";
+import { useAtom } from "jotai";
+import { useEffect, useState } from "react";
+import Skeleton from "react-loading-skeleton";
+import { ActionsGrid } from "./ActionsGrid";
+import { HeroCard } from "./HeroCard";
+import { RegisterRpEmptyState } from "./RegisterRpEmptyState";
+import { WorldId40Pane, type RpStatus } from "./WorldId40Pane";
+import { WorldIdTab, WorldIdTabs } from "./WorldIdTabs";
+
+// Compact ban notice mirroring the old dashboard's BanStatusSection; opens the
+// shared BanMessageDialog (mounted alongside) via its jotai atom.
+const BanBanner = () => {
+  const [, setIsOpened] = useAtom(banMessageDialogOpenedAtom);
+
+  return (
+    <>
+      <div className="flex items-center gap-3 rounded-[10px] border border-system-error-200 bg-system-error-50 px-5 py-3 text-system-error-600">
+        <AlertIcon className="shrink-0 text-system-error-600" />
+        <span className="min-w-0 flex-1 font-world text-13 leading-[1.3]">
+          Your app was banned, users cannot access it anymore
+        </span>
+
+        <Button
+          type="button"
+          onClick={() => setIsOpened(true)}
+          className="shrink-0 font-world text-13 font-medium text-system-error-600 transition-colors hover:text-system-error-700"
+        >
+          More Information
+        </Button>
+      </div>
+
+      <BanMessageDialog />
+    </>
+  );
+};
+
+export const WorldIdPage = (props: {
+  params: Record<string, string>;
+  searchParams: Record<string, string>;
+}) => {
+  const teamId = props.params.teamId ?? "";
+  const appId = props.params.appId ?? "";
+  const { user } = useUser() as Auth0SessionUser;
+
+  const [tab, setTab] = useState<WorldIdTab>(
+    props.searchParams.tab === "world-id-4-0" ? "world-id-4-0" : "actions",
+  );
+  const [search, setSearch] = useState("");
+  const [timePeriod, setTimePeriod] = useState<TrendPeriod>("weekly");
+
+  // The overview query both consumes the weekly bucket variables and is the
+  // source of the RP's created_at (which drives the all-time window), so
+  // created_at is mirrored through state to break the cycle. The trend hook
+  // falls back to the weekly window until it's set.
+  const [rpCreatedAt, setRpCreatedAt] = useState<string>();
+  const trend = useTrendWindow({ createdAt: rpCreatedAt, timePeriod });
+
+  const { data, loading, error, refetch } = useGetWorldIdOverviewQuery({
+    variables: {
+      app_id: appId,
+      ...trend.weeklyVariables,
+    },
+    skip: !appId,
+  });
+
+  const fetchedRpCreatedAt = data?.app?.[0]?.rp_registration?.[0]?.created_at;
+  useEffect(() => {
+    if (fetchedRpCreatedAt) setRpCreatedAt(fetchedRpCreatedAt as string);
+  }, [fetchedRpCreatedAt]);
+
+  const {
+    data: appTrendData,
+    loading: appTrendLoading,
+    error: appTrendError,
+    refetch: refetchAppTrend,
+  } = useGetWorldIdAppTrendQuery({
+    variables: {
+      app_id: appId,
+      ...trend.allTimeVariables,
+    },
+    skip: timePeriod !== "all-time" || !appId || !rpCreatedAt,
+  });
+
+  if (loading) {
+    return (
+      <SizingWrapper className="flex flex-col gap-8 py-8">
+        <Skeleton height={150} className="rounded-[10px]" />
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <Skeleton height={220} count={3} className="rounded-[10px]" />
+        </div>
+      </SizingWrapper>
+    );
+  }
+
+  // Only hard-fail without cached data: a failed refetch (e.g. after closing
+  // the enable dialog) sets `error` while `data` is still valid.
+  if (error && !data) {
+    return (
+      <SizingWrapper className="py-8">
+        <ErrorPage statusCode={500} title="Failed to load World ID" />
+      </SizingWrapper>
+    );
+  }
+
+  const app = data?.app?.[0];
+
+  if (!app) {
+    return (
+      <SizingWrapper className="py-8">
+        <ErrorPage statusCode={404} title="App not found" />
+      </SizingWrapper>
+    );
+  }
+
+  const rp = app.rp_registration?.[0];
+  const name = app.app_metadata?.[0]?.name ?? "Untitled app";
+  const hasLegacyActions = (data?.action?.length ?? 0) > 0;
+  const legacyActionsHref = hasLegacyActions
+    ? urls.actions({ team_id: teamId, app_id: appId })
+    : undefined;
+  const canRegisterRp = checkUserPermissions(user, teamId, [
+    Role_Enum.Owner,
+    Role_Enum.Admin,
+  ]);
+
+  // No RP registration yet → nudge into the existing enable-World-ID-4.0 flow.
+  if (!rp) {
+    return (
+      <SizingWrapper className="flex flex-col gap-8 py-8">
+        {app.is_banned ? <BanBanner /> : null}
+
+        <RegisterRpEmptyState
+          appId={appId}
+          initialOpen={props.searchParams.enableWorldId4 === "true"}
+          canRegisterRp={canRegisterRp}
+          isStaging={app.is_staging}
+          onRegistered={() => refetch()}
+          legacyActionsHref={legacyActionsHref}
+        />
+      </SizingWrapper>
+    );
+  }
+
+  const actionItems = (data?.action_v4 ?? []).map((action) => ({
+    id: action.id,
+    action: action.action,
+    description: action.description,
+    total: action.total?.aggregate?.count ?? 0,
+    latestAt: action.latest?.aggregate?.max?.created_at ?? null,
+    points: trendPoints(action),
+  }));
+
+  // The weekly hero trend reuses the per-action daily buckets. All time uses a
+  // separate app-level query so action-card sparklines remain weekly.
+  const weeklyHeroPoints = Array.from({ length: 7 }, (_, day) =>
+    actionItems.reduce((sum, action) => sum + (action.points[day] ?? 0), 0),
+  );
+  const allTimeHeroPoints = trendPoints(appTrendData);
+  const heroPoints =
+    timePeriod === "all-time" ? allTimeHeroPoints : weeklyHeroPoints;
+  const trendState = buildTrendState({
+    loading: timePeriod === "all-time" && appTrendLoading,
+    error: timePeriod === "all-time" && Boolean(appTrendError),
+    points: heroPoints,
+    labels: trend.labels,
+    onRetry: () => void refetchAppTrend(),
+  });
+
+  // Hero totals are summed client-side from the per-action aggregates: the
+  // per-action counts use the same filters an app-level aggregate would, and
+  // every nullifier row belongs to exactly one action.
+  const total = actionItems.reduce((sum, action) => sum + action.total, 0);
+  const week = weeklyHeroPoints.reduce((sum, count) => sum + count, 0);
+
+  return (
+    <SizingWrapper className="flex flex-col gap-8 py-8">
+      {app.is_banned ? <BanBanner /> : null}
+
+      <HeroCard
+        name={name}
+        appId={appId}
+        unique={total}
+        week={week}
+        timePeriod={timePeriod}
+        onTimePeriodChange={setTimePeriod}
+        trendRangeLabel={trend.rangeLabel}
+        trendState={trendState}
+      />
+
+      <div className="flex flex-col gap-6">
+        <WorldIdTabs
+          tab={tab}
+          onTabChange={setTab}
+          legacyActionsHref={legacyActionsHref}
+          search={search}
+          onSearchChange={setSearch}
+        />
+
+        {tab === "actions" ? (
+          <ActionsGrid
+            actions={actionItems}
+            teamId={teamId}
+            appId={appId}
+            search={search}
+            initialDialogOpen={props.searchParams.createAction === "true"}
+            onActionsChanged={() => refetch()}
+          />
+        ) : (
+          <WorldId40Pane
+            appId={appId}
+            rpId={rp.rp_id}
+            initialStatus={(rp.status as RpStatus) ?? "pending"}
+            initialStagingStatus={
+              rp.staging_status == null ? null : (rp.staging_status as RpStatus)
+            }
+            mode={rp.mode as string}
+            createdAt={rp.created_at}
+            onRpChanged={() => refetch()}
+          />
+        )}
+      </div>
+    </SizingWrapper>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/index.tsx
@@ -4,11 +4,8 @@ import { Button } from "@/components/Button";
 import { ErrorPage } from "@/components/ErrorPage";
 import { AlertIcon } from "@/components/Icons/AlertIcon";
 import { SizingWrapper } from "@/components/SizingWrapper";
-import { Role_Enum } from "@/graphql/graphql";
 import { trendPoints, type TrendPeriod } from "@/lib/day-buckets";
-import { Auth0SessionUser } from "@/lib/types";
 import { urls } from "@/lib/urls";
-import { checkUserPermissions } from "@/lib/utils";
 import {
   buildTrendState,
   useTrendWindow,
@@ -17,7 +14,6 @@ import { BanMessageDialog } from "@/scenes/PortalV3/Teams/TeamId/Apps/common/Ban
 import { banMessageDialogOpenedAtom } from "@/scenes/common/Teams/TeamId/Apps/common/BanMessageDialog/atoms";
 import { useGetWorldIdAppTrendQuery } from "@/scenes/common/Teams/TeamId/Apps/AppId/WorldId/graphql/client/get-world-id-trends.generated";
 import { useGetWorldIdOverviewQuery } from "@/scenes/common/Teams/TeamId/Apps/AppId/WorldId/page/graphql/client/get-world-id-overview.generated";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { useAtom } from "jotai";
 import { useEffect, useState } from "react";
 import Skeleton from "react-loading-skeleton";
@@ -60,7 +56,6 @@ export const WorldIdPage = (props: {
 }) => {
   const teamId = props.params.teamId ?? "";
   const appId = props.params.appId ?? "";
-  const { user } = useUser() as Auth0SessionUser;
 
   const [tab, setTab] = useState<WorldIdTab>(
     props.searchParams.tab === "world-id-4-0" ? "world-id-4-0" : "actions",
@@ -138,11 +133,6 @@ export const WorldIdPage = (props: {
   const legacyActionsHref = hasLegacyActions
     ? urls.actions({ team_id: teamId, app_id: appId })
     : undefined;
-  const canRegisterRp = checkUserPermissions(user, teamId, [
-    Role_Enum.Owner,
-    Role_Enum.Admin,
-  ]);
-
   // No RP registration yet → nudge into the existing enable-World-ID-4.0 flow.
   if (!rp) {
     return (
@@ -152,7 +142,6 @@ export const WorldIdPage = (props: {
         <RegisterRpEmptyState
           appId={appId}
           initialOpen={props.searchParams.enableWorldId4 === "true"}
-          canRegisterRp={canRegisterRp}
           isStaging={app.is_staging}
           onRegistered={() => refetch()}
           legacyActionsHref={legacyActionsHref}

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/page/graphql/client/get-world-id-overview.generated.ts
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/page/graphql/client/get-world-id-overview.generated.ts
@@ -1,0 +1,260 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { gql } from "@apollo/client";
+import { WorldIdActionTrendBucketsFragmentDoc } from "../../../graphql/client/get-world-id-trends.generated";
+import * as Apollo from "@apollo/client";
+const defaultOptions = {} as const;
+export type GetWorldIdOverviewQueryVariables = Types.Exact<{
+  app_id: Types.Scalars["String"]["input"];
+  d0: Types.Scalars["timestamptz"]["input"];
+  d1: Types.Scalars["timestamptz"]["input"];
+  d2: Types.Scalars["timestamptz"]["input"];
+  d3: Types.Scalars["timestamptz"]["input"];
+  d4: Types.Scalars["timestamptz"]["input"];
+  d5: Types.Scalars["timestamptz"]["input"];
+  d6: Types.Scalars["timestamptz"]["input"];
+  d7: Types.Scalars["timestamptz"]["input"];
+}>;
+
+export type GetWorldIdOverviewQuery = {
+  __typename?: "query_root";
+  app: Array<{
+    __typename?: "app";
+    id: string;
+    is_banned: boolean;
+    is_staging: boolean;
+    app_metadata: Array<{ __typename?: "app_metadata"; name: string }>;
+    rp_registration: Array<{
+      __typename?: "rp_registration";
+      rp_id: string;
+      app_id: string;
+      status: unknown;
+      staging_status?: unknown | null;
+      mode: unknown;
+      signer_address?: string | null;
+      created_at: string;
+    }>;
+  }>;
+  action_v4: Array<{
+    __typename?: "action_v4";
+    id: string;
+    action: string;
+    description: string;
+    created_at: string;
+    total: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    latest: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        max?: {
+          __typename?: "nullifier_v4_max_fields";
+          created_at?: string | null;
+        } | null;
+      } | null;
+    };
+    b0: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b1: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b2: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b3: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b4: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b5: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+    b6: {
+      __typename?: "nullifier_v4_aggregate";
+      aggregate?: {
+        __typename?: "nullifier_v4_aggregate_fields";
+        count: number;
+      } | null;
+    };
+  }>;
+  action: Array<{ __typename?: "action"; id: string }>;
+};
+
+export const GetWorldIdOverviewDocument = gql`
+  query GetWorldIdOverview(
+    $app_id: String!
+    $d0: timestamptz!
+    $d1: timestamptz!
+    $d2: timestamptz!
+    $d3: timestamptz!
+    $d4: timestamptz!
+    $d5: timestamptz!
+    $d6: timestamptz!
+    $d7: timestamptz!
+  ) {
+    app(where: { id: { _eq: $app_id } }) {
+      id
+      is_banned
+      is_staging
+      app_metadata {
+        name
+      }
+      rp_registration {
+        rp_id
+        app_id
+        status
+        staging_status
+        mode
+        signer_address
+        created_at
+      }
+    }
+    action_v4(
+      where: {
+        environment: { _eq: "production" }
+        rp_registration: { app: { id: { _eq: $app_id } } }
+      }
+      order_by: { created_at: desc }
+    ) {
+      id
+      action
+      description
+      created_at
+      total: nullifiers_aggregate {
+        aggregate {
+          count
+        }
+      }
+      latest: nullifiers_aggregate {
+        aggregate {
+          max {
+            created_at
+          }
+        }
+      }
+      ...WorldIdActionTrendBuckets
+    }
+    action(
+      where: { app_id: { _eq: $app_id }, action: { _neq: "" } }
+      limit: 1
+    ) {
+      id
+    }
+  }
+  ${WorldIdActionTrendBucketsFragmentDoc}
+`;
+
+/**
+ * __useGetWorldIdOverviewQuery__
+ *
+ * To run a query within a React component, call `useGetWorldIdOverviewQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetWorldIdOverviewQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetWorldIdOverviewQuery({
+ *   variables: {
+ *      app_id: // value for 'app_id'
+ *      d0: // value for 'd0'
+ *      d1: // value for 'd1'
+ *      d2: // value for 'd2'
+ *      d3: // value for 'd3'
+ *      d4: // value for 'd4'
+ *      d5: // value for 'd5'
+ *      d6: // value for 'd6'
+ *      d7: // value for 'd7'
+ *   },
+ * });
+ */
+export function useGetWorldIdOverviewQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetWorldIdOverviewQuery,
+    GetWorldIdOverviewQueryVariables
+  > &
+    (
+      | { variables: GetWorldIdOverviewQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetWorldIdOverviewQuery,
+    GetWorldIdOverviewQueryVariables
+  >(GetWorldIdOverviewDocument, options);
+}
+export function useGetWorldIdOverviewLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetWorldIdOverviewQuery,
+    GetWorldIdOverviewQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetWorldIdOverviewQuery,
+    GetWorldIdOverviewQueryVariables
+  >(GetWorldIdOverviewDocument, options);
+}
+export function useGetWorldIdOverviewSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetWorldIdOverviewQuery,
+        GetWorldIdOverviewQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetWorldIdOverviewQuery,
+    GetWorldIdOverviewQueryVariables
+  >(GetWorldIdOverviewDocument, options);
+}
+export type GetWorldIdOverviewQueryHookResult = ReturnType<
+  typeof useGetWorldIdOverviewQuery
+>;
+export type GetWorldIdOverviewLazyQueryHookResult = ReturnType<
+  typeof useGetWorldIdOverviewLazyQuery
+>;
+export type GetWorldIdOverviewSuspenseQueryHookResult = ReturnType<
+  typeof useGetWorldIdOverviewSuspenseQuery
+>;
+export type GetWorldIdOverviewQueryResult = Apollo.QueryResult<
+  GetWorldIdOverviewQuery,
+  GetWorldIdOverviewQueryVariables
+>;

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/page/graphql/client/get-world-id-overview.graphql
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/page/graphql/client/get-world-id-overview.graphql
@@ -1,12 +1,11 @@
 # Feeds the World ID landing page (hero stats + sparkline, actions grid) and the
-# World ID 4.0 pane. For World ID 4.0 there is exactly one nullifier row per
-# (human, action) and the nullifier column is globally unique, so "Unique
-# humans" is definitionally equal to "Total verifications" at every level; both
-# stat slots are sourced from the same `count`. The b0..b6 aliases are per-day
-# buckets (7 days) whose bounds ($d0..$d7) are local-midnight boundaries from
-# `weekBucketBounds`; the hero sparkline sums the buckets across actions, and
-# the hero totals are likewise summed client-side from the per-action counts
-# (same filters; every nullifier row belongs to exactly one action).
+# World ID 4.0 pane. Each stored nullifier represents one unique verification
+# for a specific (human, RP, action) context. Repeated proofs for that context
+# do not add another row, while different actions intentionally produce
+# unlinkable nullifiers. The b0..b6 aliases are per-day buckets (7 days) whose
+# bounds ($d0..$d7) are local-midnight boundaries from `weekBucketBounds`; the
+# hero sparkline and unique-verification total are summed across actions (same
+# filters; every nullifier row belongs to exactly one action).
 query GetWorldIdOverview(
   $app_id: String!
   $d0: timestamptz!

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/page/graphql/client/get-world-id-overview.graphql
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/WorldId/page/graphql/client/get-world-id-overview.graphql
@@ -1,0 +1,71 @@
+# Feeds the World ID landing page (hero stats + sparkline, actions grid) and the
+# World ID 4.0 pane. For World ID 4.0 there is exactly one nullifier row per
+# (human, action) and the nullifier column is globally unique, so "Unique
+# humans" is definitionally equal to "Total verifications" at every level; both
+# stat slots are sourced from the same `count`. The b0..b6 aliases are per-day
+# buckets (7 days) whose bounds ($d0..$d7) are local-midnight boundaries from
+# `weekBucketBounds`; the hero sparkline sums the buckets across actions, and
+# the hero totals are likewise summed client-side from the per-action counts
+# (same filters; every nullifier row belongs to exactly one action).
+query GetWorldIdOverview(
+  $app_id: String!
+  $d0: timestamptz!
+  $d1: timestamptz!
+  $d2: timestamptz!
+  $d3: timestamptz!
+  $d4: timestamptz!
+  $d5: timestamptz!
+  $d6: timestamptz!
+  $d7: timestamptz!
+) {
+  app(where: { id: { _eq: $app_id } }) {
+    id
+    is_banned
+    is_staging
+    app_metadata {
+      name
+    }
+    rp_registration {
+      rp_id
+      app_id
+      status
+      staging_status
+      mode
+      signer_address
+      created_at
+    }
+  }
+
+  action_v4(
+    where: {
+      environment: { _eq: "production" }
+      rp_registration: { app: { id: { _eq: $app_id } } }
+    }
+    order_by: { created_at: desc }
+  ) {
+    id
+    action
+    description
+    created_at
+    total: nullifiers_aggregate {
+      aggregate {
+        count
+      }
+    }
+    latest: nullifiers_aggregate {
+      aggregate {
+        max {
+          created_at
+        }
+      }
+    }
+    ...WorldIdActionTrendBuckets
+  }
+
+  # Presence of a legacy (World ID 3.0) action drives the optional
+  # "World ID 3.0 Legacy" switcher tab. Exclude the auto-created Sign in with
+  # World ID action (action = "").
+  action(where: { app_id: { _eq: $app_id }, action: { _neq: "" } }, limit: 1) {
+    id
+  }
+}

--- a/web/tests/unit/pv3-r-world-id.test.tsx
+++ b/web/tests/unit/pv3-r-world-id.test.tsx
@@ -1,0 +1,22 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown) => v3(),
+}));
+jest.mock("@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page", () => ({
+  WorldIdPage: () => <div data-testid="v3-world-id" />,
+}));
+import Page from "../../app/(portal)/teams/[teamId]/apps/[appId]/world-id/page";
+
+it("renders the v3 World ID page", async () => {
+  render(
+    await Page({
+      params: Promise.resolve({ teamId: "team_1", appId: "app_1" }),
+      searchParams: Promise.resolve({}),
+    }),
+  );
+  expect(screen.getByTestId("v3-world-id")).toBeInTheDocument();
+});

--- a/web/tests/unit/pv3-world-id-action-card.test.tsx
+++ b/web/tests/unit/pv3-world-id-action-card.test.tsx
@@ -1,0 +1,26 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { ActionCard } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionCard";
+
+it("links to the action route available in this stack slice", () => {
+  render(
+    <ActionCard
+      teamId="team_1"
+      appId="app_1"
+      action={{
+        id: "action_1",
+        action: "verify",
+        description: "",
+        total: 0,
+        latestAt: null,
+        points: Array(7).fill(0),
+      }}
+    />,
+  );
+
+  expect(screen.getByRole("link")).toHaveAttribute(
+    "href",
+    "/teams/team_1/apps/app_1/world-id-actions/action_1",
+  );
+});


### PR DESCRIPTION
## What this PR does

- Adds the Portal v3 `/world-id` page and its overview GraphQL query.
- Shows unique-verification totals, this-week totals, and weekly/all-time trends in the hero card.
- Adds searchable action cards and the World ID 4.0 action-creation dialog.
- Keeps action cards on `/world-id-actions/[actionId]`; PR #2102 renders the new detail UI on that same route.
- Adds the World ID 4.0 tab with RP metadata, registration retry, signer-key reset, and self-managed migration controls.
- Adds RP setup for apps that have not registered an RP and keeps the World ID 3.0 legacy link when legacy actions exist.
- Reconciles RP status with the chain when the 4.0 tab mounts and refreshes the parent query if the stored status is stale.
- Keeps cached overview content visible when a refetch fails, catches retry failures, and adds tab/search accessibility attributes.
- Sets the action-search input to the same 40px height as the tab controls.

## Stack

#2100 → **2/4 (this PR)** → #2102 → #2103

## Validation

- `pnpm format:check`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- World ID route and utility unit tests
- Next.js production build on Tailwind 4
