### PR TITLE
Internal Dashboard team/:id page

### DIFF
--- a/hasura/metadata/databases/default/tables/public_api_key.yaml
+++ b/hasura/metadata/databases/default/tables/public_api_key.yaml
@@ -27,8 +27,12 @@ select_permissions:
   - role: internal_dashboard_readonly
     permission:
       columns:
+        - created_at
+        - id
         - is_active
+        - name
         - team_id
+        - updated_at
       filter: {}
       allow_aggregations: true
   - role: service

--- a/hasura/metadata/databases/default/tables/public_invite.yaml
+++ b/hasura/metadata/databases/default/tables/public_invite.yaml
@@ -16,9 +16,12 @@ select_permissions:
   - role: internal_dashboard_readonly
     permission:
       columns:
+        - id
+        - email
         - expires_at
         - team_id
       filter: {}
+      allow_aggregations: true
   - role: service
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_membership.yaml
+++ b/hasura/metadata/databases/default/tables/public_membership.yaml
@@ -38,7 +38,10 @@ select_permissions:
   - role: internal_dashboard_readonly
     permission:
       columns:
+        - id
+        - role
         - team_id
+        - user_id
       filter: {}
       allow_aggregations: true
   - role: service

--- a/hasura/metadata/databases/default/tables/public_team.yaml
+++ b/hasura/metadata/databases/default/tables/public_team.yaml
@@ -23,6 +23,13 @@ array_relationships:
         table:
           name: membership
           schema: public
+  - name: invites
+    using:
+      foreign_key_constraint_on:
+        column: team_id
+        table:
+          name: invite
+          schema: public
 computed_fields:
   - name: team_owners_count
     definition:

--- a/web/api/admin/search/index.ts
+++ b/web/api/admin/search/index.ts
@@ -1,0 +1,35 @@
+import { authenticateAdminRequest } from "@/lib/admin-auth";
+import { fetchAdminGlobalSearch } from "@/scenes/Admin/search/server/fetch-global-search";
+import { NextRequest, NextResponse } from "next/server";
+
+const MIN_QUERY_LENGTH = 2;
+const MAX_QUERY_LENGTH = 128;
+
+export async function GET(req: NextRequest) {
+  const user = await authenticateAdminRequest(req.headers);
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const query = req.nextUrl.searchParams.get("q")?.trim() ?? "";
+
+  if (query.length < MIN_QUERY_LENGTH || query.length > MAX_QUERY_LENGTH) {
+    return NextResponse.json(
+      {
+        error: `Query must contain between ${MIN_QUERY_LENGTH} and ${MAX_QUERY_LENGTH} characters`,
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await fetchAdminGlobalSearch(query, user);
+    return NextResponse.json(result);
+  } catch {
+    return NextResponse.json(
+      { error: "Search is temporarily unavailable" },
+      { status: 503 },
+    );
+  }
+}

--- a/web/api/helpers/graphql.ts
+++ b/web/api/helpers/graphql.ts
@@ -6,6 +6,7 @@ import {
   generateReviewerJWT,
   generateServiceJWT,
 } from "@/api/helpers/jwts";
+import type { AdminUser } from "@/lib/admin-auth";
 import { logger } from "@/lib/logger";
 import { parse } from "graphql";
 import { GraphQLClient } from "graphql-request";
@@ -300,14 +301,18 @@ export const getAPIReviewerGraphqlClient = async () => {
   });
 };
 
