### PR TITLE
feat(home): Implement home page for the internal developer portal

### DIFF
--- a/web/api/admin/search/index.ts
+++ b/web/api/admin/search/index.ts
@@ -1,0 +1,35 @@
+import { authenticateAdminRequest } from "@/lib/admin-auth";
+import { fetchAdminGlobalSearch } from "@/scenes/Admin/search/server/fetch-global-search";
+import { NextRequest, NextResponse } from "next/server";
+
+const MIN_QUERY_LENGTH = 2;
+const MAX_QUERY_LENGTH = 128;
+
+export async function GET(req: NextRequest) {
+  const user = await authenticateAdminRequest(req.headers);
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const query = req.nextUrl.searchParams.get("q")?.trim() ?? "";
+
+  if (query.length < MIN_QUERY_LENGTH || query.length > MAX_QUERY_LENGTH) {
+    return NextResponse.json(
+      {
+        error: `Query must contain between ${MIN_QUERY_LENGTH} and ${MAX_QUERY_LENGTH} characters`,
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await fetchAdminGlobalSearch(query, user);
+    return NextResponse.json(result);
+  } catch {
+    return NextResponse.json(
+      { error: "Search is temporarily unavailable" },
+      { status: 503 },
+    );
+  }
+}

--- a/web/api/helpers/graphql.ts
+++ b/web/api/helpers/graphql.ts
@@ -6,6 +6,7 @@ import {
   generateReviewerJWT,
   generateServiceJWT,
 } from "@/api/helpers/jwts";
+import type { AdminUser } from "@/lib/admin-auth";
 import { logger } from "@/lib/logger";
 import { parse } from "graphql";
 import { GraphQLClient } from "graphql-request";
@@ -300,14 +301,18 @@ export const getAPIReviewerGraphqlClient = async () => {
   });
 };
 
-export const getInternalDashboardGraphqlClient = async () => {
-  const { requireAdminUser } = await import("@/lib/admin-auth");
-  const user = await requireAdminUser();
-
+export const getInternalDashboardGraphqlClientForUser = async (
+  user: AdminUser,
+) => {
   return new GraphQLClient(process.env.NEXT_PUBLIC_GRAPHQL_API_URL!, {
     ...sharedFetchConfig,
     headers: {
       authorization: `Bearer ${await generateInternalDashboardJWT(user)}`,
     },
   });
+};
+
+export const getInternalDashboardGraphqlClient = async () => {
+  const { requireAdminUser } = await import("@/lib/admin-auth");
+  return getInternalDashboardGraphqlClientForUser(await requireAdminUser());
 };

--- a/web/app/api/admin/search/route.ts
+++ b/web/app/api/admin/search/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "@/api/admin/search";

--- a/web/components/AdminDashboard/Search.tsx
+++ b/web/components/AdminDashboard/Search.tsx
@@ -1,37 +1,267 @@
+"use client";
+
 import { clsx } from "clsx";
 import { SearchIcon } from "@/components/Icons/SearchIcon";
+import { useRouter } from "next/navigation";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import { UIModule } from "./UIModule";
 
 type SearchProps = {
   className?: string;
 };
 
+type SearchResult = {
+  id: string;
+  name: string;
+  detail?: string | null;
+  href: string;
+  type: "App" | "Team" | "User";
+};
+
+type SearchResponse = {
+  apps: Array<{ id: string; name: string; teamId: string }>;
+  teams: Array<{ id: string; name: string }>;
+  users: Array<{ email: string | null; id: string; name: string }>;
+};
+
 export const Search = ({ className }: SearchProps) => {
+  const router = useRouter();
+  const listboxId = useId().replaceAll(":", "");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState("");
+  const [response, setResponse] = useState<SearchResponse | null>(null);
+  const [status, setStatus] = useState<"error" | "idle" | "loading" | "ready">(
+    "idle",
+  );
+  const [isFocused, setIsFocused] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [shortcutLabel, setShortcutLabel] = useState("Ctrl K");
+  const normalizedQuery = query.trim();
+  const results = useMemo<SearchResult[]>(
+    () => [
+      ...(response?.teams.map((team) => ({
+        href: `/admin/teams/${team.id}`,
+        id: team.id,
+        name: team.name,
+        type: "Team" as const,
+      })) ?? []),
+      ...(response?.apps.map((app) => ({
+        detail: app.teamId,
+        href: `/admin/apps/${app.id}`,
+        id: app.id,
+        name: app.name,
+        type: "App" as const,
+      })) ?? []),
+      ...(response?.users.map((user) => ({
+        detail: user.email,
+        href: `/admin/users/${user.id}`,
+        id: user.id,
+        name: user.name,
+        type: "User" as const,
+      })) ?? []),
+    ],
+    [response],
+  );
+  const isOpen = isFocused && normalizedQuery.length >= 2;
+
+  useEffect(() => {
+    setShortcutLabel(
+      /Mac|iPhone|iPad|iPod/i.test(navigator.platform) ? "⌘ K" : "Ctrl K",
+    );
+
+    const handleShortcut = (event: globalThis.KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setIsFocused(true);
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }
+    };
+
+    window.addEventListener("keydown", handleShortcut);
+    return () => window.removeEventListener("keydown", handleShortcut);
+  }, []);
+
+  useEffect(() => {
+    if (normalizedQuery.length < 2) {
+      setResponse(null);
+      setSelectedIndex(-1);
+      setStatus("idle");
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(async () => {
+      setStatus("loading");
+      setSelectedIndex(-1);
+
+      try {
+        const apiResponse = await fetch(
+          `/api/admin/search?q=${encodeURIComponent(normalizedQuery)}`,
+          { signal: controller.signal },
+        );
+
+        if (!apiResponse.ok) {
+          throw new Error("Admin search request failed");
+        }
+
+        const data = (await apiResponse.json()) as SearchResponse;
+        setResponse(data);
+        setStatus("ready");
+      } catch (error) {
+        if ((error as Error).name !== "AbortError") {
+          setResponse(null);
+          setStatus("error");
+        }
+      }
+    }, 300);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(timeoutId);
+    };
+  }, [normalizedQuery]);
+
+  const selectResult = (result: SearchResult) => {
+    setIsFocused(false);
+    setSelectedIndex(-1);
+    router.push(result.href);
+  };
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setIsFocused(false);
+      setSelectedIndex(-1);
+      event.currentTarget.blur();
+      return;
+    }
+
+    if (event.key === "ArrowDown" && results.length > 0) {
+      event.preventDefault();
+      setSelectedIndex((index) => (index + 1) % results.length);
+      return;
+    }
+
+    if (event.key === "ArrowUp" && results.length > 0) {
+      event.preventDefault();
+      setSelectedIndex((index) =>
+        index <= 0 ? results.length - 1 : index - 1,
+      );
+      return;
+    }
+
+    if (event.key === "Enter" && selectedIndex >= 0) {
+      event.preventDefault();
+      selectResult(results[selectedIndex]);
+    }
+  };
+
   return (
-    <UIModule
-      className={clsx(
-        "relative h-10 p-0",
-        "3xl:h-12.5",
-        "4xl:h-17.5",
-        className,
+    <div className={clsx("relative", className)}>
+      <UIModule
+        className={clsx("relative h-10 p-0", "3xl:h-12.5", "4xl:h-17.5")}
+      >
+        <SearchIcon
+          className={clsx(
+            "pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-grey-400",
+            "3xl:left-4 3xl:size-5",
+            "4xl:left-5 4xl:size-7",
+          )}
+        />
+        <input
+          aria-activedescendant={
+            selectedIndex >= 0 ? `${listboxId}-${selectedIndex}` : undefined
+          }
+          aria-autocomplete="list"
+          aria-controls={listboxId}
+          aria-expanded={isOpen}
+          aria-label="Search teams, apps, and users"
+          aria-busy={status === "loading"}
+          className={clsx(
+            "size-full rounded-16 bg-transparent py-2 pr-20 pl-9 text-14 outline-hidden placeholder:text-grey-400 focus-visible:ring-2 focus-visible:ring-blue-500",
+            "3xl:pr-24 3xl:pl-11 3xl:text-18",
+            "4xl:pr-28 4xl:pl-16 4xl:text-24",
+          )}
+          enterKeyHint="search"
+          onBlur={() => {
+            window.setTimeout(() => setIsFocused(false), 100);
+          }}
+          onChange={(event) => setQuery(event.target.value)}
+          onFocus={() => setIsFocused(true)}
+          onKeyDown={handleKeyDown}
+          placeholder="Search teams, apps, and users"
+          ref={inputRef}
+          role="combobox"
+          type="search"
+          value={query}
+        />
+        <kbd className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 rounded-8 bg-grey-100 px-2 py-1 font-sans text-11 font-medium text-grey-500 3xl:right-4 3xl:text-13 4xl:right-5 4xl:text-16">
+          {shortcutLabel}
+        </kbd>
+      </UIModule>
+      {isOpen && (
+        <div
+          className="absolute top-[calc(100%+0.25rem)] z-50 max-h-[min(32rem,70dvh)] w-full overflow-y-auto rounded-12 border border-grey-200 bg-grey-0 p-1 shadow-lg"
+          id={listboxId}
+          role="listbox"
+        >
+          {status === "loading" && (
+            <p aria-live="polite" className="px-3 py-2 text-13 text-grey-500">
+              Searching…
+            </p>
+          )}
+          {status === "error" && (
+            <p
+              aria-live="polite"
+              className="px-3 py-2 text-13 text-system-error-700"
+            >
+              Search is temporarily unavailable.
+            </p>
+          )}
+          {status === "ready" && results.length === 0 && (
+            <p aria-live="polite" className="px-3 py-2 text-13 text-grey-500">
+              No matching teams, apps, or users.
+            </p>
+          )}
+          {status === "ready" &&
+            results.map((result, index) => (
+              <button
+                aria-selected={selectedIndex === index}
+                className={clsx(
+                  "grid w-full grid-cols-[auto_minmax(0,1fr)] gap-x-3 rounded-8 px-3 py-2 text-left outline-none hover:bg-grey-100 focus-visible:ring-2 focus-visible:ring-blue-500",
+                  selectedIndex === index && "bg-blue-50",
+                )}
+                id={`${listboxId}-${index}`}
+                key={`${result.type}:${result.id}`}
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setSelectedIndex(index)}
+                onClick={() => selectResult(result)}
+                role="option"
+                type="button"
+              >
+                <span className="pt-0.5 text-11 font-medium tracking-wide text-grey-400 uppercase">
+                  {result.type}
+                </span>
+                <span className="min-w-0">
+                  <span className="block truncate text-13 font-medium text-grey-900">
+                    {result.name}
+                  </span>
+                  <span className="block truncate font-mono text-11 text-grey-500">
+                    {result.detail ?? result.id}
+                  </span>
+                </span>
+              </button>
+            ))}
+        </div>
       )}
-    >
-      <SearchIcon
-        className={clsx(
-          "pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-grey-400",
-          "3xl:left-4 3xl:size-5",
-          "4xl:left-5 4xl:size-7",
-        )}
-      />
-      <input
-        type="text"
-        placeholder="Search"
-        className={clsx(
-          "size-full rounded-16 bg-transparent py-2 pr-3 pl-9 text-14 outline-hidden placeholder:text-grey-400 focus-visible:ring-2 focus-visible:ring-blue-500",
-          "3xl:pr-4 3xl:pl-11 3xl:text-18",
-          "4xl:pr-5 4xl:pl-16 4xl:text-24",
-        )}
-      />
-    </UIModule>
+    </div>
   );
 };

