### PR TITLE
fix(portal): restore three-track grid layouts

### DIFF
--- a/web/components/Dropdown/ListItem/index.tsx
+++ b/web/components/Dropdown/ListItem/index.tsx
@@ -9,7 +9,7 @@ export const ListItem = (props: ListItemProps) => {
   return (
     <DropdownPrimitive.Item
       className={twMerge(
-        "grid-cols-auto/1fr/auto grid items-center gap-x-4 px-2 py-2.5 text-start outline-hidden hover:bg-grey-50 md:gap-x-2 md:px-4",
+        "grid grid-cols-auto-1fr-auto items-center gap-x-4 px-2 py-2.5 text-start outline-hidden hover:bg-grey-50 md:gap-x-2 md:px-4",
         className,
       )}
       {...otherProps}

--- a/web/components/InitialSteps/Step/index.tsx
+++ b/web/components/InitialSteps/Step/index.tsx
@@ -33,7 +33,7 @@ export const Step = (
     <div
       className={twMerge(
         clsx(
-          "grid-cols-auto/1fr/auto grid w-full items-center gap-x-4 border-t p-6 first-of-type:border-t-0 md:min-w-[480px]",
+          "grid w-full grid-cols-auto-1fr-auto items-center gap-x-4 border-t p-6 first-of-type:border-t-0 md:min-w-[480px]",
           {
             "cursor-not-allowed grayscale select-none": disabled,
           },

--- a/web/components/Input/index.tsx
+++ b/web/components/Input/index.tsx
@@ -72,7 +72,7 @@ export const Input = memo(function Input(props: InputInterface) {
       <fieldset
         className={twMerge(
           clsx(
-            "group grid-cols-auto/1fr/auto grid pb-2 transition-colors",
+            "group grid grid-cols-auto-1fr-auto pb-2 transition-colors",
             { "py-2": !label },
             parentClassNames,
           ),

--- a/web/components/SelectMultiple/index.tsx
+++ b/web/components/SelectMultiple/index.tsx
@@ -360,7 +360,7 @@ const Item = (props: {
         "grid cursor-pointer items-center gap-x-2 py-2 pr-5 pl-2 hover:bg-grey-50",
         {
           "grid-cols-1fr/auto": !icon,
-          "grid-cols-auto/1fr/auto": icon,
+          "grid-cols-auto-1fr-auto": icon,
         },
       )}
     >

--- a/web/components/SwitcherBox/index.tsx
+++ b/web/components/SwitcherBox/index.tsx
@@ -25,7 +25,7 @@ export const SwitcherBox = (props: {
 
   return (
     <div
-      className={clsx("grid-cols-auto/1fr/auto grid gap-x-4 p-5", className)}
+      className={clsx("grid grid-cols-auto-1fr-auto gap-x-4 p-5", className)}
     >
       <Switcher enabled={status} setEnabled={setStatus} disabled={disabled} />
       <div className="grid gap-y-2">

--- a/web/components/ToggleSection/index.tsx
+++ b/web/components/ToggleSection/index.tsx
@@ -16,7 +16,7 @@ export const ToggleSection = (props: ToggleSectionProps) => {
   return (
     <div
       className={clsx(
-        "grid-cols-auto/1fr/auto grid items-center gap-x-4 rounded-lg border border-grey-200 bg-grey-0 px-2 py-4 transition-colors hover:border-grey-700",
+        "grid grid-cols-auto-1fr-auto items-center gap-x-4 rounded-lg border border-grey-200 bg-grey-0 px-2 py-4 transition-colors hover:border-grey-700",
         className,
       )}
     >

--- a/web/scenes/Portal/Profile/Teams/page/List/Item/index.tsx
+++ b/web/scenes/Portal/Profile/Teams/page/List/Item/index.tsx
@@ -69,7 +69,7 @@ export const Item = (props: ItemsProps) => {
         },
       )}
     >
-      <div className="max-md:grid-cols-auto/1fr/auto max-md:grid max-md:items-center max-md:gap-x-4 max-md:p-4 md:contents">
+      <div className="max-md:grid max-md:grid-cols-auto-1fr-auto max-md:items-center max-md:gap-x-4 max-md:p-4 md:contents">
         <div className="md:py-4 md:pr-4">
           {!item ? (
             <Skeleton className="size-12 rounded-lg leading-normal" inline />

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/MiniKiosk/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/MiniKiosk/index.tsx
@@ -128,7 +128,7 @@ export const MiniKiosk = (props: MiniKioskProps) => {
         },
       )}
     >
-      <div className="grid-rows-auto/1fr/auto grid grow items-center justify-center">
+      <div className="grid grow grid-rows-auto-1fr-auto items-center justify-center">
         {!action && (
           <KioskError title="This request is invalid." reset={resetKiosk} />
         )}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/AppStatus/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/AppStatus/index.tsx
@@ -10,7 +10,7 @@ export const AppStatus = (props: {
   const { disabled, status, setStatus } = props;
 
   return (
-    <div className="grid-cols-auto/1fr/auto grid gap-x-4 rounded-xl border p-5">
+    <div className="grid grid-cols-auto-1fr-auto gap-x-4 rounded-xl border p-5">
       <Switcher enabled={status} setEnabled={setStatus} disabled={disabled} />
       <div className="grid gap-y-2">
         <Typography variant={TYPOGRAPHY.R3}>Activate the App</Typography>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/index.tsx
@@ -18,7 +18,7 @@ export const SignInWithWorldIdPage = async (
 
   return (
     <div className="size-full py-5">
-      <div className="md:grid-cols-auto/1fr/auto grid grid-cols-1 items-center justify-center justify-items-center gap-x-7 gap-y-6 rounded-3xl border p-8 md:justify-items-start md:border-none md:px-0">
+      <div className="grid grid-cols-1 items-center justify-center justify-items-center gap-x-7 gap-y-6 rounded-3xl border p-8 md:grid-cols-auto-1fr-auto md:justify-items-start md:border-none md:px-0">
         <Image
           src="/passport.png"
           alt="passport"

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/BanStatusSection/ban-status.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/page/BanStatusSection/ban-status.tsx
@@ -18,7 +18,7 @@ export const BanStatus = () => {
   return (
     <div
       className={
-        "grid-cols-auto/1fr/auto grid items-center gap-x-3 rounded-lg border border-system-error-200 bg-system-error-50 px-3 py-2 text-system-error-600 sm:py-0 md:px-5"
+        "grid grid-cols-auto-1fr-auto items-center gap-x-3 rounded-lg border border-system-error-200 bg-system-error-50 px-3 py-2 text-system-error-600 sm:py-0 md:px-5"
       }
     >
       <AlertIcon className="text-system-error-600" />

--- a/web/scenes/Portal/Teams/TeamId/Apps/common/ReviewStatus/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/common/ReviewStatus/index.tsx
@@ -60,7 +60,7 @@ export const ReviewStatus = (props: ReviewStatusProps) => {
     <div
       className={clsx(
         statusStyles[status]?.normal,
-        "grid-cols-auto/1fr/auto grid items-center gap-x-3 rounded-lg px-3 py-2 sm:py-0 md:px-5",
+        "grid grid-cols-auto-1fr-auto items-center gap-x-3 rounded-lg px-3 py-2 sm:py-0 md:px-5",
         className,
       )}
     >

--- a/web/scenes/Portal/layout/AppSelector/index.tsx
+++ b/web/scenes/Portal/layout/AppSelector/index.tsx
@@ -86,7 +86,7 @@ export const AppSelector = () => {
     >
       <SelectButton className={clsx({ hidden: !appId }, "px-0")}>
         {({ value }: { value: FetchAppsQuery["app"][number] }) => (
-          <div className="grid-cols-auto/1fr/auto grid max-w-[400px] items-center gap-x-2 md:max-w-[200px]">
+          <div className="grid max-w-[400px] grid-cols-auto-1fr-auto items-center gap-x-2 md:max-w-[200px]">
             {value?.verified_app_metadata?.[0]?.logo_img_url ? (
               // CDN urls should not use Next Image
               // eslint-disable-next-line @next/next/no-img-element
@@ -123,7 +123,7 @@ export const AppSelector = () => {
         {sortedApps.map((app) => (
           <SelectOption key={app.id} value={app}>
             {({ selected }) => (
-              <div className="grid-cols-auto/1fr/auto grid items-center gap-x-2 truncate">
+              <div className="grid grid-cols-auto-1fr-auto items-center gap-x-2 truncate">
                 {app?.verified_app_metadata?.[0]?.logo_img_url ? (
                   // CDN urls should not use Next Image
                   // eslint-disable-next-line @next/next/no-img-element
@@ -159,7 +159,7 @@ export const AppSelector = () => {
         ))}
         {isEnoughPermissions && (
           <SelectOption value={null}>
-            <div className="grid-cols-auto/1fr/auto grid items-center gap-x-2">
+            <div className="grid grid-cols-auto-1fr-auto items-center gap-x-2">
               <PlusCircleIcon className="size-4 text-gray-500" />
 
               <Typography variant={TYPOGRAPHY.R4}>Create new app</Typography>

--- a/web/scenes/Portal/layout/CreateAppDialog/MiniappToggleSection/index.tsx
+++ b/web/scenes/Portal/layout/CreateAppDialog/MiniappToggleSection/index.tsx
@@ -16,7 +16,7 @@ export const MiniappToggleSection = (props: MiniappToggleSectionProps) => {
   return (
     <div
       className={clsx(
-        "grid-cols-auto/1fr/auto grid items-center gap-x-4 rounded-lg border border-grey-200 bg-grey-0 px-2 py-4 transition-colors",
+        "grid grid-cols-auto-1fr-auto items-center gap-x-4 rounded-lg border border-grey-200 bg-grey-0 px-2 py-4 transition-colors",
         className,
       )}
     >

--- a/web/scenes/PortalV3/Profile/Teams/page/List/Item/index.tsx
+++ b/web/scenes/PortalV3/Profile/Teams/page/List/Item/index.tsx
@@ -69,7 +69,7 @@ export const Item = (props: ItemsProps) => {
         },
       )}
     >
-      <div className="max-md:grid-cols-auto/1fr/auto max-md:grid max-md:items-center max-md:gap-x-4 max-md:p-4 md:contents">
+      <div className="max-md:grid max-md:grid-cols-auto-1fr-auto max-md:items-center max-md:gap-x-4 max-md:p-4 md:contents">
         <div className="md:py-4 md:pr-4">
           {!item ? (
             <Skeleton className="size-12 rounded-lg leading-normal" inline />

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/MiniKiosk/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/MiniKiosk/index.tsx
@@ -128,7 +128,7 @@ export const MiniKiosk = (props: MiniKioskProps) => {
         },
       )}
     >
-      <div className="grid-rows-auto/1fr/auto grid grow items-center justify-center">
+      <div className="grid grow grid-rows-auto-1fr-auto items-center justify-center">
         {!action && (
           <KioskError title="This request is invalid." reset={resetKiosk} />
         )}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/AppStatus/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/BasicInformation/AppStatus/index.tsx
@@ -10,7 +10,7 @@ export const AppStatus = (props: {
   const { disabled, status, setStatus } = props;
 
   return (
-    <div className="grid-cols-auto/1fr/auto grid gap-x-4 rounded-xl border p-5">
+    <div className="grid grid-cols-auto-1fr-auto gap-x-4 rounded-xl border p-5">
       <Switcher enabled={status} setEnabled={setStatus} disabled={disabled} />
       <div className="grid gap-y-2">
         <Typography variant={TYPOGRAPHY.R3}>Activate the App</Typography>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/index.tsx
@@ -18,7 +18,7 @@ export const SignInWithWorldIdPage = async (
 
   return (
     <div className="size-full py-5">
-      <div className="md:grid-cols-auto/1fr/auto grid grid-cols-1 items-center justify-center justify-items-center gap-x-7 gap-y-6 rounded-3xl border p-8 md:justify-items-start md:border-none md:px-0">
+      <div className="grid grid-cols-1 items-center justify-center justify-items-center gap-x-7 gap-y-6 rounded-3xl border p-8 md:grid-cols-auto-1fr-auto md:justify-items-start md:border-none md:px-0">
         <Image
           src="/passport.png"
           alt="passport"

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -120,11 +120,11 @@
 
   --grid-template-columns-1fr\/auto: 1fr auto;
   --grid-template-columns-auto\/1fr: auto 1fr;
-  --grid-template-columns-auto\/1fr\/auto: auto 1fr auto;
+  --grid-template-columns-auto-1fr-auto: auto 1fr auto;
 
   --grid-template-rows-1fr\/auto: 1fr auto;
   --grid-template-rows-auto\/1fr: auto 1fr;
-  --grid-template-rows-auto\/1fr\/auto: auto 1fr auto;
+  --grid-template-rows-auto-1fr-auto: auto 1fr auto;
 
   --text-0: 0;
   --text-6: calc(6 * 1rem / 16);


### PR DESCRIPTION
This PR restores three-track grid layouts broken by the Tailwind v4 migration.

- Renames the invalid slash-delimited three-track grid theme tokens to valid hyphenated utilities.
- Updates all affected v2 and v3 call sites, including app and team switchers, dropdown items, and status banners.
- Verifies that Tailwind generates the base and responsive grid utilities and that the local dev server serves them.

Root cause: Tailwind v4 did not generate utilities for theme keys containing two slash separators.

Checks:
- `pnpm format:check`
- `npx tsc --noEmit`
- Focused Tailwind/PostCSS generation check
- Local dev server stylesheet verification

The broad Jest suite was also attempted; unit suites ran, while integration and E2E suites require unavailable services or a different test runner.