-export const getInternalDashboardGraphqlClient = async () => {
-  const { requireAdminUser } = await import("@/lib/admin-auth");
-  const user = await requireAdminUser();
-
+export const getInternalDashboardGraphqlClientForUser = async (
+  user: AdminUser,
+) => {
   return new GraphQLClient(process.env.NEXT_PUBLIC_GRAPHQL_API_URL!, {
     ...sharedFetchConfig,
     headers: {
       authorization: `Bearer ${await generateInternalDashboardJWT(user)}`,
     },
   });
+};
+
+export const getInternalDashboardGraphqlClient = async () => {
+  const { requireAdminUser } = await import("@/lib/admin-auth");
+  return getInternalDashboardGraphqlClientForUser(await requireAdminUser());
 };

--- a/web/app/admin/teams/[id]/page.tsx
+++ b/web/app/admin/teams/[id]/page.tsx
@@ -7,16 +7,22 @@ type PageProps = {
   params: Promise<{
     id: string;
   }>;
+  searchParams: Promise<{
+    appsPage?: string | string[];
+    appsQuery?: string | string[];
+    membersPage?: string | string[];
+    membersQuery?: string | string[];
+  }>;
 };
 
 export const metadata: Metadata = {
   title: generateMetaTitle({ left: "Team" }),
 };
 
-export default async function Page({ params }: PageProps) {
+export default async function Page({ params, searchParams }: PageProps) {
   await requireAdminUser();
 
   const { id } = await params;
 
-  return <AdminTeamPage teamId={id} />;
+  return <AdminTeamPage searchParams={searchParams} teamId={id} />;
 }

--- a/web/app/admin/users/[id]/page.tsx
+++ b/web/app/admin/users/[id]/page.tsx
@@ -7,16 +7,22 @@ type PageProps = {
   params: Promise<{
     id: string;
   }>;
+  searchParams: Promise<{
+    appsPage?: string | string[];
+    appsQuery?: string | string[];
+    teamsPage?: string | string[];
+    teamsQuery?: string | string[];
+  }>;
 };
 
 export const metadata: Metadata = {
   title: generateMetaTitle({ left: "User" }),
 };
 
-export default async function Page({ params }: PageProps) {
+export default async function Page({ params, searchParams }: PageProps) {
   await requireAdminUser();
 
   const { id } = await params;
 
-  return <AdminUserPage userId={id} />;
+  return <AdminUserPage searchParams={searchParams} userId={id} />;
 }

--- a/web/app/api/admin/search/route.ts
+++ b/web/app/api/admin/search/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "@/api/admin/search";

--- a/web/components/AdminDashboard/Search.tsx
+++ b/web/components/AdminDashboard/Search.tsx
@@ -1,37 +1,267 @@
+"use client";
+
 import { clsx } from "clsx";
 import { SearchIcon } from "@/components/Icons/SearchIcon";
+import { useRouter } from "next/navigation";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import { UIModule } from "./UIModule";
 
 type SearchProps = {
   className?: string;
 };
 
+type SearchResult = {
+  id: string;
+  name: string;
+  detail?: string | null;
+  href: string;
+  type: "App" | "Team" | "User";
+};
+
+type SearchResponse = {
+  apps: Array<{ id: string; name: string; teamId: string }>;
+  teams: Array<{ id: string; name: string }>;
+  users: Array<{ email: string | null; id: string; name: string }>;
+};
+
 export const Search = ({ className }: SearchProps) => {
+  const router = useRouter();
+  const listboxId = useId().replaceAll(":", "");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState("");
+  const [response, setResponse] = useState<SearchResponse | null>(null);
+  const [status, setStatus] = useState<"error" | "idle" | "loading" | "ready">(
+    "idle",
+  );
+  const [isFocused, setIsFocused] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [shortcutLabel, setShortcutLabel] = useState("Ctrl K");
+  const normalizedQuery = query.trim();
+  const results = useMemo<SearchResult[]>(
+    () => [
+      ...(response?.teams.map((team) => ({
+        href: `/admin/teams/${team.id}`,
+        id: team.id,
+        name: team.name,
+        type: "Team" as const,
+      })) ?? []),
+      ...(response?.apps.map((app) => ({
+        detail: app.teamId,
+        href: `/admin/apps/${app.id}`,
+        id: app.id,
+        name: app.name,
+        type: "App" as const,
+      })) ?? []),
+      ...(response?.users.map((user) => ({
+        detail: user.email,
+        href: `/admin/users/${user.id}`,
+        id: user.id,
+        name: user.name,
+        type: "User" as const,
+      })) ?? []),
+    ],
+    [response],
+  );
+  const isOpen = isFocused && normalizedQuery.length >= 2;
+
+  useEffect(() => {
+    setShortcutLabel(
+      /Mac|iPhone|iPad|iPod/i.test(navigator.platform) ? "⌘ K" : "Ctrl K",
+    );
+
+    const handleShortcut = (event: globalThis.KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setIsFocused(true);
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }
+    };
+
+    window.addEventListener("keydown", handleShortcut);
+    return () => window.removeEventListener("keydown", handleShortcut);
+  }, []);
+
+  useEffect(() => {
+    if (normalizedQuery.length < 2) {
+      setResponse(null);
+      setSelectedIndex(-1);
+      setStatus("idle");
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(async () => {
+      setStatus("loading");
+      setSelectedIndex(-1);
+
+      try {
+        const apiResponse = await fetch(
+          `/api/admin/search?q=${encodeURIComponent(normalizedQuery)}`,
+          { signal: controller.signal },
+        );
+
+        if (!apiResponse.ok) {
+          throw new Error("Admin search request failed");
+        }
+
+        const data = (await apiResponse.json()) as SearchResponse;
+        setResponse(data);
+        setStatus("ready");
+      } catch (error) {
+        if ((error as Error).name !== "AbortError") {
+          setResponse(null);
+          setStatus("error");
+        }
+      }
+    }, 300);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(timeoutId);
+    };
+  }, [normalizedQuery]);
+
+  const selectResult = (result: SearchResult) => {
+    setIsFocused(false);
+    setSelectedIndex(-1);
+    router.push(result.href);
+  };
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setIsFocused(false);
+      setSelectedIndex(-1);
+      event.currentTarget.blur();
+      return;
+    }
+
+    if (event.key === "ArrowDown" && results.length > 0) {
+      event.preventDefault();
+      setSelectedIndex((index) => (index + 1) % results.length);
+      return;
+    }
+
+    if (event.key === "ArrowUp" && results.length > 0) {
+      event.preventDefault();
+      setSelectedIndex((index) =>
+        index <= 0 ? results.length - 1 : index - 1,
+      );
+      return;
+    }
+
+    if (event.key === "Enter" && selectedIndex >= 0) {
+      event.preventDefault();
+      selectResult(results[selectedIndex]);
+    }
+  };
+
   return (
-    <UIModule
-      className={clsx(
-        "relative h-10 p-0",
-        "3xl:h-12.5",
-        "4xl:h-17.5",
-        className,
+    <div className={clsx("relative", className)}>
+      <UIModule
+        className={clsx("relative h-10 p-0", "3xl:h-12.5", "4xl:h-17.5")}
+      >
+        <SearchIcon
+          className={clsx(
+            "pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-grey-400",
+            "3xl:left-4 3xl:size-5",
+            "4xl:left-5 4xl:size-7",
+          )}
+        />
+        <input
+          aria-activedescendant={
+            selectedIndex >= 0 ? `${listboxId}-${selectedIndex}` : undefined
+          }
+          aria-autocomplete="list"
+          aria-controls={listboxId}
+          aria-expanded={isOpen}
+          aria-label="Search teams, apps, and users"
+          aria-busy={status === "loading"}
+          className={clsx(
+            "size-full rounded-16 bg-transparent py-2 pr-20 pl-9 text-14 outline-hidden placeholder:text-grey-400 focus-visible:ring-2 focus-visible:ring-blue-500",
+            "3xl:pr-24 3xl:pl-11 3xl:text-18",
+            "4xl:pr-28 4xl:pl-16 4xl:text-24",
+          )}
+          enterKeyHint="search"
+          onBlur={() => {
+            window.setTimeout(() => setIsFocused(false), 100);
+          }}
+          onChange={(event) => setQuery(event.target.value)}
+          onFocus={() => setIsFocused(true)}
+          onKeyDown={handleKeyDown}
+          placeholder="Search teams, apps, and users"
+          ref={inputRef}
+          role="combobox"
+          type="search"
+          value={query}
+        />
+        <kbd className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 rounded-8 bg-grey-100 px-2 py-1 font-sans text-11 font-medium text-grey-500 3xl:right-4 3xl:text-13 4xl:right-5 4xl:text-16">
+          {shortcutLabel}
+        </kbd>
+      </UIModule>
+      {isOpen && (
+        <div
+          className="absolute top-[calc(100%+0.25rem)] z-50 max-h-[min(32rem,70dvh)] w-full overflow-y-auto rounded-12 border border-grey-200 bg-grey-0 p-1 shadow-lg"
+          id={listboxId}
+          role="listbox"
+        >
+          {status === "loading" && (
+            <p aria-live="polite" className="px-3 py-2 text-13 text-grey-500">
+              Searching…
+            </p>
+          )}
+          {status === "error" && (
+            <p
+              aria-live="polite"
+              className="px-3 py-2 text-13 text-system-error-700"
+            >
+              Search is temporarily unavailable.
+            </p>
+          )}
+          {status === "ready" && results.length === 0 && (
+            <p aria-live="polite" className="px-3 py-2 text-13 text-grey-500">
+              No matching teams, apps, or users.
+            </p>
+          )}
+          {status === "ready" &&
+            results.map((result, index) => (
+              <button
+                aria-selected={selectedIndex === index}
+                className={clsx(
+                  "grid w-full grid-cols-[auto_minmax(0,1fr)] gap-x-3 rounded-8 px-3 py-2 text-left outline-none hover:bg-grey-100 focus-visible:ring-2 focus-visible:ring-blue-500",
+                  selectedIndex === index && "bg-blue-50",
+                )}
+                id={`${listboxId}-${index}`}
+                key={`${result.type}:${result.id}`}
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setSelectedIndex(index)}
+                onClick={() => selectResult(result)}
+                role="option"
+                type="button"
+              >
+                <span className="pt-0.5 text-11 font-medium tracking-wide text-grey-400 uppercase">
+                  {result.type}
+                </span>
+                <span className="min-w-0">
+                  <span className="block truncate text-13 font-medium text-grey-900">
+                    {result.name}
+                  </span>
+                  <span className="block truncate font-mono text-11 text-grey-500">
+                    {result.detail ?? result.id}
+                  </span>
+                </span>
+              </button>
+            ))}
+        </div>
       )}
-    >
-      <SearchIcon
-        className={clsx(
-          "pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-grey-400",
-          "3xl:left-4 3xl:size-5",
-          "4xl:left-5 4xl:size-7",
-        )}
-      />
-      <input
-        type="text"
-        placeholder="Search"
-        className={clsx(
-          "size-full rounded-16 bg-transparent py-2 pr-3 pl-9 text-14 outline-hidden placeholder:text-grey-400 focus-visible:ring-2 focus-visible:ring-blue-500",
-          "3xl:pr-4 3xl:pl-11 3xl:text-18",
-          "4xl:pr-5 4xl:pl-16 4xl:text-24",
-        )}
-      />
-    </UIModule>
+    </div>
   );
 };

--- a/web/components/AdminDashboard/Teams/Detail/TeamAppsInfiniteList.tsx
+++ b/web/components/AdminDashboard/Teams/Detail/TeamAppsInfiniteList.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type TeamApp = {
+  created_at: string;
+  deleted_at?: string | null;
+  draft_metadata: Array<{ name: string; verification_status: string }>;
+  id: string;
+  name: string;
+  verified_metadata: Array<{ name: string; verified_at?: string | null }>;
+};
+
+type TeamAppsInfiniteListProps = {
+  apps: TeamApp[];
+  currentPage: number;
+  searchQuery: string;
+  teamId: string;
+  totalPages: number;
+};
+
+export const TeamAppsInfiniteList = ({
+  apps,
+  currentPage,
+  searchQuery,
+  teamId,
+  totalPages,
+}: TeamAppsInfiniteListProps) => {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const cacheKey = `${teamId}:${searchQuery}`;
+  const cacheRef = useRef(new Map<string, Map<number, TeamApp[]>>());
+  const requestedPageRef = useRef<number | null>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [version, setVersion] = useState(0);
+
+  useEffect(() => {
+    const pages =
+      cacheRef.current.get(cacheKey) ?? new Map<number, TeamApp[]>();
+    pages.set(currentPage, apps);
+    cacheRef.current.set(cacheKey, pages);
+    requestedPageRef.current = null;
+    setIsLoading(false);
+    setVersion((value) => value + 1);
+  }, [apps, cacheKey, currentPage]);
+
+  const cachedApps = useMemo(() => {
+    const pages = cacheRef.current.get(cacheKey);
+
+    if (!pages) {
+      return apps;
+    }
+
+    const seenIds = new Set<string>();
+
+    return [...pages.entries()]
+      .sort(([firstPage], [secondPage]) => firstPage - secondPage)
+      .flatMap(([, pageApps]) => pageApps)
+      .filter((app) => {
+        if (seenIds.has(app.id)) {
+          return false;
+        }
+
+        seenIds.add(app.id);
+        return true;
+      });
+  }, [apps, cacheKey, version]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+
+    if (!sentinel || currentPage >= totalPages) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting || requestedPageRef.current) {
+          return;
+        }
+
+        const nextPage = currentPage + 1;
+        requestedPageRef.current = nextPage;
+        setIsLoading(true);
+        const params = new URLSearchParams(searchParams.toString());
+        params.set("appsPage", String(nextPage));
+        const query = params.toString();
+
+        router.replace(query ? `${pathname}?${query}` : pathname, {
+          scroll: false,
+        });
+      },
+      { rootMargin: "160px" },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [currentPage, pathname, router, searchParams, totalPages]);
+
+  if (cachedApps.length === 0) {
+    return <p className="py-3 text-14 text-grey-500">No apps found.</p>;
+  }
+
+  return (
+    <div className="min-w-0">
+      <ul className="min-w-0 divide-y divide-grey-100">
+        {cachedApps.map((app) => (
+          <li className="min-w-0 py-3 first:pt-0" key={app.id}>
+            <Link
+              className="block min-w-0 rounded-8 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              href={`/admin/apps/${app.id}`}
+              rel="noreferrer"
+              target="_blank"
+            >
+              <p className="truncate text-14 font-medium text-grey-900 hover:text-blue-500">
+                {app.name}
+              </p>
+              <p className="mt-0.5 truncate font-mono text-12 text-grey-400">
+                {app.id}
+              </p>
+              <p className="mt-1 truncate text-12 text-grey-500">
+                {app.deleted_at
+                  ? "Deleted"
+                  : app.verified_metadata[0]?.name ??
+                    app.draft_metadata[0]?.name ??
+                    "No metadata"}
+              </p>
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <div className="h-1" ref={sentinelRef} />
+      {isLoading && (
+        <p className="py-3 text-center text-12 text-grey-400">Loading more…</p>
+      )}
+    </div>
+  );
+};

--- a/web/components/AdminDashboard/Teams/Detail/TeamAppsPanel.tsx
+++ b/web/components/AdminDashboard/Teams/Detail/TeamAppsPanel.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+
+import { UIModule } from "@/components/AdminDashboard/UIModule";
+import { fetchAdminTeamAppsPage } from "@/scenes/Admin/teams/id/server/fetch-team-apps";
+
+import { TeamAppsPanelControls } from "./TeamAppsPanelControls";
+import { TeamAppsInfiniteList } from "./TeamAppsInfiniteList";
+
+type TeamAppsPanelProps = {
+  appsPage: number;
+  appsQuery: string;
+  teamId: string;
+};
+
+export const TeamAppsPanel = async ({
+  appsPage,
+  appsQuery,
+  teamId,
+}: TeamAppsPanelProps) => {
+  const { apps, currentPage, totalPages } = await fetchAdminTeamAppsPage({
+    page: appsPage,
+    searchQuery: appsQuery,
+    teamId,
+  });
+
+  return (
+    <UIModule className="flex min-h-0 min-w-0 flex-col gap-4 overflow-x-hidden overflow-y-auto p-5">
+      <div className="flex min-h-6 items-center justify-between gap-3">
+        <h2 className="text-16 font-semibold text-grey-900">Apps</h2>
+        <Link
+          className="text-12 font-medium text-blue-500 hover:text-blue-600"
+          href={`/admin/apps?query=${encodeURIComponent(`team:${teamId}`)}`}
+        >
+          View all
+        </Link>
+      </div>
+      <div className="shrink-0">
+        <TeamAppsPanelControls searchQuery={appsQuery} />
+      </div>
+      <div className="min-w-0 pt-1">
+        <TeamAppsInfiniteList
+          apps={apps}
+          currentPage={currentPage}
+          searchQuery={appsQuery}
+          teamId={teamId}
+          totalPages={totalPages}
+        />
+      </div>
+    </UIModule>
+  );
+};

--- a/web/components/AdminDashboard/Teams/Detail/TeamAppsPanelControls.tsx
+++ b/web/components/AdminDashboard/Teams/Detail/TeamAppsPanelControls.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import {
+  APPS_SEARCH_FIELDS,
+  getAppsSearchVisualSegments,
+} from "@/components/AdminDashboard/Apps/search";
+import { FieldSearch } from "@/components/AdminDashboard/common/FieldSearch";
+
+type TeamAppsPanelControlsProps = {
+  searchQuery: string;
+};
+
+export const TeamAppsPanelControls = ({
+  searchQuery,
+}: TeamAppsPanelControlsProps) => (
+  <FieldSearch
+    fields={APPS_SEARCH_FIELDS.filter((field) => field.field !== "team")}
+    getVisualSegments={getAppsSearchVisualSegments}
+    pageParam="appsPage"
+    placeholder="Search apps"
+    queryParam="appsQuery"
+    value={searchQuery}
+  />
+);

--- a/web/components/AdminDashboard/Teams/Detail/TeamMembersInfiniteList.tsx
+++ b/web/components/AdminDashboard/Teams/Detail/TeamMembersInfiniteList.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type TeamMember = {
+  id: string;
+  role: string;
+  user: {
+    email?: string | null;
+    id: string;
+    name: string;
+  };
+  user_id: string;
+};
+
+type TeamMembersInfiniteListProps = {
+  currentPage: number;
+  members: TeamMember[];
+  searchQuery: string;
+  teamId: string;
+  totalPages: number;
+};
+
+export const TeamMembersInfiniteList = ({
+  currentPage,
+  members,
+  searchQuery,
+  teamId,
+  totalPages,
+}: TeamMembersInfiniteListProps) => {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const cacheKey = `${teamId}:${searchQuery}`;
+  const cacheRef = useRef(new Map<string, Map<number, TeamMember[]>>());
+  const requestedPageRef = useRef<number | null>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [version, setVersion] = useState(0);
+
+  useEffect(() => {
+    const pages =
+      cacheRef.current.get(cacheKey) ?? new Map<number, TeamMember[]>();
+    pages.set(currentPage, members);
+    cacheRef.current.set(cacheKey, pages);
+    requestedPageRef.current = null;
+    setIsLoading(false);
+    setVersion((value) => value + 1);
+  }, [cacheKey, currentPage, members]);
+
+  const cachedMembers = useMemo(() => {
+    const pages = cacheRef.current.get(cacheKey);
+
+    if (!pages) {
+      return members;
+    }
+
+    const seenIds = new Set<string>();
+
+    return [...pages.entries()]
+      .sort(([firstPage], [secondPage]) => firstPage - secondPage)
+      .flatMap(([, pageMembers]) => pageMembers)
+      .filter((member) => {
+        if (seenIds.has(member.id)) {
+          return false;
+        }
+
+        seenIds.add(member.id);
+        return true;
+      });
+  }, [cacheKey, members, version]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+
+    if (!sentinel || currentPage >= totalPages) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting || requestedPageRef.current) {
+          return;
+        }
+
+        const nextPage = currentPage + 1;
+        requestedPageRef.current = nextPage;
+        setIsLoading(true);
+        const params = new URLSearchParams(searchParams.toString());
+        params.set("membersPage", String(nextPage));
+        const query = params.toString();
+
+        router.replace(query ? `${pathname}?${query}` : pathname, {
+          scroll: false,
+        });
+      },
+      { rootMargin: "160px" },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [currentPage, pathname, router, searchParams, totalPages]);
+
+  if (cachedMembers.length === 0) {
+    return <p className="py-3 text-14 text-grey-500">No members found.</p>;
+  }
+
+  return (
+    <div className="min-w-0">
+      <ul className="min-w-0 divide-y divide-grey-100">
+        {cachedMembers.map((membership) => {
+          const name = membership.user.name.trim();
+          const primaryLabel =
+            name || membership.user.email || membership.user.id;
+          const secondaryLabel = name
+            ? membership.user.email ?? membership.user.id
+            : membership.user.id;
+
+          return (
+            <li className="min-w-0 py-3 first:pt-0" key={membership.id}>
+              <Link
+                className="block min-w-0 rounded-8 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                href={`/admin/users/${membership.user.id}`}
+                rel="noreferrer"
+                target="_blank"
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <p className="min-w-0 flex-1 truncate text-14 font-medium text-grey-900 hover:text-blue-500">
+                    {primaryLabel}
+                  </p>
+                  <span className="text-grey-600 shrink-0 rounded-full bg-grey-100 px-2 py-0.5 text-11 font-medium">
+                    {membership.role}
+                  </span>
+                </div>
+                <p className="mt-0.5 truncate font-mono text-12 text-grey-400">
+                  {secondaryLabel}
+                </p>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="h-1" ref={sentinelRef} />
+      {isLoading && (
+        <p className="py-3 text-center text-12 text-grey-400">Loading more…</p>
+      )}
+    </div>
+  );
+};

--- a/web/components/AdminDashboard/Teams/Detail/TeamMembersPanel.tsx
+++ b/web/components/AdminDashboard/Teams/Detail/TeamMembersPanel.tsx
@@ -1,0 +1,43 @@
+import { UIModule } from "@/components/AdminDashboard/UIModule";
+import { fetchAdminTeamMembersPage } from "@/scenes/Admin/teams/id/server/fetch-team-members";
+
+import { TeamMembersInfiniteList } from "./TeamMembersInfiniteList";
+import { TeamMembersPanelControls } from "./TeamMembersPanelControls";
+
+type TeamMembersPanelProps = {
+  membersPage: number;
+  membersQuery: string;
+  teamId: string;
+};
+
+export const TeamMembersPanel = async ({
+  membersPage,
+  membersQuery,
+  teamId,
+}: TeamMembersPanelProps) => {
+  const { currentPage, members, totalPages } = await fetchAdminTeamMembersPage({
+    page: membersPage,
+    searchQuery: membersQuery,
+    teamId,
+  });
+
+  return (
+    <UIModule className="flex min-h-0 min-w-0 flex-col gap-4 overflow-x-hidden overflow-y-auto p-5">
+      <div className="flex min-h-6 items-center">
+        <h2 className="text-16 font-semibold text-grey-900">Members</h2>
+      </div>
+      <div className="shrink-0">
+        <TeamMembersPanelControls searchQuery={membersQuery} />
+      </div>
+      <div className="min-w-0 pt-1">
+        <TeamMembersInfiniteList
+          currentPage={currentPage}
+          members={members}
+          searchQuery={membersQuery}
+          teamId={teamId}
+          totalPages={totalPages}
+        />
+      </div>
+    </UIModule>
+  );
+};

--- a/web/components/AdminDashboard/Teams/Detail/TeamMembersPanelControls.tsx
+++ b/web/components/AdminDashboard/Teams/Detail/TeamMembersPanelControls.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { FieldSearch } from "@/components/AdminDashboard/common/FieldSearch";
+
+const memberSearchFields = [
+  { field: "id", examples: ["id:user_"], type: "string" as const },
+  { field: "name", examples: ['name:"Jane Doe"'], type: "string" as const },
+  { field: "email", examples: ["email:example.com"], type: "string" as const },
+  { field: "role", examples: ["role:OWNER"], type: "string" as const },
+];
+
+type TeamMembersPanelControlsProps = {
+  searchQuery: string;
+};
+
+export const TeamMembersPanelControls = ({
+  searchQuery,
+}: TeamMembersPanelControlsProps) => (
+  <FieldSearch
+    fields={memberSearchFields}
+    getVisualSegments={(query) => [{ type: "text", value: query }]}
+    pageParam="membersPage"
+    placeholder="Search members"
+    queryParam="membersQuery"
+    value={searchQuery}
+  />
+);

--- a/web/components/AdminDashboard/UIModule.tsx
+++ b/web/components/AdminDashboard/UIModule.tsx
@@ -10,7 +10,7 @@ export const UIModule = ({ children, className }: UIModuleProps) => {
   return (
     <div
       className={twMerge(
-        "rounded-16 border border-grey-200 bg-grey-0/90 p-1.5 shadow-lg backdrop-blur-md",
+        "overscroll-none rounded-16 border border-grey-200 bg-grey-0/90 p-1.5 shadow-lg backdrop-blur-md",
         className,
       )}
     >

--- a/web/components/AdminDashboard/UIModule.tsx
+++ b/web/components/AdminDashboard/UIModule.tsx
@@ -10,7 +10,7 @@ export const UIModule = ({ children, className }: UIModuleProps) => {
   return (
     <div
       className={twMerge(
-        "overscroll-none rounded-16 border border-grey-200 bg-grey-0/90 p-1.5 shadow-lg backdrop-blur-md",
+        "overscroll-none rounded-16 border border-grey-200 bg-grey-0/90 p-1.5 backdrop-blur-md",
         className,
       )}
     >

--- a/web/components/AdminDashboard/Users/Detail/UserAppsInfiniteList.tsx
+++ b/web/components/AdminDashboard/Users/Detail/UserAppsInfiniteList.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type UserApp = {
+  deleted_at?: string | null;
+  draft_metadata: Array<{ name: string; verification_status: string }>;
+  id: string;
+  name: string;
+  team: { id: string; name: string };
+  verified_metadata: Array<{ name: string; verified_at?: string | null }>;
+};
+
+type UserAppsInfiniteListProps = {
+  apps: UserApp[];
+  currentPage: number;
+  searchQuery: string;
+  totalPages: number;
+  userId: string;
+};
+
+export const UserAppsInfiniteList = ({
+  apps,
+  currentPage,
+  searchQuery,
+  totalPages,
+  userId,
+}: UserAppsInfiniteListProps) => {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const cacheKey = `${userId}:${searchQuery}`;
+  const cacheRef = useRef(new Map<string, Map<number, UserApp[]>>());
+  const requestedPageRef = useRef<number | null>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [version, setVersion] = useState(0);
+
+  useEffect(() => {
+    const pages =
+      cacheRef.current.get(cacheKey) ?? new Map<number, UserApp[]>();
+    pages.set(currentPage, apps);
+    cacheRef.current.set(cacheKey, pages);
+    requestedPageRef.current = null;
+    setIsLoading(false);
+    setVersion((value) => value + 1);
+  }, [apps, cacheKey, currentPage]);
+
+  const cachedApps = useMemo(() => {
+    const pages = cacheRef.current.get(cacheKey);
+
+    if (!pages) {
+      return apps;
+    }
+
+    const seenIds = new Set<string>();
+
+    return [...pages.entries()]
+      .sort(([firstPage], [secondPage]) => firstPage - secondPage)
+      .flatMap(([, pageApps]) => pageApps)
+      .filter((app) => {
+        if (seenIds.has(app.id)) {
+          return false;
+        }
+
+        seenIds.add(app.id);
+        return true;
+      });
+  }, [apps, cacheKey, version]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+
+    if (!sentinel || currentPage >= totalPages) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting || requestedPageRef.current) {
+          return;
+        }
+
+        const nextPage = currentPage + 1;
+        requestedPageRef.current = nextPage;
+        setIsLoading(true);
+        const params = new URLSearchParams(searchParams.toString());
+        params.set("appsPage", String(nextPage));
+        const query = params.toString();
+
+        router.replace(query ? `${pathname}?${query}` : pathname, {
+          scroll: false,
+        });
+      },
+      { rootMargin: "160px" },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [currentPage, pathname, router, searchParams, totalPages]);
+
+  if (cachedApps.length === 0) {
+    return <p className="py-3 text-14 text-grey-500">No apps found.</p>;
+  }
+
+  return (
+    <div className="min-w-0">
+      <ul className="min-w-0 divide-y divide-grey-100">
+        {cachedApps.map((app) => (
+          <li className="min-w-0 py-3 first:pt-0" key={app.id}>
+            <Link
+              className="block min-w-0 rounded-8 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              href={`/admin/apps/${app.id}`}
+              rel="noreferrer"
+              target="_blank"
+            >
+              <p className="truncate text-14 font-medium text-grey-900 hover:text-blue-500">
+                {app.name}
+              </p>
+              <p className="mt-0.5 truncate font-mono text-12 text-grey-400">
+                {app.id}
+              </p>
+              <p className="mt-1 truncate text-12 text-grey-500">
+                {app.team.name} ·{" "}
+                {app.deleted_at
+                  ? "Deleted"
+                  : app.verified_metadata[0]?.name ??
+                    app.draft_metadata[0]?.name ??
+                    "No metadata"}
+              </p>
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <div className="h-1" ref={sentinelRef} />
+      {isLoading && (
+        <p className="py-3 text-center text-12 text-grey-400">Loading more…</p>
+      )}
+    </div>
+  );
+};

--- a/web/components/AdminDashboard/Users/Detail/UserAppsPanel.tsx
+++ b/web/components/AdminDashboard/Users/Detail/UserAppsPanel.tsx
@@ -1,0 +1,45 @@
+import { UIModule } from "@/components/AdminDashboard/UIModule";
+import { fetchAdminUserAppsPage } from "@/scenes/Admin/users/id/server/fetch-user-apps";
+
+import { UserAppsInfiniteList } from "./UserAppsInfiniteList";
+import { UserAppsPanelControls } from "./UserAppsPanelControls";
+
+type UserAppsPanelProps = {
+  appsPage: number;
+  appsQuery: string;
+  userId: string;
+};
+
+export const UserAppsPanel = async ({
+  appsPage,
+  appsQuery,
+  userId,
+}: UserAppsPanelProps) => {
+  const { apps, currentPage, totalPages } = await fetchAdminUserAppsPage({
+    page: appsPage,
+    searchQuery: appsQuery,
+    userId,
+  });
+
+  return (
+    <UIModule className="flex min-h-0 min-w-0 flex-col gap-4 overflow-x-hidden overflow-y-auto p-5">
+      <div className="flex min-h-6 items-center">
+        <h2 className="text-16 font-semibold text-grey-900">
+          Apps in user’s teams
+        </h2>
+      </div>
+      <div className="shrink-0">
+        <UserAppsPanelControls searchQuery={appsQuery} />
+      </div>
+      <div className="min-w-0 pt-1">
+        <UserAppsInfiniteList
+          apps={apps}
+          currentPage={currentPage}
+          searchQuery={appsQuery}
+          totalPages={totalPages}
+          userId={userId}
+        />
+      </div>
+    </UIModule>
+  );
+};

--- a/web/components/AdminDashboard/Users/Detail/UserAppsPanelControls.tsx
+++ b/web/components/AdminDashboard/Users/Detail/UserAppsPanelControls.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import {
+  APPS_SEARCH_FIELDS,
+  getAppsSearchVisualSegments,
+} from "@/components/AdminDashboard/Apps/search";
+import { FieldSearch } from "@/components/AdminDashboard/common/FieldSearch";
+
+type UserAppsPanelControlsProps = {
+  searchQuery: string;
+};
+
+export const UserAppsPanelControls = ({
+  searchQuery,
+}: UserAppsPanelControlsProps) => (
+  <FieldSearch
+    fields={APPS_SEARCH_FIELDS.filter((field) => field.field !== "team")}
+    getVisualSegments={getAppsSearchVisualSegments}
+    pageParam="appsPage"
+    placeholder="Search apps"
+    queryParam="appsQuery"
+    value={searchQuery}
+  />
+);

--- a/web/components/AdminDashboard/Users/Detail/UserTeamsInfiniteList.tsx
+++ b/web/components/AdminDashboard/Users/Detail/UserTeamsInfiniteList.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { StatusBadge } from "@/components/AdminDashboard/Teams/StatusBadge";
+
+type UserTeam = {
+  id: string;
+  role: string;
+  team: {
+    deleted_at?: string | null;
+    id: string;
+    name: string;
+  };
+};
+
+type UserTeamsInfiniteListProps = {
+  currentPage: number;
+  searchQuery: string;
+  teams: UserTeam[];
+  totalPages: number;
+  userId: string;
+};
+
+export const UserTeamsInfiniteList = ({
+  currentPage,
+  searchQuery,
+  teams,
+  totalPages,
+  userId,
+}: UserTeamsInfiniteListProps) => {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const cacheKey = `${userId}:${searchQuery}`;
+  const cacheRef = useRef(new Map<string, Map<number, UserTeam[]>>());
+  const requestedPageRef = useRef<number | null>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [version, setVersion] = useState(0);
+
+  useEffect(() => {
+    const pages =
+      cacheRef.current.get(cacheKey) ?? new Map<number, UserTeam[]>();
+    pages.set(currentPage, teams);
+    cacheRef.current.set(cacheKey, pages);
+    requestedPageRef.current = null;
+    setIsLoading(false);
+    setVersion((value) => value + 1);
+  }, [cacheKey, currentPage, teams]);
+
+  const cachedTeams = useMemo(() => {
+    const pages = cacheRef.current.get(cacheKey);
+
+    if (!pages) {
+      return teams;
+    }
+
+    const seenIds = new Set<string>();
+
+    return [...pages.entries()]
+      .sort(([firstPage], [secondPage]) => firstPage - secondPage)
+      .flatMap(([, pageTeams]) => pageTeams)
+      .filter((membership) => {
+        if (seenIds.has(membership.id)) {
+          return false;
+        }
+
+        seenIds.add(membership.id);
+        return true;
+      });
+  }, [cacheKey, teams, version]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+
+    if (!sentinel || currentPage >= totalPages) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting || requestedPageRef.current) {
+          return;
+        }
+
+        const nextPage = currentPage + 1;
+        requestedPageRef.current = nextPage;
+        setIsLoading(true);
+        const params = new URLSearchParams(searchParams.toString());
+        params.set("teamsPage", String(nextPage));
+        const query = params.toString();
+
+        router.replace(query ? `${pathname}?${query}` : pathname, {
+          scroll: false,
+        });
+      },
+      { rootMargin: "160px" },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [currentPage, pathname, router, searchParams, totalPages]);
+
+  if (cachedTeams.length === 0) {
+    return <p className="py-3 text-14 text-grey-500">No teams found.</p>;
+  }
+
+  return (
+    <div className="min-w-0">
+      <ul className="min-w-0 divide-y divide-grey-100">
+        {cachedTeams.map((membership) => {
+          const status = membership.team.deleted_at ? "Deleted" : "Active";
+
+          return (
+            <li className="min-w-0 py-3 first:pt-0" key={membership.id}>
+              <Link
+                className="block min-w-0 rounded-8 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                href={`/admin/teams/${membership.team.id}`}
+                rel="noreferrer"
+                target="_blank"
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <p className="min-w-0 flex-1 truncate text-14 font-medium text-grey-900 hover:text-blue-500">
+                    {membership.team.name}
+                  </p>
+                  <span className="text-grey-600 shrink-0 rounded-full bg-grey-100 px-2 py-0.5 text-11 font-medium">
+                    {membership.role}
+                  </span>
+                </div>
+                <div className="mt-1 flex items-center justify-between gap-2">
+                  <p className="truncate font-mono text-12 text-grey-400">
+                    {membership.team.id}
+                  </p>
+                  <StatusBadge status={status} />
+                </div>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="h-1" ref={sentinelRef} />
+      {isLoading && (
+        <p className="py-3 text-center text-12 text-grey-400">Loading more…</p>
+      )}
+    </div>
+  );
+};

--- a/web/components/AdminDashboard/Users/Detail/UserTeamsPanel.tsx
+++ b/web/components/AdminDashboard/Users/Detail/UserTeamsPanel.tsx
@@ -1,0 +1,43 @@
+import { UIModule } from "@/components/AdminDashboard/UIModule";
+import { fetchAdminUserTeamsPage } from "@/scenes/Admin/users/id/server/fetch-user-teams";
+
+import { UserTeamsInfiniteList } from "./UserTeamsInfiniteList";
+import { UserTeamsPanelControls } from "./UserTeamsPanelControls";
+
+type UserTeamsPanelProps = {
+  teamsPage: number;
+  teamsQuery: string;
+  userId: string;
+};
+
+export const UserTeamsPanel = async ({
+  teamsPage,
+  teamsQuery,
+  userId,
+}: UserTeamsPanelProps) => {
+  const { currentPage, teams, totalPages } = await fetchAdminUserTeamsPage({
+    page: teamsPage,
+    searchQuery: teamsQuery,
+    userId,
+  });
+
+  return (
+    <UIModule className="flex min-h-0 min-w-0 flex-col gap-4 overflow-x-hidden overflow-y-auto p-5">
+      <div className="flex min-h-6 items-center">
+        <h2 className="text-16 font-semibold text-grey-900">Teams</h2>
+      </div>
+      <div className="shrink-0">
+        <UserTeamsPanelControls searchQuery={teamsQuery} />
+      </div>
+      <div className="min-w-0 pt-1">
+        <UserTeamsInfiniteList
+          currentPage={currentPage}
+          searchQuery={teamsQuery}
+          teams={teams}
+          totalPages={totalPages}
+          userId={userId}
+        />
+      </div>
+    </UIModule>
+  );
+};

--- a/web/components/AdminDashboard/Users/Detail/UserTeamsPanelControls.tsx
+++ b/web/components/AdminDashboard/Users/Detail/UserTeamsPanelControls.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { FieldSearch } from "@/components/AdminDashboard/common/FieldSearch";
+
+const teamSearchFields = [
+  { field: "id", examples: ["id:team_"], type: "string" as const },
+  { field: "name", examples: ['name:"My team"'], type: "string" as const },
+  { field: "role", examples: ["role:OWNER"], type: "string" as const },
+  {
+    field: "status",
+    examples: ["status:active", "status:deleted"],
+    type: "string" as const,
+  },
+];
+
+type UserTeamsPanelControlsProps = {
+  searchQuery: string;
+};
+
+export const UserTeamsPanelControls = ({
+  searchQuery,
+}: UserTeamsPanelControlsProps) => (
+  <FieldSearch
+    fields={teamSearchFields}
+    getVisualSegments={(query) => [{ type: "text", value: query }]}
+    pageParam="teamsPage"
+    placeholder="Search teams"
+    queryParam="teamsQuery"
+    value={searchQuery}
+  />
+);

--- a/web/components/AdminDashboard/common/FieldSearch.tsx
+++ b/web/components/AdminDashboard/common/FieldSearch.tsx
@@ -15,14 +15,18 @@ type AnchorStyle = CSSProperties & {
 type FieldSearchProps = {
   fields: readonly SearchField[];
   getVisualSegments: (query: string) => SearchVisualSegment[];
+  pageParam?: string;
   placeholder: string;
+  queryParam?: string;
   value: string;
 };
 
 export const FieldSearch = ({
   fields,
   getVisualSegments,
+  pageParam = "page",
   placeholder,
+  queryParam = "query",
   value,
 }: FieldSearchProps) => {
   const pathname = usePathname();
@@ -64,12 +68,12 @@ export const FieldSearch = ({
 
       const params = new URLSearchParams(searchParams.toString());
       if (nextValue) {
-        params.set("query", nextValue);
+        params.set(queryParam, nextValue);
       } else {
-        params.delete("query");
+        params.delete(queryParam);
       }
 
-      params.delete("page");
+      params.delete(pageParam);
       committedSearchValueRef.current = nextValue;
       const query = params.toString();
       router.replace(query ? `${pathname}?${query}` : pathname, {
@@ -78,7 +82,13 @@ export const FieldSearch = ({
     }, 300);
 
     return () => window.clearTimeout(timeoutId);
-  }, [pathname, router, searchParams, searchValue]);
+  }, [pageParam, pathname, queryParam, router, searchParams, searchValue]);
+
+  useEffect(() => {
+    if (searchValue) {
+      popoverRef.current?.hidePopover();
+    }
+  }, [searchValue]);
 
   const insertSnippet = (snippet: string) => {
     const input = inputRef.current;
@@ -165,7 +175,11 @@ export const FieldSearch = ({
         onBlur={hideSuggestions}
         onChange={(event) => setSearchValue(event.target.value)}
         onClick={syncSearchScrollLeft}
-        onFocus={() => popoverRef.current?.showPopover()}
+        onFocus={() => {
+          if (!searchValue) {
+            popoverRef.current?.showPopover();
+          }
+        }}
         onKeyDown={handleSearchKeyDown}
         onKeyUp={syncSearchScrollLeft}
         onScroll={syncSearchScrollLeft}

--- a/web/components/AdminDashboard/common/LimitSelector.tsx
+++ b/web/components/AdminDashboard/common/LimitSelector.tsx
@@ -13,13 +13,17 @@ type AnchorStyle = CSSProperties & {
 
 type LimitSelectorProps<Limit extends number> = {
   className?: string;
+  limitParam?: string;
   options: readonly Limit[];
+  pageParam?: string;
   value: Limit;
 };
 
 export const LimitSelector = <Limit extends number>({
   className,
+  limitParam = "limit",
   options,
+  pageParam = "page",
   value,
 }: LimitSelectorProps<Limit>) => {
   const pathname = usePathname();
@@ -33,8 +37,8 @@ export const LimitSelector = <Limit extends number>({
 
   const handleSelect = (nextValue: Limit) => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set("limit", String(nextValue));
-    params.delete("page");
+    params.set(limitParam, String(nextValue));
+    params.delete(pageParam);
     const query = params.toString();
     router.replace(query ? `${pathname}?${query}` : pathname, {
       scroll: false,
@@ -62,7 +66,7 @@ export const LimitSelector = <Limit extends number>({
         <ChevronDown className="size-4 text-grey-400" />
       </button>
       <div
-        className="fixed inset-auto [top:anchor(bottom)] [left:anchor(left)] m-0 mt-1 min-w-28 rounded-12 border border-grey-200 bg-grey-0 p-1 shadow-lg backdrop:bg-transparent"
+        className="fixed inset-auto top-[anchor(bottom)] left-[anchor(left)] m-0 mt-1 min-w-28 rounded-12 border border-grey-200 bg-grey-0 p-1 shadow-lg backdrop:bg-transparent"
         id={popoverId}
         popover="auto"
         ref={popoverRef}

--- a/web/components/AdminDashboard/common/ListPagination.tsx
+++ b/web/components/AdminDashboard/common/ListPagination.tsx
@@ -10,6 +10,7 @@ type ListPaginationProps = {
   ariaLabel: string;
   currentPage: number;
   limit: number;
+  pageParam?: string;
   pageInputId: string;
   totalItems: number;
   totalPages: number;
@@ -44,6 +45,7 @@ export const ListPagination = ({
   ariaLabel,
   currentPage,
   limit,
+  pageParam = "page",
   pageInputId,
   totalItems,
   totalPages,
@@ -66,8 +68,8 @@ export const ListPagination = ({
     const params = new URLSearchParams(searchParams.toString());
     setDisplayedPage(nextPage);
     setPageInputValue(String(nextPage));
-    if (nextPage === 1) params.delete("page");
-    else params.set("page", String(nextPage));
+    if (nextPage === 1) params.delete(pageParam);
+    else params.set(pageParam, String(nextPage));
     const query = params.toString();
     router.replace(query ? `${pathname}?${query}` : pathname, {
       scroll: false,

--- a/web/graphql/graphql.schema.json
+++ b/web/graphql/graphql.schema.json
@@ -38816,6 +38816,100 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "invite_aggregate_bool_exp",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "count",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "invite_aggregate_bool_exp_count",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "invite_aggregate_bool_exp_count",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "arguments",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "invite_select_column",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "distinct",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "filter",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "invite_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "predicate",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "Int_comparison_exp",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "invite_aggregate_fields",
         "description": "aggregate fields of \"invite\"",
@@ -38896,6 +38990,100 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "invite_aggregate_order_by",
+        "description": "order by aggregate values of table \"invite\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "count",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "invite_max_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "invite_min_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "invite_arr_rel_insert_input",
+        "description": "input type for inserting array relation for remote table \"invite\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "data",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "invite_insert_input",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_conflict",
+            "description": "upsert condition",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "invite_on_conflict",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -39170,6 +39358,65 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "invite_max_order_by",
+        "description": "order by max() on columns of table \"invite\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "email",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expires_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "invite_min_fields",
         "description": "aggregate min on columns",
@@ -39225,6 +39472,65 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "invite_min_order_by",
+        "description": "order by min() on columns of table \"invite\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "email",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expires_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -83660,6 +83966,200 @@
             "deprecationReason": null
           },
           {
+            "name": "invites",
+            "description": "An array relationship",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "invite_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "invite_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "invite_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "invite",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "invites_aggregate",
+            "description": "An aggregate relationship",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "invite_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "invite_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "invite_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "invite_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "memberships",
             "description": "An array relationship",
             "args": [
@@ -84292,6 +84792,30 @@
             "deprecationReason": null
           },
           {
+            "name": "invites",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "invite_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "invites_aggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "invite_aggregate_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "memberships",
             "description": null,
             "type": {
@@ -84433,6 +84957,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "invites",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "invite_arr_rel_insert_input",
               "ofType": null
             },
             "defaultValue": null,
@@ -84859,6 +85395,18 @@
             "type": {
               "kind": "ENUM",
               "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "invites_aggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "invite_aggregate_order_by",
               "ofType": null
             },
             "defaultValue": null,

--- a/web/graphql/graphql.ts
+++ b/web/graphql/graphql.ts
@@ -5350,6 +5350,17 @@ export type Invite_Aggregate = {
   nodes: Array<Invite>;
 };
 
+export type Invite_Aggregate_Bool_Exp = {
+  count?: InputMaybe<Invite_Aggregate_Bool_Exp_Count>;
+};
+
+export type Invite_Aggregate_Bool_Exp_Count = {
+  arguments?: InputMaybe<Array<Invite_Select_Column>>;
+  distinct?: InputMaybe<Scalars["Boolean"]["input"]>;
+  filter?: InputMaybe<Invite_Bool_Exp>;
+  predicate: Int_Comparison_Exp;
+};
+
 /** aggregate fields of "invite" */
 export type Invite_Aggregate_Fields = {
   __typename?: "invite_aggregate_fields";
@@ -5362,6 +5373,20 @@ export type Invite_Aggregate_Fields = {
 export type Invite_Aggregate_FieldsCountArgs = {
   columns?: InputMaybe<Array<Invite_Select_Column>>;
   distinct?: InputMaybe<Scalars["Boolean"]["input"]>;
+};
+
+/** order by aggregate values of table "invite" */
+export type Invite_Aggregate_Order_By = {
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Invite_Max_Order_By>;
+  min?: InputMaybe<Invite_Min_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "invite" */
+export type Invite_Arr_Rel_Insert_Input = {
+  data: Array<Invite_Insert_Input>;
+  /** upsert condition */
+  on_conflict?: InputMaybe<Invite_On_Conflict>;
 };
 
 /** Boolean expression to filter rows from the table "invite". All fields are combined with a logical 'AND'. */
@@ -5400,6 +5425,14 @@ export type Invite_Max_Fields = {
   team_id?: Maybe<Scalars["String"]["output"]>;
 };
 
+/** order by max() on columns of table "invite" */
+export type Invite_Max_Order_By = {
+  email?: InputMaybe<Order_By>;
+  expires_at?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  team_id?: InputMaybe<Order_By>;
+};
+
 /** aggregate min on columns */
 export type Invite_Min_Fields = {
   __typename?: "invite_min_fields";
@@ -5407,6 +5440,14 @@ export type Invite_Min_Fields = {
   expires_at?: Maybe<Scalars["timestamptz"]["output"]>;
   id?: Maybe<Scalars["String"]["output"]>;
   team_id?: Maybe<Scalars["String"]["output"]>;
+};
+
+/** order by min() on columns of table "invite" */
+export type Invite_Min_Order_By = {
+  email?: InputMaybe<Order_By>;
+  expires_at?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  team_id?: InputMaybe<Order_By>;
 };
 
 /** response of any mutation on the table "invite" */
@@ -11832,6 +11873,10 @@ export type Team = {
   deleted_at?: Maybe<Scalars["timestamptz"]["output"]>;
   id: Scalars["String"]["output"];
   /** An array relationship */
+  invites: Array<Invite>;
+  /** An aggregate relationship */
+  invites_aggregate: Invite_Aggregate;
+  /** An array relationship */
   memberships: Array<Membership>;
   /** An aggregate relationship */
   memberships_aggregate: Membership_Aggregate;
@@ -11875,6 +11920,24 @@ export type TeamApps_AggregateArgs = {
   offset?: InputMaybe<Scalars["Int"]["input"]>;
   order_by?: InputMaybe<Array<App_Order_By>>;
   where?: InputMaybe<App_Bool_Exp>;
+};
+
+/** columns and relationships of "team" */
+export type TeamInvitesArgs = {
+  distinct_on?: InputMaybe<Array<Invite_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Invite_Order_By>>;
+  where?: InputMaybe<Invite_Bool_Exp>;
+};
+
+/** columns and relationships of "team" */
+export type TeamInvites_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Invite_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Invite_Order_By>>;
+  where?: InputMaybe<Invite_Bool_Exp>;
 };
 
 /** columns and relationships of "team" */
@@ -11943,6 +12006,8 @@ export type Team_Bool_Exp = {
   created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
   deleted_at?: InputMaybe<Timestamptz_Comparison_Exp>;
   id?: InputMaybe<String_Comparison_Exp>;
+  invites?: InputMaybe<Invite_Bool_Exp>;
+  invites_aggregate?: InputMaybe<Invite_Aggregate_Bool_Exp>;
   memberships?: InputMaybe<Membership_Bool_Exp>;
   memberships_aggregate?: InputMaybe<Membership_Aggregate_Bool_Exp>;
   name?: InputMaybe<String_Comparison_Exp>;
@@ -11963,6 +12028,7 @@ export type Team_Insert_Input = {
   created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   deleted_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   id?: InputMaybe<Scalars["String"]["input"]>;
+  invites?: InputMaybe<Invite_Arr_Rel_Insert_Input>;
   memberships?: InputMaybe<Membership_Arr_Rel_Insert_Input>;
   name?: InputMaybe<Scalars["String"]["input"]>;
   updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
@@ -12022,6 +12088,7 @@ export type Team_Order_By = {
   created_at?: InputMaybe<Order_By>;
   deleted_at?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
+  invites_aggregate?: InputMaybe<Invite_Aggregate_Order_By>;
   memberships_aggregate?: InputMaybe<Membership_Aggregate_Order_By>;
   name?: InputMaybe<Order_By>;
   team_owners_count?: InputMaybe<Order_By>;

--- a/web/scenes/Admin/apps/graphql/server/fetch-admin-app-details.generated.ts
+++ b/web/scenes/Admin/apps/graphql/server/fetch-admin-app-details.generated.ts
@@ -1,0 +1,136 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type FetchAdminAppDetailsQueryVariables = Types.Exact<{
+  appId: Types.Scalars["String"]["input"];
+}>;
+
+export type FetchAdminAppDetailsQuery = {
+  __typename?: "query_root";
+  app_by_pk?: {
+    __typename?: "app";
+    id: string;
+    name: string;
+    team_id: string;
+    created_at: string;
+    deleted_at?: string | null;
+    team: {
+      __typename?: "team";
+      id: string;
+      name?: string | null;
+      created_at: string;
+      deleted_at?: string | null;
+    };
+    draft_metadata: Array<{
+      __typename?: "app_metadata";
+      name: string;
+      verification_status: string;
+      updated_at: string;
+    }>;
+    verified_metadata: Array<{
+      __typename?: "app_metadata";
+      name: string;
+      verification_status: string;
+      verified_at?: string | null;
+      updated_at: string;
+    }>;
+  } | null;
+  metadata_versions: Array<{
+    __typename?: "app_metadata";
+    app_id: string;
+    name: string;
+    verification_status: string;
+    updated_at: string;
+    verified_at?: string | null;
+  }>;
+};
+
+export const FetchAdminAppDetailsDocument = gql`
+  query FetchAdminAppDetails($appId: String!) {
+    app_by_pk(id: $appId) {
+      id
+      name
+      team_id
+      created_at
+      deleted_at
+      team {
+        id
+        name
+        created_at
+        deleted_at
+      }
+      draft_metadata: app_metadata(
+        where: { verification_status: { _neq: "verified" } }
+        order_by: { updated_at: desc }
+        limit: 1
+      ) {
+        name
+        verification_status
+        updated_at
+      }
+      verified_metadata: app_metadata(
+        where: { verification_status: { _eq: "verified" } }
+        order_by: { verified_at: desc }
+        limit: 1
+      ) {
+        name
+        verification_status
+        verified_at
+        updated_at
+      }
+    }
+    metadata_versions: app_metadata(
+      where: { app_id: { _eq: $appId } }
+      order_by: { updated_at: desc }
+      limit: 25
+    ) {
+      app_id
+      name
+      verification_status
+      updated_at
+      verified_at
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchAdminAppDetails(
+      variables: FetchAdminAppDetailsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchAdminAppDetailsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchAdminAppDetailsQuery>(
+            FetchAdminAppDetailsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchAdminAppDetails",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/apps/graphql/server/fetch-admin-app-details.gql
+++ b/web/scenes/Admin/apps/graphql/server/fetch-admin-app-details.gql
@@ -1,0 +1,45 @@
+query FetchAdminAppDetails($appId: String!) {
+  app_by_pk(id: $appId) {
+    id
+    name
+    team_id
+    created_at
+    deleted_at
+    team {
+      id
+      name
+      created_at
+      deleted_at
+    }
+    draft_metadata: app_metadata(
+      where: { verification_status: { _neq: "verified" } }
+      order_by: { updated_at: desc }
+      limit: 1
+    ) {
+      name
+      verification_status
+      updated_at
+    }
+    verified_metadata: app_metadata(
+      where: { verification_status: { _eq: "verified" } }
+      order_by: { verified_at: desc }
+      limit: 1
+    ) {
+      name
+      verification_status
+      verified_at
+      updated_at
+    }
+  }
+  metadata_versions: app_metadata(
+    where: { app_id: { _eq: $appId } }
+    order_by: { updated_at: desc }
+    limit: 25
+  ) {
+    app_id
+    name
+    verification_status
+    updated_at
+    verified_at
+  }
+}

--- a/web/scenes/Admin/apps/id/page.tsx
+++ b/web/scenes/Admin/apps/id/page.tsx
@@ -1,13 +1,240 @@
-import { UIModule } from "@/components/AdminDashboard/UIModule";
+import Link from "next/link";
+import { notFound } from "next/navigation";
 
-export const AdminAppPage = ({ appId }: { appId: string }) => (
-  <UIModule className="p-5">
-    <h1 className="text-24 font-semibold tracking-[-0.02em] text-grey-900">
-      App details
-    </h1>
-    <p className="mt-2 font-mono text-14 text-grey-500">{appId}</p>
-    <p className="mt-4 text-14 text-grey-500">
-      Detailed app inspection is not available yet.
-    </p>
-  </UIModule>
-);
+import { AppStatus, type StatusVariant } from "@/components/AppStatus";
+import { StatusBadge } from "@/components/AdminDashboard/Teams/StatusBadge";
+import { TeamMetric } from "@/components/AdminDashboard/Teams/TeamMetric";
+import { UIModule } from "@/components/AdminDashboard/UIModule";
+import { fetchAdminAppDetails } from "./server/fetch-app-details";
+
+type AdminAppPageProps = {
+  appId: string;
+};
+
+const metadataStatusVariants = new Set<StatusVariant>([
+  "awaiting_review",
+  "changes_requested",
+  "unverified",
+  "verified",
+]);
+
+const getMetadataStatus = (status?: string | null) =>
+  status && metadataStatusVariants.has(status as StatusVariant)
+    ? (status as StatusVariant)
+    : null;
+
+const metadataStatusLabels: Record<StatusVariant, string> = {
+  awaiting_review: "In review",
+  changes_requested: "Rejected",
+  unverified: "Not verified",
+  verified: "Verified",
+};
+
+export const AdminAppPage = async ({ appId }: AdminAppPageProps) => {
+  const details = await fetchAdminAppDetails(appId);
+
+  if (!details) {
+    notFound();
+  }
+
+  const draftStatus = getMetadataStatus(
+    details.draftMetadata?.verification_status,
+  );
+  const verifiedStatus = getMetadataStatus(
+    details.verifiedMetadata?.verification_status,
+  );
+  const teamStatus = details.team.deleted_at ? "Deleted" : "Active";
+  const latestMetadataUpdate = details.metadataVersions[0]?.updated_at;
+  const workflowStatus = draftStatus ?? verifiedStatus;
+
+  return (
+    <div className="grid h-full min-h-0 grid-rows-auto/1fr gap-y-4">
+      <UIModule className="p-5">
+        <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+          <div className="min-w-0">
+            <div className="mb-2 text-12 font-medium tracking-wide text-grey-400 uppercase">
+              Admin / Apps
+            </div>
+            <h1 className="text-24 font-semibold tracking-[-0.02em] text-grey-900">
+              {details.verifiedMetadata?.name ??
+                details.draftMetadata?.name ??
+                details.app.name ??
+                "Unnamed app"}
+            </h1>
+            <p className="mt-2 max-w-2xl text-14 text-grey-500">
+              Review application identity and metadata workflow.
+            </p>
+          </div>
+
+          <div className="min-w-0 rounded-12 border border-grey-200 bg-grey-50 px-3 py-2">
+            <div className="text-11 font-medium tracking-wide text-grey-400 uppercase">
+              App ID
+            </div>
+            <div className="mt-1 truncate font-mono text-13 font-medium text-grey-900">
+              {appId}
+            </div>
+            <div className="mt-3">
+              <span className="inline-flex rounded-full border border-grey-300 bg-grey-100 px-2 py-1 text-12 font-medium text-grey-500">
+                {details.app.deleted_at ? "Deleted" : "Not deleted"}
+              </span>
+            </div>
+          </div>
+        </div>
+      </UIModule>
+
+      <div className="grid h-full min-h-0 w-full grid-cols-1 gap-4 lg:grid-cols-[minmax(0,7fr)_minmax(0,3fr)]">
+        <UIModule className="min-h-0 overflow-auto p-5">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-16 font-semibold text-grey-900">Overview</h2>
+            <Link
+              className="text-12 font-medium text-blue-500 hover:text-blue-600"
+              href="/admin/apps"
+            >
+              All apps
+            </Link>
+          </div>
+          <dl className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-4">
+            <TeamMetric
+              label="Workflow status"
+              value={
+                workflowStatus
+                  ? metadataStatusLabels[workflowStatus]
+                  : "No metadata"
+              }
+            />
+            <TeamMetric
+              label="Created"
+              value={details.app.created_at.slice(0, 10)}
+            />
+            <TeamMetric
+              label="Last metadata update"
+              value={latestMetadataUpdate?.slice(0, 10) ?? "—"}
+            />
+            <TeamMetric
+              label="Verified at"
+              value={details.verifiedMetadata?.verified_at?.slice(0, 10) ?? "—"}
+            />
+          </dl>
+          <dl className="mt-6 grid gap-2 text-14">
+            <div className="flex justify-between gap-4 border-b border-grey-100 py-2">
+              <dt className="text-grey-500">Source name</dt>
+              <dd className="truncate font-medium text-grey-900">
+                {details.app.name}
+              </dd>
+            </div>
+            <div className="flex justify-between gap-4 border-b border-grey-100 py-2">
+              <dt className="text-grey-500">Deleted at</dt>
+              <dd className="font-medium text-grey-900">
+                {details.app.deleted_at?.slice(0, 10) ?? "—"}
+              </dd>
+            </div>
+          </dl>
+          <section className="mt-6">
+            <h3 className="text-14 font-semibold text-grey-900">
+              Metadata workflow
+            </h3>
+            <p className="mt-1 text-12 text-grey-500">
+              Metadata status does not represent the full application status.
+            </p>
+            <div className="mt-2 divide-y divide-grey-100">
+              <div className="flex items-center justify-between gap-3 py-3">
+                <div className="min-w-0">
+                  <p className="text-12 text-grey-500">Latest draft</p>
+                  <p className="truncate text-14 font-medium text-grey-900">
+                    {details.draftMetadata?.name ?? "No draft metadata"}
+                  </p>
+                  {details.draftMetadata && (
+                    <time className="text-12 text-grey-500">
+                      Updated {details.draftMetadata.updated_at.slice(0, 10)}
+                    </time>
+                  )}
+                </div>
+                {draftStatus && <AppStatus status={draftStatus} />}
+              </div>
+              <div className="flex items-center justify-between gap-3 py-3">
+                <div className="min-w-0">
+                  <p className="text-12 text-grey-500">Verified metadata</p>
+                  <p className="truncate text-14 font-medium text-grey-900">
+                    {details.verifiedMetadata?.name ?? "No verified metadata"}
+                  </p>
+                  {details.verifiedMetadata?.verified_at && (
+                    <time className="text-12 text-grey-500">
+                      Verified{" "}
+                      {details.verifiedMetadata.verified_at.slice(0, 10)}
+                    </time>
+                  )}
+                </div>
+                {verifiedStatus && <AppStatus status={verifiedStatus} />}
+              </div>
+            </div>
+          </section>
+          <section className="mt-6">
+            <h3 className="text-14 font-semibold text-grey-900">
+              Metadata history
+            </h3>
+            <div className="mt-2 divide-y divide-grey-100">
+              {details.metadataVersions.length === 0 ? (
+                <p className="py-3 text-14 text-grey-500">
+                  No metadata history.
+                </p>
+              ) : (
+                details.metadataVersions.map((metadata) => {
+                  const status = getMetadataStatus(
+                    metadata.verification_status,
+                  );
+
+                  return (
+                    <div
+                      className="flex items-center justify-between gap-3 py-3"
+                      key={`${metadata.app_id}:${metadata.updated_at}`}
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate text-14 font-medium text-grey-900">
+                          {metadata.name}
+                        </p>
+                        <time className="text-12 text-grey-500">
+                          Updated {metadata.updated_at.slice(0, 10)}
+                        </time>
+                      </div>
+                      {status && <AppStatus status={status} />}
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </section>
+        </UIModule>
+        <UIModule className="self-start p-5">
+          <h2 className="text-16 font-semibold text-grey-900">Owning team</h2>
+          <Link
+            className="group mt-4 block min-w-0 rounded-8 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            href={`/admin/teams/${details.team.id}`}
+            rel="noreferrer"
+            target="_blank"
+          >
+            <p className="truncate text-14 font-medium text-grey-900 transition-colors group-hover:text-blue-500">
+              {details.team.name}
+            </p>
+            <p className="mt-1 truncate font-mono text-12 text-grey-400">
+              {details.team.id}
+            </p>
+          </Link>
+          <dl className="mt-4 grid gap-2 text-14">
+            <div className="flex items-center justify-between gap-4 border-b border-grey-100 py-2">
+              <dt className="text-grey-500">Status</dt>
+              <dd>
+                <StatusBadge status={teamStatus} />
+              </dd>
+            </div>
+            <div className="flex justify-between gap-4 border-b border-grey-100 py-2">
+              <dt className="text-grey-500">Created</dt>
+              <dd className="font-medium text-grey-900">
+                {details.team.created_at.slice(0, 10)}
+              </dd>
+            </div>
+          </dl>
+        </UIModule>
+      </div>
+    </div>
+  );
+};

--- a/web/scenes/Admin/apps/id/server/fetch-app-details.ts
+++ b/web/scenes/Admin/apps/id/server/fetch-app-details.ts
@@ -1,0 +1,29 @@
+import "server-only";
+
+import { getInternalDashboardGraphqlClient } from "@/api/helpers/graphql";
+import { logger } from "@/lib/logger";
+
+import { getSdk } from "../../graphql/server/fetch-admin-app-details.generated";
+
+export const fetchAdminAppDetails = async (appId: string) => {
+  const client = await getInternalDashboardGraphqlClient();
+
+  try {
+    const data = await getSdk(client).FetchAdminAppDetails({ appId });
+
+    if (!data.app_by_pk) {
+      return null;
+    }
+
+    return {
+      app: data.app_by_pk,
+      draftMetadata: data.app_by_pk.draft_metadata[0] ?? null,
+      metadataVersions: data.metadata_versions,
+      team: data.app_by_pk.team,
+      verifiedMetadata: data.app_by_pk.verified_metadata[0] ?? null,
+    };
+  } catch (error) {
+    logger.error("Failed to fetch admin app details", { appId, error });
+    throw error;
+  }
+};

--- a/web/scenes/Admin/graphql/server/fetch-admin-home.generated.ts
+++ b/web/scenes/Admin/graphql/server/fetch-admin-home.generated.ts
@@ -1,0 +1,386 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type FetchAdminHomeQueryVariables = Types.Exact<{
+  recentSince: Types.Scalars["timestamptz"]["input"];
+  recentLimit: Types.Scalars["Int"]["input"];
+}>;
+
+export type FetchAdminHomeQuery = {
+  __typename?: "query_root";
+  active_teams: {
+    __typename?: "team_aggregate";
+    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
+  };
+  deleted_teams: {
+    __typename?: "team_aggregate";
+    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
+  };
+  new_teams: {
+    __typename?: "team_aggregate";
+    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
+  };
+  total_users: {
+    __typename?: "user_aggregate";
+    aggregate?: { __typename?: "user_aggregate_fields"; count: number } | null;
+  };
+  new_users: {
+    __typename?: "user_aggregate";
+    aggregate?: { __typename?: "user_aggregate_fields"; count: number } | null;
+  };
+  active_apps: {
+    __typename?: "app_aggregate";
+    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
+  };
+  deleted_apps: {
+    __typename?: "app_aggregate";
+    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
+  };
+  new_apps: {
+    __typename?: "app_aggregate";
+    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
+  };
+  pending_invites: {
+    __typename?: "invite_aggregate";
+    aggregate?: {
+      __typename?: "invite_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  active_api_keys: {
+    __typename?: "api_key_aggregate";
+    aggregate?: {
+      __typename?: "api_key_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  teams_without_owner: Array<{
+    __typename?: "team";
+    id: string;
+    name?: string | null;
+    created_at: string;
+  }>;
+  users_without_teams: Array<{
+    __typename?: "user";
+    id: string;
+    name: string;
+    email?: string | null;
+    created_at: string;
+  }>;
+  apps_without_metadata: Array<{
+    __typename?: "app";
+    id: string;
+    name: string;
+    team_id: string;
+    created_at: string;
+  }>;
+  owner_memberships: Array<{
+    __typename?: "membership";
+    user: {
+      __typename?: "user";
+      id: string;
+      name: string;
+      email?: string | null;
+    };
+    team: {
+      __typename?: "team";
+      id: string;
+      name?: string | null;
+      memberships_aggregate: {
+        __typename?: "membership_aggregate";
+        aggregate?: {
+          __typename?: "membership_aggregate_fields";
+          count: number;
+        } | null;
+      };
+    };
+  }>;
+  workflow_apps: Array<{
+    __typename?: "app";
+    id: string;
+    name: string;
+    team_id: string;
+    draft_metadata: Array<{
+      __typename?: "app_metadata";
+      name: string;
+      updated_at: string;
+      verification_status: string;
+    }>;
+    verified_metadata: Array<{
+      __typename?: "app_metadata";
+      name: string;
+      verified_at?: string | null;
+      verification_status: string;
+    }>;
+  }>;
+  recent_teams: Array<{
+    __typename?: "team";
+    id: string;
+    name?: string | null;
+    created_at: string;
+    deleted_at?: string | null;
+  }>;
+  recent_users: Array<{
+    __typename?: "user";
+    id: string;
+    name: string;
+    email?: string | null;
+    created_at: string;
+  }>;
+  recent_apps: Array<{
+    __typename?: "app";
+    id: string;
+    name: string;
+    team_id: string;
+    created_at: string;
+    draft_metadata: Array<{
+      __typename?: "app_metadata";
+      verification_status: string;
+    }>;
+    verified_metadata: Array<{
+      __typename?: "app_metadata";
+      verification_status: string;
+    }>;
+  }>;
+  recent_metadata: Array<{
+    __typename?: "app_metadata";
+    app_id: string;
+    name: string;
+    updated_at: string;
+    verification_status: string;
+  }>;
+};
+
+export const FetchAdminHomeDocument = gql`
+  query FetchAdminHome($recentSince: timestamptz!, $recentLimit: Int!) {
+    active_teams: team_aggregate(where: { deleted_at: { _is_null: true } }) {
+      aggregate {
+        count
+      }
+    }
+    deleted_teams: team_aggregate(where: { deleted_at: { _is_null: false } }) {
+      aggregate {
+        count
+      }
+    }
+    new_teams: team_aggregate(
+      where: {
+        deleted_at: { _is_null: true }
+        created_at: { _gte: $recentSince }
+      }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    total_users: user_aggregate {
+      aggregate {
+        count
+      }
+    }
+    new_users: user_aggregate(where: { created_at: { _gte: $recentSince } }) {
+      aggregate {
+        count
+      }
+    }
+    active_apps: app_aggregate(where: { deleted_at: { _is_null: true } }) {
+      aggregate {
+        count
+      }
+    }
+    deleted_apps: app_aggregate(where: { deleted_at: { _is_null: false } }) {
+      aggregate {
+        count
+      }
+    }
+    new_apps: app_aggregate(
+      where: {
+        deleted_at: { _is_null: true }
+        created_at: { _gte: $recentSince }
+      }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    pending_invites: invite_aggregate(
+      where: { expires_at: { _gte: "now()" } }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    active_api_keys: api_key_aggregate(where: { is_active: { _eq: true } }) {
+      aggregate {
+        count
+      }
+    }
+    teams_without_owner: team(
+      where: {
+        _and: [
+          { deleted_at: { _is_null: true } }
+          { _not: { memberships: { role: { _eq: OWNER } } } }
+        ]
+      }
+      order_by: { created_at: desc }
+    ) {
+      id
+      name
+      created_at
+    }
+    users_without_teams: user(
+      where: { _not: { memberships: {} } }
+      order_by: { created_at: desc }
+    ) {
+      id
+      name
+      email
+      created_at
+    }
+    apps_without_metadata: app(
+      where: {
+        _and: [
+          { deleted_at: { _is_null: true } }
+          { _not: { app_metadata: {} } }
+        ]
+      }
+      order_by: { created_at: desc }
+    ) {
+      id
+      name
+      team_id
+      created_at
+    }
+    owner_memberships: membership(
+      where: { role: { _eq: OWNER }, team: { deleted_at: { _is_null: true } } }
+    ) {
+      user {
+        id
+        name
+        email
+      }
+      team {
+        id
+        name
+        memberships_aggregate(where: { role: { _eq: OWNER } }) {
+          aggregate {
+            count
+          }
+        }
+      }
+    }
+    workflow_apps: app(
+      where: { deleted_at: { _is_null: true } }
+      order_by: { created_at: desc }
+    ) {
+      id
+      name
+      team_id
+      draft_metadata: app_metadata(
+        where: { verification_status: { _neq: "verified" } }
+        order_by: { updated_at: desc }
+        limit: 1
+      ) {
+        name
+        updated_at
+        verification_status
+      }
+      verified_metadata: app_metadata(
+        where: { verification_status: { _eq: "verified" } }
+        order_by: { verified_at: desc }
+        limit: 1
+      ) {
+        name
+        verified_at
+        verification_status
+      }
+    }
+    recent_teams: team(order_by: { created_at: desc }, limit: $recentLimit) {
+      id
+      name
+      created_at
+      deleted_at
+    }
+    recent_users: user(order_by: { created_at: desc }, limit: $recentLimit) {
+      id
+      name
+      email
+      created_at
+    }
+    recent_apps: app(
+      where: { deleted_at: { _is_null: true } }
+      order_by: { created_at: desc }
+      limit: $recentLimit
+    ) {
+      id
+      name
+      team_id
+      created_at
+      draft_metadata: app_metadata(
+        where: { verification_status: { _neq: "verified" } }
+        order_by: { updated_at: desc }
+        limit: 1
+      ) {
+        verification_status
+      }
+      verified_metadata: app_metadata(
+        where: { verification_status: { _eq: "verified" } }
+        order_by: { verified_at: desc }
+        limit: 1
+      ) {
+        verification_status
+      }
+    }
+    recent_metadata: app_metadata(
+      order_by: { updated_at: desc }
+      limit: $recentLimit
+    ) {
+      app_id
+      name
+      updated_at
+      verification_status
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchAdminHome(
+      variables: FetchAdminHomeQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchAdminHomeQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchAdminHomeQuery>(
+            FetchAdminHomeDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchAdminHome",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/graphql/server/fetch-admin-home.gql
+++ b/web/scenes/Admin/graphql/server/fetch-admin-home.gql
@@ -1,0 +1,184 @@
+query FetchAdminHome($recentSince: timestamptz!, $recentLimit: Int!) {
+  active_teams: team_aggregate(where: { deleted_at: { _is_null: true } }) {
+    aggregate {
+      count
+    }
+  }
+  deleted_teams: team_aggregate(where: { deleted_at: { _is_null: false } }) {
+    aggregate {
+      count
+    }
+  }
+  new_teams: team_aggregate(
+    where: {
+      deleted_at: { _is_null: true }
+      created_at: { _gte: $recentSince }
+    }
+  ) {
+    aggregate {
+      count
+    }
+  }
+  total_users: user_aggregate {
+    aggregate {
+      count
+    }
+  }
+  new_users: user_aggregate(where: { created_at: { _gte: $recentSince } }) {
+    aggregate {
+      count
+    }
+  }
+  active_apps: app_aggregate(where: { deleted_at: { _is_null: true } }) {
+    aggregate {
+      count
+    }
+  }
+  deleted_apps: app_aggregate(where: { deleted_at: { _is_null: false } }) {
+    aggregate {
+      count
+    }
+  }
+  new_apps: app_aggregate(
+    where: {
+      deleted_at: { _is_null: true }
+      created_at: { _gte: $recentSince }
+    }
+  ) {
+    aggregate {
+      count
+    }
+  }
+  pending_invites: invite_aggregate(where: { expires_at: { _gte: "now()" } }) {
+    aggregate {
+      count
+    }
+  }
+  active_api_keys: api_key_aggregate(where: { is_active: { _eq: true } }) {
+    aggregate {
+      count
+    }
+  }
+  teams_without_owner: team(
+    where: {
+      _and: [
+        { deleted_at: { _is_null: true } }
+        { _not: { memberships: { role: { _eq: OWNER } } } }
+      ]
+    }
+    order_by: { created_at: desc }
+  ) {
+    id
+    name
+    created_at
+  }
+  users_without_teams: user(
+    where: { _not: { memberships: {} } }
+    order_by: { created_at: desc }
+  ) {
+    id
+    name
+    email
+    created_at
+  }
+  apps_without_metadata: app(
+    where: {
+      _and: [{ deleted_at: { _is_null: true } }, { _not: { app_metadata: {} } }]
+    }
+    order_by: { created_at: desc }
+  ) {
+    id
+    name
+    team_id
+    created_at
+  }
+  owner_memberships: membership(
+    where: { role: { _eq: OWNER }, team: { deleted_at: { _is_null: true } } }
+  ) {
+    user {
+      id
+      name
+      email
+    }
+    team {
+      id
+      name
+      memberships_aggregate(where: { role: { _eq: OWNER } }) {
+        aggregate {
+          count
+        }
+      }
+    }
+  }
+  workflow_apps: app(
+    where: { deleted_at: { _is_null: true } }
+    order_by: { created_at: desc }
+  ) {
+    id
+    name
+    team_id
+    draft_metadata: app_metadata(
+      where: { verification_status: { _neq: "verified" } }
+      order_by: { updated_at: desc }
+      limit: 1
+    ) {
+      name
+      updated_at
+      verification_status
+    }
+    verified_metadata: app_metadata(
+      where: { verification_status: { _eq: "verified" } }
+      order_by: { verified_at: desc }
+      limit: 1
+    ) {
+      name
+      verified_at
+      verification_status
+    }
+  }
+  recent_teams: team(order_by: { created_at: desc }, limit: $recentLimit) {
+    id
+    name
+    created_at
+    deleted_at
+  }
+  recent_users: user(order_by: { created_at: desc }, limit: $recentLimit) {
+    id
+    name
+    email
+    created_at
+  }
+  recent_apps: app(
+    where: { deleted_at: { _is_null: true } }
+    order_by: { created_at: desc }
+    limit: $recentLimit
+  ) {
+    id
+    name
+    team_id
+    created_at
+    draft_metadata: app_metadata(
+      where: { verification_status: { _neq: "verified" } }
+      order_by: { updated_at: desc }
+      limit: 1
+    ) {
+      verification_status
+    }
+    verified_metadata: app_metadata(
+      where: { verification_status: { _eq: "verified" } }
+      order_by: { verified_at: desc }
+      limit: 1
+    ) {
+      verification_status
+    }
+  }
+  recent_metadata: app_metadata(
+    order_by: { updated_at: desc }
+    limit: $recentLimit
+  ) {
+    app_id
+    name
+    updated_at
+    verification_status
+  }
+}

--- a/web/scenes/Admin/layout.tsx
+++ b/web/scenes/Admin/layout.tsx
@@ -19,7 +19,7 @@ export const AdminLayout = ({ children }: { children: React.ReactNode }) => {
       <div
         className={clsx(
           // Common styles
-          "relative grid min-h-dvh overflow-x-clip bg-grey-50 p-4",
+          "relative grid min-h-dvh overflow-x-clip bg-grey-100 p-4",
 
           // Desktop styles
           "lg:grid lg:h-dvh lg:grid-cols-[auto_1fr] lg:gap-x-4 lg:overflow-hidden",

--- a/web/scenes/Admin/page.tsx
+++ b/web/scenes/Admin/page.tsx
@@ -1,8 +1,334 @@
-export const AdminPage = () => {
+import { AppStatus, type StatusVariant } from "@/components/AppStatus";
+import { StatusBadge } from "@/components/AdminDashboard/Teams/StatusBadge";
+import { UIModule } from "@/components/AdminDashboard/UIModule";
+import Link from "next/link";
+
+import { fetchAdminHome, type AdminMetadataStatus } from "./server/fetch-home";
+
+const formatDate = (value: string) => value.slice(0, 10);
+
+const preview = <Value,>(items: Value[]) => items.slice(0, 5);
+
+const isAppStatus = (
+  status: AdminMetadataStatus | null,
+): status is StatusVariant => Boolean(status);
+
+type MetricCardProps = {
+  detail: string;
+  href: string;
+  label: string;
+  value: number;
+};
+
+const MetricCard = ({ detail, href, label, value }: MetricCardProps) => (
+  <Link
+    className="rounded-12 border border-grey-200 bg-grey-50 p-4 transition-colors hover:border-blue-300 hover:bg-blue-50 focus-visible:ring-2 focus-visible:ring-blue-500"
+    href={href}
+  >
+    <div className="text-11 font-medium tracking-wide text-grey-400 uppercase">
+      {label}
+    </div>
+    <div className="mt-2 text-24 font-semibold tracking-[-0.02em] text-grey-900">
+      {value}
+    </div>
+    <div className="mt-1 text-12 text-grey-500">{detail}</div>
+  </Link>
+);
+
+type QueueSectionProps = {
+  children: React.ReactNode;
+  count: number;
+  title: string;
+};
+
+const QueueSection = ({ children, count, title }: QueueSectionProps) => (
+  <section className="rounded-12 border border-grey-200 bg-grey-50 p-3">
+    <div className="flex items-center justify-between gap-3">
+      <h3 className="text-14 font-semibold text-grey-900">{title}</h3>
+      <span className="rounded-full border border-grey-200 bg-grey-0 px-2.5 py-1 text-12 font-semibold text-grey-700">
+        {count}
+      </span>
+    </div>
+    {count === 0 ? (
+      <p className="mt-2 text-13 text-grey-500">Nothing needs attention.</p>
+    ) : (
+      <div className="mt-2 divide-y divide-grey-200">{children}</div>
+    )}
+  </section>
+);
+
+const EntityLink = ({
+  detail,
+  href,
+  label,
+}: {
+  detail?: string | null;
+  href: string;
+  label: string;
+}) => (
+  <Link
+    className="flex min-w-0 items-center justify-between gap-3 rounded-8 px-2 py-2.5 text-13 transition-colors outline-none hover:bg-grey-0 focus-visible:ring-2 focus-visible:ring-blue-500"
+    href={href}
+  >
+    <span className="truncate font-medium text-grey-900 hover:text-blue-600">
+      {label}
+    </span>
+    {detail && <span className="shrink-0 text-12 text-grey-500">{detail}</span>}
+  </Link>
+);
+
+export const AdminPage = async () => {
+  const home = await fetchAdminHome();
+
   return (
-    <div className="grid h-full place-items-center">
-      <div className="text-center">
-        <h1 className="text-lg font-medium">Internal dashboard</h1>
+    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-4">
+      <UIModule className="min-h-0 overflow-y-auto p-5">
+        <h1 className="text-24 font-semibold tracking-[-0.02em] text-grey-900">
+          Internal dashboard
+        </h1>
+        <p className="mt-2 max-w-2xl text-14 text-grey-500">
+          Monitor Developer Portal data and investigate operational issues.
+        </p>
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          <MetricCard
+            detail={`${home.inventory.newTeams} new in 30 days`}
+            href="/admin/teams"
+            label="Active teams"
+            value={home.inventory.activeTeams}
+          />
+          <MetricCard
+            detail={`${home.inventory.newApps} new in 30 days`}
+            href="/admin/apps"
+            label="Active apps"
+            value={home.inventory.activeApps}
+          />
+          <MetricCard
+            detail={`${home.inventory.newUsers} new in 30 days`}
+            href="/admin/users"
+            label="Users"
+            value={home.inventory.totalUsers}
+          />
+          <MetricCard
+            detail={`${home.inventory.deletedTeams} deleted`}
+            href="/admin/teams?query=status%3Adeleted"
+            label="Teams"
+            value={home.inventory.activeTeams + home.inventory.deletedTeams}
+          />
+          <MetricCard
+            detail={`${home.inventory.deletedApps} deleted`}
+            href="/admin/apps"
+            label="Apps"
+            value={home.inventory.activeApps + home.inventory.deletedApps}
+          />
+          <MetricCard
+            detail={`${home.inventory.activeApiKeys} active API keys`}
+            href="/admin/teams"
+            label="Pending invites"
+            value={home.inventory.pendingInvites}
+          />
+        </div>
+      </UIModule>
+
+      <div className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+        <UIModule className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden p-5">
+          <div>
+            <h2 className="text-16 font-semibold text-grey-900">
+              Needs attention
+            </h2>
+            <p className="mt-1 text-13 text-grey-500">
+              Data states that may need support or operational follow-up.
+            </p>
+          </div>
+          <div className="mt-4 grid min-h-0 gap-3 overflow-y-auto pr-1">
+            <QueueSection
+              count={home.queues.appsAwaitingReview.length}
+              title="Apps in review"
+            >
+              {preview(home.queues.appsAwaitingReview).map((app) => (
+                <EntityLink
+                  detail={app.updatedAt ? formatDate(app.updatedAt) : undefined}
+                  href={`/admin/apps/${app.id}`}
+                  key={app.id}
+                  label={app.name}
+                />
+              ))}
+            </QueueSection>
+            <QueueSection
+              count={home.queues.appsChangesRequested.length}
+              title="Apps with changes requested"
+            >
+              {preview(home.queues.appsChangesRequested).map((app) => (
+                <EntityLink
+                  detail={app.updatedAt ? formatDate(app.updatedAt) : undefined}
+                  href={`/admin/apps/${app.id}`}
+                  key={app.id}
+                  label={app.name}
+                />
+              ))}
+            </QueueSection>
+            <QueueSection
+              count={home.queues.appsWithoutMetadata.length}
+              title="Apps without metadata"
+            >
+              {preview(home.queues.appsWithoutMetadata).map((app) => (
+                <EntityLink
+                  detail={app.teamId}
+                  href={`/admin/apps/${app.id}`}
+                  key={app.id}
+                  label={app.name}
+                />
+              ))}
+            </QueueSection>
+            <QueueSection
+              count={home.queues.teamsWithoutOwner.length}
+              title="Teams without an owner"
+            >
+              {preview(home.queues.teamsWithoutOwner).map((team) => (
+                <EntityLink
+                  href={`/admin/teams/${team.id}`}
+                  key={team.id}
+                  label={team.name}
+                />
+              ))}
+            </QueueSection>
+            <QueueSection
+              count={home.queues.soleOwnerTeams.length}
+              title="Teams with one owner"
+            >
+              {preview(home.queues.soleOwnerTeams).map((team) => (
+                <EntityLink
+                  detail={team.owner.name}
+                  href={`/admin/teams/${team.id}`}
+                  key={team.id}
+                  label={team.name}
+                />
+              ))}
+            </QueueSection>
+            <QueueSection
+              count={home.queues.usersWithoutTeams.length}
+              title="Users without a team"
+            >
+              {preview(home.queues.usersWithoutTeams).map((user) => (
+                <EntityLink
+                  detail={user.email}
+                  href={`/admin/users/${user.id}`}
+                  key={user.id}
+                  label={user.name}
+                />
+              ))}
+            </QueueSection>
+          </div>
+        </UIModule>
+
+        <UIModule className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden p-5">
+          <div>
+            <h2 className="text-16 font-semibold text-grey-900">
+              Recent changes
+            </h2>
+            <p className="mt-1 text-13 text-grey-500">
+              Newly created entities and the latest metadata updates.
+            </p>
+          </div>
+          <div className="mt-4 grid min-h-0 gap-3 overflow-y-auto pr-1">
+            <section className="rounded-12 border border-grey-200 bg-grey-50 p-3">
+              <h3 className="text-grey-600 text-12 font-semibold tracking-[0.08em] uppercase">
+                Apps
+              </h3>
+              <div className="mt-1 divide-y divide-grey-100">
+                {home.recent.apps.map((app) => (
+                  <Link
+                    className="flex items-center justify-between gap-3 py-2 outline-none hover:text-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+                    href={`/admin/apps/${app.id}`}
+                    key={app.id}
+                  >
+                    <span className="min-w-0 truncate text-13 font-medium text-grey-900">
+                      {app.name}
+                    </span>
+                    <span className="flex shrink-0 items-center gap-2">
+                      {isAppStatus(app.status) && (
+                        <AppStatus
+                          className="px-2 py-0.5"
+                          status={app.status}
+                        />
+                      )}
+                      <time className="text-12 text-grey-500">
+                        {formatDate(app.createdAt)}
+                      </time>
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </section>
+            <section className="rounded-12 border border-grey-200 bg-grey-50 p-3">
+              <h3 className="text-grey-600 text-12 font-semibold tracking-[0.08em] uppercase">
+                Teams
+              </h3>
+              <div className="mt-1 divide-y divide-grey-100">
+                {home.recent.teams.map((team) => (
+                  <Link
+                    className="flex items-center justify-between gap-3 py-2 outline-none hover:text-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+                    href={`/admin/teams/${team.id}`}
+                    key={team.id}
+                  >
+                    <span className="min-w-0 truncate text-13 font-medium text-grey-900">
+                      {team.name}
+                    </span>
+                    <span className="flex shrink-0 items-center gap-2">
+                      <StatusBadge status={team.status} />
+                      <time className="text-12 text-grey-500">
+                        {formatDate(team.createdAt)}
+                      </time>
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </section>
+            <section className="rounded-12 border border-grey-200 bg-grey-50 p-3">
+              <h3 className="text-grey-600 text-12 font-semibold tracking-[0.08em] uppercase">
+                Users
+              </h3>
+              <div className="mt-1 divide-y divide-grey-100">
+                {home.recent.users.map((user) => (
+                  <EntityLink
+                    detail={formatDate(user.createdAt)}
+                    href={`/admin/users/${user.id}`}
+                    key={user.id}
+                    label={user.name}
+                  />
+                ))}
+              </div>
+            </section>
+            <section className="rounded-12 border border-grey-200 bg-grey-50 p-3">
+              <h3 className="text-grey-600 text-12 font-semibold tracking-[0.08em] uppercase">
+                Metadata updates
+              </h3>
+              <div className="mt-1 divide-y divide-grey-100">
+                {home.recent.metadata.map((metadata) => (
+                  <Link
+                    className="flex items-center justify-between gap-3 py-2 outline-none hover:text-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+                    href={`/admin/apps/${metadata.appId}`}
+                    key={`${metadata.appId}:${metadata.updatedAt}`}
+                  >
+                    <span className="min-w-0 truncate text-13 font-medium text-grey-900">
+                      {metadata.name}
+                    </span>
+                    <span className="flex shrink-0 items-center gap-2">
+                      {isAppStatus(metadata.status) && (
+                        <AppStatus
+                          className="px-2 py-0.5"
+                          status={metadata.status}
+                        />
+                      )}
+                      <time className="text-12 text-grey-500">
+                        {formatDate(metadata.updatedAt)}
+                      </time>
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          </div>
+        </UIModule>
       </div>
     </div>
   );

--- a/web/scenes/Admin/search/graphql/server/fetch-admin-global-search.generated.ts
+++ b/web/scenes/Admin/search/graphql/server/fetch-admin-global-search.generated.ts
@@ -1,0 +1,140 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type FetchAdminGlobalSearchQueryVariables = Types.Exact<{
+  appsWhere: Types.App_Bool_Exp;
+  includeApps: Types.Scalars["Boolean"]["input"];
+  includeTeams: Types.Scalars["Boolean"]["input"];
+  includeUsers: Types.Scalars["Boolean"]["input"];
+  limit: Types.Scalars["Int"]["input"];
+  teamsWhere: Types.Team_Bool_Exp;
+  usersWhere: Types.User_Bool_Exp;
+}>;
+
+export type FetchAdminGlobalSearchQuery = {
+  __typename?: "query_root";
+  apps?: Array<{
+    __typename?: "app";
+    id: string;
+    name: string;
+    team_id: string;
+  }>;
+  apps_aggregate?: {
+    __typename?: "app_aggregate";
+    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
+  };
+  teams?: Array<{ __typename?: "team"; id: string; name?: string | null }>;
+  teams_aggregate?: {
+    __typename?: "team_aggregate";
+    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
+  };
+  users?: Array<{
+    __typename?: "user";
+    id: string;
+    name: string;
+    email?: string | null;
+  }>;
+  users_aggregate?: {
+    __typename?: "user_aggregate";
+    aggregate?: { __typename?: "user_aggregate_fields"; count: number } | null;
+  };
+};
+
+export const FetchAdminGlobalSearchDocument = gql`
+  query FetchAdminGlobalSearch(
+    $appsWhere: app_bool_exp!
+    $includeApps: Boolean!
+    $includeTeams: Boolean!
+    $includeUsers: Boolean!
+    $limit: Int!
+    $teamsWhere: team_bool_exp!
+    $usersWhere: user_bool_exp!
+  ) {
+    apps: app(
+      where: $appsWhere
+      order_by: [{ name: asc }, { id: asc }]
+      limit: $limit
+    ) @include(if: $includeApps) {
+      id
+      name
+      team_id
+    }
+    apps_aggregate: app_aggregate(where: $appsWhere)
+      @include(if: $includeApps) {
+      aggregate {
+        count
+      }
+    }
+    teams: team(
+      where: $teamsWhere
+      order_by: [{ name: asc }, { id: asc }]
+      limit: $limit
+    ) @include(if: $includeTeams) {
+      id
+      name
+    }
+    teams_aggregate: team_aggregate(where: $teamsWhere)
+      @include(if: $includeTeams) {
+      aggregate {
+        count
+      }
+    }
+    users: user(
+      where: $usersWhere
+      order_by: [{ name: asc }, { id: asc }]
+      limit: $limit
+    ) @include(if: $includeUsers) {
+      id
+      name
+      email
+    }
+    users_aggregate: user_aggregate(where: $usersWhere)
+      @include(if: $includeUsers) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchAdminGlobalSearch(
+      variables: FetchAdminGlobalSearchQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchAdminGlobalSearchQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchAdminGlobalSearchQuery>(
+            FetchAdminGlobalSearchDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchAdminGlobalSearch",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/search/graphql/server/fetch-admin-global-search.gql
+++ b/web/scenes/Admin/search/graphql/server/fetch-admin-global-search.gql
@@ -1,0 +1,53 @@
+query FetchAdminGlobalSearch(
+  $appsWhere: app_bool_exp!
+  $includeApps: Boolean!
+  $includeTeams: Boolean!
+  $includeUsers: Boolean!
+  $limit: Int!
+  $teamsWhere: team_bool_exp!
+  $usersWhere: user_bool_exp!
+) {
+  apps: app(
+    where: $appsWhere
+    order_by: [{ name: asc }, { id: asc }]
+    limit: $limit
+  ) @include(if: $includeApps) {
+    id
+    name
+    team_id
+  }
+  apps_aggregate: app_aggregate(where: $appsWhere) @include(if: $includeApps) {
+    aggregate {
+      count
+    }
+  }
+  teams: team(
+    where: $teamsWhere
+    order_by: [{ name: asc }, { id: asc }]
+    limit: $limit
+  ) @include(if: $includeTeams) {
+    id
+    name
+  }
+  teams_aggregate: team_aggregate(where: $teamsWhere)
+    @include(if: $includeTeams) {
+    aggregate {
+      count
+    }
+  }
+  users: user(
+    where: $usersWhere
+    order_by: [{ name: asc }, { id: asc }]
+    limit: $limit
+  ) @include(if: $includeUsers) {
+    id
+    name
+    email
+  }
+  users_aggregate: user_aggregate(where: $usersWhere)
+    @include(if: $includeUsers) {
+    aggregate {
+      count
+    }
+  }
+}

--- a/web/scenes/Admin/search/server/create-global-search-where.ts
+++ b/web/scenes/Admin/search/server/create-global-search-where.ts
@@ -1,0 +1,82 @@
+import type {
+  App_Bool_Exp,
+  Team_Bool_Exp,
+  User_Bool_Exp,
+} from "@/graphql/graphql";
+
+export type GlobalSearchTarget = "apps" | "teams" | "users";
+
+export type GlobalSearchQuery = {
+  appsWhere: App_Bool_Exp;
+  targets: ReadonlySet<GlobalSearchTarget>;
+  teamsWhere: Team_Bool_Exp;
+  usersWhere: User_Bool_Exp;
+};
+
+const entityIdPattern = /^(app|team|user)_[a-f0-9]{4,}$/i;
+const fullEntityIdPattern = /^(app|team|user)_[a-f0-9]{32}$/i;
+
+const noResultsWhere = { id: { _eq: "" } };
+
+const hasEmail = (query: string) => query.includes("@");
+
+const getTargets = (query: string): ReadonlySet<GlobalSearchTarget> => {
+  const entityIdMatch = query.match(entityIdPattern);
+
+  if (entityIdMatch) {
+    return new Set([
+      `${entityIdMatch[1].toLowerCase()}s` as GlobalSearchTarget,
+    ]);
+  }
+
+  return hasEmail(query)
+    ? new Set(["users"])
+    : new Set(["apps", "teams", "users"]);
+};
+
+const getIdPredicate = (query: string) =>
+  fullEntityIdPattern.test(query) ? { _eq: query } : { _ilike: `${query}%` };
+
+export const createGlobalSearchQuery = (
+  rawQuery: string,
+): GlobalSearchQuery => {
+  const query = rawQuery.trim();
+  const targets = getTargets(query);
+  const idPredicate = getIdPredicate(query);
+
+  return {
+    appsWhere: targets.has("apps")
+      ? entityIdPattern.test(query)
+        ? { id: idPredicate }
+        : {
+            _or: [
+              { id: { _ilike: `%${query}%` } },
+              { name: { _ilike: `%${query}%` } },
+              { team_id: { _ilike: `%${query}%` } },
+            ],
+          }
+      : noResultsWhere,
+    targets,
+    teamsWhere: targets.has("teams")
+      ? entityIdPattern.test(query)
+        ? { id: idPredicate }
+        : {
+            _or: [
+              { id: { _ilike: `%${query}%` } },
+              { name: { _ilike: `%${query}%` } },
+            ],
+          }
+      : noResultsWhere,
+    usersWhere: targets.has("users")
+      ? entityIdPattern.test(query)
+        ? { id: idPredicate }
+        : {
+            _or: [
+              { email: { _ilike: `%${query}%` } },
+              { id: { _ilike: `%${query}%` } },
+              { name: { _ilike: `%${query}%` } },
+            ],
+          }
+      : noResultsWhere,
+  };
+};

--- a/web/scenes/Admin/search/server/fetch-global-search.ts
+++ b/web/scenes/Admin/search/server/fetch-global-search.ts
@@ -1,0 +1,74 @@
+import "server-only";
+
+import { getInternalDashboardGraphqlClientForUser } from "@/api/helpers/graphql";
+import type { AdminUser } from "@/lib/admin-auth";
+import { logger } from "@/lib/logger";
+
+import {
+  createGlobalSearchQuery,
+  type GlobalSearchTarget,
+} from "./create-global-search-where";
+import { getSdk } from "../graphql/server/fetch-admin-global-search.generated";
+
+export type GlobalSearchResult = {
+  apps: Array<{ id: string; name: string; teamId: string }>;
+  query: string;
+  teams: Array<{ id: string; name: string }>;
+  totals: Record<GlobalSearchTarget, number>;
+  users: Array<{ email: string | null; id: string; name: string }>;
+};
+
+const getCount = (aggregate?: { aggregate?: { count: number } | null }) =>
+  aggregate?.aggregate?.count ?? 0;
+
+export const fetchAdminGlobalSearch = async (
+  query: string,
+  user: AdminUser,
+): Promise<GlobalSearchResult> => {
+  const trimmedQuery = query.trim();
+  const { appsWhere, targets, teamsWhere, usersWhere } =
+    createGlobalSearchQuery(trimmedQuery);
+  const client = await getInternalDashboardGraphqlClientForUser(user);
+
+  try {
+    const data = await getSdk(client).FetchAdminGlobalSearch({
+      appsWhere,
+      includeApps: targets.has("apps"),
+      includeTeams: targets.has("teams"),
+      includeUsers: targets.has("users"),
+      limit: 5,
+      teamsWhere,
+      usersWhere,
+    });
+
+    return {
+      apps: (data.apps ?? []).map((app) => ({
+        id: app.id,
+        name: app.name,
+        teamId: app.team_id,
+      })),
+      query: trimmedQuery,
+      teams: (data.teams ?? []).map((team) => ({
+        id: team.id,
+        name: team.name ?? "Unnamed team",
+      })),
+      totals: {
+        apps: getCount(data.apps_aggregate),
+        teams: getCount(data.teams_aggregate),
+        users: getCount(data.users_aggregate),
+      },
+      users: (data.users ?? []).map((resultUser) => ({
+        email: resultUser.email ?? null,
+        id: resultUser.id,
+        name: resultUser.name,
+      })),
+    };
+  } catch (error) {
+    logger.error("Failed to fetch admin global search results", {
+      error,
+      query: trimmedQuery,
+      subject: user.subject,
+    });
+    throw error;
+  }
+};

--- a/web/scenes/Admin/server/fetch-home.ts
+++ b/web/scenes/Admin/server/fetch-home.ts
@@ -1,0 +1,153 @@
+import "server-only";
+
+import { getInternalDashboardGraphqlClient } from "@/api/helpers/graphql";
+import { logger } from "@/lib/logger";
+
+import {
+  type FetchAdminHomeQuery,
+  getSdk,
+} from "../graphql/server/fetch-admin-home.generated";
+
+export type AdminMetadataStatus =
+  | "awaiting_review"
+  | "changes_requested"
+  | "unverified"
+  | "verified";
+
+type HomeWorkflowApp = FetchAdminHomeQuery["workflow_apps"][number];
+type WorkflowStatusSource = {
+  draft_metadata: ReadonlyArray<{ verification_status: string }>;
+  verified_metadata: ReadonlyArray<{ verification_status: string }>;
+};
+
+const metadataStatuses = new Set<AdminMetadataStatus>([
+  "awaiting_review",
+  "changes_requested",
+  "unverified",
+  "verified",
+]);
+
+const getCount = (aggregate: { aggregate?: { count: number } | null }) =>
+  aggregate.aggregate?.count ?? 0;
+
+export const getWorkflowStatus = (
+  app: WorkflowStatusSource,
+): AdminMetadataStatus | null => {
+  const status =
+    app.draft_metadata[0]?.verification_status ??
+    app.verified_metadata[0]?.verification_status;
+
+  return status && metadataStatuses.has(status as AdminMetadataStatus)
+    ? (status as AdminMetadataStatus)
+    : null;
+};
+
+const mapWorkflowApp = (app: HomeWorkflowApp) => ({
+  id: app.id,
+  name:
+    app.draft_metadata[0]?.name ?? app.verified_metadata[0]?.name ?? app.name,
+  status: getWorkflowStatus(app),
+  teamId: app.team_id,
+  updatedAt: app.draft_metadata[0]?.updated_at ?? null,
+});
+
+export const fetchAdminHome = async () => {
+  const client = await getInternalDashboardGraphqlClient();
+  const recentSince = new Date(
+    Date.now() - 30 * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  try {
+    const data = await getSdk(client).FetchAdminHome({
+      recentLimit: 5,
+      recentSince,
+    });
+    const workflowApps = data.workflow_apps.map(mapWorkflowApp);
+    const soleOwnerTeams = data.owner_memberships
+      .filter(
+        (membership) =>
+          membership.team.memberships_aggregate.aggregate?.count === 1,
+      )
+      .map((membership) => ({
+        id: membership.team.id,
+        name: membership.team.name ?? "Unnamed team",
+        owner: {
+          email: membership.user.email,
+          id: membership.user.id,
+          name: membership.user.name,
+        },
+      }));
+
+    return {
+      inventory: {
+        activeApiKeys: getCount(data.active_api_keys),
+        activeApps: getCount(data.active_apps),
+        activeTeams: getCount(data.active_teams),
+        deletedApps: getCount(data.deleted_apps),
+        deletedTeams: getCount(data.deleted_teams),
+        newApps: getCount(data.new_apps),
+        newTeams: getCount(data.new_teams),
+        newUsers: getCount(data.new_users),
+        pendingInvites: getCount(data.pending_invites),
+        totalUsers: getCount(data.total_users),
+      },
+      queues: {
+        appsAwaitingReview: workflowApps.filter(
+          (app) => app.status === "awaiting_review",
+        ),
+        appsChangesRequested: workflowApps.filter(
+          (app) => app.status === "changes_requested",
+        ),
+        appsWithoutMetadata: data.apps_without_metadata.map((app) => ({
+          id: app.id,
+          name: app.name,
+          teamId: app.team_id,
+        })),
+        soleOwnerTeams,
+        teamsWithoutOwner: data.teams_without_owner.map((team) => ({
+          id: team.id,
+          name: team.name ?? "Unnamed team",
+        })),
+        usersWithoutTeams: data.users_without_teams.map((user) => ({
+          email: user.email,
+          id: user.id,
+          name: user.name,
+        })),
+      },
+      recent: {
+        apps: data.recent_apps.map((app) => ({
+          createdAt: app.created_at,
+          id: app.id,
+          name: app.name,
+          status: getWorkflowStatus(app),
+          teamId: app.team_id,
+        })),
+        metadata: data.recent_metadata.map((metadata) => ({
+          appId: metadata.app_id,
+          name: metadata.name,
+          status: metadataStatuses.has(
+            metadata.verification_status as AdminMetadataStatus,
+          )
+            ? (metadata.verification_status as AdminMetadataStatus)
+            : null,
+          updatedAt: metadata.updated_at,
+        })),
+        teams: data.recent_teams.map((team) => ({
+          createdAt: team.created_at,
+          id: team.id,
+          name: team.name ?? "Unnamed team",
+          status: team.deleted_at ? ("Deleted" as const) : ("Active" as const),
+        })),
+        users: data.recent_users.map((user) => ({
+          createdAt: user.created_at,
+          email: user.email,
+          id: user.id,
+          name: user.name,
+        })),
+      },
+    };
+  } catch (error) {
+    logger.error("Failed to fetch admin home", { error });
+    throw error;
+  }
+};

--- a/web/scenes/Admin/teams/graphql/server/fetch-admin-team-apps.generated.ts
+++ b/web/scenes/Admin/teams/graphql/server/fetch-admin-team-apps.generated.ts
@@ -1,0 +1,112 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type FetchAdminTeamAppsQueryVariables = Types.Exact<{
+  limit: Types.Scalars["Int"]["input"];
+  offset: Types.Scalars["Int"]["input"];
+  where: Types.App_Bool_Exp;
+}>;
+
+export type FetchAdminTeamAppsQuery = {
+  __typename?: "query_root";
+  app: Array<{
+    __typename?: "app";
+    id: string;
+    name: string;
+    created_at: string;
+    deleted_at?: string | null;
+    draft_metadata: Array<{
+      __typename?: "app_metadata";
+      name: string;
+      verification_status: string;
+    }>;
+    verified_metadata: Array<{
+      __typename?: "app_metadata";
+      name: string;
+      verified_at?: string | null;
+    }>;
+  }>;
+  app_aggregate: {
+    __typename?: "app_aggregate";
+    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
+  };
+};
+
+export const FetchAdminTeamAppsDocument = gql`
+  query FetchAdminTeamApps($limit: Int!, $offset: Int!, $where: app_bool_exp!) {
+    app(
+      limit: $limit
+      offset: $offset
+      order_by: { name: asc }
+      where: $where
+    ) {
+      id
+      name
+      created_at
+      deleted_at
+      draft_metadata: app_metadata(
+        where: { verification_status: { _neq: "verified" } }
+        order_by: { updated_at: desc }
+        limit: 1
+      ) {
+        name
+        verification_status
+      }
+      verified_metadata: app_metadata(
+        where: { verification_status: { _eq: "verified" } }
+        order_by: { verified_at: desc }
+        limit: 1
+      ) {
+        name
+        verified_at
+      }
+    }
+    app_aggregate(where: $where) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchAdminTeamApps(
+      variables: FetchAdminTeamAppsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchAdminTeamAppsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchAdminTeamAppsQuery>(
+            FetchAdminTeamAppsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchAdminTeamApps",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/teams/graphql/server/fetch-admin-team-apps.gql
+++ b/web/scenes/Admin/teams/graphql/server/fetch-admin-team-apps.gql
@@ -1,0 +1,29 @@
+query FetchAdminTeamApps($limit: Int!, $offset: Int!, $where: app_bool_exp!) {
+  app(limit: $limit, offset: $offset, order_by: { name: asc }, where: $where) {
+    id
+    name
+    created_at
+    deleted_at
+    draft_metadata: app_metadata(
+      where: { verification_status: { _neq: "verified" } }
+      order_by: { updated_at: desc }
+      limit: 1
+    ) {
+      name
+      verification_status
+    }
+    verified_metadata: app_metadata(
+      where: { verification_status: { _eq: "verified" } }
+      order_by: { verified_at: desc }
+      limit: 1
+    ) {
+      name
+      verified_at
+    }
+  }
+  app_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+}

--- a/web/scenes/Admin/teams/graphql/server/fetch-admin-team-details.generated.ts
+++ b/web/scenes/Admin/teams/graphql/server/fetch-admin-team-details.generated.ts
@@ -1,0 +1,155 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type FetchAdminTeamDetailsQueryVariables = Types.Exact<{
+  teamId: Types.Scalars["String"]["input"];
+}>;
+
+export type FetchAdminTeamDetailsQuery = {
+  __typename?: "query_root";
+  team_by_pk?: {
+    __typename?: "team";
+    id: string;
+    name?: string | null;
+    created_at: string;
+    deleted_at?: string | null;
+  } | null;
+  membership_aggregate: {
+    __typename?: "membership_aggregate";
+    aggregate?: {
+      __typename?: "membership_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  app_aggregate: {
+    __typename?: "app_aggregate";
+    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
+  };
+  invite_aggregate: {
+    __typename?: "invite_aggregate";
+    aggregate?: {
+      __typename?: "invite_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  api_key_aggregate: {
+    __typename?: "api_key_aggregate";
+    aggregate?: {
+      __typename?: "api_key_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  invite: Array<{
+    __typename?: "invite";
+    id: string;
+    email: string;
+    expires_at: string;
+  }>;
+  api_key: Array<{
+    __typename?: "api_key";
+    id: string;
+    name: string;
+    created_at: string;
+    updated_at: string;
+    is_active: boolean;
+  }>;
+};
+
+export const FetchAdminTeamDetailsDocument = gql`
+  query FetchAdminTeamDetails($teamId: String!) {
+    team_by_pk(id: $teamId) {
+      id
+      name
+      created_at
+      deleted_at
+    }
+    membership_aggregate(where: { team_id: { _eq: $teamId } }) {
+      aggregate {
+        count
+      }
+    }
+    app_aggregate(
+      where: { team_id: { _eq: $teamId }, deleted_at: { _is_null: true } }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    invite_aggregate(
+      where: { team_id: { _eq: $teamId }, expires_at: { _gte: "now()" } }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    api_key_aggregate(
+      where: { team_id: { _eq: $teamId }, is_active: { _eq: true } }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    invite(
+      where: { team_id: { _eq: $teamId } }
+      order_by: { expires_at: asc }
+      limit: 25
+    ) {
+      id
+      email
+      expires_at
+    }
+    api_key(
+      where: { team_id: { _eq: $teamId } }
+      order_by: [{ is_active: desc }, { created_at: desc }]
+      limit: 25
+    ) {
+      id
+      name
+      created_at
+      updated_at
+      is_active
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchAdminTeamDetails(
+      variables: FetchAdminTeamDetailsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchAdminTeamDetailsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchAdminTeamDetailsQuery>(
+            FetchAdminTeamDetailsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchAdminTeamDetails",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/teams/graphql/server/fetch-admin-team-details.gql
+++ b/web/scenes/Admin/teams/graphql/server/fetch-admin-team-details.gql
@@ -1,0 +1,54 @@
+query FetchAdminTeamDetails($teamId: String!) {
+  team_by_pk(id: $teamId) {
+    id
+    name
+    created_at
+    deleted_at
+  }
+  membership_aggregate(where: { team_id: { _eq: $teamId } }) {
+    aggregate {
+      count
+    }
+  }
+  app_aggregate(
+    where: { team_id: { _eq: $teamId }, deleted_at: { _is_null: true } }
+  ) {
+    aggregate {
+      count
+    }
+  }
+  invite_aggregate(
+    where: { team_id: { _eq: $teamId }, expires_at: { _gte: "now()" } }
+  ) {
+    aggregate {
+      count
+    }
+  }
+  api_key_aggregate(
+    where: { team_id: { _eq: $teamId }, is_active: { _eq: true } }
+  ) {
+    aggregate {
+      count
+    }
+  }
+  invite(
+    where: { team_id: { _eq: $teamId } }
+    order_by: { expires_at: asc }
+    limit: 25
+  ) {
+    id
+    email
+    expires_at
+  }
+  api_key(
+    where: { team_id: { _eq: $teamId } }
+    order_by: [{ is_active: desc }, { created_at: desc }]
+    limit: 25
+  ) {
+    id
+    name
+    created_at
+    updated_at
+    is_active
+  }
+}

--- a/web/scenes/Admin/teams/graphql/server/fetch-admin-team-members.generated.ts
+++ b/web/scenes/Admin/teams/graphql/server/fetch-admin-team-members.generated.ts
@@ -1,0 +1,104 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type FetchAdminTeamMembersQueryVariables = Types.Exact<{
+  limit: Types.Scalars["Int"]["input"];
+  offset: Types.Scalars["Int"]["input"];
+  where: Types.Membership_Bool_Exp;
+}>;
+
+export type FetchAdminTeamMembersQuery = {
+  __typename?: "query_root";
+  membership: Array<{
+    __typename?: "membership";
+    id: string;
+    role: Types.Role_Enum;
+    user_id: string;
+    user: {
+      __typename?: "user";
+      id: string;
+      name: string;
+      email?: string | null;
+      created_at: string;
+    };
+  }>;
+  membership_aggregate: {
+    __typename?: "membership_aggregate";
+    aggregate?: {
+      __typename?: "membership_aggregate_fields";
+      count: number;
+    } | null;
+  };
+};
+
+export const FetchAdminTeamMembersDocument = gql`
+  query FetchAdminTeamMembers(
+    $limit: Int!
+    $offset: Int!
+    $where: membership_bool_exp!
+  ) {
+    membership(
+      limit: $limit
+      offset: $offset
+      order_by: { user: { name: asc } }
+      where: $where
+    ) {
+      id
+      role
+      user_id
+      user {
+        id
+        name
+        email
+        created_at
+      }
+    }
+    membership_aggregate(where: $where) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchAdminTeamMembers(
+      variables: FetchAdminTeamMembersQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchAdminTeamMembersQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchAdminTeamMembersQuery>(
+            FetchAdminTeamMembersDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchAdminTeamMembers",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/teams/graphql/server/fetch-admin-team-members.gql
+++ b/web/scenes/Admin/teams/graphql/server/fetch-admin-team-members.gql
@@ -1,0 +1,27 @@
+query FetchAdminTeamMembers(
+  $limit: Int!
+  $offset: Int!
+  $where: membership_bool_exp!
+) {
+  membership(
+    limit: $limit
+    offset: $offset
+    order_by: { user: { name: asc } }
+    where: $where
+  ) {
+    id
+    role
+    user_id
+    user {
+      id
+      name
+      email
+      created_at
+    }
+  }
+  membership_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+}

--- a/web/scenes/Admin/teams/graphql/server/fetch-admin-teams.generated.ts
+++ b/web/scenes/Admin/teams/graphql/server/fetch-admin-teams.generated.ts
@@ -28,10 +28,7 @@ export type FetchAdminTeamsQuery = {
   }>;
   team_aggregate: {
     __typename?: "team_aggregate";
-    aggregate?: {
-      __typename?: "team_aggregate_fields";
-      count: number;
-    } | null;
+    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
   };
   membership?: Array<{ __typename?: "membership"; team_id: string }>;
   app?: Array<{ __typename?: "app"; team_id: string }>;
@@ -101,7 +98,7 @@ export function getSdk(
 ) {
   return {
     FetchAdminTeams(
-      variables?: FetchAdminTeamsQueryVariables,
+      variables: FetchAdminTeamsQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
     ): Promise<FetchAdminTeamsQuery> {
       return withWrapper(

--- a/web/scenes/Admin/teams/id/page.tsx
+++ b/web/scenes/Admin/teams/id/page.tsx
@@ -1,10 +1,57 @@
+import { Suspense } from "react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { TeamAppsPanel } from "@/components/AdminDashboard/Teams/Detail/TeamAppsPanel";
+import { TeamMembersPanel } from "@/components/AdminDashboard/Teams/Detail/TeamMembersPanel";
+import { StatusBadge } from "@/components/AdminDashboard/Teams/StatusBadge";
+import { TeamMetric } from "@/components/AdminDashboard/Teams/TeamMetric";
 import { UIModule } from "@/components/AdminDashboard/UIModule";
+import { parseAppsPage } from "@/components/AdminDashboard/Apps/pagination";
+import { parseAppsSearchQuery } from "@/components/AdminDashboard/Apps/search";
+import { parseUsersPage } from "@/components/AdminDashboard/Users/pagination";
+import { parseUsersSearchQuery } from "@/components/AdminDashboard/Users/search";
+import { fetchAdminTeamDetails } from "./server/fetch-team-details";
 
 type AdminTeamPageProps = {
+  searchParams?: Promise<{
+    appsPage?: string | string[];
+    appsQuery?: string | string[];
+    membersPage?: string | string[];
+    membersQuery?: string | string[];
+  }>;
   teamId: string;
 };
 
-export const AdminTeamPage = ({ teamId }: AdminTeamPageProps) => {
+const PanelSkeleton = ({ label }: { label: string }) => (
+  <UIModule className="grid min-h-0 grid-rows-[auto_auto_1fr] gap-3 p-5">
+    <h2 className="text-16 font-semibold text-grey-900">{label}</h2>
+    <div className="h-9 animate-pulse rounded-12 bg-grey-100" />
+    <div className="space-y-3">
+      <div className="h-12 animate-pulse rounded-8 bg-grey-100" />
+      <div className="h-12 animate-pulse rounded-8 bg-grey-100" />
+      <div className="h-12 animate-pulse rounded-8 bg-grey-100" />
+    </div>
+  </UIModule>
+);
+
+export const AdminTeamPage = async ({
+  searchParams = Promise.resolve({}),
+  teamId,
+}: AdminTeamPageProps) => {
+  const params = await searchParams;
+  const appsPage = parseAppsPage(params.appsPage);
+  const appsQuery = parseAppsSearchQuery(params.appsQuery);
+  const membersPage = parseUsersPage(params.membersPage);
+  const membersQuery = parseUsersSearchQuery(params.membersQuery);
+  const details = await fetchAdminTeamDetails(teamId);
+
+  if (!details) {
+    notFound();
+  }
+
+  const status = details.team.deleted_at ? "Deleted" : "Active";
+
   return (
     <div className="grid h-full min-h-0 grid-rows-auto/1fr gap-y-4">
       <UIModule className="p-5">
@@ -14,7 +61,7 @@ export const AdminTeamPage = ({ teamId }: AdminTeamPageProps) => {
               Admin / Teams
             </div>
             <h1 className="text-24 font-semibold tracking-[-0.02em] text-grey-900">
-              Team details
+              {details.team.name ?? "Unnamed team"}
             </h1>
             <p className="mt-2 max-w-2xl text-14 text-grey-500">
               Review team-level information, usage, and related resources.
@@ -28,15 +75,109 @@ export const AdminTeamPage = ({ teamId }: AdminTeamPageProps) => {
             <div className="mt-1 truncate font-mono text-13 font-medium text-grey-900">
               {teamId}
             </div>
+            <div className="mt-3">
+              <StatusBadge status={status} />
+            </div>
           </div>
         </div>
       </UIModule>
 
-      <UIModule className="grid min-h-0 place-items-center p-4">
-        <div className="text-center text-sm text-grey-500">
-          Team details will be added here.
-        </div>
-      </UIModule>
+      <div className="grid h-full min-h-0 w-full grid-cols-1 gap-4 lg:grid-cols-[minmax(0,7fr)_minmax(0,3fr)] lg:grid-rows-2">
+        <UIModule className="min-h-0 overflow-auto p-5 lg:row-span-2">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-16 font-semibold text-grey-900">Overview</h2>
+            <Link
+              className="text-12 font-medium text-blue-500 hover:text-blue-600"
+              href="/admin/teams"
+            >
+              All teams
+            </Link>
+          </div>
+          <dl className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-4">
+            <TeamMetric label="Members" value={details.membersCount} />
+            <TeamMetric label="Apps" value={details.appsCount} />
+            <TeamMetric
+              label="Pending invites"
+              value={details.pendingInvitesCount}
+            />
+            <TeamMetric
+              label="Active API keys"
+              value={details.activeApiKeysCount}
+            />
+          </dl>
+          <dl className="mt-6 grid gap-2 text-14">
+            <div className="flex justify-between gap-4 border-b border-grey-100 py-2">
+              <dt className="text-grey-500">Created</dt>
+              <dd className="font-medium text-grey-900">
+                {details.team.created_at.slice(0, 10)}
+              </dd>
+            </div>
+          </dl>
+          <section className="mt-6">
+            <h3 className="text-14 font-semibold text-grey-900">API keys</h3>
+            <div className="mt-2 divide-y divide-grey-100">
+              {details.apiKeys.length === 0 ? (
+                <p className="py-3 text-14 text-grey-500">No API keys.</p>
+              ) : (
+                details.apiKeys.map((apiKey) => (
+                  <div
+                    className="flex items-center justify-between gap-3 py-3"
+                    key={apiKey.id}
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-14 font-medium text-grey-900">
+                        {apiKey.name}
+                      </p>
+                      <p className="truncate font-mono text-12 text-grey-400">
+                        {apiKey.id}
+                      </p>
+                    </div>
+                    <span className="shrink-0 text-12 text-grey-500">
+                      {apiKey.is_active ? "Active" : "Inactive"}
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+          <section className="mt-6">
+            <h3 className="text-14 font-semibold text-grey-900">Invites</h3>
+            <div className="mt-2 divide-y divide-grey-100">
+              {details.invites.length === 0 ? (
+                <p className="py-3 text-14 text-grey-500">No invites.</p>
+              ) : (
+                details.invites.map((invite) => (
+                  <div
+                    className="flex items-center justify-between gap-3 py-3"
+                    key={invite.id}
+                  >
+                    <p className="truncate text-14 text-grey-900">
+                      {invite.email}
+                    </p>
+                    <time className="shrink-0 text-12 text-grey-500">
+                      {invite.expires_at.slice(0, 10)}
+                    </time>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        </UIModule>
+        <Suspense fallback={<PanelSkeleton label="Apps" />}>
+          <TeamAppsPanel
+            appsPage={appsPage}
+            appsQuery={appsQuery}
+            teamId={teamId}
+          />
+        </Suspense>
+        <Suspense fallback={<PanelSkeleton label="Members" />}>
+          <TeamMembersPanel
+            membersPage={membersPage}
+            membersQuery={membersQuery}
+            teamId={teamId}
+          />
+        </Suspense>
+      </div>
     </div>
   );
 };

--- a/web/scenes/Admin/teams/id/server/fetch-team-apps.ts
+++ b/web/scenes/Admin/teams/id/server/fetch-team-apps.ts
@@ -1,0 +1,55 @@
+import "server-only";
+
+import {
+  clampAppsPage,
+  getAppsOffset,
+  getAppsTotalPages,
+} from "@/components/AdminDashboard/Apps/pagination";
+import { createAppsWhere } from "@/scenes/Admin/apps/server/fetch-apps";
+import { getInternalDashboardGraphqlClient } from "@/api/helpers/graphql";
+import type { App_Bool_Exp } from "@/graphql/graphql";
+import { logger } from "@/lib/logger";
+
+import { getSdk } from "../../graphql/server/fetch-admin-team-apps.generated";
+
+export const TEAM_DETAIL_LIST_LIMIT = 10;
+
+export const createAdminTeamAppsWhere = (
+  teamId: string,
+  searchQuery: string,
+): App_Bool_Exp => ({
+  _and: [{ team_id: { _eq: teamId } }, createAppsWhere(searchQuery)],
+});
+
+export const fetchAdminTeamAppsPage = async ({
+  page,
+  searchQuery,
+  teamId,
+}: {
+  page: number;
+  searchQuery: string;
+  teamId: string;
+}) => {
+  const client = await getInternalDashboardGraphqlClient();
+  const where = createAdminTeamAppsWhere(teamId, searchQuery);
+
+  try {
+    const data = await getSdk(client).FetchAdminTeamApps({
+      limit: TEAM_DETAIL_LIST_LIMIT,
+      offset: getAppsOffset(page, TEAM_DETAIL_LIST_LIMIT),
+      where,
+    });
+    const appsAmount = data.app_aggregate.aggregate?.count ?? data.app.length;
+    const totalPages = getAppsTotalPages(appsAmount, TEAM_DETAIL_LIST_LIMIT);
+
+    return {
+      apps: data.app,
+      appsAmount,
+      currentPage: clampAppsPage(page, totalPages),
+      totalPages,
+    };
+  } catch (error) {
+    logger.error("Failed to fetch admin team apps", { error, teamId });
+    throw error;
+  }
+};

--- a/web/scenes/Admin/teams/id/server/fetch-team-details.ts
+++ b/web/scenes/Admin/teams/id/server/fetch-team-details.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import { getInternalDashboardGraphqlClient } from "@/api/helpers/graphql";
+import { logger } from "@/lib/logger";
+
+import { getSdk } from "../../graphql/server/fetch-admin-team-details.generated";
+
+export const fetchAdminTeamDetails = async (teamId: string) => {
+  const client = await getInternalDashboardGraphqlClient();
+
+  try {
+    const data = await getSdk(client).FetchAdminTeamDetails({ teamId });
+
+    if (!data.team_by_pk) {
+      return null;
+    }
+
+    return {
+      apiKeys: data.api_key,
+      appsCount: data.app_aggregate.aggregate?.count ?? 0,
+      invites: data.invite,
+      membersCount: data.membership_aggregate.aggregate?.count ?? 0,
+      pendingInvitesCount: data.invite_aggregate.aggregate?.count ?? 0,
+      activeApiKeysCount: data.api_key_aggregate.aggregate?.count ?? 0,
+      team: data.team_by_pk,
+    };
+  } catch (error) {
+    logger.error("Failed to fetch admin team details", { error, teamId });
+    throw error;
+  }
+};

--- a/web/scenes/Admin/teams/id/server/fetch-team-members.ts
+++ b/web/scenes/Admin/teams/id/server/fetch-team-members.ts
@@ -1,0 +1,113 @@
+import "server-only";
+
+import {
+  clampUsersPage,
+  getUsersOffset,
+  getUsersTotalPages,
+} from "@/components/AdminDashboard/Users/pagination";
+import { getInternalDashboardGraphqlClient } from "@/api/helpers/graphql";
+import type { Membership_Bool_Exp, Role_Enum } from "@/graphql/graphql";
+import { logger } from "@/lib/logger";
+
+import {
+  getSdk,
+  type FetchAdminTeamMembersQuery,
+} from "../../graphql/server/fetch-admin-team-members.generated";
+
+import { TEAM_DETAIL_LIST_LIMIT } from "./fetch-team-apps";
+
+const getSearchPredicate = (value: string) => ({ _ilike: `%${value}%` });
+const roleValues = ["ADMIN", "MEMBER", "OWNER"] as const;
+
+export const createAdminTeamMembersWhere = (
+  teamId: string,
+  searchQuery: string,
+): Membership_Bool_Exp => {
+  const search = searchQuery.trim();
+
+  if (!search) {
+    return { team_id: { _eq: teamId } };
+  }
+
+  const fieldMatch = search.match(/^(id|name|email|role):(.+)$/i);
+  const [, field, rawValue] = fieldMatch ?? [];
+  const value = rawValue?.trim() ?? search;
+  const role = value.toUpperCase();
+  const isRole = roleValues.includes(role as Role_Enum);
+
+  if (field === "role") {
+    if (!isRole) {
+      return {
+        _and: [{ team_id: { _eq: teamId } }, { user_id: { _in: [] } }],
+      };
+    }
+
+    return {
+      _and: [
+        { team_id: { _eq: teamId } },
+        { role: { _eq: role as Role_Enum } },
+      ],
+    };
+  }
+
+  let searchWhere: Membership_Bool_Exp;
+
+  if (field === "id") {
+    searchWhere = { user_id: getSearchPredicate(value) };
+  } else if (field === "name") {
+    searchWhere = { user: { name: getSearchPredicate(value) } };
+  } else if (field === "email") {
+    searchWhere = { user: { email: getSearchPredicate(value) } };
+  } else {
+    searchWhere = {
+      _or: [
+        { user_id: getSearchPredicate(value) },
+        { user: { name: getSearchPredicate(value) } },
+        { user: { email: getSearchPredicate(value) } },
+      ],
+    };
+  }
+
+  return {
+    _and: [{ team_id: { _eq: teamId } }, searchWhere],
+  };
+};
+
+export type AdminTeamMember = FetchAdminTeamMembersQuery["membership"][number];
+
+export const fetchAdminTeamMembersPage = async ({
+  page,
+  searchQuery,
+  teamId,
+}: {
+  page: number;
+  searchQuery: string;
+  teamId: string;
+}) => {
+  const client = await getInternalDashboardGraphqlClient();
+  const where = createAdminTeamMembersWhere(teamId, searchQuery);
+
+  try {
+    const data = await getSdk(client).FetchAdminTeamMembers({
+      limit: TEAM_DETAIL_LIST_LIMIT,
+      offset: getUsersOffset(page, TEAM_DETAIL_LIST_LIMIT),
+      where,
+    });
+    const membersAmount =
+      data.membership_aggregate.aggregate?.count ?? data.membership.length;
+    const totalPages = getUsersTotalPages(
+      membersAmount,
+      TEAM_DETAIL_LIST_LIMIT,
+    );
+
+    return {
+      currentPage: clampUsersPage(page, totalPages),
+      members: data.membership,
+      membersAmount,
+      totalPages,
+    };
+  } catch (error) {
+    logger.error("Failed to fetch admin team members", { error, teamId });
+    throw error;
+  }
+};

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-user-apps.generated.ts
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-user-apps.generated.ts
@@ -4,27 +4,31 @@ import * as Types from "@/graphql/graphql";
 import { GraphQLClient, RequestOptions } from "graphql-request";
 import gql from "graphql-tag";
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
-export type FetchAdminAppsQueryVariables = Types.Exact<{
-  includeCreatedAt: Types.Scalars["Boolean"]["input"];
-  includeDraftMetadata: Types.Scalars["Boolean"]["input"];
-  includeTeamId: Types.Scalars["Boolean"]["input"];
-  includeVerifiedMetadata: Types.Scalars["Boolean"]["input"];
+export type FetchAdminUserAppsQueryVariables = Types.Exact<{
   limit: Types.Scalars["Int"]["input"];
   offset: Types.Scalars["Int"]["input"];
-  orderBy: Array<Types.App_Order_By> | Types.App_Order_By;
   where: Types.App_Bool_Exp;
 }>;
 
-export type FetchAdminAppsQuery = {
+export type FetchAdminUserAppsQuery = {
   __typename?: "query_root";
   app: Array<{
     __typename?: "app";
     id: string;
     name: string;
-    team_id?: string;
-    created_at?: string;
-    draft_metadata?: Array<{ __typename?: "app_metadata"; name: string }>;
-    verified_metadata?: Array<{ __typename?: "app_metadata"; name: string }>;
+    created_at: string;
+    deleted_at?: string | null;
+    team: { __typename?: "team"; id: string; name?: string | null };
+    draft_metadata: Array<{
+      __typename?: "app_metadata";
+      name: string;
+      verification_status: string;
+    }>;
+    verified_metadata: Array<{
+      __typename?: "app_metadata";
+      name: string;
+      verified_at?: string | null;
+    }>;
   }>;
   app_aggregate: {
     __typename?: "app_aggregate";
@@ -32,35 +36,37 @@ export type FetchAdminAppsQuery = {
   };
 };
 
-export const FetchAdminAppsDocument = gql`
-  query FetchAdminApps(
-    $includeCreatedAt: Boolean!
-    $includeDraftMetadata: Boolean!
-    $includeTeamId: Boolean!
-    $includeVerifiedMetadata: Boolean!
-    $limit: Int!
-    $offset: Int!
-    $orderBy: [app_order_by!]!
-    $where: app_bool_exp!
-  ) {
-    app(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
+export const FetchAdminUserAppsDocument = gql`
+  query FetchAdminUserApps($limit: Int!, $offset: Int!, $where: app_bool_exp!) {
+    app(
+      limit: $limit
+      offset: $offset
+      order_by: { name: asc }
+      where: $where
+    ) {
       id
       name
-      team_id @include(if: $includeTeamId)
-      created_at @include(if: $includeCreatedAt)
+      created_at
+      deleted_at
+      team {
+        id
+        name
+      }
       draft_metadata: app_metadata(
         where: { verification_status: { _neq: "verified" } }
         order_by: { updated_at: desc }
         limit: 1
-      ) @include(if: $includeDraftMetadata) {
+      ) {
         name
+        verification_status
       }
       verified_metadata: app_metadata(
         where: { verification_status: { _eq: "verified" } }
         order_by: { verified_at: desc }
         limit: 1
-      ) @include(if: $includeVerifiedMetadata) {
+      ) {
         name
+        verified_at
       }
     }
     app_aggregate(where: $where) {
@@ -90,18 +96,18 @@ export function getSdk(
   withWrapper: SdkFunctionWrapper = defaultWrapper,
 ) {
   return {
-    FetchAdminApps(
-      variables: FetchAdminAppsQueryVariables,
+    FetchAdminUserApps(
+      variables: FetchAdminUserAppsQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<FetchAdminAppsQuery> {
+    ): Promise<FetchAdminUserAppsQuery> {
       return withWrapper(
         (wrappedRequestHeaders) =>
-          client.request<FetchAdminAppsQuery>(
-            FetchAdminAppsDocument,
+          client.request<FetchAdminUserAppsQuery>(
+            FetchAdminUserAppsDocument,
             variables,
             { ...requestHeaders, ...wrappedRequestHeaders },
           ),
-        "FetchAdminApps",
+        "FetchAdminUserApps",
         "query",
         variables,
       );

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-user-apps.gql
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-user-apps.gql
@@ -1,0 +1,33 @@
+query FetchAdminUserApps($limit: Int!, $offset: Int!, $where: app_bool_exp!) {
+  app(limit: $limit, offset: $offset, order_by: { name: asc }, where: $where) {
+    id
+    name
+    created_at
+    deleted_at
+    team {
+      id
+      name
+    }
+    draft_metadata: app_metadata(
+      where: { verification_status: { _neq: "verified" } }
+      order_by: { updated_at: desc }
+      limit: 1
+    ) {
+      name
+      verification_status
+    }
+    verified_metadata: app_metadata(
+      where: { verification_status: { _eq: "verified" } }
+      order_by: { verified_at: desc }
+      limit: 1
+    ) {
+      name
+      verified_at
+    }
+  }
+  app_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+}

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-user-details.generated.ts
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-user-details.generated.ts
@@ -1,0 +1,193 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type FetchAdminUserDetailsQueryVariables = Types.Exact<{
+  userId: Types.Scalars["String"]["input"];
+}>;
+
+export type FetchAdminUserDetailsQuery = {
+  __typename?: "query_root";
+  user_by_pk?: {
+    __typename?: "user";
+    id: string;
+    name: string;
+    email?: string | null;
+    created_at: string;
+  } | null;
+  memberships: {
+    __typename?: "membership_aggregate";
+    aggregate?: {
+      __typename?: "membership_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  owners: {
+    __typename?: "membership_aggregate";
+    aggregate?: {
+      __typename?: "membership_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  admins: {
+    __typename?: "membership_aggregate";
+    aggregate?: {
+      __typename?: "membership_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  members: {
+    __typename?: "membership_aggregate";
+    aggregate?: {
+      __typename?: "membership_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  apps: {
+    __typename?: "app_aggregate";
+    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
+  };
+  owner_memberships: Array<{
+    __typename?: "membership";
+    id: string;
+    team: {
+      __typename?: "team";
+      id: string;
+      name?: string | null;
+      deleted_at?: string | null;
+      memberships_aggregate: {
+        __typename?: "membership_aggregate";
+        aggregate?: {
+          __typename?: "membership_aggregate_fields";
+          count: number;
+        } | null;
+      };
+    };
+  }>;
+  deleted_team_memberships: Array<{
+    __typename?: "membership";
+    id: string;
+    team: {
+      __typename?: "team";
+      id: string;
+      name?: string | null;
+      deleted_at?: string | null;
+    };
+  }>;
+};
+
+export const FetchAdminUserDetailsDocument = gql`
+  query FetchAdminUserDetails($userId: String!) {
+    user_by_pk(id: $userId) {
+      id
+      name
+      email
+      created_at
+    }
+    memberships: membership_aggregate(where: { user_id: { _eq: $userId } }) {
+      aggregate {
+        count
+      }
+    }
+    owners: membership_aggregate(
+      where: { user_id: { _eq: $userId }, role: { _eq: OWNER } }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    admins: membership_aggregate(
+      where: { user_id: { _eq: $userId }, role: { _eq: ADMIN } }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    members: membership_aggregate(
+      where: { user_id: { _eq: $userId }, role: { _eq: MEMBER } }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    apps: app_aggregate(
+      where: {
+        deleted_at: { _is_null: true }
+        team: { memberships: { user_id: { _eq: $userId } } }
+      }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    owner_memberships: membership(
+      where: { user_id: { _eq: $userId }, role: { _eq: OWNER } }
+    ) {
+      id
+      team {
+        id
+        name
+        deleted_at
+        memberships_aggregate(where: { role: { _eq: OWNER } }) {
+          aggregate {
+            count
+          }
+        }
+      }
+    }
+    deleted_team_memberships: membership(
+      where: {
+        user_id: { _eq: $userId }
+        team: { deleted_at: { _is_null: false } }
+      }
+    ) {
+      id
+      team {
+        id
+        name
+        deleted_at
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchAdminUserDetails(
+      variables: FetchAdminUserDetailsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchAdminUserDetailsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchAdminUserDetailsQuery>(
+            FetchAdminUserDetailsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchAdminUserDetails",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-user-details.gql
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-user-details.gql
@@ -1,0 +1,72 @@
+query FetchAdminUserDetails($userId: String!) {
+  user_by_pk(id: $userId) {
+    id
+    name
+    email
+    created_at
+  }
+  memberships: membership_aggregate(where: { user_id: { _eq: $userId } }) {
+    aggregate {
+      count
+    }
+  }
+  owners: membership_aggregate(
+    where: { user_id: { _eq: $userId }, role: { _eq: OWNER } }
+  ) {
+    aggregate {
+      count
+    }
+  }
+  admins: membership_aggregate(
+    where: { user_id: { _eq: $userId }, role: { _eq: ADMIN } }
+  ) {
+    aggregate {
+      count
+    }
+  }
+  members: membership_aggregate(
+    where: { user_id: { _eq: $userId }, role: { _eq: MEMBER } }
+  ) {
+    aggregate {
+      count
+    }
+  }
+  apps: app_aggregate(
+    where: {
+      deleted_at: { _is_null: true }
+      team: { memberships: { user_id: { _eq: $userId } } }
+    }
+  ) {
+    aggregate {
+      count
+    }
+  }
+  owner_memberships: membership(
+    where: { user_id: { _eq: $userId }, role: { _eq: OWNER } }
+  ) {
+    id
+    team {
+      id
+      name
+      deleted_at
+      memberships_aggregate(where: { role: { _eq: OWNER } }) {
+        aggregate {
+          count
+        }
+      }
+    }
+  }
+  deleted_team_memberships: membership(
+    where: {
+      user_id: { _eq: $userId }
+      team: { deleted_at: { _is_null: false } }
+    }
+  ) {
+    id
+    team {
+      id
+      name
+      deleted_at
+    }
+  }
+}

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-user-teams.generated.ts
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-user-teams.generated.ts
@@ -1,0 +1,102 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type FetchAdminUserTeamsQueryVariables = Types.Exact<{
+  limit: Types.Scalars["Int"]["input"];
+  offset: Types.Scalars["Int"]["input"];
+  where: Types.Membership_Bool_Exp;
+}>;
+
+export type FetchAdminUserTeamsQuery = {
+  __typename?: "query_root";
+  membership: Array<{
+    __typename?: "membership";
+    id: string;
+    role: Types.Role_Enum;
+    team_id: string;
+    team: {
+      __typename?: "team";
+      id: string;
+      name?: string | null;
+      deleted_at?: string | null;
+    };
+  }>;
+  membership_aggregate: {
+    __typename?: "membership_aggregate";
+    aggregate?: {
+      __typename?: "membership_aggregate_fields";
+      count: number;
+    } | null;
+  };
+};
+
+export const FetchAdminUserTeamsDocument = gql`
+  query FetchAdminUserTeams(
+    $limit: Int!
+    $offset: Int!
+    $where: membership_bool_exp!
+  ) {
+    membership(
+      limit: $limit
+      offset: $offset
+      order_by: { team: { name: asc } }
+      where: $where
+    ) {
+      id
+      role
+      team_id
+      team {
+        id
+        name
+        deleted_at
+      }
+    }
+    membership_aggregate(where: $where) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchAdminUserTeams(
+      variables: FetchAdminUserTeamsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchAdminUserTeamsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchAdminUserTeamsQuery>(
+            FetchAdminUserTeamsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchAdminUserTeams",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-user-teams.gql
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-user-teams.gql
@@ -1,0 +1,26 @@
+query FetchAdminUserTeams(
+  $limit: Int!
+  $offset: Int!
+  $where: membership_bool_exp!
+) {
+  membership(
+    limit: $limit
+    offset: $offset
+    order_by: { team: { name: asc } }
+    where: $where
+  ) {
+    id
+    role
+    team_id
+    team {
+      id
+      name
+      deleted_at
+    }
+  }
+  membership_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+}

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-users.generated.ts
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-users.generated.ts
@@ -1,10 +1,9 @@
+/* eslint-disable */
 import * as Types from "@/graphql/graphql";
 
 import { GraphQLClient, RequestOptions } from "graphql-request";
 import gql from "graphql-tag";
-
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
-
 export type FetchAdminUsersQueryVariables = Types.Exact<{
   includeCreatedAt: Types.Scalars["Boolean"]["input"];
   includeEmail: Types.Scalars["Boolean"]["input"];
@@ -33,10 +32,7 @@ export type FetchAdminUsersQuery = {
   }>;
   user_aggregate: {
     __typename?: "user_aggregate";
-    aggregate?: {
-      __typename?: "user_aggregate_fields";
-      count: number;
-    } | null;
+    aggregate?: { __typename?: "user_aggregate_fields"; count: number } | null;
   };
 };
 
@@ -73,10 +69,15 @@ export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
   operationName: string,
   operationType?: string,
-  variables?: unknown,
+  variables?: any,
 ) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (action) => action();
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
 
 export function getSdk(
   client: GraphQLClient,
@@ -84,7 +85,7 @@ export function getSdk(
 ) {
   return {
     FetchAdminUsers(
-      variables?: FetchAdminUsersQueryVariables,
+      variables: FetchAdminUsersQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
     ): Promise<FetchAdminUsersQuery> {
       return withWrapper(
@@ -101,5 +102,4 @@ export function getSdk(
     },
   };
 }
-
 export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/users/id/page.tsx
+++ b/web/scenes/Admin/users/id/page.tsx
@@ -1,10 +1,54 @@
+import Link from "next/link";
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
+
+import { UserAppsPanel } from "@/components/AdminDashboard/Users/Detail/UserAppsPanel";
+import { UserTeamsPanel } from "@/components/AdminDashboard/Users/Detail/UserTeamsPanel";
+import { UserMetric } from "@/components/AdminDashboard/Users/UserMetric";
 import { UIModule } from "@/components/AdminDashboard/UIModule";
+import { parseAppsPage } from "@/components/AdminDashboard/Apps/pagination";
+import { parseAppsSearchQuery } from "@/components/AdminDashboard/Apps/search";
+import { parseUsersPage } from "@/components/AdminDashboard/Users/pagination";
+import { parseUsersSearchQuery } from "@/components/AdminDashboard/Users/search";
+import { fetchAdminUserDetails } from "./server/fetch-user-details";
 
 type AdminUserPageProps = {
+  searchParams?: Promise<{
+    appsPage?: string | string[];
+    appsQuery?: string | string[];
+    teamsPage?: string | string[];
+    teamsQuery?: string | string[];
+  }>;
   userId: string;
 };
 
-export const AdminUserPage = ({ userId }: AdminUserPageProps) => {
+const PanelSkeleton = ({ label }: { label: string }) => (
+  <UIModule className="grid min-h-0 grid-rows-[auto_auto_1fr] gap-3 p-5">
+    <h2 className="text-16 font-semibold text-grey-900">{label}</h2>
+    <div className="h-9 animate-pulse rounded-12 bg-grey-100" />
+    <div className="space-y-3">
+      <div className="h-12 animate-pulse rounded-8 bg-grey-100" />
+      <div className="h-12 animate-pulse rounded-8 bg-grey-100" />
+      <div className="h-12 animate-pulse rounded-8 bg-grey-100" />
+    </div>
+  </UIModule>
+);
+
+export const AdminUserPage = async ({
+  searchParams = Promise.resolve({}),
+  userId,
+}: AdminUserPageProps) => {
+  const params = await searchParams;
+  const appsPage = parseAppsPage(params.appsPage);
+  const appsQuery = parseAppsSearchQuery(params.appsQuery);
+  const teamsPage = parseUsersPage(params.teamsPage);
+  const teamsQuery = parseUsersSearchQuery(params.teamsQuery);
+  const details = await fetchAdminUserDetails(userId);
+
+  if (!details) {
+    notFound();
+  }
+
   return (
     <div className="grid h-full min-h-0 grid-rows-auto/1fr gap-y-4">
       <UIModule className="p-5">
@@ -14,10 +58,10 @@ export const AdminUserPage = ({ userId }: AdminUserPageProps) => {
               Admin / Users
             </div>
             <h1 className="text-24 font-semibold tracking-[-0.02em] text-grey-900">
-              User details
+              {details.user.name || "Unnamed user"}
             </h1>
             <p className="mt-2 max-w-2xl text-14 text-grey-500">
-              Review user-level information and related teams.
+              Review user-level information and related resources.
             </p>
           </div>
 
@@ -28,15 +72,112 @@ export const AdminUserPage = ({ userId }: AdminUserPageProps) => {
             <div className="mt-1 truncate font-mono text-13 font-medium text-grey-900">
               {userId}
             </div>
+            <div className="mt-3 truncate text-12 text-grey-500">
+              {details.user.email ?? "No email"}
+            </div>
+            <div className="mt-1 text-12 text-grey-500">
+              Created {details.user.created_at.slice(0, 10)}
+            </div>
           </div>
         </div>
       </UIModule>
 
-      <UIModule className="grid min-h-0 place-items-center p-4">
-        <div className="text-center text-sm text-grey-500">
-          User details will be added here.
-        </div>
-      </UIModule>
+      <div className="grid h-full min-h-0 w-full grid-cols-1 gap-4 lg:grid-cols-[minmax(0,7fr)_minmax(0,3fr)] lg:grid-rows-2">
+        <UIModule className="min-h-0 overflow-auto p-5 lg:row-span-2">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-16 font-semibold text-grey-900">Overview</h2>
+            <Link
+              className="text-12 font-medium text-blue-500 hover:text-blue-600"
+              href="/admin/users"
+            >
+              All users
+            </Link>
+          </div>
+          <dl className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-4">
+            <UserMetric label="Teams" value={details.teamsCount} />
+            <UserMetric label="Owner" value={details.ownerCount} />
+            <UserMetric label="Admin" value={details.adminCount} />
+            <UserMetric label="Active apps" value={details.activeAppsCount} />
+          </dl>
+          <dl className="mt-6 grid gap-2 text-14">
+            <div className="flex justify-between gap-4 border-b border-grey-100 py-2">
+              <dt className="text-grey-500">Email</dt>
+              <dd className="truncate font-medium text-grey-900">
+                {details.user.email ?? "No email"}
+              </dd>
+            </div>
+            <div className="flex justify-between gap-4 border-b border-grey-100 py-2">
+              <dt className="text-grey-500">Created</dt>
+              <dd className="font-medium text-grey-900">
+                {details.user.created_at.slice(0, 10)}
+              </dd>
+            </div>
+            <div className="flex justify-between gap-4 border-b border-grey-100 py-2">
+              <dt className="text-grey-500">Member roles</dt>
+              <dd className="font-medium text-grey-900">
+                {details.memberCount}
+              </dd>
+            </div>
+          </dl>
+          {details.soleOwnerTeams.length > 0 && (
+            <section className="mt-6">
+              <h3 className="text-14 font-semibold text-grey-900">
+                Sole owner teams
+              </h3>
+              <p className="mt-1 text-12 text-grey-500">
+                Removing this user could leave these teams without an owner.
+              </p>
+              <div className="mt-2 divide-y divide-grey-100">
+                {details.soleOwnerTeams.map((team) => (
+                  <Link
+                    className="block py-3 text-14 font-medium text-blue-500 hover:text-blue-600"
+                    href={`/admin/teams/${team.id}`}
+                    key={team.id}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    {team.name}
+                  </Link>
+                ))}
+              </div>
+            </section>
+          )}
+          {details.deletedTeams.length > 0 && (
+            <section className="mt-6">
+              <h3 className="text-14 font-semibold text-grey-900">
+                Deleted teams
+              </h3>
+              <div className="mt-2 divide-y divide-grey-100">
+                {details.deletedTeams.map((team) => (
+                  <Link
+                    className="block py-3 text-14 font-medium text-blue-500 hover:text-blue-600"
+                    href={`/admin/teams/${team.id}`}
+                    key={team.id}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    {team.name}
+                  </Link>
+                ))}
+              </div>
+            </section>
+          )}
+        </UIModule>
+        <Suspense fallback={<PanelSkeleton label="Teams" />}>
+          <UserTeamsPanel
+            teamsPage={teamsPage}
+            teamsQuery={teamsQuery}
+            userId={userId}
+          />
+        </Suspense>
+        <Suspense fallback={<PanelSkeleton label="Apps in user’s teams" />}>
+          <UserAppsPanel
+            appsPage={appsPage}
+            appsQuery={appsQuery}
+            userId={userId}
+          />
+        </Suspense>
+      </div>
     </div>
   );
 };

--- a/web/scenes/Admin/users/id/server/fetch-user-apps.ts
+++ b/web/scenes/Admin/users/id/server/fetch-user-apps.ts
@@ -1,0 +1,74 @@
+import "server-only";
+
+import {
+  clampAppsPage,
+  getAppsOffset,
+  getAppsTotalPages,
+} from "@/components/AdminDashboard/Apps/pagination";
+import { createAppsWhere } from "@/scenes/Admin/apps/server/fetch-apps";
+import { getInternalDashboardGraphqlClient } from "@/api/helpers/graphql";
+import type { App_Bool_Exp } from "@/graphql/graphql";
+import { logger } from "@/lib/logger";
+
+import {
+  getSdk,
+  type FetchAdminUserAppsQuery,
+} from "../../graphql/server/fetch-admin-user-apps.generated";
+
+export const USER_DETAIL_LIST_LIMIT = 10;
+
+export const createAdminUserAppsWhere = (
+  userId: string,
+  searchQuery: string,
+): App_Bool_Exp => ({
+  _and: [
+    { team: { memberships: { user_id: { _eq: userId } } } },
+    createAppsWhere(searchQuery),
+  ],
+});
+
+type RawAdminUserApp = FetchAdminUserAppsQuery["app"][number];
+
+export type AdminUserApp = Omit<RawAdminUserApp, "team"> & {
+  team: Omit<RawAdminUserApp["team"], "name"> & { name: string };
+};
+
+export const fetchAdminUserAppsPage = async ({
+  page,
+  searchQuery,
+  userId,
+}: {
+  page: number;
+  searchQuery: string;
+  userId: string;
+}) => {
+  const client = await getInternalDashboardGraphqlClient();
+  const where = createAdminUserAppsWhere(userId, searchQuery);
+
+  try {
+    const data = await getSdk(client).FetchAdminUserApps({
+      limit: USER_DETAIL_LIST_LIMIT,
+      offset: getAppsOffset(page, USER_DETAIL_LIST_LIMIT),
+      where,
+    });
+    const appsAmount = data.app_aggregate.aggregate?.count ?? data.app.length;
+    const totalPages = getAppsTotalPages(appsAmount, USER_DETAIL_LIST_LIMIT);
+    const apps: AdminUserApp[] = data.app.map((app) => ({
+      ...app,
+      team: {
+        ...app.team,
+        name: app.team.name ?? "Unnamed team",
+      },
+    }));
+
+    return {
+      apps,
+      appsAmount,
+      currentPage: clampAppsPage(page, totalPages),
+      totalPages,
+    };
+  } catch (error) {
+    logger.error("Failed to fetch admin user apps", { error, userId });
+    throw error;
+  }
+};

--- a/web/scenes/Admin/users/id/server/fetch-user-details.ts
+++ b/web/scenes/Admin/users/id/server/fetch-user-details.ts
@@ -1,0 +1,37 @@
+import "server-only";
+
+import { getInternalDashboardGraphqlClient } from "@/api/helpers/graphql";
+import { logger } from "@/lib/logger";
+
+import { getSdk } from "../../graphql/server/fetch-admin-user-details.generated";
+
+export const fetchAdminUserDetails = async (userId: string) => {
+  const client = await getInternalDashboardGraphqlClient();
+
+  try {
+    const data = await getSdk(client).FetchAdminUserDetails({ userId });
+
+    if (!data.user_by_pk) {
+      return null;
+    }
+
+    return {
+      activeAppsCount: data.apps.aggregate?.count ?? 0,
+      adminCount: data.admins.aggregate?.count ?? 0,
+      deletedTeams: data.deleted_team_memberships.map(({ team }) => team),
+      memberCount: data.members.aggregate?.count ?? 0,
+      ownerCount: data.owners.aggregate?.count ?? 0,
+      soleOwnerTeams: data.owner_memberships
+        .filter(
+          ({ team }) =>
+            (team.memberships_aggregate.aggregate?.count ?? 0) === 1,
+        )
+        .map(({ team }) => team),
+      teamsCount: data.memberships.aggregate?.count ?? 0,
+      user: data.user_by_pk,
+    };
+  } catch (error) {
+    logger.error("Failed to fetch admin user details", { error, userId });
+    throw error;
+  }
+};

--- a/web/scenes/Admin/users/id/server/fetch-user-teams.ts
+++ b/web/scenes/Admin/users/id/server/fetch-user-teams.ts
@@ -1,0 +1,125 @@
+import "server-only";
+
+import {
+  clampUsersPage,
+  getUsersOffset,
+  getUsersTotalPages,
+} from "@/components/AdminDashboard/Users/pagination";
+import { getInternalDashboardGraphqlClient } from "@/api/helpers/graphql";
+import type { Membership_Bool_Exp, Role_Enum } from "@/graphql/graphql";
+import { logger } from "@/lib/logger";
+
+import {
+  getSdk,
+  type FetchAdminUserTeamsQuery,
+} from "../../graphql/server/fetch-admin-user-teams.generated";
+import { USER_DETAIL_LIST_LIMIT } from "./fetch-user-apps";
+
+const roleValues = ["ADMIN", "MEMBER", "OWNER"] as const;
+
+const getSearchPredicate = (value: string) => ({ _ilike: `%${value}%` });
+
+export const createAdminUserTeamsWhere = (
+  userId: string,
+  searchQuery: string,
+): Membership_Bool_Exp => {
+  const scope = { user_id: { _eq: userId } };
+  const search = searchQuery.trim();
+
+  if (!search) {
+    return scope;
+  }
+
+  const fieldMatch = search.match(/^(id|name|role|status):(.+)$/i);
+  const [, field, rawValue] = fieldMatch ?? [];
+  const value = rawValue?.trim() ?? search;
+
+  if (field === "role") {
+    const role = value.toUpperCase();
+
+    return {
+      _and: [
+        scope,
+        roleValues.includes(role as Role_Enum)
+          ? { role: { _eq: role as Role_Enum } }
+          : { team_id: { _in: [] } },
+      ],
+    };
+  }
+
+  if (field === "status") {
+    const status = value.toLowerCase();
+
+    return {
+      _and: [
+        scope,
+        status === "active"
+          ? { team: { deleted_at: { _is_null: true } } }
+          : status === "deleted"
+            ? { team: { deleted_at: { _is_null: false } } }
+            : { team_id: { _in: [] } },
+      ],
+    };
+  }
+
+  const searchWhere: Membership_Bool_Exp =
+    field === "id"
+      ? { team_id: getSearchPredicate(value) }
+      : field === "name"
+        ? { team: { name: getSearchPredicate(value) } }
+        : {
+            _or: [
+              { team_id: getSearchPredicate(value) },
+              { team: { name: getSearchPredicate(value) } },
+            ],
+          };
+
+  return { _and: [scope, searchWhere] };
+};
+
+type RawAdminUserTeam = FetchAdminUserTeamsQuery["membership"][number];
+
+export type AdminUserTeam = Omit<RawAdminUserTeam, "team"> & {
+  team: Omit<RawAdminUserTeam["team"], "name"> & { name: string };
+};
+
+export const fetchAdminUserTeamsPage = async ({
+  page,
+  searchQuery,
+  userId,
+}: {
+  page: number;
+  searchQuery: string;
+  userId: string;
+}) => {
+  const client = await getInternalDashboardGraphqlClient();
+  const where = createAdminUserTeamsWhere(userId, searchQuery);
+
+  try {
+    const data = await getSdk(client).FetchAdminUserTeams({
+      limit: USER_DETAIL_LIST_LIMIT,
+      offset: getUsersOffset(page, USER_DETAIL_LIST_LIMIT),
+      where,
+    });
+    const teamsAmount =
+      data.membership_aggregate.aggregate?.count ?? data.membership.length;
+    const totalPages = getUsersTotalPages(teamsAmount, USER_DETAIL_LIST_LIMIT);
+    const teams: AdminUserTeam[] = data.membership.map((membership) => ({
+      ...membership,
+      team: {
+        ...membership.team,
+        name: membership.team.name ?? "Unnamed team",
+      },
+    }));
+
+    return {
+      currentPage: clampUsersPage(page, totalPages),
+      teams,
+      teamsAmount,
+      totalPages,
+    };
+  } catch (error) {
+    logger.error("Failed to fetch admin user teams", { error, userId });
+    throw error;
+  }
+};

--- a/web/tests/api/admin/search.test.ts
+++ b/web/tests/api/admin/search.test.ts
@@ -1,0 +1,88 @@
+const mockAuthenticateAdminRequest = jest.fn();
+const mockFetchAdminGlobalSearch = jest.fn();
+
+jest.mock("@/lib/admin-auth", () => ({
+  authenticateAdminRequest: (...args: unknown[]) =>
+    mockAuthenticateAdminRequest(...args),
+}));
+
+jest.mock("@/scenes/Admin/search/server/fetch-global-search", () => ({
+  fetchAdminGlobalSearch: (...args: unknown[]) =>
+    mockFetchAdminGlobalSearch(...args),
+}));
+
+import { GET } from "@/api/admin/search";
+import { NextRequest } from "next/server";
+
+const user = {
+  email: "admin@example.com",
+  role: "internal_dashboard_readonly",
+  subject: "admin-subject",
+};
+
+const createRequest = (query = "") =>
+  new NextRequest(`http://localhost/api/admin/search?q=${query}`);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("/api/admin/search", () => {
+  it("returns 401 when the request is unauthenticated", async () => {
+    mockAuthenticateAdminRequest.mockResolvedValue(null);
+
+    const response = await GET(createRequest("wallet"));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+    expect(mockFetchAdminGlobalSearch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a query outside the accepted length range", async () => {
+    mockAuthenticateAdminRequest.mockResolvedValue(user);
+
+    const response = await GET(createRequest("a"));
+
+    expect(response.status).toBe(400);
+    expect(mockFetchAdminGlobalSearch).not.toHaveBeenCalled();
+  });
+
+  it("returns grouped search results for an authenticated admin", async () => {
+    mockAuthenticateAdminRequest.mockResolvedValue(user);
+    mockFetchAdminGlobalSearch.mockResolvedValue({
+      apps: [
+        { id: "app_current", name: "Current app", teamId: "team_current" },
+      ],
+      query: "current",
+      teams: [],
+      totals: { apps: 1, teams: 0, users: 0 },
+      users: [],
+    });
+
+    const response = await GET(createRequest("current"));
+
+    expect(response.status).toBe(200);
+    expect(mockFetchAdminGlobalSearch).toHaveBeenCalledWith("current", user);
+    expect(await response.json()).toEqual({
+      apps: [
+        { id: "app_current", name: "Current app", teamId: "team_current" },
+      ],
+      query: "current",
+      teams: [],
+      totals: { apps: 1, teams: 0, users: 0 },
+      users: [],
+    });
+  });
+
+  it("returns 503 when the search data fetch fails", async () => {
+    mockAuthenticateAdminRequest.mockResolvedValue(user);
+    mockFetchAdminGlobalSearch.mockRejectedValue(new Error("GraphQL failed"));
+
+    const response = await GET(createRequest("current"));
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "Search is temporarily unavailable",
+    });
+  });
+});

--- a/web/tests/unit/admin-app-detail-fetch.test.ts
+++ b/web/tests/unit/admin-app-detail-fetch.test.ts
@@ -1,0 +1,111 @@
+const mockFetchAdminAppDetails = jest.fn();
+
+jest.mock("server-only", () => ({}));
+
+jest.mock("@/api/helpers/graphql", () => ({
+  getInternalDashboardGraphqlClient: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock(
+  "@/scenes/Admin/apps/graphql/server/fetch-admin-app-details.generated",
+  () => ({
+    getSdk: () => ({ FetchAdminAppDetails: mockFetchAdminAppDetails }),
+  }),
+);
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+import { logger } from "@/lib/logger";
+import { fetchAdminAppDetails } from "@/scenes/Admin/apps/id/server/fetch-app-details";
+
+describe("admin app detail fetch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("maps app identity, team, and metadata workflow", async () => {
+    mockFetchAdminAppDetails.mockResolvedValue({
+      app_by_pk: {
+        created_at: "2026-01-01",
+        deleted_at: null,
+        draft_metadata: [
+          {
+            name: "Draft app",
+            updated_at: "2026-01-02",
+            verification_status: "awaiting_review",
+          },
+        ],
+        id: "app_current",
+        name: "Current app",
+        team: {
+          created_at: "2026-01-01",
+          deleted_at: null,
+          id: "team_current",
+          name: "Current team",
+        },
+        team_id: "team_current",
+        verified_metadata: [
+          {
+            name: "Verified app",
+            updated_at: "2026-01-03",
+            verification_status: "verified",
+            verified_at: "2026-01-03",
+          },
+        ],
+      },
+      metadata_versions: [
+        {
+          app_id: "app_current",
+          name: "Verified app",
+          updated_at: "2026-01-03",
+          verification_status: "verified",
+          verified_at: "2026-01-03",
+        },
+      ],
+    });
+
+    await expect(fetchAdminAppDetails("app_current")).resolves.toEqual(
+      expect.objectContaining({
+        app: expect.objectContaining({
+          id: "app_current",
+          name: "Current app",
+        }),
+        draftMetadata: expect.objectContaining({ name: "Draft app" }),
+        metadataVersions: [expect.objectContaining({ name: "Verified app" })],
+        team: expect.objectContaining({
+          id: "team_current",
+          name: "Current team",
+        }),
+        verifiedMetadata: expect.objectContaining({ name: "Verified app" }),
+      }),
+    );
+  });
+
+  it("returns null when the app does not exist", async () => {
+    mockFetchAdminAppDetails.mockResolvedValue({
+      app_by_pk: null,
+      metadata_versions: [],
+    });
+
+    await expect(fetchAdminAppDetails("app_missing")).resolves.toBeNull();
+  });
+
+  it("logs and throws GraphQL errors", async () => {
+    const error = new Error("GraphQL request failed");
+    mockFetchAdminAppDetails.mockRejectedValue(error);
+
+    await expect(fetchAdminAppDetails("app_current")).rejects.toThrow(error);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "Failed to fetch admin app details",
+      {
+        appId: "app_current",
+        error,
+      },
+    );
+  });
+});

--- a/web/tests/unit/admin-global-search-where.test.ts
+++ b/web/tests/unit/admin-global-search-where.test.ts
@@ -1,0 +1,52 @@
+import { createGlobalSearchQuery } from "@/scenes/Admin/search/server/create-global-search-where";
+
+describe("admin global search where clauses", () => {
+  it("routes a complete app ID to an exact app-only search", () => {
+    const query = "app_0123456789abcdef0123456789abcdef";
+
+    expect(createGlobalSearchQuery(query)).toEqual({
+      appsWhere: { id: { _eq: query } },
+      targets: new Set(["apps"]),
+      teamsWhere: { id: { _eq: "" } },
+      usersWhere: { id: { _eq: "" } },
+    });
+  });
+
+  it("routes an email search to users", () => {
+    const query = createGlobalSearchQuery("admin@example.com");
+
+    expect(query.targets).toEqual(new Set(["users"]));
+    expect(query.usersWhere).toEqual({
+      _or: [
+        { email: { _ilike: "%admin@example.com%" } },
+        { id: { _ilike: "%admin@example.com%" } },
+        { name: { _ilike: "%admin@example.com%" } },
+      ],
+    });
+    expect(query.appsWhere).toEqual({ id: { _eq: "" } });
+    expect(query.teamsWhere).toEqual({ id: { _eq: "" } });
+  });
+
+  it("searches every entity type for a plain text query", () => {
+    const query = createGlobalSearchQuery("wallet");
+
+    expect(query.targets).toEqual(new Set(["apps", "teams", "users"]));
+    expect(query.appsWhere).toEqual({
+      _or: [
+        { id: { _ilike: "%wallet%" } },
+        { name: { _ilike: "%wallet%" } },
+        { team_id: { _ilike: "%wallet%" } },
+      ],
+    });
+    expect(query.teamsWhere).toEqual({
+      _or: [{ id: { _ilike: "%wallet%" } }, { name: { _ilike: "%wallet%" } }],
+    });
+    expect(query.usersWhere).toEqual({
+      _or: [
+        { email: { _ilike: "%wallet%" } },
+        { id: { _ilike: "%wallet%" } },
+        { name: { _ilike: "%wallet%" } },
+      ],
+    });
+  });
+});

--- a/web/tests/unit/admin-global-search.test.tsx
+++ b/web/tests/unit/admin-global-search.test.tsx
@@ -1,0 +1,120 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import { Search } from "@/components/AdminDashboard/Search";
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  global.fetch = mockFetch;
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+const searchInput = () => screen.getByRole("combobox");
+
+describe("admin global search", () => {
+  it.each([
+    ["Command", { key: "k", metaKey: true }],
+    ["Control", { ctrlKey: true, key: "k" }],
+  ])("focuses the input with %s + K", (_label, shortcut) => {
+    render(<Search />);
+
+    fireEvent.keyDown(window, shortcut);
+
+    expect(searchInput()).toHaveFocus();
+  });
+
+  it("waits for the debounce period then displays grouped results", async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        apps: [
+          {
+            id: "app_current",
+            name: "Current app",
+            teamId: "team_current",
+          },
+        ],
+        teams: [{ id: "team_current", name: "Current team" }],
+        users: [],
+      }),
+      ok: true,
+    });
+
+    render(<Search />);
+    fireEvent.focus(searchInput());
+    fireEvent.change(searchInput(), { target: { value: "current" } });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/admin/search?q=current",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(screen.getByRole("option", { name: /Current team/i })).toBeVisible();
+    expect(screen.getByRole("option", { name: /Current app/i })).toBeVisible();
+  });
+
+  it("navigates to the keyboard-selected result", async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        apps: [
+          { id: "app_current", name: "Current app", teamId: "team_current" },
+        ],
+        teams: [],
+        users: [],
+      }),
+      ok: true,
+    });
+
+    render(<Search />);
+    fireEvent.focus(searchInput());
+    fireEvent.change(searchInput(), { target: { value: "current" } });
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    fireEvent.keyDown(searchInput(), { key: "ArrowDown" });
+    fireEvent.keyDown(searchInput(), { key: "Enter" });
+
+    expect(mockPush).toHaveBeenCalledWith("/admin/apps/app_current");
+  });
+
+  it("aborts an outstanding request when the query changes", async () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+
+    render(<Search />);
+    fireEvent.focus(searchInput());
+    fireEvent.change(searchInput(), { target: { value: "first" } });
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    const firstSignal = mockFetch.mock.calls[0][1].signal as AbortSignal;
+
+    fireEvent.change(searchInput(), { target: { value: "second" } });
+
+    expect(firstSignal.aborted).toBe(true);
+  });
+});

--- a/web/tests/unit/admin-home-fetch.test.ts
+++ b/web/tests/unit/admin-home-fetch.test.ts
@@ -1,0 +1,209 @@
+const mockFetchAdminHome = jest.fn();
+
+jest.mock("server-only", () => ({}));
+
+jest.mock("@/api/helpers/graphql", () => ({
+  getInternalDashboardGraphqlClient: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock("@/scenes/Admin/graphql/server/fetch-admin-home.generated", () => ({
+  getSdk: () => ({ FetchAdminHome: mockFetchAdminHome }),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn() },
+}));
+
+import { logger } from "@/lib/logger";
+import {
+  fetchAdminHome,
+  getWorkflowStatus,
+} from "@/scenes/Admin/server/fetch-home";
+
+const aggregate = (count: number) => ({ aggregate: { count } });
+
+const createHomeResponse = () => ({
+  active_api_keys: aggregate(3),
+  active_apps: aggregate(7),
+  active_teams: aggregate(5),
+  apps_without_metadata: [
+    {
+      created_at: "2026-07-01T00:00:00.000Z",
+      id: "app_without_metadata",
+      name: "Missing metadata",
+      team_id: "team_current",
+    },
+  ],
+  deleted_apps: aggregate(2),
+  deleted_teams: aggregate(1),
+  new_apps: aggregate(4),
+  new_teams: aggregate(2),
+  new_users: aggregate(6),
+  owner_memberships: [
+    {
+      team: {
+        id: "team_sole_owner",
+        memberships_aggregate: aggregate(1),
+        name: "Sole owner team",
+      },
+      user: {
+        email: "owner@example.com",
+        id: "user_owner",
+        name: "Owner",
+      },
+    },
+    {
+      team: {
+        id: "team_multiple_owners",
+        memberships_aggregate: aggregate(2),
+        name: "Multiple owners",
+      },
+      user: {
+        email: "second@example.com",
+        id: "user_second",
+        name: "Second owner",
+      },
+    },
+  ],
+  pending_invites: aggregate(2),
+  recent_apps: [
+    {
+      created_at: "2026-07-10T00:00:00.000Z",
+      draft_metadata: [{ verification_status: "awaiting_review" }],
+      id: "app_recent",
+      name: "Recent app",
+      team_id: "team_current",
+      verified_metadata: [],
+    },
+  ],
+  recent_metadata: [
+    {
+      app_id: "app_recent",
+      name: "Recent app",
+      updated_at: "2026-07-11T00:00:00.000Z",
+      verification_status: "awaiting_review",
+    },
+  ],
+  recent_teams: [
+    {
+      created_at: "2026-07-10T00:00:00.000Z",
+      deleted_at: null,
+      id: "team_recent",
+      name: "Recent team",
+    },
+  ],
+  recent_users: [
+    {
+      created_at: "2026-07-10T00:00:00.000Z",
+      email: "recent@example.com",
+      id: "user_recent",
+      name: "Recent user",
+    },
+  ],
+  teams_without_owner: [
+    {
+      created_at: "2026-07-09T00:00:00.000Z",
+      id: "team_without_owner",
+      name: "No owner team",
+    },
+  ],
+  total_users: aggregate(11),
+  users_without_teams: [
+    {
+      created_at: "2026-07-09T00:00:00.000Z",
+      email: "unassigned@example.com",
+      id: "user_without_team",
+      name: "Unassigned user",
+    },
+  ],
+  workflow_apps: [
+    {
+      draft_metadata: [
+        {
+          name: "Reviewed app",
+          updated_at: "2026-07-10T00:00:00.000Z",
+          verification_status: "changes_requested",
+        },
+      ],
+      id: "app_changes_requested",
+      name: "Source app name",
+      team_id: "team_current",
+      verified_metadata: [
+        {
+          name: "Previously verified app",
+          verification_status: "verified",
+          verified_at: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    },
+    {
+      draft_metadata: [
+        {
+          name: "Waiting app",
+          updated_at: "2026-07-09T00:00:00.000Z",
+          verification_status: "awaiting_review",
+        },
+      ],
+      id: "app_waiting_review",
+      name: "Waiting source app",
+      team_id: "team_current",
+      verified_metadata: [],
+    },
+  ],
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("admin home fetch", () => {
+  it("uses the current draft metadata status and maps dashboard queues", async () => {
+    mockFetchAdminHome.mockResolvedValue(createHomeResponse());
+
+    const home = await fetchAdminHome();
+
+    expect(home.inventory).toEqual({
+      activeApiKeys: 3,
+      activeApps: 7,
+      activeTeams: 5,
+      deletedApps: 2,
+      deletedTeams: 1,
+      newApps: 4,
+      newTeams: 2,
+      newUsers: 6,
+      pendingInvites: 2,
+      totalUsers: 11,
+    });
+    expect(home.queues.appsAwaitingReview).toEqual([
+      expect.objectContaining({ id: "app_waiting_review" }),
+    ]);
+    expect(home.queues.appsChangesRequested).toEqual([
+      expect.objectContaining({ id: "app_changes_requested" }),
+    ]);
+    expect(home.queues.soleOwnerTeams).toEqual([
+      expect.objectContaining({ id: "team_sole_owner" }),
+    ]);
+    expect(home.queues.usersWithoutTeams).toEqual([
+      expect.objectContaining({ id: "user_without_team" }),
+    ]);
+  });
+
+  it("prioritizes the latest non-verified metadata over verified metadata", () => {
+    expect(
+      getWorkflowStatus({
+        draft_metadata: [{ verification_status: "changes_requested" }],
+        verified_metadata: [{ verification_status: "verified" }],
+      }),
+    ).toBe("changes_requested");
+  });
+
+  it("logs and rethrows GraphQL errors", async () => {
+    const error = new Error("GraphQL request failed");
+    mockFetchAdminHome.mockRejectedValue(error);
+
+    await expect(fetchAdminHome()).rejects.toThrow(error);
+    expect(logger.error).toHaveBeenCalledWith("Failed to fetch admin home", {
+      error,
+    });
+  });
+});

--- a/web/tests/unit/admin-team-detail-fetch.test.ts
+++ b/web/tests/unit/admin-team-detail-fetch.test.ts
@@ -1,0 +1,168 @@
+const mockFetchAdminTeamApps = jest.fn();
+const mockFetchAdminTeamDetails = jest.fn();
+const mockFetchAdminTeamMembers = jest.fn();
+
+jest.mock("server-only", () => ({}));
+
+jest.mock("@/api/helpers/graphql", () => ({
+  getInternalDashboardGraphqlClient: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock(
+  "@/scenes/Admin/teams/graphql/server/fetch-admin-team-apps.generated",
+  () => ({
+    getSdk: () => ({ FetchAdminTeamApps: mockFetchAdminTeamApps }),
+  }),
+);
+
+jest.mock(
+  "@/scenes/Admin/teams/graphql/server/fetch-admin-team-details.generated",
+  () => ({
+    getSdk: () => ({ FetchAdminTeamDetails: mockFetchAdminTeamDetails }),
+  }),
+);
+
+jest.mock(
+  "@/scenes/Admin/teams/graphql/server/fetch-admin-team-members.generated",
+  () => ({
+    getSdk: () => ({ FetchAdminTeamMembers: mockFetchAdminTeamMembers }),
+  }),
+);
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+import {
+  createAdminTeamAppsWhere,
+  fetchAdminTeamAppsPage,
+} from "@/scenes/Admin/teams/id/server/fetch-team-apps";
+import { fetchAdminTeamDetails } from "@/scenes/Admin/teams/id/server/fetch-team-details";
+import {
+  createAdminTeamMembersWhere,
+  fetchAdminTeamMembersPage,
+} from "@/scenes/Admin/teams/id/server/fetch-team-members";
+
+describe("admin team detail fetch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("keeps app searches scoped to the route team", () => {
+    expect(createAdminTeamAppsWhere("team_current", "team:team_other")).toEqual(
+      {
+        _and: [
+          { team_id: { _eq: "team_current" } },
+          { team_id: { _ilike: "%team_other%" } },
+        ],
+      },
+    );
+  });
+
+  it("keeps member searches scoped to the route team", () => {
+    expect(
+      createAdminTeamMembersWhere("team_current", "email:world.org"),
+    ).toEqual({
+      _and: [
+        { team_id: { _eq: "team_current" } },
+        { user: { email: { _ilike: "%world.org%" } } },
+      ],
+    });
+  });
+
+  it("does not apply plain search text to the role enum", () => {
+    expect(createAdminTeamMembersWhere("team_current", "test")).toEqual({
+      _and: [
+        { team_id: { _eq: "team_current" } },
+        {
+          _or: [
+            { user_id: { _ilike: "%test%" } },
+            { user: { name: { _ilike: "%test%" } } },
+            { user: { email: { _ilike: "%test%" } } },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("maps overview aggregates and inventories", async () => {
+    mockFetchAdminTeamDetails.mockResolvedValue({
+      api_key: [{ id: "key_1", is_active: true }],
+      api_key_aggregate: { aggregate: { count: 1 } },
+      app_aggregate: { aggregate: { count: 2 } },
+      invite: [
+        { email: "admin@example.com", expires_at: "2026-08-01", id: "inv_1" },
+      ],
+      invite_aggregate: { aggregate: { count: 1 } },
+      membership_aggregate: { aggregate: { count: 3 } },
+      team_by_pk: {
+        created_at: "2026-01-01",
+        deleted_at: null,
+        id: "team_current",
+        name: "Current team",
+      },
+    });
+
+    await expect(fetchAdminTeamDetails("team_current")).resolves.toEqual(
+      expect.objectContaining({
+        activeApiKeysCount: 1,
+        appsCount: 2,
+        membersCount: 3,
+        pendingInvitesCount: 1,
+      }),
+    );
+  });
+
+  it("returns null when the team does not exist", async () => {
+    mockFetchAdminTeamDetails.mockResolvedValue({
+      api_key: [],
+      api_key_aggregate: { aggregate: { count: 0 } },
+      app_aggregate: { aggregate: { count: 0 } },
+      invite: [],
+      invite_aggregate: { aggregate: { count: 0 } },
+      membership_aggregate: { aggregate: { count: 0 } },
+      team_by_pk: null,
+    });
+
+    await expect(fetchAdminTeamDetails("team_missing")).resolves.toBeNull();
+  });
+
+  it("uses offset pagination for apps and members", async () => {
+    mockFetchAdminTeamApps.mockResolvedValue({
+      app: [],
+      app_aggregate: { aggregate: { count: 21 } },
+    });
+    mockFetchAdminTeamMembers.mockResolvedValue({
+      membership: [],
+      membership_aggregate: { aggregate: { count: 21 } },
+    });
+
+    await fetchAdminTeamAppsPage({
+      page: 2,
+      searchQuery: "",
+      teamId: "team_current",
+    });
+    await fetchAdminTeamMembersPage({
+      page: 2,
+      searchQuery: "",
+      teamId: "team_current",
+    });
+
+    expect(mockFetchAdminTeamApps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 10,
+        offset: 10,
+        where: { _and: [{ team_id: { _eq: "team_current" } }, {}] },
+      }),
+    );
+    expect(mockFetchAdminTeamMembers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 10,
+        offset: 10,
+        where: { team_id: { _eq: "team_current" } },
+      }),
+    );
+  });
+});

--- a/web/tests/unit/admin-user-detail-fetch.test.ts
+++ b/web/tests/unit/admin-user-detail-fetch.test.ts
@@ -1,0 +1,202 @@
+const mockFetchAdminUserApps = jest.fn();
+const mockFetchAdminUserDetails = jest.fn();
+const mockFetchAdminUserTeams = jest.fn();
+
+jest.mock("server-only", () => ({}));
+
+jest.mock("@/api/helpers/graphql", () => ({
+  getInternalDashboardGraphqlClient: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock(
+  "@/scenes/Admin/users/graphql/server/fetch-admin-user-apps.generated",
+  () => ({
+    getSdk: () => ({ FetchAdminUserApps: mockFetchAdminUserApps }),
+  }),
+);
+
+jest.mock(
+  "@/scenes/Admin/users/graphql/server/fetch-admin-user-details.generated",
+  () => ({
+    getSdk: () => ({ FetchAdminUserDetails: mockFetchAdminUserDetails }),
+  }),
+);
+
+jest.mock(
+  "@/scenes/Admin/users/graphql/server/fetch-admin-user-teams.generated",
+  () => ({
+    getSdk: () => ({ FetchAdminUserTeams: mockFetchAdminUserTeams }),
+  }),
+);
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+import {
+  createAdminUserAppsWhere,
+  fetchAdminUserAppsPage,
+} from "@/scenes/Admin/users/id/server/fetch-user-apps";
+import { fetchAdminUserDetails } from "@/scenes/Admin/users/id/server/fetch-user-details";
+import {
+  createAdminUserTeamsWhere,
+  fetchAdminUserTeamsPage,
+} from "@/scenes/Admin/users/id/server/fetch-user-teams";
+
+describe("admin user detail fetch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("keeps app searches scoped to teams of the route user", () => {
+    expect(createAdminUserAppsWhere("user_current", "team:team_other")).toEqual(
+      {
+        _and: [
+          { team: { memberships: { user_id: { _eq: "user_current" } } } },
+          { team_id: { _ilike: "%team_other%" } },
+        ],
+      },
+    );
+  });
+
+  it("keeps team searches scoped to the route user", () => {
+    expect(createAdminUserTeamsWhere("user_current", "name:World")).toEqual({
+      _and: [
+        { user_id: { _eq: "user_current" } },
+        { team: { name: { _ilike: "%World%" } } },
+      ],
+    });
+  });
+
+  it("returns no matches for an invalid role or status", () => {
+    expect(createAdminUserTeamsWhere("user_current", "role:invalid")).toEqual({
+      _and: [{ user_id: { _eq: "user_current" } }, { team_id: { _in: [] } }],
+    });
+    expect(createAdminUserTeamsWhere("user_current", "status:unknown")).toEqual(
+      {
+        _and: [{ user_id: { _eq: "user_current" } }, { team_id: { _in: [] } }],
+      },
+    );
+  });
+
+  it("maps aggregates and support warnings", async () => {
+    mockFetchAdminUserDetails.mockResolvedValue({
+      admins: { aggregate: { count: 1 } },
+      apps: { aggregate: { count: 4 } },
+      deleted_team_memberships: [
+        {
+          id: "membership_deleted",
+          team: {
+            deleted_at: "2026-01-01",
+            id: "team_deleted",
+            name: "Deleted",
+          },
+        },
+      ],
+      members: { aggregate: { count: 2 } },
+      memberships: { aggregate: { count: 5 } },
+      owner_memberships: [
+        {
+          id: "membership_sole",
+          team: {
+            deleted_at: null,
+            id: "team_sole",
+            memberships_aggregate: { aggregate: { count: 1 } },
+            name: "Sole owner",
+          },
+        },
+        {
+          id: "membership_shared",
+          team: {
+            deleted_at: null,
+            id: "team_shared",
+            memberships_aggregate: { aggregate: { count: 2 } },
+            name: "Shared owner",
+          },
+        },
+      ],
+      owners: { aggregate: { count: 2 } },
+      user_by_pk: {
+        created_at: "2026-01-01",
+        email: "admin@example.com",
+        id: "user_current",
+        name: "Current user",
+      },
+    });
+
+    await expect(fetchAdminUserDetails("user_current")).resolves.toEqual(
+      expect.objectContaining({
+        activeAppsCount: 4,
+        adminCount: 1,
+        deletedTeams: [
+          { deleted_at: "2026-01-01", id: "team_deleted", name: "Deleted" },
+        ],
+        memberCount: 2,
+        ownerCount: 2,
+        soleOwnerTeams: [
+          expect.objectContaining({ id: "team_sole", name: "Sole owner" }),
+        ],
+        teamsCount: 5,
+      }),
+    );
+  });
+
+  it("returns null when the user does not exist", async () => {
+    mockFetchAdminUserDetails.mockResolvedValue({
+      admins: { aggregate: { count: 0 } },
+      apps: { aggregate: { count: 0 } },
+      deleted_team_memberships: [],
+      members: { aggregate: { count: 0 } },
+      memberships: { aggregate: { count: 0 } },
+      owner_memberships: [],
+      owners: { aggregate: { count: 0 } },
+      user_by_pk: null,
+    });
+
+    await expect(fetchAdminUserDetails("user_missing")).resolves.toBeNull();
+  });
+
+  it("uses offset pagination for apps and teams", async () => {
+    mockFetchAdminUserApps.mockResolvedValue({
+      app: [],
+      app_aggregate: { aggregate: { count: 21 } },
+    });
+    mockFetchAdminUserTeams.mockResolvedValue({
+      membership: [],
+      membership_aggregate: { aggregate: { count: 21 } },
+    });
+
+    await fetchAdminUserAppsPage({
+      page: 2,
+      searchQuery: "",
+      userId: "user_current",
+    });
+    await fetchAdminUserTeamsPage({
+      page: 2,
+      searchQuery: "",
+      userId: "user_current",
+    });
+
+    expect(mockFetchAdminUserApps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 10,
+        offset: 10,
+        where: {
+          _and: [
+            { team: { memberships: { user_id: { _eq: "user_current" } } } },
+            {},
+          ],
+        },
+      }),
+    );
+    expect(mockFetchAdminUserTeams).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 10,
+        offset: 10,
+        where: { user_id: { _eq: "user_current" } },
+      }),
+    );
+  });
+});

--- a/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
+++ b/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+const tablesPath = path.join(
+  __dirname,
+  "../../..",
+  "hasura/metadata/databases/default/tables",
+);
+
+const getReadonlyPermission = (filename: string) => {
+  const metadata = readFileSync(path.join(tablesPath, filename), "utf8");
+  const start = metadata.indexOf("  - role: internal_dashboard_readonly");
+  const end = metadata.indexOf("\n  - role:", start + 1);
+
+  return end === -1 ? metadata.slice(start) : metadata.slice(start, end);
+};
+
+describe("internal dashboard detail permissions", () => {
+  it("allows only team member fields needed by the detail page", () => {
+    const permission = getReadonlyPermission("public_membership.yaml");
+
+    expect(permission).toContain("- id");
+    expect(permission).toContain("- role");
+    expect(permission).toContain("- team_id");
+    expect(permission).toContain("- user_id");
+    expect(permission).not.toContain("- created_at");
+    expect(permission).not.toContain("- updated_at");
+  });
+
+  it("allows invite identity and expiry for internal support", () => {
+    const permission = getReadonlyPermission("public_invite.yaml");
+
+    expect(permission).toContain("- id");
+    expect(permission).toContain("- email");
+    expect(permission).toContain("- expires_at");
+    expect(permission).toContain("allow_aggregations: true");
+  });
+
+  it("allows API key inventory fields but never the API key secret", () => {
+    const permission = getReadonlyPermission("public_api_key.yaml");
+
+    expect(permission).toContain("- id");
+    expect(permission).toContain("- name");
+    expect(permission).toContain("- created_at");
+    expect(permission).toContain("- updated_at");
+    expect(permission).toContain("- is_active");
+    expect(permission).not.toContain("- api_key");
+  });
+});


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Adds the internal admin team details page.

It shows team metadata and metrics, limited invite/API-key inventories, and related Apps and Members. Apps and Members use team-scoped server queries with search and lazy infinite loading; loaded pages are cached per team and search query.

Extends the read-only Hasura role with only the fields required for the page. API-key secrets remain inaccessible.

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.

---

<img width="1699" height="1246" alt="image" src="https://github.com/user-attachments/assets/f365e292-9f89-4730-b580-2dc10e6503d8" />