### PR TITLE
fix(portal): coerce External category on remaining app_mode write paths

### DIFF
--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -35,7 +35,10 @@ import {
   uploadAppImage,
 } from "@/api/helpers/app-image-storage";
 import { checkRateLimit } from "@/api/helpers/rate-limit";
-import { CategoryNameIterable } from "@/lib/categories";
+import {
+  CategoryNameIterable,
+  resolveAppStoreCategory,
+} from "@/lib/categories";
 import { logger } from "@/lib/logger";
 import { getImageEndpoint } from "@/lib/utils";
 import { mainAppStoreFormReviewSubmitSchema } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/FormSchema/form-schema";
@@ -959,8 +962,10 @@ const tools = {
 
   create_app: async (input, ctx) => {
     const args = await parseInput(createAppSchema, input);
-    const category =
-      args.category ?? (args.app_mode === "mini-app" ? "Other" : "External");
+    const category = resolveAppStoreCategory(
+      args.category,
+      args.app_mode === "mini-app",
+    );
 
     if (!CategoryNameIterable.includes(category as any)) {
       throw new McpError("Invalid app category.", -32602);

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/server/submit.ts
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/server/submit.ts
@@ -83,6 +83,9 @@ export async function validateAndUpdateSetupServerSide(
     await getUpdateSetupSdk(client).UpdateSetup({
       app_metadata_id,
       app_mode: parsedInitialValues.app_mode,
+      // Switching to a mini app must not leave the store-hiding "External"
+      // category behind; clear it as part of the same update.
+      clear_external_category: parsedInitialValues.app_mode === "mini-app",
       associated_domains,
       contracts,
       permit2_tokens,

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/server/submit.ts
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/server/submit.ts
@@ -83,6 +83,9 @@ export async function validateAndUpdateSetupServerSide(
     await getUpdateSetupSdk(client).UpdateSetup({
       app_metadata_id,
       app_mode: parsedInitialValues.app_mode,
+      // Switching to a mini app must not leave the store-hiding "External"
+      // category behind; clear it as part of the same update.
+      clear_external_category: parsedInitialValues.app_mode === "mini-app",
       associated_domains,
       contracts,
       permit2_tokens,

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/graphql/server/update-setup.generated.ts
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/graphql/server/update-setup.generated.ts
@@ -23,6 +23,7 @@ export type UpdateSetupMutationVariables = Types.Exact<{
   can_use_attestation: Types.Scalars["Boolean"]["input"];
   is_allowed_unlimited_notifications: Types.Scalars["Boolean"]["input"];
   max_notifications_per_day: Types.Scalars["Int"]["input"];
+  clear_external_category?: Types.InputMaybe<Types.Scalars["Boolean"]["input"]>;
 }>;
 
 export type UpdateSetupMutation = {
@@ -30,6 +31,10 @@ export type UpdateSetupMutation = {
   update_app_metadata_by_pk?: {
     __typename?: "app_metadata";
     id: string;
+  } | null;
+  cleared_external_category?: {
+    __typename?: "app_metadata_mutation_response";
+    affected_rows: number;
   } | null;
 };
 
@@ -45,6 +50,7 @@ export const UpdateSetupDocument = gql`
     $can_use_attestation: Boolean!
     $is_allowed_unlimited_notifications: Boolean!
     $max_notifications_per_day: Int!
+    $clear_external_category: Boolean = false
   ) {
     update_app_metadata_by_pk(
       pk_columns: { id: $app_metadata_id }
@@ -61,6 +67,12 @@ export const UpdateSetupDocument = gql`
       }
     ) {
       id
+    }
+    cleared_external_category: update_app_metadata(
+      where: { id: { _eq: $app_metadata_id }, category: { _eq: "External" } }
+      _set: { category: "Other" }
+    ) @include(if: $clear_external_category) {
+      affected_rows
     }
   }
 `;

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/graphql/server/update-setup.graphql
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/graphql/server/update-setup.graphql
@@ -9,6 +9,7 @@ mutation UpdateSetup(
   $can_use_attestation: Boolean!
   $is_allowed_unlimited_notifications: Boolean!
   $max_notifications_per_day: Int!
+  $clear_external_category: Boolean = false
 ) {
   update_app_metadata_by_pk(
     pk_columns: { id: $app_metadata_id }
@@ -25,5 +26,15 @@ mutation UpdateSetup(
     }
   ) {
     id
+  }
+  # When this update switches the app to a mini app, drop an existing
+  # "External" category: like the external app_mode it hides the app from the
+  # mini app store, so mini apps must not use it. Only touches rows still
+  # set to "External".
+  cleared_external_category: update_app_metadata(
+    where: { id: { _eq: $app_metadata_id }, category: { _eq: "External" } }
+    _set: { category: "Other" }
+  ) @include(if: $clear_external_category) {
+    affected_rows
   }
 }

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -503,6 +503,40 @@ describe("/api/mcp", () => {
     );
   });
 
+  it("coerces the External category to Other for a mini app", async () => {
+    const res = await POST(
+      callTool("create_app", {
+        name: "MCP Mini External",
+        app_mode: "mini-app",
+        integration_url: "https://example.com",
+        category: "External",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    // A mini app must never be persisted under the store-hiding External
+    // category, even when explicitly requested via MCP.
+    expect(payload.app.app_metadata[0].category).toBe("Other");
+  });
+
+  it("keeps the External category for an external app", async () => {
+    const res = await POST(
+      callTool("create_app", {
+        name: "MCP External",
+        app_mode: "external",
+        integration_url: "https://example.com",
+        category: "External",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.app.app_metadata[0].category).toBe("External");
+  });
+
   it("rejects staging app creation", async () => {
     const res = await POST(
       callTool("create_app", {


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Follow-up to #2108. That PR stopped a mini app from ending up under the store-hiding "External" category via the config toggle, autosave, creation, and submit-for-review, but two other `app_mode` write paths could still leave the invalid state in a draft (both were backstopped by the submit-for-review block, so neither could reach the store — this just makes the data consistent everywhere). This PR routes MCP `create_app` through the shared `resolveAppStoreCategory` helper so an explicit `category:"External"` on a mini app is coerced to "Other", and extends the `UpdateSetup` mutation (used by the Advanced / Mini App Permissions form) with the same conditional clear as `UpdateAppMode` — switching to mini-app now resets a lingering "External" category to "Other" in the same request. The invariant "mini app ⇒ category ≠ External" now holds at every write path.

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
