### PR TITLE
fix(portal): link v2 logo to team overview

### DIFF
--- a/web/scenes/Portal/layout/Header/index.tsx
+++ b/web/scenes/Portal/layout/Header/index.tsx
@@ -7,7 +7,7 @@ import { SizingWrapper } from "@/components/SizingWrapper";
 import { urls } from "@/lib/urls";
 import { useAtom, useSetAtom } from "jotai";
 import { useParams } from "next/navigation";
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect } from "react";
 import { colorAtom } from "@/scenes/common/layout/color-atom";
 import { Color } from "@/scenes/common/Profile/types";
 import { AppSelector } from "../AppSelector";
@@ -18,21 +18,13 @@ import { createAppDialogOpenedAtom } from "@/scenes/common/layout/Header/atoms";
 export const Header = (props: { color: Color | null }) => {
   const setColor = useSetAtom(colorAtom);
   const [open, setOpen] = useAtom(createAppDialogOpenedAtom);
-  const { teamId, appId } = useParams() as { teamId?: string; appId?: string };
+  const { teamId } = useParams() as { teamId?: string };
 
   useEffect(() => {
     setColor(props.color);
   }, [props.color, setColor]);
 
-  const logoHref = useMemo(() => {
-    if (teamId && appId) {
-      return urls.app({ team_id: teamId, app_id: appId });
-    }
-    if (teamId) {
-      return urls.teams({ team_id: teamId });
-    }
-    return "/";
-  }, [teamId, appId]);
+  const logoHref = teamId ? urls.teams({ team_id: teamId }) : "/";
 
   return (
     <header className="max-md:sticky max-md:top-0 max-md:z-10 max-md:mb-6 max-md:border-b max-md:border-gray-200 max-md:bg-grey-0">

--- a/web/tests/unit/portal-v2-header.test.tsx
+++ b/web/tests/unit/portal-v2-header.test.tsx
@@ -1,0 +1,59 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+const useParams = jest.fn();
+jest.mock("next/navigation", () => ({
+  useParams: () => useParams(),
+}));
+
+jest.mock("@/components/Icons/WorldIcon", () => ({
+  WorldIcon: () => <span>World logo</span>,
+}));
+
+jest.mock("@/components/LoggedUserNav", () => ({
+  LoggedUserNav: () => null,
+}));
+
+jest.mock("@/scenes/Portal/layout/AppSelector", () => ({
+  AppSelector: () => null,
+}));
+
+jest.mock("@/scenes/Portal/layout/CreateAppDialog/index-v4", () => ({
+  CreateAppDialogV4: () => null,
+}));
+
+import { Header } from "@/scenes/Portal/layout/Header";
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// #region World logo routing
+describe("v2 Header [World logo routing]", () => {
+  it("links to the team when viewing an app", () => {
+    useParams.mockReturnValue({ teamId: "team_1", appId: "app_1" });
+
+    render(<Header color={null} />);
+
+    expect(screen.getByRole("link", { name: "World logo" })).toHaveAttribute(
+      "href",
+      "/teams/team_1",
+    );
+  });
+
+  it("links to the portal root when no team is selected", () => {
+    useParams.mockReturnValue({});
+
+    render(<Header color={null} />);
+
+    expect(screen.getByRole("link", { name: "World logo" })).toHaveAttribute(
+      "href",
+      "/",
+    );
+  });
+});
+// #endregion


### PR DESCRIPTION
This PR updates the Portal V2 header so the World logo returns users to the current team overview.

- Link the World logo to `/teams/{teamId}` even when viewing an app.
- Preserve the `/` fallback when no team is selected.
- Add focused regression coverage for both routes.

Validation:
- `pnpm exec jest tests/unit/portal-v2-header.test.tsx --watchman=false`
- `pnpm exec tsc --noEmit`
- `pnpm format:check`