### PR TITLE
feat(portal, config): report autosave failures to telemetry

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/hook/use-autosave-with-status.ts
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/hook/use-autosave-with-status.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import posthog from "posthog-js";
 import { useCallback, useEffect, useRef } from "react";
 import { FieldValues, UseFormReturn } from "react-hook-form";
 import { useSaveStatusActions } from "../SaveStatus";
@@ -29,6 +30,10 @@ export const useAutosaveWithStatus = <T extends FieldValues>(
   const ctxRef = useRef(ctx);
   ctxRef.current = ctx;
 
+  // Last observed status.state, so we report a failure once per transition
+  // into "error" rather than on every re-render / status push.
+  const lastStateRef = useRef<AutosaveStatus["state"]>("idle");
+
   // Funnel every save through the provider's shared queue so concurrent
   // debounced saves from different forms can't race on overlapping
   // app_metadata columns. Falls back to direct invocation if no provider.
@@ -45,6 +50,19 @@ export const useAutosaveWithStatus = <T extends FieldValues>(
     enabled: options.enabled,
     debounceMs: options.debounceMs,
     onStatus: (status: AutosaveStatus) => {
+      // Report save failures to telemetry. Without this, a failed autosave
+      // (network error, WAF/proxy rejection, server error) only surfaces as a
+      // local "Couldn't save" pill and — when it happens during the
+      // submit-for-review flushAll — as a generic toast, leaving us with no
+      // signal about which form failed or why. `form_id` + `message` make this
+      // class of failure diagnosable.
+      if (status.state === "error" && lastStateRef.current !== "error") {
+        posthog.capture("config_autosave_failed", {
+          form_id: idRef.current,
+          message: status.error?.message,
+        });
+      }
+      lastStateRef.current = status.state;
       ctxRef.current?.pushStatus(idRef.current, status);
     },
     onPendingChange: (isPending: boolean) => {

--- a/web/tests/unit/use-autosave-with-status.test.tsx
+++ b/web/tests/unit/use-autosave-with-status.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import { useAutosaveWithStatus } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/hook/use-autosave-with-status";
+
+// #region Mocks
+jest.mock("posthog-js", () => ({
+  __esModule: true,
+  default: { capture: jest.fn() },
+}));
+import posthog from "posthog-js";
+const captureMock = posthog.capture as jest.Mock;
+// #endregion
+
+// #region Test Data
+type Values = { name: string; url: string };
+const DEBOUNCE_MS = 30;
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Rendered without a SaveStatusProvider on purpose: useSaveStatusActions()
+// returns null, exercising the null-safe ctx branches, and leaving the
+// telemetry behavior (which does not depend on the provider) under test.
+const setup = (
+  save: (data: Values, signal: AbortSignal) => Promise<void>,
+  id = "advanced-setup",
+) =>
+  renderHook(() => {
+    const form = useForm<Values>({
+      defaultValues: { name: "", url: "" },
+      mode: "onChange",
+    });
+    form.register("name");
+    form.register("url");
+    useAutosaveWithStatus<Values>({
+      id,
+      form,
+      save,
+      enabled: true,
+      debounceMs: DEBOUNCE_MS,
+    });
+    return { form };
+  });
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// #region config_autosave_failed telemetry
+describe("useAutosaveWithStatus telemetry", () => {
+  it("reports config_autosave_failed with form id and message when a save fails", async () => {
+    const save = jest.fn().mockRejectedValue(new Error("network blew up"));
+    const { result } = setup(save, "advanced-setup");
+
+    await act(async () => {
+      result.current.form.setValue("name", "x", { shouldDirty: true });
+    });
+    await act(async () => {
+      await wait(DEBOUNCE_MS * 4);
+    });
+
+    expect(captureMock).toHaveBeenCalledWith(
+      "config_autosave_failed",
+      expect.objectContaining({
+        form_id: "advanced-setup",
+        message: "network blew up",
+      }),
+    );
+  });
+
+  it("does not report when the save succeeds", async () => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    const { result } = setup(save);
+
+    await act(async () => {
+      result.current.form.setValue("name", "ok", { shouldDirty: true });
+    });
+    await act(async () => {
+      await wait(DEBOUNCE_MS * 4);
+    });
+
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it("reports once per error transition, not on every retry attempt of the same failure", async () => {
+    const save = jest.fn().mockRejectedValue(new Error("still failing"));
+    const { result } = setup(save);
+
+    await act(async () => {
+      result.current.form.setValue("name", "x", { shouldDirty: true });
+    });
+    await act(async () => {
+      await wait(DEBOUNCE_MS * 4);
+    });
+
+    // A single failed save produces a single error transition → one report.
+    expect(captureMock).toHaveBeenCalledTimes(1);
+  });
+});
+// #endregion


### PR DESCRIPTION
## Context

While investigating why Holdstation Wallet got **413 Content Too Large** on *Submit for review*, the failure was hard to diagnose partly because the client **swallows the error**: a failed config autosave surfaces only as a local "Couldn't save" pill, and during the submit-for-review `flushAll()` as a generic "Some changes could not be saved" toast. Nothing is reported, so we had zero signal about *which* form failed or *why* (the actual cause was a WAF rule returning 413 for ~8 KB Server Action bodies — see world-id-deploy#545).

## Change

`useAutosaveWithStatus` now emits a `config_autosave_failed` PostHog event once per transition into the `error` state, tagged with `form_id` and the error `message`.

- Pure addition — no control-flow change; the existing status/pill behavior is untouched.
- Fires for real save failures (network / proxy / server errors) via the autosave error path; deduped per transition so retries of the same failure don't spam.
- Consistent with the existing `app_submit_review_attempted` PostHog events in this feature.

With this, the Holdstation case would have shown `config_autosave_failed { form_id: "advanced-setup", message: … }` instead of being invisible — aligned with the "no swallowed errors / no observability blind spots" principle.

## Tests

Added `use-autosave-with-status.test.tsx` (mirrors the existing `use-autosave` suite): reports once with form id + message on failure, silent on success, once per error transition.

> Note: I could not execute `jest`/`tsc` in this sandbox (the checkout's deps aren't resolvable by the local `npx`); relying on CI + `@codex review` for verification. The change was validated by inspection against the existing test patterns and the hook's null-safe context handling.

## Follow-up / related

- The user-facing blocker is fixed by **world-id-deploy#545** (WAF `BodySizeLimit` rule raised from 8 KB → 1 MB). This PR is the observability half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)