### PR TITLE
fix(verify): treat sandbox environment as staging

### DIFF
--- a/web/api/v4/verify/request-schema.ts
+++ b/web/api/v4/verify/request-schema.ts
@@ -185,8 +185,14 @@ export const schema = yup
     // We use this field to detect session proofs in custom validation
     session_id: yup.string().strict().optional(),
 
-    // Optional environment to specify which verifier contract to use
-    environment: yup.string().oneOf(["production", "staging"]).optional(),
+    // Sandbox uses the staging verifier and storage partition.
+    environment: yup
+      .string()
+      .transform((environment) =>
+        environment === "sandbox" ? "staging" : environment,
+      )
+      .oneOf(["production", "staging"])
+      .optional(),
 
     // Optional World App integrity attestation bundle. When present, it is
     // verified before proof verification.

--- a/web/tests/api/v4/request-schema.test.ts
+++ b/web/tests/api/v4/request-schema.test.ts
@@ -28,6 +28,26 @@ describe("v4 verify request schema", () => {
     expect(parsed.responses[0]?.signal_hash).toBe("0x0");
   });
 
+  it('normalizes the "sandbox" environment to "staging"', async () => {
+    const parsed = await schema.validate({
+      protocol_version: "4.0",
+      nonce: "0x01",
+      action: "test-action",
+      environment: "sandbox",
+      responses: [
+        {
+          identifier: "credential",
+          issuer_schema_id: 128,
+          nullifier: "0x02",
+          expires_at_min: 1772584197,
+          proof: ["0x1", "0x2", "0x3", "0x4", "0x5"],
+        },
+      ],
+    });
+
+    expect(parsed.environment).toBe("staging");
+  });
+
   it("accepts optional top-level integrity_bundle", async () => {
     const parsed = await schema.validate({
       protocol_version: "4.0",

--- a/web/tests/api/v4/verify.test.ts
+++ b/web/tests/api/v4/verify.test.ts
@@ -90,12 +90,12 @@ beforeEach(() => {
 
 // #region Integrity bundle environment
 describe("/api/v4/verify [integrity bundle]", () => {
-  it("passes the request environment to integrity bundle verification", async () => {
+  it('treats the "sandbox" environment as "staging"', async () => {
     const req = createRequest({
       protocol_version: "4.0",
       nonce: "1",
       action: "verify",
-      environment: "staging",
+      environment: "sandbox",
       integrity_bundle: integrityBundle,
       responses: [v4Response],
     });


### PR DESCRIPTION
This PR makes `/api/v4/verify` accept the `sandbox` environment and route it through the existing staging behavior.

- normalizes `sandbox` to `staging` at the request-schema boundary
- reuses staging verifier selection, integrity configuration, and action storage
- adds schema and endpoint regression coverage
- validates all 44 v4 API tests, TypeScript, formatting, and the staged secret scan