--- a/web/components/AdminDashboard/UIModule.tsx
+++ b/web/components/AdminDashboard/UIModule.tsx
@@ -10,7 +10,7 @@ export const UIModule = ({ children, className }: UIModuleProps) => {
   return (
     <div
       className={twMerge(
-        "overscroll-none rounded-16 border border-grey-200 bg-grey-0/90 p-1.5 shadow-lg backdrop-blur-md",
+        "overscroll-none rounded-16 border border-grey-200 bg-grey-0/90 p-1.5 backdrop-blur-md",
         className,
       )}
     >

--- a/web/scenes/Admin/apps/graphql/server/fetch-admin-app-details.generated.ts
+++ b/web/scenes/Admin/apps/graphql/server/fetch-admin-app-details.generated.ts
@@ -1,10 +1,9 @@
+/* eslint-disable */
 import * as Types from "@/graphql/graphql";
 
 import { GraphQLClient, RequestOptions } from "graphql-request";
 import gql from "graphql-tag";
-
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
-
 export type FetchAdminAppDetailsQueryVariables = Types.Exact<{
   appId: Types.Scalars["String"]["input"];
 }>;
@@ -21,7 +20,7 @@ export type FetchAdminAppDetailsQuery = {
     team: {
       __typename?: "team";
       id: string;
-      name: string;
+      name?: string | null;
       created_at: string;
       deleted_at?: string | null;
     };
@@ -101,10 +100,15 @@ export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
   operationName: string,
   operationType?: string,
-  variables?: unknown,
+  variables?: any,
 ) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (action) => action();
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
 
 export function getSdk(
   client: GraphQLClient,
@@ -112,7 +116,7 @@ export function getSdk(
 ) {
   return {
     FetchAdminAppDetails(
-      variables?: FetchAdminAppDetailsQueryVariables,
+      variables: FetchAdminAppDetailsQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
     ): Promise<FetchAdminAppDetailsQuery> {
       return withWrapper(
@@ -129,5 +133,4 @@ export function getSdk(
     },
   };
 }
-
 export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/apps/graphql/server/fetch-admin-apps.generated.ts
+++ b/web/scenes/Admin/apps/graphql/server/fetch-admin-apps.generated.ts
@@ -1,10 +1,9 @@
+/* eslint-disable */
 import * as Types from "@/graphql/graphql";
 
 import { GraphQLClient, RequestOptions } from "graphql-request";
 import gql from "graphql-tag";
-
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
-
 export type FetchAdminAppsQueryVariables = Types.Exact<{
   includeCreatedAt: Types.Scalars["Boolean"]["input"];
   includeDraftMetadata: Types.Scalars["Boolean"]["input"];
@@ -29,10 +28,7 @@ export type FetchAdminAppsQuery = {
   }>;
   app_aggregate: {
     __typename?: "app_aggregate";
-    aggregate?: {
-      __typename?: "app_aggregate_fields";
-      count: number;
-    } | null;
+    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
   };
 };
 
@@ -79,10 +75,15 @@ export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
   operationName: string,
   operationType?: string,
-  variables?: unknown,
+  variables?: any,
 ) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (action) => action();
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
 
 export function getSdk(
   client: GraphQLClient,
@@ -90,7 +91,7 @@ export function getSdk(
 ) {
   return {
     FetchAdminApps(
-      variables?: FetchAdminAppsQueryVariables,
+      variables: FetchAdminAppsQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
     ): Promise<FetchAdminAppsQuery> {
       return withWrapper(
@@ -107,5 +108,4 @@ export function getSdk(
     },
   };
 }
-
 export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/graphql/server/fetch-admin-home.generated.ts
+++ b/web/scenes/Admin/graphql/server/fetch-admin-home.generated.ts
@@ -1,0 +1,386 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type FetchAdminHomeQueryVariables = Types.Exact<{
+  recentSince: Types.Scalars["timestamptz"]["input"];
+  recentLimit: Types.Scalars["Int"]["input"];
+}>;
+
+export type FetchAdminHomeQuery = {
+  __typename?: "query_root";
+  active_teams: {
+    __typename?: "team_aggregate";
+    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
+  };
+  deleted_teams: {
+    __typename?: "team_aggregate";
+    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
+  };
+  new_teams: {
+    __typename?: "team_aggregate";
+    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
+  };
+  total_users: {
+    __typename?: "user_aggregate";
+    aggregate?: { __typename?: "user_aggregate_fields"; count: number } | null;
+  };
+  new_users: {
+    __typename?: "user_aggregate";
+    aggregate?: { __typename?: "user_aggregate_fields"; count: number } | null;
+  };
+  active_apps: {
+    __typename?: "app_aggregate";
+    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
+  };
+  deleted_apps: {
+    __typename?: "app_aggregate";
+    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
+  };
+  new_apps: {
+    __typename?: "app_aggregate";
+    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
+  };
+  pending_invites: {
+    __typename?: "invite_aggregate";
+    aggregate?: {
+      __typename?: "invite_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  active_api_keys: {
+    __typename?: "api_key_aggregate";
+    aggregate?: {
+      __typename?: "api_key_aggregate_fields";
+      count: number;
+    } | null;
+  };
+  teams_without_owner: Array<{
+    __typename?: "team";
+    id: string;
+    name?: string | null;
+    created_at: string;
+  }>;
+  users_without_teams: Array<{
+    __typename?: "user";
+    id: string;
+    name: string;
+    email?: string | null;
+    created_at: string;
+  }>;
+  apps_without_metadata: Array<{
+    __typename?: "app";
+    id: string;
+    name: string;
+    team_id: string;
+    created_at: string;
+  }>;
+  owner_memberships: Array<{
+    __typename?: "membership";
+    user: {
+      __typename?: "user";
+      id: string;
+      name: string;
+      email?: string | null;
+    };
+    team: {
+      __typename?: "team";
+      id: string;
+      name?: string | null;
+      memberships_aggregate: {
+        __typename?: "membership_aggregate";
+        aggregate?: {
+          __typename?: "membership_aggregate_fields";
+          count: number;
+        } | null;
+      };
+    };
+  }>;
+  workflow_apps: Array<{
+    __typename?: "app";
+    id: string;
+    name: string;
+    team_id: string;
+    draft_metadata: Array<{
+      __typename?: "app_metadata";
+      name: string;
+      updated_at: string;
+      verification_status: string;
+    }>;
+    verified_metadata: Array<{
+      __typename?: "app_metadata";
+      name: string;
+      verified_at?: string | null;
+      verification_status: string;
+    }>;
+  }>;
+  recent_teams: Array<{
+    __typename?: "team";
+    id: string;
+    name?: string | null;
+    created_at: string;
+    deleted_at?: string | null;
+  }>;
+  recent_users: Array<{
+    __typename?: "user";
+    id: string;
+    name: string;
+    email?: string | null;
+    created_at: string;
+  }>;
+  recent_apps: Array<{
+    __typename?: "app";
+    id: string;
+    name: string;
+    team_id: string;
+    created_at: string;
+    draft_metadata: Array<{
+      __typename?: "app_metadata";
+      verification_status: string;
+    }>;
+    verified_metadata: Array<{
+      __typename?: "app_metadata";
+      verification_status: string;
+    }>;
+  }>;
+  recent_metadata: Array<{
+    __typename?: "app_metadata";
+    app_id: string;
+    name: string;
+    updated_at: string;
+    verification_status: string;
+  }>;
+};
+
+export const FetchAdminHomeDocument = gql`
+  query FetchAdminHome($recentSince: timestamptz!, $recentLimit: Int!) {
+    active_teams: team_aggregate(where: { deleted_at: { _is_null: true } }) {
+      aggregate {
+        count
+      }
+    }
+    deleted_teams: team_aggregate(where: { deleted_at: { _is_null: false } }) {
+      aggregate {
+        count
+      }
+    }
+    new_teams: team_aggregate(
+      where: {
+        deleted_at: { _is_null: true }
+        created_at: { _gte: $recentSince }
+      }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    total_users: user_aggregate {
+      aggregate {
+        count
+      }
+    }
+    new_users: user_aggregate(where: { created_at: { _gte: $recentSince } }) {
+      aggregate {
+        count
+      }
+    }
+    active_apps: app_aggregate(where: { deleted_at: { _is_null: true } }) {
+      aggregate {
+        count
+      }
+    }
+    deleted_apps: app_aggregate(where: { deleted_at: { _is_null: false } }) {
+      aggregate {
+        count
+      }
+    }
+    new_apps: app_aggregate(
+      where: {
+        deleted_at: { _is_null: true }
+        created_at: { _gte: $recentSince }
+      }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    pending_invites: invite_aggregate(
+      where: { expires_at: { _gte: "now()" } }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    active_api_keys: api_key_aggregate(where: { is_active: { _eq: true } }) {
+      aggregate {
+        count
+      }
+    }
+    teams_without_owner: team(
+      where: {
+        _and: [
+          { deleted_at: { _is_null: true } }
+          { _not: { memberships: { role: { _eq: OWNER } } } }
+        ]
+      }
+      order_by: { created_at: desc }
+    ) {
+      id
+      name
+      created_at
+    }
+    users_without_teams: user(
+      where: { _not: { memberships: {} } }
+      order_by: { created_at: desc }
+    ) {
+      id
+      name
+      email
+      created_at
+    }
+    apps_without_metadata: app(
+      where: {
+        _and: [
+          { deleted_at: { _is_null: true } }
+          { _not: { app_metadata: {} } }
+        ]
+      }
+      order_by: { created_at: desc }
+    ) {
+      id
+      name
+      team_id
+      created_at
+    }
+    owner_memberships: membership(
+      where: { role: { _eq: OWNER }, team: { deleted_at: { _is_null: true } } }
+    ) {
+      user {
+        id
+        name
+        email
+      }
+      team {
+        id
+        name
+        memberships_aggregate(where: { role: { _eq: OWNER } }) {
+          aggregate {
+            count
+          }
+        }
+      }
+    }
+    workflow_apps: app(
+      where: { deleted_at: { _is_null: true } }
+      order_by: { created_at: desc }
+    ) {
+      id
+      name
+      team_id
+      draft_metadata: app_metadata(
+        where: { verification_status: { _neq: "verified" } }
+        order_by: { updated_at: desc }
+        limit: 1
+      ) {
+        name
+        updated_at
+        verification_status
+      }
+      verified_metadata: app_metadata(
+        where: { verification_status: { _eq: "verified" } }
+        order_by: { verified_at: desc }
+        limit: 1
+      ) {
+        name
+        verified_at
+        verification_status
+      }
+    }
+    recent_teams: team(order_by: { created_at: desc }, limit: $recentLimit) {
+      id
+      name
+      created_at
+      deleted_at
+    }
+    recent_users: user(order_by: { created_at: desc }, limit: $recentLimit) {
+      id
+      name
+      email
+      created_at
+    }
+    recent_apps: app(
+      where: { deleted_at: { _is_null: true } }
+      order_by: { created_at: desc }
+      limit: $recentLimit
+    ) {
+      id
+      name
+      team_id
+      created_at
+      draft_metadata: app_metadata(
+        where: { verification_status: { _neq: "verified" } }
+        order_by: { updated_at: desc }
+        limit: 1
+      ) {
+        verification_status
+      }
+      verified_metadata: app_metadata(
+        where: { verification_status: { _eq: "verified" } }
+        order_by: { verified_at: desc }
+        limit: 1
+      ) {
+        verification_status
+      }
+    }
+    recent_metadata: app_metadata(
+      order_by: { updated_at: desc }
+      limit: $recentLimit
+    ) {
+      app_id
+      name
+      updated_at
+      verification_status
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchAdminHome(
+      variables: FetchAdminHomeQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchAdminHomeQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchAdminHomeQuery>(
+            FetchAdminHomeDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchAdminHome",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/graphql/server/fetch-admin-home.gql
+++ b/web/scenes/Admin/graphql/server/fetch-admin-home.gql
@@ -1,0 +1,184 @@
+query FetchAdminHome($recentSince: timestamptz!, $recentLimit: Int!) {
+  active_teams: team_aggregate(where: { deleted_at: { _is_null: true } }) {
+    aggregate {
+      count
+    }
+  }
+  deleted_teams: team_aggregate(where: { deleted_at: { _is_null: false } }) {
+    aggregate {
+      count
+    }
+  }
+  new_teams: team_aggregate(
+    where: {
+      deleted_at: { _is_null: true }
+      created_at: { _gte: $recentSince }
+    }
+  ) {
+    aggregate {
+      count
+    }
+  }
+  total_users: user_aggregate {
+    aggregate {
+      count
+    }
+  }
+  new_users: user_aggregate(where: { created_at: { _gte: $recentSince } }) {
+    aggregate {
+      count
+    }
+  }
+  active_apps: app_aggregate(where: { deleted_at: { _is_null: true } }) {
+    aggregate {
+      count
+    }
+  }
+  deleted_apps: app_aggregate(where: { deleted_at: { _is_null: false } }) {
+    aggregate {
+      count
+    }
+  }
+  new_apps: app_aggregate(
+    where: {
+      deleted_at: { _is_null: true }
+      created_at: { _gte: $recentSince }
+    }
+  ) {
+    aggregate {
+      count
+    }
+  }
+  pending_invites: invite_aggregate(where: { expires_at: { _gte: "now()" } }) {
+    aggregate {
+      count
+    }
+  }
+  active_api_keys: api_key_aggregate(where: { is_active: { _eq: true } }) {
+    aggregate {
+      count
+    }
+  }
+  teams_without_owner: team(
+    where: {
+      _and: [
+        { deleted_at: { _is_null: true } }
+        { _not: { memberships: { role: { _eq: OWNER } } } }
+      ]
+    }
+    order_by: { created_at: desc }
+  ) {
+    id
+    name
+    created_at
+  }
+  users_without_teams: user(
+    where: { _not: { memberships: {} } }
+    order_by: { created_at: desc }
+  ) {
+    id
+    name
+    email
+    created_at
+  }
+  apps_without_metadata: app(
+    where: {
+      _and: [{ deleted_at: { _is_null: true } }, { _not: { app_metadata: {} } }]
+    }
+    order_by: { created_at: desc }
+  ) {
+    id
+    name
+    team_id
+    created_at
+  }
+  owner_memberships: membership(
+    where: { role: { _eq: OWNER }, team: { deleted_at: { _is_null: true } } }
+  ) {
+    user {
+      id
+      name
+      email
+    }
+    team {
+      id
+      name
+      memberships_aggregate(where: { role: { _eq: OWNER } }) {
+        aggregate {
+          count
+        }
+      }
+    }
+  }
+  workflow_apps: app(
+    where: { deleted_at: { _is_null: true } }
+    order_by: { created_at: desc }
+  ) {
+    id
+    name
+    team_id
+    draft_metadata: app_metadata(
+      where: { verification_status: { _neq: "verified" } }
+      order_by: { updated_at: desc }
+      limit: 1
+    ) {
+      name
+      updated_at
+      verification_status
+    }
+    verified_metadata: app_metadata(
+      where: { verification_status: { _eq: "verified" } }
+      order_by: { verified_at: desc }
+      limit: 1
+    ) {
+      name
+      verified_at
+      verification_status
+    }
+  }
+  recent_teams: team(order_by: { created_at: desc }, limit: $recentLimit) {
+    id
+    name
+    created_at
+    deleted_at
+  }
+  recent_users: user(order_by: { created_at: desc }, limit: $recentLimit) {
+    id
+    name
+    email
+    created_at
+  }
+  recent_apps: app(
+    where: { deleted_at: { _is_null: true } }
+    order_by: { created_at: desc }
+    limit: $recentLimit
+  ) {
+    id
+    name
+    team_id
+    created_at
+    draft_metadata: app_metadata(
+      where: { verification_status: { _neq: "verified" } }
+      order_by: { updated_at: desc }
+      limit: 1
+    ) {
+      verification_status
+    }
+    verified_metadata: app_metadata(
+      where: { verification_status: { _eq: "verified" } }
+      order_by: { verified_at: desc }
+      limit: 1
+    ) {
+      verification_status
+    }
+  }
+  recent_metadata: app_metadata(
+    order_by: { updated_at: desc }
+    limit: $recentLimit
+  ) {
+    app_id
+    name
+    updated_at
+    verification_status
+  }
+}

--- a/web/scenes/Admin/layout.tsx
+++ b/web/scenes/Admin/layout.tsx
@@ -19,7 +19,7 @@ export const AdminLayout = ({ children }: { children: React.ReactNode }) => {
       <div
         className={clsx(
           // Common styles
-          "relative grid min-h-dvh overflow-x-clip bg-grey-50 p-4",
+          "relative grid min-h-dvh overflow-x-clip bg-grey-100 p-4",
 
           // Desktop styles
           "lg:grid lg:h-dvh lg:grid-cols-[auto_1fr] lg:gap-x-4 lg:overflow-hidden",

--- a/web/scenes/Admin/page.tsx
+++ b/web/scenes/Admin/page.tsx
@@ -1,8 +1,334 @@
-export const AdminPage = () => {
+import { AppStatus, type StatusVariant } from "@/components/AppStatus";
+import { StatusBadge } from "@/components/AdminDashboard/Teams/StatusBadge";
+import { UIModule } from "@/components/AdminDashboard/UIModule";
+import Link from "next/link";
+
+import { fetchAdminHome, type AdminMetadataStatus } from "./server/fetch-home";
+
+const formatDate = (value: string) => value.slice(0, 10);
+
+const preview = <Value,>(items: Value[]) => items.slice(0, 5);
+
+const isAppStatus = (
+  status: AdminMetadataStatus | null,
+): status is StatusVariant => Boolean(status);
+
+type MetricCardProps = {
+  detail: string;
+  href: string;
+  label: string;
+  value: number;
+};
+
+const MetricCard = ({ detail, href, label, value }: MetricCardProps) => (
+  <Link
+    className="rounded-12 border border-grey-200 bg-grey-50 p-4 transition-colors hover:border-blue-300 hover:bg-blue-50 focus-visible:ring-2 focus-visible:ring-blue-500"
+    href={href}
+  >
+    <div className="text-11 font-medium tracking-wide text-grey-400 uppercase">
+      {label}
+    </div>
+    <div className="mt-2 text-24 font-semibold tracking-[-0.02em] text-grey-900">
+      {value}
+    </div>
+    <div className="mt-1 text-12 text-grey-500">{detail}</div>
+  </Link>
+);
+
+type QueueSectionProps = {
+  children: React.ReactNode;
+  count: number;
+  title: string;
+};
+
+const QueueSection = ({ children, count, title }: QueueSectionProps) => (
+  <section className="rounded-12 border border-grey-200 bg-grey-50 p-3">
+    <div className="flex items-center justify-between gap-3">
+      <h3 className="text-14 font-semibold text-grey-900">{title}</h3>
+      <span className="rounded-full border border-grey-200 bg-grey-0 px-2.5 py-1 text-12 font-semibold text-grey-700">
+        {count}
+      </span>
+    </div>
+    {count === 0 ? (
+      <p className="mt-2 text-13 text-grey-500">Nothing needs attention.</p>
+    ) : (
+      <div className="mt-2 divide-y divide-grey-200">{children}</div>
+    )}
+  </section>
+);
+
+const EntityLink = ({
+  detail,
+  href,
+  label,
+}: {
+  detail?: string | null;
+  href: string;
+  label: string;
+}) => (
+  <Link
+    className="flex min-w-0 items-center justify-between gap-3 rounded-8 px-2 py-2.5 text-13 transition-colors outline-none hover:bg-grey-0 focus-visible:ring-2 focus-visible:ring-blue-500"
+    href={href}
+  >
+    <span className="truncate font-medium text-grey-900 hover:text-blue-600">
+      {label}
+    </span>
+    {detail && <span className="shrink-0 text-12 text-grey-500">{detail}</span>}
+  </Link>
+);
+
+export const AdminPage = async () => {
+  const home = await fetchAdminHome();
+
   return (
-    <div className="grid h-full place-items-center">
-      <div className="text-center">
-        <h1 className="text-lg font-medium">Internal dashboard</h1>
+    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-4">
+      <UIModule className="min-h-0 overflow-y-auto p-5">
+        <h1 className="text-24 font-semibold tracking-[-0.02em] text-grey-900">
+          Internal dashboard
+        </h1>
+        <p className="mt-2 max-w-2xl text-14 text-grey-500">
+          Monitor Developer Portal data and investigate operational issues.
+        </p>
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          <MetricCard
+            detail={`${home.inventory.newTeams} new in 30 days`}
+            href="/admin/teams"
+            label="Active teams"
+            value={home.inventory.activeTeams}
+          />
+          <MetricCard
+            detail={`${home.inventory.newApps} new in 30 days`}
+            href="/admin/apps"
+            label="Active apps"
+            value={home.inventory.activeApps}
+          />
+          <MetricCard
+            detail={`${home.inventory.newUsers} new in 30 days`}
+            href="/admin/users"
+            label="Users"
+            value={home.inventory.totalUsers}
+          />
+          <MetricCard
+            detail={`${home.inventory.deletedTeams} deleted`}
+            href="/admin/teams?query=status%3Adeleted"
+            label="Teams"
+            value={home.inventory.activeTeams + home.inventory.deletedTeams}
+          />
+          <MetricCard
+            detail={`${home.inventory.deletedApps} deleted`}
+            href="/admin/apps"
+            label="Apps"
+            value={home.inventory.activeApps + home.inventory.deletedApps}
+          />
+          <MetricCard
+            detail={`${home.inventory.activeApiKeys} active API keys`}
+            href="/admin/teams"
+            label="Pending invites"
+            value={home.inventory.pendingInvites}
+          />
+        </div>
+      </UIModule>
+
+      <div className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+        <UIModule className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden p-5">
+          <div>
+            <h2 className="text-16 font-semibold text-grey-900">
+              Needs attention
+            </h2>
+            <p className="mt-1 text-13 text-grey-500">
+              Data states that may need support or operational follow-up.
+            </p>
+          </div>
+          <div className="mt-4 grid min-h-0 gap-3 overflow-y-auto pr-1">
+            <QueueSection
+              count={home.queues.appsAwaitingReview.length}
+              title="Apps in review"
+            >
+              {preview(home.queues.appsAwaitingReview).map((app) => (
+                <EntityLink
+                  detail={app.updatedAt ? formatDate(app.updatedAt) : undefined}
+                  href={`/admin/apps/${app.id}`}
+                  key={app.id}
+                  label={app.name}
+                />
+              ))}
+            </QueueSection>
+            <QueueSection
+              count={home.queues.appsChangesRequested.length}
+              title="Apps with changes requested"
+            >
+              {preview(home.queues.appsChangesRequested).map((app) => (
+                <EntityLink
+                  detail={app.updatedAt ? formatDate(app.updatedAt) : undefined}
+                  href={`/admin/apps/${app.id}`}
+                  key={app.id}
+                  label={app.name}
+                />
+              ))}
+            </QueueSection>
+            <QueueSection
+              count={home.queues.appsWithoutMetadata.length}
+              title="Apps without metadata"
+            >
+              {preview(home.queues.appsWithoutMetadata).map((app) => (
+                <EntityLink
+                  detail={app.teamId}
+                  href={`/admin/apps/${app.id}`}
+                  key={app.id}
+                  label={app.name}
+                />
+              ))}
+            </QueueSection>
+            <QueueSection
+              count={home.queues.teamsWithoutOwner.length}
+              title="Teams without an owner"
+            >
+              {preview(home.queues.teamsWithoutOwner).map((team) => (
+                <EntityLink
+                  href={`/admin/teams/${team.id}`}
+                  key={team.id}
+                  label={team.name}
+                />
+              ))}
+            </QueueSection>
+            <QueueSection
+              count={home.queues.soleOwnerTeams.length}
+              title="Teams with one owner"
+            >
+              {preview(home.queues.soleOwnerTeams).map((team) => (
+                <EntityLink
+                  detail={team.owner.name}
+                  href={`/admin/teams/${team.id}`}
+                  key={team.id}
+                  label={team.name}
+                />
+              ))}
+            </QueueSection>
+            <QueueSection
+              count={home.queues.usersWithoutTeams.length}
+              title="Users without a team"
+            >
+              {preview(home.queues.usersWithoutTeams).map((user) => (
+                <EntityLink
+                  detail={user.email}
+                  href={`/admin/users/${user.id}`}
+                  key={user.id}
+                  label={user.name}
+                />
+              ))}
+            </QueueSection>
+          </div>
+        </UIModule>
+
+        <UIModule className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden p-5">
+          <div>
+            <h2 className="text-16 font-semibold text-grey-900">
+              Recent changes
+            </h2>
+            <p className="mt-1 text-13 text-grey-500">
+              Newly created entities and the latest metadata updates.
+            </p>
+          </div>
+          <div className="mt-4 grid min-h-0 gap-3 overflow-y-auto pr-1">
+            <section className="rounded-12 border border-grey-200 bg-grey-50 p-3">
+              <h3 className="text-grey-600 text-12 font-semibold tracking-[0.08em] uppercase">
+                Apps
+              </h3>
+              <div className="mt-1 divide-y divide-grey-100">
+                {home.recent.apps.map((app) => (
+                  <Link
+                    className="flex items-center justify-between gap-3 py-2 outline-none hover:text-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+                    href={`/admin/apps/${app.id}`}
+                    key={app.id}
+                  >
+                    <span className="min-w-0 truncate text-13 font-medium text-grey-900">
+                      {app.name}
+                    </span>
+                    <span className="flex shrink-0 items-center gap-2">
+                      {isAppStatus(app.status) && (
+                        <AppStatus
+                          className="px-2 py-0.5"
+                          status={app.status}
+                        />
+                      )}
+                      <time className="text-12 text-grey-500">
+                        {formatDate(app.createdAt)}
+                      </time>
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </section>
+            <section className="rounded-12 border border-grey-200 bg-grey-50 p-3">
+              <h3 className="text-grey-600 text-12 font-semibold tracking-[0.08em] uppercase">
+                Teams
+              </h3>
+              <div className="mt-1 divide-y divide-grey-100">
+                {home.recent.teams.map((team) => (
+                  <Link
+                    className="flex items-center justify-between gap-3 py-2 outline-none hover:text-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+                    href={`/admin/teams/${team.id}`}
+                    key={team.id}
+                  >
+                    <span className="min-w-0 truncate text-13 font-medium text-grey-900">
+                      {team.name}
+                    </span>
+                    <span className="flex shrink-0 items-center gap-2">
+                      <StatusBadge status={team.status} />
+                      <time className="text-12 text-grey-500">
+                        {formatDate(team.createdAt)}
+                      </time>
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </section>
+            <section className="rounded-12 border border-grey-200 bg-grey-50 p-3">
+              <h3 className="text-grey-600 text-12 font-semibold tracking-[0.08em] uppercase">
+                Users
+              </h3>
+              <div className="mt-1 divide-y divide-grey-100">
+                {home.recent.users.map((user) => (
+                  <EntityLink
+                    detail={formatDate(user.createdAt)}
+                    href={`/admin/users/${user.id}`}
+                    key={user.id}
+                    label={user.name}
+                  />
+                ))}
+              </div>
+            </section>
+            <section className="rounded-12 border border-grey-200 bg-grey-50 p-3">
+              <h3 className="text-grey-600 text-12 font-semibold tracking-[0.08em] uppercase">
+                Metadata updates
+              </h3>
+              <div className="mt-1 divide-y divide-grey-100">
+                {home.recent.metadata.map((metadata) => (
+                  <Link
+                    className="flex items-center justify-between gap-3 py-2 outline-none hover:text-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+                    href={`/admin/apps/${metadata.appId}`}
+                    key={`${metadata.appId}:${metadata.updatedAt}`}
+                  >
+                    <span className="min-w-0 truncate text-13 font-medium text-grey-900">
+                      {metadata.name}
+                    </span>
+                    <span className="flex shrink-0 items-center gap-2">
+                      {isAppStatus(metadata.status) && (
+                        <AppStatus
+                          className="px-2 py-0.5"
+                          status={metadata.status}
+                        />
+                      )}
+                      <time className="text-12 text-grey-500">
+                        {formatDate(metadata.updatedAt)}
+                      </time>
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          </div>
+        </UIModule>
       </div>
     </div>
   );

--- a/web/scenes/Admin/search/graphql/server/fetch-admin-global-search.generated.ts
+++ b/web/scenes/Admin/search/graphql/server/fetch-admin-global-search.generated.ts
@@ -1,0 +1,140 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type FetchAdminGlobalSearchQueryVariables = Types.Exact<{
+  appsWhere: Types.App_Bool_Exp;
+  includeApps: Types.Scalars["Boolean"]["input"];
+  includeTeams: Types.Scalars["Boolean"]["input"];
+  includeUsers: Types.Scalars["Boolean"]["input"];
+  limit: Types.Scalars["Int"]["input"];
+  teamsWhere: Types.Team_Bool_Exp;
+  usersWhere: Types.User_Bool_Exp;
+}>;
+
+export type FetchAdminGlobalSearchQuery = {
+  __typename?: "query_root";
+  apps?: Array<{
+    __typename?: "app";
+    id: string;
+    name: string;
+    team_id: string;
+  }>;
+  apps_aggregate?: {
+    __typename?: "app_aggregate";
+    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
+  };
+  teams?: Array<{ __typename?: "team"; id: string; name?: string | null }>;
+  teams_aggregate?: {
+    __typename?: "team_aggregate";
+    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
+  };
+  users?: Array<{
+    __typename?: "user";
+    id: string;
+    name: string;
+    email?: string | null;
+  }>;
+  users_aggregate?: {
+    __typename?: "user_aggregate";
+    aggregate?: { __typename?: "user_aggregate_fields"; count: number } | null;
+  };
+};
+
+export const FetchAdminGlobalSearchDocument = gql`
+  query FetchAdminGlobalSearch(
+    $appsWhere: app_bool_exp!
+    $includeApps: Boolean!
+    $includeTeams: Boolean!
+    $includeUsers: Boolean!
+    $limit: Int!
+    $teamsWhere: team_bool_exp!
+    $usersWhere: user_bool_exp!
+  ) {
+    apps: app(
+      where: $appsWhere
+      order_by: [{ name: asc }, { id: asc }]
+      limit: $limit
+    ) @include(if: $includeApps) {
+      id
+      name
+      team_id
+    }
+    apps_aggregate: app_aggregate(where: $appsWhere)
+      @include(if: $includeApps) {
+      aggregate {
+        count
+      }
+    }
+    teams: team(
+      where: $teamsWhere
+      order_by: [{ name: asc }, { id: asc }]
+      limit: $limit
+    ) @include(if: $includeTeams) {
+      id
+      name
+    }
+    teams_aggregate: team_aggregate(where: $teamsWhere)
+      @include(if: $includeTeams) {
+      aggregate {
+        count
+      }
+    }
+    users: user(
+      where: $usersWhere
+      order_by: [{ name: asc }, { id: asc }]
+      limit: $limit
+    ) @include(if: $includeUsers) {
+      id
+      name
+      email
+    }
+    users_aggregate: user_aggregate(where: $usersWhere)
+      @include(if: $includeUsers) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchAdminGlobalSearch(
+      variables: FetchAdminGlobalSearchQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchAdminGlobalSearchQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchAdminGlobalSearchQuery>(
+            FetchAdminGlobalSearchDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchAdminGlobalSearch",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/search/graphql/server/fetch-admin-global-search.gql
+++ b/web/scenes/Admin/search/graphql/server/fetch-admin-global-search.gql
@@ -1,0 +1,53 @@
+query FetchAdminGlobalSearch(
+  $appsWhere: app_bool_exp!
+  $includeApps: Boolean!
+  $includeTeams: Boolean!
+  $includeUsers: Boolean!
+  $limit: Int!
+  $teamsWhere: team_bool_exp!
+  $usersWhere: user_bool_exp!
+) {
+  apps: app(
+    where: $appsWhere
+    order_by: [{ name: asc }, { id: asc }]
+    limit: $limit
+  ) @include(if: $includeApps) {
+    id
+    name
+    team_id
+  }
+  apps_aggregate: app_aggregate(where: $appsWhere) @include(if: $includeApps) {
+    aggregate {
+      count
+    }
+  }
+  teams: team(
+    where: $teamsWhere
+    order_by: [{ name: asc }, { id: asc }]
+    limit: $limit
+  ) @include(if: $includeTeams) {
+    id
+    name
+  }
+  teams_aggregate: team_aggregate(where: $teamsWhere)
+    @include(if: $includeTeams) {
+    aggregate {
+      count
+    }
+  }
+  users: user(
+    where: $usersWhere
+    order_by: [{ name: asc }, { id: asc }]
+    limit: $limit
+  ) @include(if: $includeUsers) {
+    id
+    name
+    email
+  }
+  users_aggregate: user_aggregate(where: $usersWhere)
+    @include(if: $includeUsers) {
+    aggregate {
+      count
+    }
+  }
+}

--- a/web/scenes/Admin/search/server/create-global-search-where.ts
+++ b/web/scenes/Admin/search/server/create-global-search-where.ts
@@ -1,0 +1,82 @@
+import type {
+  App_Bool_Exp,
+  Team_Bool_Exp,
+  User_Bool_Exp,
+} from "@/graphql/graphql";
+
+export type GlobalSearchTarget = "apps" | "teams" | "users";
+
+export type GlobalSearchQuery = {
+  appsWhere: App_Bool_Exp;
+  targets: ReadonlySet<GlobalSearchTarget>;
+  teamsWhere: Team_Bool_Exp;
+  usersWhere: User_Bool_Exp;
+};
+
+const entityIdPattern = /^(app|team|user)_[a-f0-9]{4,}$/i;
+const fullEntityIdPattern = /^(app|team|user)_[a-f0-9]{32}$/i;
+
+const noResultsWhere = { id: { _eq: "" } };
+
+const hasEmail = (query: string) => query.includes("@");
+
+const getTargets = (query: string): ReadonlySet<GlobalSearchTarget> => {
+  const entityIdMatch = query.match(entityIdPattern);
+
+  if (entityIdMatch) {
+    return new Set([
+      `${entityIdMatch[1].toLowerCase()}s` as GlobalSearchTarget,
+    ]);
+  }
+
+  return hasEmail(query)
+    ? new Set(["users"])
+    : new Set(["apps", "teams", "users"]);
+};
+
+const getIdPredicate = (query: string) =>
+  fullEntityIdPattern.test(query) ? { _eq: query } : { _ilike: `${query}%` };
+
+export const createGlobalSearchQuery = (
+  rawQuery: string,
+): GlobalSearchQuery => {
+  const query = rawQuery.trim();
+  const targets = getTargets(query);
+  const idPredicate = getIdPredicate(query);
+
+  return {
+    appsWhere: targets.has("apps")
+      ? entityIdPattern.test(query)
+        ? { id: idPredicate }
+        : {
+            _or: [
+              { id: { _ilike: `%${query}%` } },
+              { name: { _ilike: `%${query}%` } },
+              { team_id: { _ilike: `%${query}%` } },
+            ],
+          }
+      : noResultsWhere,
+    targets,
+    teamsWhere: targets.has("teams")
+      ? entityIdPattern.test(query)
+        ? { id: idPredicate }
+        : {
+            _or: [
+              { id: { _ilike: `%${query}%` } },
+              { name: { _ilike: `%${query}%` } },
+            ],
+          }
+      : noResultsWhere,
+    usersWhere: targets.has("users")
+      ? entityIdPattern.test(query)
+        ? { id: idPredicate }
+        : {
+            _or: [
+              { email: { _ilike: `%${query}%` } },
+              { id: { _ilike: `%${query}%` } },
+              { name: { _ilike: `%${query}%` } },
+            ],
+          }
+      : noResultsWhere,
+  };
+};

--- a/web/scenes/Admin/search/server/fetch-global-search.ts
+++ b/web/scenes/Admin/search/server/fetch-global-search.ts
@@ -1,0 +1,74 @@
+import "server-only";
+
+import { getInternalDashboardGraphqlClientForUser } from "@/api/helpers/graphql";
+import type { AdminUser } from "@/lib/admin-auth";
+import { logger } from "@/lib/logger";
+
+import {
+  createGlobalSearchQuery,
+  type GlobalSearchTarget,
+} from "./create-global-search-where";
+import { getSdk } from "../graphql/server/fetch-admin-global-search.generated";
+
+export type GlobalSearchResult = {
+  apps: Array<{ id: string; name: string; teamId: string }>;
+  query: string;
+  teams: Array<{ id: string; name: string }>;
+  totals: Record<GlobalSearchTarget, number>;
+  users: Array<{ email: string | null; id: string; name: string }>;
+};
+
+const getCount = (aggregate?: { aggregate?: { count: number } | null }) =>
+  aggregate?.aggregate?.count ?? 0;
+
+export const fetchAdminGlobalSearch = async (
+  query: string,
+  user: AdminUser,
+): Promise<GlobalSearchResult> => {
+  const trimmedQuery = query.trim();
+  const { appsWhere, targets, teamsWhere, usersWhere } =
+    createGlobalSearchQuery(trimmedQuery);
+  const client = await getInternalDashboardGraphqlClientForUser(user);
+
+  try {
+    const data = await getSdk(client).FetchAdminGlobalSearch({
+      appsWhere,
+      includeApps: targets.has("apps"),
+      includeTeams: targets.has("teams"),
+      includeUsers: targets.has("users"),
+      limit: 5,
+      teamsWhere,
+      usersWhere,
+    });
+
+    return {
+      apps: (data.apps ?? []).map((app) => ({
+        id: app.id,
+        name: app.name,
+        teamId: app.team_id,
+      })),
+      query: trimmedQuery,
+      teams: (data.teams ?? []).map((team) => ({
+        id: team.id,
+        name: team.name ?? "Unnamed team",
+      })),
+      totals: {
+        apps: getCount(data.apps_aggregate),
+        teams: getCount(data.teams_aggregate),
+        users: getCount(data.users_aggregate),
+      },
+      users: (data.users ?? []).map((resultUser) => ({
+        email: resultUser.email ?? null,
+        id: resultUser.id,
+        name: resultUser.name,
+      })),
+    };
+  } catch (error) {
+    logger.error("Failed to fetch admin global search results", {
+      error,
+      query: trimmedQuery,
+      subject: user.subject,
+    });
+    throw error;
+  }
+};

--- a/web/scenes/Admin/server/fetch-home.ts
+++ b/web/scenes/Admin/server/fetch-home.ts
@@ -1,0 +1,153 @@
+import "server-only";
+
+import { getInternalDashboardGraphqlClient } from "@/api/helpers/graphql";
+import { logger } from "@/lib/logger";
+
+import {
+  type FetchAdminHomeQuery,
+  getSdk,
+} from "../graphql/server/fetch-admin-home.generated";
+
+export type AdminMetadataStatus =
+  | "awaiting_review"
+  | "changes_requested"
+  | "unverified"
+  | "verified";
+
+type HomeWorkflowApp = FetchAdminHomeQuery["workflow_apps"][number];
+type WorkflowStatusSource = {
+  draft_metadata: ReadonlyArray<{ verification_status: string }>;
+  verified_metadata: ReadonlyArray<{ verification_status: string }>;
+};
+
+const metadataStatuses = new Set<AdminMetadataStatus>([
+  "awaiting_review",
+  "changes_requested",
+  "unverified",
+  "verified",
+]);
+
+const getCount = (aggregate: { aggregate?: { count: number } | null }) =>
+  aggregate.aggregate?.count ?? 0;
+
+export const getWorkflowStatus = (
+  app: WorkflowStatusSource,
+): AdminMetadataStatus | null => {
+  const status =
+    app.draft_metadata[0]?.verification_status ??
+    app.verified_metadata[0]?.verification_status;
+
+  return status && metadataStatuses.has(status as AdminMetadataStatus)
+    ? (status as AdminMetadataStatus)
+    : null;
+};
+
+const mapWorkflowApp = (app: HomeWorkflowApp) => ({
+  id: app.id,
+  name:
+    app.draft_metadata[0]?.name ?? app.verified_metadata[0]?.name ?? app.name,
+  status: getWorkflowStatus(app),
+  teamId: app.team_id,
+  updatedAt: app.draft_metadata[0]?.updated_at ?? null,
+});
+
+export const fetchAdminHome = async () => {
+  const client = await getInternalDashboardGraphqlClient();
+  const recentSince = new Date(
+    Date.now() - 30 * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  try {
+    const data = await getSdk(client).FetchAdminHome({
+      recentLimit: 5,
+      recentSince,
+    });
+    const workflowApps = data.workflow_apps.map(mapWorkflowApp);
+    const soleOwnerTeams = data.owner_memberships
+      .filter(
+        (membership) =>
+          membership.team.memberships_aggregate.aggregate?.count === 1,
+      )
+      .map((membership) => ({
+        id: membership.team.id,
+        name: membership.team.name ?? "Unnamed team",
+        owner: {
+          email: membership.user.email,
+          id: membership.user.id,
+          name: membership.user.name,
+        },
+      }));
+
+    return {
+      inventory: {
+        activeApiKeys: getCount(data.active_api_keys),
+        activeApps: getCount(data.active_apps),
+        activeTeams: getCount(data.active_teams),
+        deletedApps: getCount(data.deleted_apps),
+        deletedTeams: getCount(data.deleted_teams),
+        newApps: getCount(data.new_apps),
+        newTeams: getCount(data.new_teams),
+        newUsers: getCount(data.new_users),
+        pendingInvites: getCount(data.pending_invites),
+        totalUsers: getCount(data.total_users),
+      },
+      queues: {
+        appsAwaitingReview: workflowApps.filter(
+          (app) => app.status === "awaiting_review",
+        ),
+        appsChangesRequested: workflowApps.filter(
+          (app) => app.status === "changes_requested",
+        ),
+        appsWithoutMetadata: data.apps_without_metadata.map((app) => ({
+          id: app.id,
+          name: app.name,
+          teamId: app.team_id,
+        })),
+        soleOwnerTeams,
+        teamsWithoutOwner: data.teams_without_owner.map((team) => ({
+          id: team.id,
+          name: team.name ?? "Unnamed team",
+        })),
+        usersWithoutTeams: data.users_without_teams.map((user) => ({
+          email: user.email,
+          id: user.id,
+          name: user.name,
+        })),
+      },
+      recent: {
+        apps: data.recent_apps.map((app) => ({
+          createdAt: app.created_at,
+          id: app.id,
+          name: app.name,
+          status: getWorkflowStatus(app),
+          teamId: app.team_id,
+        })),
+        metadata: data.recent_metadata.map((metadata) => ({
+          appId: metadata.app_id,
+          name: metadata.name,
+          status: metadataStatuses.has(
+            metadata.verification_status as AdminMetadataStatus,
+          )
+            ? (metadata.verification_status as AdminMetadataStatus)
+            : null,
+          updatedAt: metadata.updated_at,
+        })),
+        teams: data.recent_teams.map((team) => ({
+          createdAt: team.created_at,
+          id: team.id,
+          name: team.name ?? "Unnamed team",
+          status: team.deleted_at ? ("Deleted" as const) : ("Active" as const),
+        })),
+        users: data.recent_users.map((user) => ({
+          createdAt: user.created_at,
+          email: user.email,
+          id: user.id,
+          name: user.name,
+        })),
+      },
+    };
+  } catch (error) {
+    logger.error("Failed to fetch admin home", { error });
+    throw error;
+  }
+};

--- a/web/scenes/Admin/teams/graphql/server/fetch-admin-teams.generated.ts
+++ b/web/scenes/Admin/teams/graphql/server/fetch-admin-teams.generated.ts
@@ -28,10 +28,7 @@ export type FetchAdminTeamsQuery = {
   }>;
   team_aggregate: {
     __typename?: "team_aggregate";
-    aggregate?: {
-      __typename?: "team_aggregate_fields";
-      count: number;
-    } | null;
+    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
   };
   membership?: Array<{ __typename?: "membership"; team_id: string }>;
   app?: Array<{ __typename?: "app"; team_id: string }>;
@@ -101,7 +98,7 @@ export function getSdk(
 ) {
   return {
     FetchAdminTeams(
-      variables?: FetchAdminTeamsQueryVariables,
+      variables: FetchAdminTeamsQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
     ): Promise<FetchAdminTeamsQuery> {
       return withWrapper(

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-user-apps.generated.ts
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-user-apps.generated.ts
@@ -1,10 +1,9 @@
+/* eslint-disable */
 import * as Types from "@/graphql/graphql";
 
 import { GraphQLClient, RequestOptions } from "graphql-request";
 import gql from "graphql-tag";
-
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
-
 export type FetchAdminUserAppsQueryVariables = Types.Exact<{
   limit: Types.Scalars["Int"]["input"];
   offset: Types.Scalars["Int"]["input"];
@@ -19,7 +18,7 @@ export type FetchAdminUserAppsQuery = {
     name: string;
     created_at: string;
     deleted_at?: string | null;
-    team: { __typename?: "team"; id: string; name: string };
+    team: { __typename?: "team"; id: string; name?: string | null };
     draft_metadata: Array<{
       __typename?: "app_metadata";
       name: string;
@@ -82,10 +81,15 @@ export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
   operationName: string,
   operationType?: string,
-  variables?: unknown,
+  variables?: any,
 ) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (action) => action();
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
 
 export function getSdk(
   client: GraphQLClient,
@@ -93,7 +97,7 @@ export function getSdk(
 ) {
   return {
     FetchAdminUserApps(
-      variables?: FetchAdminUserAppsQueryVariables,
+      variables: FetchAdminUserAppsQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
     ): Promise<FetchAdminUserAppsQuery> {
       return withWrapper(
@@ -110,5 +114,4 @@ export function getSdk(
     },
   };
 }
-
 export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-user-details.generated.ts
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-user-details.generated.ts
@@ -1,10 +1,9 @@
+/* eslint-disable */
 import * as Types from "@/graphql/graphql";
 
 import { GraphQLClient, RequestOptions } from "graphql-request";
 import gql from "graphql-tag";
-
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
-
 export type FetchAdminUserDetailsQueryVariables = Types.Exact<{
   userId: Types.Scalars["String"]["input"];
 }>;
@@ -56,7 +55,7 @@ export type FetchAdminUserDetailsQuery = {
     team: {
       __typename?: "team";
       id: string;
-      name: string;
+      name?: string | null;
       deleted_at?: string | null;
       memberships_aggregate: {
         __typename?: "membership_aggregate";
@@ -73,7 +72,7 @@ export type FetchAdminUserDetailsQuery = {
     team: {
       __typename?: "team";
       id: string;
-      name: string;
+      name?: string | null;
       deleted_at?: string | null;
     };
   }>;
@@ -158,10 +157,15 @@ export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
   operationName: string,
   operationType?: string,
-  variables?: unknown,
+  variables?: any,
 ) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (action) => action();
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
 
 export function getSdk(
   client: GraphQLClient,
@@ -169,7 +173,7 @@ export function getSdk(
 ) {
   return {
     FetchAdminUserDetails(
-      variables?: FetchAdminUserDetailsQueryVariables,
+      variables: FetchAdminUserDetailsQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
     ): Promise<FetchAdminUserDetailsQuery> {
       return withWrapper(
@@ -186,5 +190,4 @@ export function getSdk(
     },
   };
 }
-
 export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-user-teams.generated.ts
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-user-teams.generated.ts
@@ -1,10 +1,9 @@
+/* eslint-disable */
 import * as Types from "@/graphql/graphql";
 
 import { GraphQLClient, RequestOptions } from "graphql-request";
 import gql from "graphql-tag";
-
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
-
 export type FetchAdminUserTeamsQueryVariables = Types.Exact<{
   limit: Types.Scalars["Int"]["input"];
   offset: Types.Scalars["Int"]["input"];
@@ -21,7 +20,7 @@ export type FetchAdminUserTeamsQuery = {
     team: {
       __typename?: "team";
       id: string;
-      name: string;
+      name?: string | null;
       deleted_at?: string | null;
     };
   }>;
@@ -67,10 +66,15 @@ export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
   operationName: string,
   operationType?: string,
-  variables?: unknown,
+  variables?: any,
 ) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (action) => action();
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
 
 export function getSdk(
   client: GraphQLClient,
@@ -78,7 +82,7 @@ export function getSdk(
 ) {
   return {
     FetchAdminUserTeams(
-      variables?: FetchAdminUserTeamsQueryVariables,
+      variables: FetchAdminUserTeamsQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
     ): Promise<FetchAdminUserTeamsQuery> {
       return withWrapper(
@@ -95,5 +99,4 @@ export function getSdk(
     },
   };
 }
-
 export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-users.generated.ts
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-users.generated.ts
@@ -1,10 +1,9 @@
+/* eslint-disable */
 import * as Types from "@/graphql/graphql";
 
 import { GraphQLClient, RequestOptions } from "graphql-request";
 import gql from "graphql-tag";
-
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
-
 export type FetchAdminUsersQueryVariables = Types.Exact<{
   includeCreatedAt: Types.Scalars["Boolean"]["input"];
   includeEmail: Types.Scalars["Boolean"]["input"];
@@ -33,10 +32,7 @@ export type FetchAdminUsersQuery = {
   }>;
   user_aggregate: {
     __typename?: "user_aggregate";
-    aggregate?: {
-      __typename?: "user_aggregate_fields";
-      count: number;
-    } | null;
+    aggregate?: { __typename?: "user_aggregate_fields"; count: number } | null;
   };
 };
 
@@ -73,10 +69,15 @@ export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
   operationName: string,
   operationType?: string,
-  variables?: unknown,
+  variables?: any,
 ) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (action) => action();
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
 
 export function getSdk(
   client: GraphQLClient,
@@ -84,7 +85,7 @@ export function getSdk(
 ) {
   return {
     FetchAdminUsers(
-      variables?: FetchAdminUsersQueryVariables,
+      variables: FetchAdminUsersQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
     ): Promise<FetchAdminUsersQuery> {
       return withWrapper(
@@ -101,5 +102,4 @@ export function getSdk(
     },
   };
 }
-
 export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/users/id/server/fetch-user-apps.ts
+++ b/web/scenes/Admin/users/id/server/fetch-user-apps.ts
@@ -27,7 +27,11 @@ export const createAdminUserAppsWhere = (
   ],
 });
 
-export type AdminUserApp = FetchAdminUserAppsQuery["app"][number];
+type RawAdminUserApp = FetchAdminUserAppsQuery["app"][number];
+
+export type AdminUserApp = Omit<RawAdminUserApp, "team"> & {
+  team: Omit<RawAdminUserApp["team"], "name"> & { name: string };
+};
 
 export const fetchAdminUserAppsPage = async ({
   page,
@@ -49,9 +53,16 @@ export const fetchAdminUserAppsPage = async ({
     });
     const appsAmount = data.app_aggregate.aggregate?.count ?? data.app.length;
     const totalPages = getAppsTotalPages(appsAmount, USER_DETAIL_LIST_LIMIT);
+    const apps: AdminUserApp[] = data.app.map((app) => ({
+      ...app,
+      team: {
+        ...app.team,
+        name: app.team.name ?? "Unnamed team",
+      },
+    }));
 
     return {
-      apps: data.app,
+      apps,
       appsAmount,
       currentPage: clampAppsPage(page, totalPages),
       totalPages,

--- a/web/scenes/Admin/users/id/server/fetch-user-teams.ts
+++ b/web/scenes/Admin/users/id/server/fetch-user-teams.ts
@@ -77,7 +77,11 @@ export const createAdminUserTeamsWhere = (
   return { _and: [scope, searchWhere] };
 };
 
-export type AdminUserTeam = FetchAdminUserTeamsQuery["membership"][number];
+type RawAdminUserTeam = FetchAdminUserTeamsQuery["membership"][number];
+
+export type AdminUserTeam = Omit<RawAdminUserTeam, "team"> & {
+  team: Omit<RawAdminUserTeam["team"], "name"> & { name: string };
+};
 
 export const fetchAdminUserTeamsPage = async ({
   page,
@@ -100,10 +104,17 @@ export const fetchAdminUserTeamsPage = async ({
     const teamsAmount =
       data.membership_aggregate.aggregate?.count ?? data.membership.length;
     const totalPages = getUsersTotalPages(teamsAmount, USER_DETAIL_LIST_LIMIT);
+    const teams: AdminUserTeam[] = data.membership.map((membership) => ({
+      ...membership,
+      team: {
+        ...membership.team,
+        name: membership.team.name ?? "Unnamed team",
+      },
+    }));
 
     return {
       currentPage: clampUsersPage(page, totalPages),
-      teams: data.membership,
+      teams,
       teamsAmount,
       totalPages,
     };

--- a/web/tests/api/admin/search.test.ts
+++ b/web/tests/api/admin/search.test.ts
@@ -1,0 +1,88 @@
+const mockAuthenticateAdminRequest = jest.fn();
+const mockFetchAdminGlobalSearch = jest.fn();
+
+jest.mock("@/lib/admin-auth", () => ({
+  authenticateAdminRequest: (...args: unknown[]) =>
+    mockAuthenticateAdminRequest(...args),
+}));
+
+jest.mock("@/scenes/Admin/search/server/fetch-global-search", () => ({
+  fetchAdminGlobalSearch: (...args: unknown[]) =>
+    mockFetchAdminGlobalSearch(...args),
+}));
+
+import { GET } from "@/api/admin/search";
+import { NextRequest } from "next/server";
+
+const user = {
+  email: "admin@example.com",
+  role: "internal_dashboard_readonly",
+  subject: "admin-subject",
+};
+
+const createRequest = (query = "") =>
+  new NextRequest(`http://localhost/api/admin/search?q=${query}`);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("/api/admin/search", () => {
+  it("returns 401 when the request is unauthenticated", async () => {
+    mockAuthenticateAdminRequest.mockResolvedValue(null);
+
+    const response = await GET(createRequest("wallet"));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+    expect(mockFetchAdminGlobalSearch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a query outside the accepted length range", async () => {
+    mockAuthenticateAdminRequest.mockResolvedValue(user);
+
+    const response = await GET(createRequest("a"));
+
+    expect(response.status).toBe(400);
+    expect(mockFetchAdminGlobalSearch).not.toHaveBeenCalled();
+  });
+
+  it("returns grouped search results for an authenticated admin", async () => {
+    mockAuthenticateAdminRequest.mockResolvedValue(user);
+    mockFetchAdminGlobalSearch.mockResolvedValue({
+      apps: [
+        { id: "app_current", name: "Current app", teamId: "team_current" },
+      ],
+      query: "current",
+      teams: [],
+      totals: { apps: 1, teams: 0, users: 0 },
+      users: [],
+    });
+
+    const response = await GET(createRequest("current"));
+
+    expect(response.status).toBe(200);
+    expect(mockFetchAdminGlobalSearch).toHaveBeenCalledWith("current", user);
+    expect(await response.json()).toEqual({
+      apps: [
+        { id: "app_current", name: "Current app", teamId: "team_current" },
+      ],
+      query: "current",
+      teams: [],
+      totals: { apps: 1, teams: 0, users: 0 },
+      users: [],
+    });
+  });
+
+  it("returns 503 when the search data fetch fails", async () => {
+    mockAuthenticateAdminRequest.mockResolvedValue(user);
+    mockFetchAdminGlobalSearch.mockRejectedValue(new Error("GraphQL failed"));
+
+    const response = await GET(createRequest("current"));
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "Search is temporarily unavailable",
+    });
+  });
+});

--- a/web/tests/unit/admin-global-search-where.test.ts
+++ b/web/tests/unit/admin-global-search-where.test.ts
@@ -1,0 +1,52 @@
+import { createGlobalSearchQuery } from "@/scenes/Admin/search/server/create-global-search-where";
+
+describe("admin global search where clauses", () => {
+  it("routes a complete app ID to an exact app-only search", () => {
+    const query = "app_0123456789abcdef0123456789abcdef";
+
+    expect(createGlobalSearchQuery(query)).toEqual({
+      appsWhere: { id: { _eq: query } },
+      targets: new Set(["apps"]),
+      teamsWhere: { id: { _eq: "" } },
+      usersWhere: { id: { _eq: "" } },
+    });
+  });
+
+  it("routes an email search to users", () => {
+    const query = createGlobalSearchQuery("admin@example.com");
+
+    expect(query.targets).toEqual(new Set(["users"]));
+    expect(query.usersWhere).toEqual({
+      _or: [
+        { email: { _ilike: "%admin@example.com%" } },
+        { id: { _ilike: "%admin@example.com%" } },
+        { name: { _ilike: "%admin@example.com%" } },
+      ],
+    });
+    expect(query.appsWhere).toEqual({ id: { _eq: "" } });
+    expect(query.teamsWhere).toEqual({ id: { _eq: "" } });
+  });
+
+  it("searches every entity type for a plain text query", () => {
+    const query = createGlobalSearchQuery("wallet");
+
+    expect(query.targets).toEqual(new Set(["apps", "teams", "users"]));
+    expect(query.appsWhere).toEqual({
+      _or: [
+        { id: { _ilike: "%wallet%" } },
+        { name: { _ilike: "%wallet%" } },
+        { team_id: { _ilike: "%wallet%" } },
+      ],
+    });
+    expect(query.teamsWhere).toEqual({
+      _or: [{ id: { _ilike: "%wallet%" } }, { name: { _ilike: "%wallet%" } }],
+    });
+    expect(query.usersWhere).toEqual({
+      _or: [
+        { email: { _ilike: "%wallet%" } },
+        { id: { _ilike: "%wallet%" } },
+        { name: { _ilike: "%wallet%" } },
+      ],
+    });
+  });
+});

--- a/web/tests/unit/admin-global-search.test.tsx
+++ b/web/tests/unit/admin-global-search.test.tsx
@@ -1,0 +1,120 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import { Search } from "@/components/AdminDashboard/Search";
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  global.fetch = mockFetch;
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+const searchInput = () => screen.getByRole("combobox");
+
+describe("admin global search", () => {
+  it.each([
+    ["Command", { key: "k", metaKey: true }],
+    ["Control", { ctrlKey: true, key: "k" }],
+  ])("focuses the input with %s + K", (_label, shortcut) => {
+    render(<Search />);
+
+    fireEvent.keyDown(window, shortcut);
+
+    expect(searchInput()).toHaveFocus();
+  });
+
+  it("waits for the debounce period then displays grouped results", async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        apps: [
+          {
+            id: "app_current",
+            name: "Current app",
+            teamId: "team_current",
+          },
+        ],
+        teams: [{ id: "team_current", name: "Current team" }],
+        users: [],
+      }),
+      ok: true,
+    });
+
+    render(<Search />);
+    fireEvent.focus(searchInput());
+    fireEvent.change(searchInput(), { target: { value: "current" } });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/admin/search?q=current",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(screen.getByRole("option", { name: /Current team/i })).toBeVisible();
+    expect(screen.getByRole("option", { name: /Current app/i })).toBeVisible();
+  });
+
+  it("navigates to the keyboard-selected result", async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        apps: [
+          { id: "app_current", name: "Current app", teamId: "team_current" },
+        ],
+        teams: [],
+        users: [],
+      }),
+      ok: true,
+    });
+
+    render(<Search />);
+    fireEvent.focus(searchInput());
+    fireEvent.change(searchInput(), { target: { value: "current" } });
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    fireEvent.keyDown(searchInput(), { key: "ArrowDown" });
+    fireEvent.keyDown(searchInput(), { key: "Enter" });
+
+    expect(mockPush).toHaveBeenCalledWith("/admin/apps/app_current");
+  });
+
+  it("aborts an outstanding request when the query changes", async () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+
+    render(<Search />);
+    fireEvent.focus(searchInput());
+    fireEvent.change(searchInput(), { target: { value: "first" } });
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    const firstSignal = mockFetch.mock.calls[0][1].signal as AbortSignal;
+
+    fireEvent.change(searchInput(), { target: { value: "second" } });
+
+    expect(firstSignal.aborted).toBe(true);
+  });
+});

--- a/web/tests/unit/admin-home-fetch.test.ts
+++ b/web/tests/unit/admin-home-fetch.test.ts
@@ -1,0 +1,209 @@
+const mockFetchAdminHome = jest.fn();
+
+jest.mock("server-only", () => ({}));
+
+jest.mock("@/api/helpers/graphql", () => ({
+  getInternalDashboardGraphqlClient: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock("@/scenes/Admin/graphql/server/fetch-admin-home.generated", () => ({
+  getSdk: () => ({ FetchAdminHome: mockFetchAdminHome }),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn() },
+}));
+
+import { logger } from "@/lib/logger";
+import {
+  fetchAdminHome,
+  getWorkflowStatus,
+} from "@/scenes/Admin/server/fetch-home";
+
+const aggregate = (count: number) => ({ aggregate: { count } });
+
+const createHomeResponse = () => ({
+  active_api_keys: aggregate(3),
+  active_apps: aggregate(7),
+  active_teams: aggregate(5),
+  apps_without_metadata: [
+    {
+      created_at: "2026-07-01T00:00:00.000Z",
+      id: "app_without_metadata",
+      name: "Missing metadata",
+      team_id: "team_current",
+    },
+  ],
+  deleted_apps: aggregate(2),
+  deleted_teams: aggregate(1),
+  new_apps: aggregate(4),
+  new_teams: aggregate(2),
+  new_users: aggregate(6),
+  owner_memberships: [
+    {
+      team: {
+        id: "team_sole_owner",
+        memberships_aggregate: aggregate(1),
+        name: "Sole owner team",
+      },
+      user: {
+        email: "owner@example.com",
+        id: "user_owner",
+        name: "Owner",
+      },
+    },
+    {
+      team: {
+        id: "team_multiple_owners",
+        memberships_aggregate: aggregate(2),
+        name: "Multiple owners",
+      },
+      user: {
+        email: "second@example.com",
+        id: "user_second",
+        name: "Second owner",
+      },
+    },
+  ],
+  pending_invites: aggregate(2),
+  recent_apps: [
+    {
+      created_at: "2026-07-10T00:00:00.000Z",
+      draft_metadata: [{ verification_status: "awaiting_review" }],
+      id: "app_recent",
+      name: "Recent app",
+      team_id: "team_current",
+      verified_metadata: [],
+    },
+  ],
+  recent_metadata: [
+    {
+      app_id: "app_recent",
+      name: "Recent app",
+      updated_at: "2026-07-11T00:00:00.000Z",
+      verification_status: "awaiting_review",
+    },
+  ],
+  recent_teams: [
+    {
+      created_at: "2026-07-10T00:00:00.000Z",
+      deleted_at: null,
+      id: "team_recent",
+      name: "Recent team",
+    },
+  ],
+  recent_users: [
+    {
+      created_at: "2026-07-10T00:00:00.000Z",
+      email: "recent@example.com",
+      id: "user_recent",
+      name: "Recent user",
+    },
+  ],
+  teams_without_owner: [
+    {
+      created_at: "2026-07-09T00:00:00.000Z",
+      id: "team_without_owner",
+      name: "No owner team",
+    },
+  ],
+  total_users: aggregate(11),
+  users_without_teams: [
+    {
+      created_at: "2026-07-09T00:00:00.000Z",
+      email: "unassigned@example.com",
+      id: "user_without_team",
+      name: "Unassigned user",
+    },
+  ],
+  workflow_apps: [
+    {
+      draft_metadata: [
+        {
+          name: "Reviewed app",
+          updated_at: "2026-07-10T00:00:00.000Z",
+          verification_status: "changes_requested",
+        },
+      ],
+      id: "app_changes_requested",
+      name: "Source app name",
+      team_id: "team_current",
+      verified_metadata: [
+        {
+          name: "Previously verified app",
+          verification_status: "verified",
+          verified_at: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    },
+    {
+      draft_metadata: [
+        {
+          name: "Waiting app",
+          updated_at: "2026-07-09T00:00:00.000Z",
+          verification_status: "awaiting_review",
+        },
+      ],
+      id: "app_waiting_review",
+      name: "Waiting source app",
+      team_id: "team_current",
+      verified_metadata: [],
+    },
+  ],
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("admin home fetch", () => {
+  it("uses the current draft metadata status and maps dashboard queues", async () => {
+    mockFetchAdminHome.mockResolvedValue(createHomeResponse());
+
+    const home = await fetchAdminHome();
+
+    expect(home.inventory).toEqual({
+      activeApiKeys: 3,
+      activeApps: 7,
+      activeTeams: 5,
+      deletedApps: 2,
+      deletedTeams: 1,
+      newApps: 4,
+      newTeams: 2,
+      newUsers: 6,
+      pendingInvites: 2,
+      totalUsers: 11,
+    });
+    expect(home.queues.appsAwaitingReview).toEqual([
+      expect.objectContaining({ id: "app_waiting_review" }),
+    ]);
+    expect(home.queues.appsChangesRequested).toEqual([
+      expect.objectContaining({ id: "app_changes_requested" }),
+    ]);
+    expect(home.queues.soleOwnerTeams).toEqual([
+      expect.objectContaining({ id: "team_sole_owner" }),
+    ]);
+    expect(home.queues.usersWithoutTeams).toEqual([
+      expect.objectContaining({ id: "user_without_team" }),
+    ]);
+  });
+
+  it("prioritizes the latest non-verified metadata over verified metadata", () => {
+    expect(
+      getWorkflowStatus({
+        draft_metadata: [{ verification_status: "changes_requested" }],
+        verified_metadata: [{ verification_status: "verified" }],
+      }),
+    ).toBe("changes_requested");
+  });
+
+  it("logs and rethrows GraphQL errors", async () => {
+    const error = new Error("GraphQL request failed");
+    mockFetchAdminHome.mockRejectedValue(error);
+
+    await expect(fetchAdminHome()).rejects.toThrow(error);
+    expect(logger.error).toHaveBeenCalledWith("Failed to fetch admin home", {
+      error,
+    });
+  });
+});


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Adds the first read-only Internal Developer Portal dashboard for admins.

- Adds inventory metrics, operational attention queues, and recent entity changes.
- Adds global search for teams, apps, and users with keyboard navigation and `Cmd/Ctrl + K`.
- Adds app-detail data fetching and related GraphQL queries.
- Improves admin UI layout, scrolling behavior, and visual hierarchy.
- Updates the admin layout background for better module contrast.
- Adds unit and API coverage for dashboard data, search behavior, and app-detail fetching.

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.

---

<img width="1384" height="1154" alt="image" src="https://github.com/user-attachments/assets/b054c4bc-e00b-419a-a3e5-4a21ada41ef9" />
