### PR TITLE
fix(portal): validate webhook URLs to block SSRF write path (VULN-6369)

### DIFF
--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -165,11 +165,12 @@ const parseIPv4Octets = (host: string): number[] | null => {
 };
 
 /**
- * True when an IPv4 address falls in a loopback, private, link-local, or other
- * non-public range that a webhook target must never point at.
+ * True when an IPv4 address is anything other than a public unicast address:
+ * loopback, private, link-local, CGNAT, documentation/benchmarking/special-use,
+ * multicast, or reserved/broadcast. A webhook target must never point at these.
  */
 const isBlockedIPv4 = (octets: number[]): boolean => {
-  const [a, b] = octets;
+  const [a, b, c] = octets;
 
   if (a === 0) return true; // 0.0.0.0/8 "this host"
   if (a === 10) return true; // 10.0.0.0/8 private
@@ -177,7 +178,14 @@ const isBlockedIPv4 = (octets: number[]): boolean => {
   if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
   if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (incl. cloud metadata 169.254.169.254)
   if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
+  if (a === 192 && b === 0 && c === 0) return true; // 192.0.0.0/24 IETF protocol assignments
+  if (a === 192 && b === 0 && c === 2) return true; // 192.0.2.0/24 TEST-NET-1
+  if (a === 192 && b === 88 && c === 99) return true; // 192.88.99.0/24 6to4 relay anycast
   if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
+  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15 benchmarking
+  if (a === 198 && b === 51 && c === 100) return true; // 198.51.100.0/24 TEST-NET-2
+  if (a === 203 && b === 0 && c === 113) return true; // 203.0.113.0/24 TEST-NET-3
+  if (a >= 224) return true; // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved (incl. 255.255.255.255 broadcast)
 
   return false;
 };
@@ -267,11 +275,16 @@ const containsControlCharacter = (value: string): boolean => {
  * app-backend, which is the component that performs the request.
  */
 export const validateWebhookUrl = (candidate: string): boolean => {
-  const value = candidate?.trim();
-  if (!value) return false;
+  if (!candidate) return false;
 
-  // Reject control characters / newlines to avoid request or header smuggling.
-  if (containsControlCharacter(value)) return false;
+  // Reject control characters / newlines on the RAW value, before trimming.
+  // trim() would strip leading/trailing controls (e.g. a trailing newline) and
+  // let them slip past this smuggling check, while the form schema still
+  // persists the untrimmed string.
+  if (containsControlCharacter(candidate)) return false;
+
+  const value = candidate.trim();
+  if (!value) return false;
 
   let parsed: URL;
   try {

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -183,15 +183,16 @@ const isBlockedIPv4 = (octets: number[]): boolean => {
 };
 
 /**
- * Extracts the embedded IPv4 address from an IPv4-mapped (`::ffff:a.b.c.d`) or
- * deprecated IPv4-compatible (`::a.b.c.d`) IPv6 literal. `URL.hostname`
- * canonicalizes the trailing IPv4 to two hex groups (e.g. `::ffff:7f00:1`), so
- * both the dotted and the hex forms are handled. Anchored to `::` so a genuine
- * global IPv6 address is never misread as an embedded IPv4.
+ * Extracts the embedded IPv4 address from an IPv4-mapped IPv6 literal
+ * (`::ffff:a.b.c.d`). `URL.hostname` canonicalizes the trailing IPv4 to two hex
+ * groups (e.g. `::ffff:7f00:1`), so both the dotted and the hex forms are
+ * handled. Requires the `::ffff:` marker so only genuine IPv4-mapped addresses
+ * match; the deprecated IPv4-compatible form (`::a.b.c.d`) and other `::/96`
+ * literals are handled by isBlockedIPv6's `::/96` rule instead.
  */
 const extractEmbeddedIPv4 = (addr: string): number[] | null => {
-  const dotted = addr.match(/^::(ffff:)?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-  if (dotted) return parseIPv4Octets(dotted[2]);
+  const dotted = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (dotted) return parseIPv4Octets(dotted[1]);
 
   const mapped = addr.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
   if (mapped) {
@@ -204,16 +205,28 @@ const extractEmbeddedIPv4 = (addr: string): number[] | null => {
 
 /**
  * True when an IPv6 address (without surrounding brackets) is loopback,
- * unspecified, unique-local, link-local, or an IPv4-mapped address that itself
- * points at a blocked IPv4 range.
+ * unspecified, unique-local, link-local, an IPv4-mapped address that itself
+ * points at a blocked IPv4 range, or any other `::/96` literal.
  */
 const isBlockedIPv6 = (host: string): boolean => {
   const addr = host.toLowerCase();
 
   if (addr === "::" || addr === "::1") return true; // unspecified / loopback
 
+  // IPv4-mapped (::ffff:a.b.c.d): block based on the embedded IPv4.
   const embedded = extractEmbeddedIPv4(addr);
   if (embedded) return isBlockedIPv4(embedded);
+
+  // ::/96 (first 96 bits zero) covers the unspecified range and the deprecated
+  // IPv4-compatible form (::a.b.c.d, which URL canonicalizes to ::hhhh:hhhh —
+  // e.g. ::127.0.0.1 -> ::7f00:1). None of it is publicly routable, so block
+  // the whole range: "::" followed by at most the low 32 bits (<=2 hextets or a
+  // dotted quad).
+  if (
+    /^::([0-9a-f]{1,4}(:[0-9a-f]{1,4})?|\d{1,3}(\.\d{1,3}){3})?$/.test(addr)
+  ) {
+    return true;
+  }
 
   const firstHextet = addr.split(":")[0];
   if (firstHextet) {
@@ -271,8 +284,14 @@ export const validateWebhookUrl = (candidate: string): boolean => {
   // require HTTPS regardless of environment.
   if (parsed.protocol !== "https:") return false;
 
-  // `URL.hostname` keeps the brackets around IPv6 literals; strip them.
-  const hostname = parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  // `URL.hostname` keeps the brackets around IPv6 literals; strip them. Also
+  // strip a trailing "root" dot: URL preserves it on names (`localhost.`,
+  // `foo.localhost.`) though not on IPs, and a resolver may treat the
+  // root-qualified special-use name as loopback — normalize before the checks.
+  const hostname = parsed.hostname
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.+$/, "")
+    .toLowerCase();
   if (!hostname) return false;
 
   // Block localhost by name (and any *.localhost subdomain).

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -142,6 +142,154 @@ export const validateUri = (candidate: string, isStaging: boolean): boolean => {
 };
 
 /**
+ * Parses a canonical dotted-decimal IPv4 string into its four octets.
+ * Returns null when the value is not a plain dotted-decimal IPv4 literal.
+ *
+ * The WHATWG URL parser already canonicalizes alternate IPv4 encodings
+ * (hex `0x7f000001`, octal `0177.0.0.1`, decimal `2130706433`, shorthand
+ * `127.1`, bare integers) to dotted-decimal in `URL.hostname`, so only the
+ * canonical form needs to be handled here.
+ */
+const parseIPv4Octets = (host: string): number[] | null => {
+  const parts = host.split(".");
+  if (parts.length !== 4) return null;
+
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const value = Number(part);
+    if (value > 255) return null;
+    octets.push(value);
+  }
+  return octets;
+};
+
+/**
+ * True when an IPv4 address falls in a loopback, private, link-local, or other
+ * non-public range that a webhook target must never point at.
+ */
+const isBlockedIPv4 = (octets: number[]): boolean => {
+  const [a, b] = octets;
+
+  if (a === 0) return true; // 0.0.0.0/8 "this host"
+  if (a === 10) return true; // 10.0.0.0/8 private
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (incl. cloud metadata 169.254.169.254)
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
+
+  return false;
+};
+
+/**
+ * Extracts the embedded IPv4 address from an IPv4-mapped (`::ffff:a.b.c.d`) or
+ * deprecated IPv4-compatible (`::a.b.c.d`) IPv6 literal. `URL.hostname`
+ * canonicalizes the trailing IPv4 to two hex groups (e.g. `::ffff:7f00:1`), so
+ * both the dotted and the hex forms are handled. Anchored to `::` so a genuine
+ * global IPv6 address is never misread as an embedded IPv4.
+ */
+const extractEmbeddedIPv4 = (addr: string): number[] | null => {
+  const dotted = addr.match(/^::(ffff:)?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (dotted) return parseIPv4Octets(dotted[2]);
+
+  const mapped = addr.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (mapped) {
+    const hi = parseInt(mapped[1], 16);
+    const lo = parseInt(mapped[2], 16);
+    return [(hi >> 8) & 0xff, hi & 0xff, (lo >> 8) & 0xff, lo & 0xff];
+  }
+  return null;
+};
+
+/**
+ * True when an IPv6 address (without surrounding brackets) is loopback,
+ * unspecified, unique-local, link-local, or an IPv4-mapped address that itself
+ * points at a blocked IPv4 range.
+ */
+const isBlockedIPv6 = (host: string): boolean => {
+  const addr = host.toLowerCase();
+
+  if (addr === "::" || addr === "::1") return true; // unspecified / loopback
+
+  const embedded = extractEmbeddedIPv4(addr);
+  if (embedded) return isBlockedIPv4(embedded);
+
+  const firstHextet = addr.split(":")[0];
+  if (firstHextet) {
+    const value = parseInt(firstHextet, 16);
+    if (!Number.isNaN(value)) {
+      if (value >= 0xfc00 && value <= 0xfdff) return true; // fc00::/7 unique-local
+      if (value >= 0xfe80 && value <= 0xfebf) return true; // fe80::/10 link-local
+      if (value >= 0xfec0 && value <= 0xfeff) return true; // fec0::/10 deprecated site-local
+    }
+  }
+  return false;
+};
+
+/**
+ * True when the string contains an ASCII control character (0x00-0x1F) or DEL
+ * (0x7F). Used to reject request/header smuggling attempts in a webhook URL.
+ */
+const containsControlCharacter = (value: string): boolean => {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+};
+
+/**
+ * Validates a partner action webhook URL before it is stored.
+ *
+ * app-backend later fetches this value server-side and POSTs the (RSA-encrypted)
+ * proof payload to it, so an attacker-controlled URL is a Server-Side Request
+ * Forgery (SSRF) sink (VULN-6369 / CE25-C014). This is the write-layer denylist:
+ * it requires HTTPS and rejects literal loopback, private, link-local, cloud
+ * metadata, and IPv6 loopback/unique-local/link-local targets — including
+ * alternate IPv4 encodings and IPv4-mapped IPv6 that `URL` canonicalizes.
+ *
+ * This does NOT resolve DNS: a hostname that resolves to a private address, and
+ * DNS-rebinding between validation and fetch, must be defended at egress time in
+ * app-backend, which is the component that performs the request.
+ */
+export const validateWebhookUrl = (candidate: string): boolean => {
+  const value = candidate?.trim();
+  if (!value) return false;
+
+  // Reject control characters / newlines to avoid request or header smuggling.
+  if (containsControlCharacter(value)) return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  // Webhooks carry sensitive proof payloads and are fetched server-side, so
+  // require HTTPS regardless of environment.
+  if (parsed.protocol !== "https:") return false;
+
+  // `URL.hostname` keeps the brackets around IPv6 literals; strip them.
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (!hostname) return false;
+
+  // Block localhost by name (and any *.localhost subdomain).
+  if (hostname === "localhost" || hostname.endsWith(".localhost")) {
+    return false;
+  }
+
+  const ipv4 = parseIPv4Octets(hostname);
+  if (ipv4) return !isBlockedIPv4(ipv4);
+
+  if (hostname.includes(":")) return !isBlockedIPv6(hostname);
+
+  // A DNS name that is not a literal IP — allowed at the write layer.
+  return true;
+};
+
+/**
  * Checks if the code is running in the server
  * @returns True if the code is running in the server, false otherwise
  */

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
@@ -1,5 +1,5 @@
 import { validatePublicKey } from "@/lib/crypto.server";
-import { validateUri, validateUrl } from "@/lib/utils";
+import { validateUri, validateWebhookUrl } from "@/lib/utils";
 import * as yup from "yup";
 
 export type ActionContext = {
@@ -20,10 +20,14 @@ export const createUpdateActionSchema = (context: ActionContext) => {
       webhook_uri: yup
         .string()
         .optional()
-        .test("is-url", "Must be a valid URL", (value) => {
-          if (!value || !context.isProduction) return true;
-          return validateUrl(value, !context.isProduction);
-        }),
+        .test(
+          "is-webhook-url",
+          "Webhook URL must be a valid HTTPS URL and cannot target a private, loopback, or internal network address",
+          (value) => {
+            if (!value) return true;
+            return validateWebhookUrl(value);
+          },
+        ),
       webhook_pem: yup
         .string()
         .optional()

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
@@ -3,7 +3,7 @@ import {
   allowedCommonCharactersRegex,
   allowedTitleCharactersRegex,
 } from "@/lib/schema";
-import { validateUri, validateUrl } from "@/lib/utils";
+import { validateUri, validateWebhookUrl } from "@/lib/utils";
 import * as yup from "yup";
 
 // Check if not in production
@@ -41,10 +41,14 @@ export const createActionSchema = (context: ActionContext) => {
       webhook_uri: yup
         .string()
         .optional()
-        .test("is-url", "Must be a valid URL", (value) => {
-          if (!value || !context.isProduction) return true;
-          return validateUrl(value, !context.isProduction);
-        }),
+        .test(
+          "is-webhook-url",
+          "Webhook URL must be a valid HTTPS URL and cannot target a private, loopback, or internal network address",
+          (value) => {
+            if (!value) return true;
+            return validateWebhookUrl(value);
+          },
+        ),
       webhook_pem: yup
         .string()
         .optional()

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/UpdateAction/server/form-schema.ts
@@ -1,5 +1,5 @@
 import { validatePublicKey } from "@/lib/crypto.server";
-import { validateUri, validateUrl } from "@/lib/utils";
+import { validateUri, validateWebhookUrl } from "@/lib/utils";
 import * as yup from "yup";
 
 export type ActionContext = {
@@ -20,10 +20,14 @@ export const createUpdateActionSchema = (context: ActionContext) => {
       webhook_uri: yup
         .string()
         .optional()
-        .test("is-url", "Must be a valid URL", (value) => {
-          if (!value || !context.isProduction) return true;
-          return validateUrl(value, !context.isProduction);
-        }),
+        .test(
+          "is-webhook-url",
+          "Webhook URL must be a valid HTTPS URL and cannot target a private, loopback, or internal network address",
+          (value) => {
+            if (!value) return true;
+            return validateWebhookUrl(value);
+          },
+        ),
       webhook_pem: yup
         .string()
         .optional()

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/page/CreateActionModal/server/form-schema.ts
@@ -3,7 +3,7 @@ import {
   allowedCommonCharactersRegex,
   allowedTitleCharactersRegex,
 } from "@/lib/schema";
-import { validateUri, validateUrl } from "@/lib/utils";
+import { validateUri, validateWebhookUrl } from "@/lib/utils";
 import * as yup from "yup";
 
 // Check if not in production
@@ -41,10 +41,14 @@ export const createActionSchema = (context: ActionContext) => {
       webhook_uri: yup
         .string()
         .optional()
-        .test("is-url", "Must be a valid URL", (value) => {
-          if (!value || !context.isProduction) return true;
-          return validateUrl(value, !context.isProduction);
-        }),
+        .test(
+          "is-webhook-url",
+          "Webhook URL must be a valid HTTPS URL and cannot target a private, loopback, or internal network address",
+          (value) => {
+            if (!value) return true;
+            return validateWebhookUrl(value);
+          },
+        ),
       webhook_pem: yup
         .string()
         .optional()

--- a/web/tests/api/action-schema.test.ts
+++ b/web/tests/api/action-schema.test.ts
@@ -42,3 +42,40 @@ describe("createActionSchema post-action deep links", () => {
     ).resolves.toBeTruthy();
   });
 });
+
+// Regression for VULN-6369 / CE25-C014: the create/update action schema must
+// reject SSRF-prone webhook_uri values (loopback, private, link-local, cloud
+// metadata, non-HTTPS) so app-backend never fetches an internal target. The
+// field-level webhook_uri test runs regardless of app_flow_on_complete, and —
+// unlike the old behavior — is no longer skipped on the staging deployment.
+describe("createActionSchema webhook_uri SSRF validation", () => {
+  const withWebhook = (webhook_uri: string) => ({ ...baseValues, webhook_uri });
+
+  test("rejects a cloud-metadata webhook_uri in production", async () => {
+    const schema = createActionSchema({ isProduction: true });
+    await expect(
+      schema.validate(withWebhook("https://169.254.169.254/latest/meta-data/")),
+    ).rejects.toBeTruthy();
+  });
+
+  test("rejects a loopback webhook_uri in staging (validation not skipped)", async () => {
+    const schema = createActionSchema({ isProduction: false });
+    await expect(
+      schema.validate(withWebhook("https://127.0.0.1/hook")),
+    ).rejects.toBeTruthy();
+  });
+
+  test("rejects a non-HTTPS webhook_uri", async () => {
+    const schema = createActionSchema({ isProduction: true });
+    await expect(
+      schema.validate(withWebhook("http://collector.example.com/hook")),
+    ).rejects.toBeTruthy();
+  });
+
+  test("accepts a public HTTPS webhook_uri", async () => {
+    const schema = createActionSchema({ isProduction: true });
+    await expect(
+      schema.validate(withWebhook("https://collector.example.com/ce25")),
+    ).resolves.toBeTruthy();
+  });
+});

--- a/web/tests/api/utils.test.ts
+++ b/web/tests/api/utils.test.ts
@@ -258,6 +258,7 @@ describe("validateWebhookUrl()", () => {
       "https://100.128.0.1/hook", // just above CGNAT 100.64.0.0/10
       "https://169.253.255.255/hook", // just below link-local 169.254.0.0/16
       "https://[2606:4700:4700::1111]/hook", // public IPv6
+      "https://collector.example.com./hook", // trailing root dot, public FQDN
     ])("accepts %s", (url) => {
       expect(validateWebhookUrl(url)).toBe(true);
     });
@@ -285,6 +286,8 @@ describe("validateWebhookUrl()", () => {
       "https://localhost:8443/hook",
       "https://foo.localhost/hook",
       "https://api.internal.localhost/hook",
+      "https://localhost./hook", // root-qualified (trailing dot)
+      "https://foo.localhost./hook", // root-qualified subdomain
     ])("rejects %s", (url) => {
       expect(validateWebhookUrl(url)).toBe(false);
     });
@@ -353,6 +356,17 @@ describe("validateWebhookUrl()", () => {
       "https://[::ffff:10.0.0.1]/hook",
       "https://[::ffff:7f00:1]/hook", // hex form of 127.0.0.1
       "https://[::ffff:a9fe:a9fe]/hook", // hex form of 169.254.169.254
+    ])("rejects %s", (url) => {
+      expect(validateWebhookUrl(url)).toBe(false);
+    });
+  });
+
+  describe("rejects IPv4-compatible and other ::/96 IPv6 literals", () => {
+    test.each([
+      "https://[::127.0.0.1]/hook", // canonicalizes to ::7f00:1
+      "https://[::7f00:1]/hook", // hex form of ::127.0.0.1
+      "https://[::a9fe:a9fe]/hook", // ::169.254.169.254
+      "https://[::8.8.8.8]/hook", // deprecated IPv4-compatible, not publicly routable
     ])("rejects %s", (url) => {
       expect(validateWebhookUrl(url)).toBe(false);
     });

--- a/web/tests/api/utils.test.ts
+++ b/web/tests/api/utils.test.ts
@@ -259,6 +259,9 @@ describe("validateWebhookUrl()", () => {
       "https://169.253.255.255/hook", // just below link-local 169.254.0.0/16
       "https://[2606:4700:4700::1111]/hook", // public IPv6
       "https://collector.example.com./hook", // trailing root dot, public FQDN
+      "https://223.255.255.255/hook", // just below multicast 224.0.0.0/4
+      "https://198.17.255.255/hook", // just below benchmarking 198.18.0.0/15
+      "https://198.20.0.1/hook", // just above benchmarking 198.18.0.0/15
     ])("accepts %s", (url) => {
       expect(validateWebhookUrl(url)).toBe(true);
     });
@@ -307,6 +310,24 @@ describe("validateWebhookUrl()", () => {
       "https://169.254.0.1/hook", // link-local
       "https://100.64.0.1/hook", // CGNAT
       "https://100.127.255.255/hook",
+    ])("rejects %s", (url) => {
+      expect(validateWebhookUrl(url)).toBe(false);
+    });
+  });
+
+  describe("rejects multicast, reserved, and special-purpose IPv4", () => {
+    test.each([
+      "https://192.0.0.1/hook", // 192.0.0.0/24 protocol assignments
+      "https://192.0.2.1/hook", // TEST-NET-1
+      "https://192.88.99.1/hook", // 6to4 relay anycast
+      "https://198.18.0.1/hook", // benchmarking
+      "https://198.19.255.255/hook", // benchmarking (top of /15)
+      "https://198.51.100.1/hook", // TEST-NET-2
+      "https://203.0.113.1/hook", // TEST-NET-3
+      "https://224.0.0.1/hook", // multicast
+      "https://239.255.255.250/hook", // SSDP multicast
+      "https://240.0.0.1/hook", // reserved
+      "https://255.255.255.255/hook", // limited broadcast
     ])("rejects %s", (url) => {
       expect(validateWebhookUrl(url)).toBe(false);
     });
@@ -383,6 +404,10 @@ describe("validateWebhookUrl()", () => {
       "https://example.com/" + CR + LF + "x",
       "https://example.com/" + TAB + "x",
       "https://example.com/" + NUL,
+      "https://collector.example.com/hook" + LF, // trailing (trim() would strip)
+      LF + "https://collector.example.com/hook", // leading (trim() would strip)
+      "https://collector.example.com/hook" + TAB, // trailing tab
+      CR + "https://collector.example.com/hook", // leading CR
     ])("rejects url with an embedded control character", (url) => {
       expect(validateWebhookUrl(url)).toBe(false);
     });

--- a/web/tests/api/utils.test.ts
+++ b/web/tests/api/utils.test.ts
@@ -1,5 +1,10 @@
 import { canVerifyForAction } from "@/api/helpers/verify";
-import { isValidHostName, validateUri, validateUrl } from "@/lib/utils";
+import {
+  isValidHostName,
+  validateUri,
+  validateUrl,
+  validateWebhookUrl,
+} from "@/lib/utils";
 
 describe("canVerifyForAction()", () => {
   test("can verify if it has not verified before", () => {
@@ -235,6 +240,137 @@ describe("isValidHostName()", () => {
       process.env.NEXT_PUBLIC_APP_ENV = "production";
       process.env.NEXT_PUBLIC_IMAGES_CDN_URL = "https://cdn.example.com";
       expect(isValidHostName(makeRequest("localhost:3000"))).toBe(true);
+    });
+  });
+});
+
+describe("validateWebhookUrl()", () => {
+  describe("accepts public HTTPS targets", () => {
+    test.each([
+      "https://collector.example.com/ce25-c014",
+      "https://sub.domain.example.com:8443/path?x=1",
+      "https://8.8.8.8/hook",
+      "https://11.0.0.1/hook", // just outside 10.0.0.0/8
+      "https://172.15.0.1/hook", // just below 172.16.0.0/12
+      "https://172.32.0.1/hook", // just above 172.16.0.0/12
+      "https://192.169.0.1/hook", // just outside 192.168.0.0/16
+      "https://100.63.255.255/hook", // just below CGNAT 100.64.0.0/10
+      "https://100.128.0.1/hook", // just above CGNAT 100.64.0.0/10
+      "https://169.253.255.255/hook", // just below link-local 169.254.0.0/16
+      "https://[2606:4700:4700::1111]/hook", // public IPv6
+    ])("accepts %s", (url) => {
+      expect(validateWebhookUrl(url)).toBe(true);
+    });
+  });
+
+  describe("rejects non-HTTPS and malformed URLs", () => {
+    test.each([
+      "",
+      "   ",
+      "http://collector.example.com/hook",
+      "http://localhost:8000/hook",
+      "ftp://example.com/hook",
+      "worldapp://callback",
+      "example.com/path",
+      "https://",
+      "not a url",
+    ])("rejects %j", (url) => {
+      expect(validateWebhookUrl(url)).toBe(false);
+    });
+  });
+
+  describe("rejects localhost by name", () => {
+    test.each([
+      "https://localhost/hook",
+      "https://localhost:8443/hook",
+      "https://foo.localhost/hook",
+      "https://api.internal.localhost/hook",
+    ])("rejects %s", (url) => {
+      expect(validateWebhookUrl(url)).toBe(false);
+    });
+  });
+
+  describe("rejects loopback, private, link-local, and metadata IPv4", () => {
+    test.each([
+      "https://127.0.0.1/hook", // loopback
+      "https://127.1.2.3:8443/hook", // loopback range
+      "https://0.0.0.0/hook", // this-host
+      "https://10.0.0.1/hook", // private
+      "https://10.255.255.255/hook",
+      "https://172.16.0.1/hook", // private
+      "https://172.31.255.255/hook",
+      "https://192.168.1.1/hook", // private
+      "https://169.254.169.254/latest/meta-data/", // cloud metadata
+      "https://169.254.0.1/hook", // link-local
+      "https://100.64.0.1/hook", // CGNAT
+      "https://100.127.255.255/hook",
+    ])("rejects %s", (url) => {
+      expect(validateWebhookUrl(url)).toBe(false);
+    });
+  });
+
+  describe("rejects alternate IPv4 encodings resolving to blocked ranges", () => {
+    test.each([
+      "https://0x7f000001/hook", // 127.0.0.1 (hex)
+      "https://2130706433/hook", // 127.0.0.1 (decimal)
+      "https://017700000001/hook", // 127.0.0.1 (octal)
+      "https://127.1/hook", // 127.0.0.1 (shorthand)
+      "https://0/hook", // 0.0.0.0 (bare integer)
+      "https://0300.0250.0.1/hook", // 192.168.0.1 (octal)
+    ])("rejects %s", (url) => {
+      expect(validateWebhookUrl(url)).toBe(false);
+    });
+  });
+
+  describe("rejects credentials-obscured internal hosts", () => {
+    test.each([
+      "https://user:pass@127.0.0.1/hook",
+      "https://example.com@169.254.169.254/hook",
+    ])("rejects %s", (url) => {
+      expect(validateWebhookUrl(url)).toBe(false);
+    });
+  });
+
+  describe("rejects loopback, unspecified, ULA, and link-local IPv6", () => {
+    test.each([
+      "https://[::1]/hook", // loopback
+      "https://[::]/hook", // unspecified
+      "https://[0::0]/hook", // unspecified
+      "https://[fd00::1]/hook", // unique-local
+      "https://[fc00::1]/hook",
+      "https://[fe80::1]/hook", // link-local
+      "https://[febf::1]/hook",
+      "https://[fec0::1]/hook", // deprecated site-local
+    ])("rejects %s", (url) => {
+      expect(validateWebhookUrl(url)).toBe(false);
+    });
+  });
+
+  describe("rejects IPv4-mapped IPv6 pointing at blocked ranges", () => {
+    test.each([
+      "https://[::ffff:127.0.0.1]/hook",
+      "https://[::ffff:169.254.169.254]/hook",
+      "https://[::ffff:10.0.0.1]/hook",
+      "https://[::ffff:7f00:1]/hook", // hex form of 127.0.0.1
+      "https://[::ffff:a9fe:a9fe]/hook", // hex form of 169.254.169.254
+    ])("rejects %s", (url) => {
+      expect(validateWebhookUrl(url)).toBe(false);
+    });
+  });
+
+  describe("rejects URLs containing control characters", () => {
+    const LF = String.fromCharCode(0x0a);
+    const CR = String.fromCharCode(0x0d);
+    const TAB = String.fromCharCode(0x09);
+    const NUL = String.fromCharCode(0x00);
+
+    test.each([
+      "https://example.com/" + LF + "Host: evil",
+      "https://example.com/" + CR + LF + "x",
+      "https://example.com/" + TAB + "x",
+      "https://example.com/" + NUL,
+    ])("rejects url with an embedded control character", (url) => {
+      expect(validateWebhookUrl(url)).toBe(false);
     });
   });
 });

--- a/web/tests/integration/api-key-security.test.ts
+++ b/web/tests/integration/api-key-security.test.ts
@@ -381,3 +381,67 @@ describe("API key action insert permissions", () => {
     },
   );
 });
+
+/**
+ * Regression for the api_key role's action UPDATE permission.
+ *
+ * H1 Report Reference: #3846290 / VULN-6369 (CE25-C014)
+ *
+ * The partner webhook SSRF PoC upserts webhook_uri/webhook_pem through
+ * `on_conflict: { update_columns: [...] }`, which is governed by the same
+ * update-column permission as a direct `_set`. The partner-only columns are
+ * excluded from the api_key update permission, so Hasura rejects them in
+ * 'action_set_input' regardless of the caller — partners set them through the
+ * service-role UI path, which additionally validates the webhook URL.
+ */
+describe("API key action update permissions", () => {
+  const PARTNER_ONLY_COLUMNS: Array<[string, string]> = [
+    ["webhook_uri", '"https://attacker.example.com/webhook"'],
+    ["webhook_pem", '"attacker-pem"'],
+    ["app_flow_on_complete", "VERIFY"],
+    ["post_action_deep_link_ios", '"worldapp://attacker-ios"'],
+    ["post_action_deep_link_android", '"worldapp://attacker-android"'],
+  ];
+
+  const getSeededApp = async () => {
+    const { rows } = (await integrationDBExecuteQuery(
+      `SELECT id AS app_id, team_id FROM "public"."app" WHERE team_id IS NOT NULL LIMIT 1`,
+    )) as { rows: Array<{ app_id: string; team_id: string }> };
+
+    expect(rows.length).toBe(1);
+    return rows[0];
+  };
+
+  test.each(PARTNER_ONLY_COLUMNS)(
+    "api_key role cannot set partner-only column '%s' on update",
+    async (column, literal) => {
+      const { app_id, team_id } = await getSeededApp();
+      const client = await getAPIClient({ team_id });
+
+      // The forbidden field is placed inline in _set so it is validated against
+      // the api_key role's action_set_input type.
+      const mutation = gql`
+        mutation UpdateActionWithPartnerColumn($app_id: String!) {
+          update_action(
+            where: { app_id: { _eq: $app_id } }
+            _set: { ${column}: ${literal} }
+          ) {
+            affected_rows
+          }
+        }
+      `;
+
+      let error: any;
+      try {
+        await client.mutate({ mutation, variables: { app_id } });
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeDefined();
+      expect(error.graphQLErrors?.[0]?.message).toContain(
+        `field '${column}' not found in type: 'action_set_input'`,
+      );
+    },
+  );
+});


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Partner action `webhook_uri` is fetched server-side by app-backend, so an attacker-controlled value is a blind SSRF sink (VULN-6369 / CE25-C014). The `api_key` Hasura write path was already closed (PR #2077); this closes the remaining service-role UI write path, where the old check skipped validation entirely on the staging deployment and let any `https://` host through — including `169.254.169.254`, `127.0.0.1`, and private/IPv6 ranges. This adds `validateWebhookUrl()` (HTTPS-only, plus a loopback / private / link-local / cloud-metadata / IPv6 / IPv4-mapped / alternate-encoding denylist) and wires it into the four action form-schemas (Portal + PortalV3, create + update), backed by unit, schema, and `api_key`-update regression tests. DNS-rebinding and resolution-time egress defense must still be added in `app-backend-main` (cross-repo), which is the service that actually resolves and fetches the URL.

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
