### PR TITLE
Enhance Admin Dashboard with new logical models and optimized queries

### DIFF
--- a/hasura/metadata/databases/databases.yaml
+++ b/hasura/metadata/databases/databases.yaml
@@ -11,3 +11,359 @@
       use_prepared_statements: true
   tables: "!include default/tables/tables.yaml"
   functions: "!include default/functions/functions.yaml"
+  logical_models:
+    - name: admin_dashboard_inventory
+      fields:
+        - name: active_api_keys
+          type:
+            scalar: bigint
+            nullable: false
+        - name: active_apps
+          type:
+            scalar: bigint
+            nullable: false
+        - name: active_teams
+          type:
+            scalar: bigint
+            nullable: false
+        - name: deleted_apps
+          type:
+            scalar: bigint
+            nullable: false
+        - name: deleted_teams
+          type:
+            scalar: bigint
+            nullable: false
+        - name: new_apps
+          type:
+            scalar: bigint
+            nullable: false
+        - name: new_teams
+          type:
+            scalar: bigint
+            nullable: false
+        - name: new_users
+          type:
+            scalar: bigint
+            nullable: false
+        - name: pending_invites
+          type:
+            scalar: bigint
+            nullable: false
+        - name: total_users
+          type:
+            scalar: bigint
+            nullable: false
+      select_permissions:
+        - role: internal_dashboard_readonly
+          permission:
+            columns:
+              - active_api_keys
+              - active_apps
+              - active_teams
+              - deleted_apps
+              - deleted_teams
+              - new_apps
+              - new_teams
+              - new_users
+              - pending_invites
+              - total_users
+            filter: {}
+    - name: admin_dashboard_queue
+      fields:
+        - name: email
+          type:
+            scalar: varchar
+            nullable: true
+        - name: id
+          type:
+            scalar: varchar
+            nullable: false
+        - name: kind
+          type:
+            scalar: varchar
+            nullable: false
+        - name: name
+          type:
+            scalar: varchar
+            nullable: true
+        - name: owner_email
+          type:
+            scalar: varchar
+            nullable: true
+        - name: owner_id
+          type:
+            scalar: varchar
+            nullable: true
+        - name: owner_name
+          type:
+            scalar: varchar
+            nullable: true
+        - name: team_id
+          type:
+            scalar: varchar
+            nullable: true
+        - name: total_count
+          type:
+            scalar: bigint
+            nullable: false
+        - name: updated_at
+          type:
+            scalar: timestamptz
+            nullable: true
+      select_permissions:
+        - role: internal_dashboard_readonly
+          permission:
+            columns:
+              - email
+              - id
+              - kind
+              - name
+              - owner_email
+              - owner_id
+              - owner_name
+              - team_id
+              - total_count
+              - updated_at
+            filter: {}
+  native_queries:
+    - root_field_name: admin_dashboard_inventory
+      arguments: {}
+      code: |
+        WITH team_counts AS (
+          SELECT
+            COUNT(*) FILTER (WHERE deleted_at IS NULL) AS active_teams,
+            COUNT(*) FILTER (WHERE deleted_at IS NOT NULL) AS deleted_teams,
+            COUNT(*) FILTER (
+              WHERE deleted_at IS NULL
+                AND created_at >= CURRENT_TIMESTAMP - INTERVAL '30 days'
+            ) AS new_teams
+          FROM public.team
+        ),
+        user_counts AS (
+          SELECT
+            COUNT(*) AS total_users,
+            COUNT(*) FILTER (
+              WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '30 days'
+            ) AS new_users
+          FROM public."user"
+        ),
+        app_counts AS (
+          SELECT
+            COUNT(*) FILTER (WHERE deleted_at IS NULL) AS active_apps,
+            COUNT(*) FILTER (WHERE deleted_at IS NOT NULL) AS deleted_apps,
+            COUNT(*) FILTER (
+              WHERE deleted_at IS NULL
+                AND created_at >= CURRENT_TIMESTAMP - INTERVAL '30 days'
+            ) AS new_apps
+          FROM public.app
+        ),
+        invite_counts AS (
+          SELECT COUNT(*) AS pending_invites
+          FROM public.invite
+          WHERE expires_at >= CURRENT_TIMESTAMP
+        ),
+        api_key_counts AS (
+          SELECT COUNT(*) AS active_api_keys
+          FROM public.api_key
+          WHERE is_active = true
+        )
+        SELECT
+          api_key_counts.active_api_keys,
+          app_counts.active_apps,
+          team_counts.active_teams,
+          app_counts.deleted_apps,
+          team_counts.deleted_teams,
+          app_counts.new_apps,
+          team_counts.new_teams,
+          user_counts.new_users,
+          invite_counts.pending_invites,
+          user_counts.total_users
+        FROM team_counts, user_counts, app_counts, invite_counts, api_key_counts
+      returns: admin_dashboard_inventory
+    - root_field_name: admin_dashboard_queues
+      arguments: {}
+      code: |
+        WITH apps_awaiting_review AS (
+          SELECT
+            'apps_awaiting_review'::varchar AS kind,
+            app.id,
+            COALESCE(app_metadata.name, app.name) AS name,
+            app.team_id,
+            COUNT(*) OVER() AS total_count,
+            app_metadata.updated_at
+          FROM public.app
+          JOIN public.app_metadata ON app_metadata.app_id = app.id
+          WHERE app.deleted_at IS NULL
+            AND app_metadata.verification_status = 'awaiting_review'
+          ORDER BY app.created_at DESC
+          LIMIT 5
+        ),
+        apps_changes_requested AS (
+          SELECT
+            'apps_changes_requested'::varchar AS kind,
+            app.id,
+            COALESCE(app_metadata.name, app.name) AS name,
+            app.team_id,
+            COUNT(*) OVER() AS total_count,
+            app_metadata.updated_at
+          FROM public.app
+          JOIN public.app_metadata ON app_metadata.app_id = app.id
+          WHERE app.deleted_at IS NULL
+            AND app_metadata.verification_status = 'changes_requested'
+          ORDER BY app.created_at DESC
+          LIMIT 5
+        ),
+        apps_without_metadata AS (
+          SELECT
+            'apps_without_metadata'::varchar AS kind,
+            app.id,
+            app.name,
+            app.team_id,
+            COUNT(*) OVER() AS total_count,
+            NULL::timestamptz AS updated_at
+          FROM public.app
+          WHERE app.deleted_at IS NULL
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.app_metadata
+              WHERE app_metadata.app_id = app.id
+            )
+          ORDER BY app.created_at DESC
+          LIMIT 5
+        ),
+        teams_without_owner AS (
+          SELECT
+            'teams_without_owner'::varchar AS kind,
+            team.id,
+            team.name,
+            COUNT(*) OVER() AS total_count
+          FROM public.team
+          WHERE team.deleted_at IS NULL
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.membership
+              WHERE membership.team_id = team.id
+                AND membership.role = 'OWNER'
+            )
+          ORDER BY team.created_at DESC
+          LIMIT 5
+        ),
+        sole_owner_teams AS (
+          SELECT
+            'sole_owner_teams'::varchar AS kind,
+            team.id,
+            team.name,
+            owner.email AS owner_email,
+            owner.id AS owner_id,
+            owner.name AS owner_name,
+            COUNT(*) OVER() AS total_count
+          FROM (
+            SELECT membership.team_id
+            FROM public.membership
+            WHERE membership.role = 'OWNER'
+            GROUP BY membership.team_id
+            HAVING COUNT(*) = 1
+          ) AS sole_owner_memberships
+          JOIN public.team ON team.id = sole_owner_memberships.team_id
+          JOIN public.membership ON membership.team_id = team.id
+            AND membership.role = 'OWNER'
+          JOIN public."user" AS owner ON owner.id = membership.user_id
+          WHERE team.deleted_at IS NULL
+          ORDER BY team.created_at DESC
+          LIMIT 5
+        ),
+        users_without_teams AS (
+          SELECT
+            'users_without_teams'::varchar AS kind,
+            "user".id,
+            "user".name,
+            "user".email,
+            COUNT(*) OVER() AS total_count
+          FROM public."user"
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM public.membership
+            WHERE membership.user_id = "user".id
+          )
+          ORDER BY "user".created_at DESC
+          LIMIT 5
+        )
+        SELECT
+          kind,
+          id,
+          name,
+          team_id,
+          NULL::varchar AS email,
+          NULL::varchar AS owner_email,
+          NULL::varchar AS owner_id,
+          NULL::varchar AS owner_name,
+          total_count,
+          updated_at
+        FROM apps_awaiting_review
+        UNION ALL
+        SELECT
+          kind,
+          id,
+          name,
+          team_id,
+          NULL::varchar,
+          NULL::varchar,
+          NULL::varchar,
+          NULL::varchar,
+          total_count,
+          updated_at
+        FROM apps_changes_requested
+        UNION ALL
+        SELECT
+          kind,
+          id,
+          name,
+          team_id,
+          NULL::varchar,
+          NULL::varchar,
+          NULL::varchar,
+          NULL::varchar,
+          total_count,
+          updated_at
+        FROM apps_without_metadata
+        UNION ALL
+        SELECT
+          kind,
+          id,
+          name,
+          NULL::varchar,
+          NULL::varchar,
+          NULL::varchar,
+          NULL::varchar,
+          NULL::varchar,
+          total_count,
+          NULL::timestamptz
+        FROM teams_without_owner
+        UNION ALL
+        SELECT
+          kind,
+          id,
+          name,
+          NULL::varchar,
+          NULL::varchar,
+          owner_email,
+          owner_id,
+          owner_name,
+          total_count,
+          NULL::timestamptz
+        FROM sole_owner_teams
+        UNION ALL
+        SELECT
+          kind,
+          id,
+          name,
+          NULL::varchar,
+          email,
+          NULL::varchar,
+          NULL::varchar,
+          NULL::varchar,
+          total_count,
+          NULL::timestamptz
+        FROM users_without_teams
+      returns: admin_dashboard_queue

--- a/hasura/migrations/default/1784295767078_optimize_admin_dashboard_queries/down.sql
+++ b/hasura/migrations/default/1784295767078_optimize_admin_dashboard_queries/down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS "public"."membership_owner_team_id_idx";
+DROP INDEX IF EXISTS "public"."membership_team_id_role_idx";
+DROP INDEX IF EXISTS "public"."membership_user_id_role_idx";

--- a/hasura/migrations/default/1784295767078_optimize_admin_dashboard_queries/up.sql
+++ b/hasura/migrations/default/1784295767078_optimize_admin_dashboard_queries/up.sql
@@ -1,0 +1,9 @@
+CREATE INDEX IF NOT EXISTS "membership_user_id_role_idx"
+  ON "public"."membership" USING btree ("user_id", "role");
+
+CREATE INDEX IF NOT EXISTS "membership_team_id_role_idx"
+  ON "public"."membership" USING btree ("team_id", "role");
+
+CREATE INDEX IF NOT EXISTS "membership_owner_team_id_idx"
+  ON "public"."membership" USING btree ("team_id")
+  WHERE "role" = 'OWNER';

--- a/web/api/helpers/graphql.ts
+++ b/web/api/helpers/graphql.ts
@@ -11,12 +11,46 @@ import { logger } from "@/lib/logger";
 import { parse } from "graphql";
 import { GraphQLClient } from "graphql-request";
 
-/** Total per-request timeout, including any retry attempts. */
 const REQUEST_TIMEOUT_MS = 15_000;
 
 /** Retry plan for idempotent (query) operations only. Backoffs in ms, applied
  *  between attempts. Length = max retries beyond the first attempt. */
 const QUERY_RETRY_BACKOFFS_MS = [200, 500];
+
+export type GraphqlFetchPolicy = {
+  clientName: string;
+  retryBackoffsMs: readonly number[];
+  timeoutMs: number;
+};
+
+const defaultGraphqlFetchPolicy: GraphqlFetchPolicy = {
+  clientName: "default",
+  retryBackoffsMs: QUERY_RETRY_BACKOFFS_MS,
+  timeoutMs: REQUEST_TIMEOUT_MS,
+};
+
+export const internalDashboardGraphqlFetchPolicy: GraphqlFetchPolicy = {
+  clientName: "internal_dashboard",
+  retryBackoffsMs: [],
+  timeoutMs: REQUEST_TIMEOUT_MS,
+};
+
+const getOperationName = (body: BodyInit | null | undefined) => {
+  if (typeof body !== "string" || body.length === 0) {
+    return undefined;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(body);
+    return parsed &&
+      typeof parsed === "object" &&
+      typeof (parsed as { operationName?: unknown }).operationName === "string"
+      ? (parsed as { operationName: string }).operationName
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 /**
  * Inspect a serialized GraphQL request body (the JSON `graphql-request` puts on
@@ -202,18 +236,21 @@ const combineSignals = (
  */
 export const makeGraphqlFetchWithRetry = (
   fetchImpl: typeof fetch,
+  policy: GraphqlFetchPolicy = defaultGraphqlFetchPolicy,
 ): typeof fetch => {
   return async (input, init) => {
     const body = init?.body ?? null;
     const retryable = isRetryableOperation(body);
     const callerSignal = init?.signal ?? null;
-    const backoffs = retryable ? QUERY_RETRY_BACKOFFS_MS : [];
+    const backoffs = retryable ? policy.retryBackoffsMs : [];
     const maxAttempts = backoffs.length + 1;
+    const operationName = getOperationName(body);
+    const startedAt = Date.now();
 
     let lastError: unknown;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      const signal = combineSignals(callerSignal, REQUEST_TIMEOUT_MS);
+      const signal = combineSignals(callerSignal, policy.timeoutMs);
       try {
         // Pass through everything we received, swapping in our combined signal.
         return await fetchImpl(input, { ...init, signal });
@@ -225,6 +262,19 @@ export const makeGraphqlFetchWithRetry = (
         // upstream short-circuit), honour it immediately rather than treating
         // the resulting AbortError as a retryable transport failure.
         const callerAborted = callerSignal?.aborted ?? false;
+
+        logger.warn("graphql transport request failed", {
+          attempt,
+          elapsedMs: Date.now() - startedAt,
+          error:
+            err instanceof Error
+              ? { name: err.name, message: err.message }
+              : String(err),
+          graphqlClient: policy.clientName,
+          maxAttempts,
+          operationName,
+          retryable,
+        });
 
         if (isLast || !transport || callerAborted) {
           throw err;
@@ -239,6 +289,8 @@ export const makeGraphqlFetchWithRetry = (
             err instanceof Error
               ? { name: err.name, message: err.message }
               : String(err),
+          graphqlClient: policy.clientName,
+          operationName,
         });
         await sleep(delay);
       }
@@ -257,6 +309,12 @@ export const graphqlFetchWithRetry: typeof fetch =
   makeGraphqlFetchWithRetry(baseFetch);
 
 const sharedFetchConfig = { fetch: graphqlFetchWithRetry } as const;
+const internalDashboardFetchConfig = {
+  fetch: makeGraphqlFetchWithRetry(
+    baseFetch,
+    internalDashboardGraphqlFetchPolicy,
+  ),
+} as const;
 
 /**
  * Used for generated requests
@@ -305,7 +363,7 @@ export const getInternalDashboardGraphqlClientForUser = async (
   user: AdminUser,
 ) => {
   return new GraphQLClient(process.env.NEXT_PUBLIC_GRAPHQL_API_URL!, {
-    ...sharedFetchConfig,
+    ...internalDashboardFetchConfig,
     headers: {
       authorization: `Bearer ${await generateInternalDashboardJWT(user)}`,
     },

--- a/web/app/admin/error.tsx
+++ b/web/app/admin/error.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+import { toast } from "react-toastify";
+
+type AdminErrorProps = {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+};
+
+export default function AdminError({ error, unstable_retry }: AdminErrorProps) {
+  useEffect(() => {
+    toast.error("Unable to load the admin dashboard. Please try again.", {
+      toastId: "admin-dashboard-load-error",
+    });
+  }, [error]);
+
+  return (
+    <div className="flex size-full min-h-0 items-center justify-center p-5">
+      <section
+        aria-live="assertive"
+        className="w-full max-w-xl rounded-16 border border-red-200 bg-red-50 p-5 text-grey-900"
+        role="alert"
+      >
+        <h1 className="text-20 font-semibold">Dashboard unavailable</h1>
+        <p className="mt-2 text-14 text-grey-700">
+          The dashboard data could not be loaded. The rest of the admin
+          navigation is still available.
+        </p>
+        <button
+          className="mt-4 rounded-8 bg-grey-900 px-4 py-2 text-14 font-medium text-grey-0 transition-colors hover:bg-grey-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+          onClick={unstable_retry}
+          type="button"
+        >
+          Try again
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/web/app/admin/error.tsx
+++ b/web/app/admin/error.tsx
@@ -5,10 +5,10 @@ import { toast } from "react-toastify";
 
 type AdminErrorProps = {
   error: Error & { digest?: string };
-  unstable_retry: () => void;
+  reset: () => void;
 };
 
-export default function AdminError({ error, unstable_retry }: AdminErrorProps) {
+export default function AdminError({ error, reset }: AdminErrorProps) {
   useEffect(() => {
     toast.error("Unable to load the admin dashboard. Please try again.", {
       toastId: "admin-dashboard-load-error",
@@ -29,7 +29,7 @@ export default function AdminError({ error, unstable_retry }: AdminErrorProps) {
         </p>
         <button
           className="mt-4 rounded-8 bg-grey-900 px-4 py-2 text-14 font-medium text-grey-0 transition-colors hover:bg-grey-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
-          onClick={unstable_retry}
+          onClick={reset}
           type="button"
         >
           Try again

--- a/web/graphql/graphql.schema.json
+++ b/web/graphql/graphql.schema.json
@@ -3022,6 +3022,53 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "accept_team_invite_args",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_invite_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_team_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_user_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "action",
         "description": "columns and relationships of \"action\"",
@@ -11934,6 +11981,1090 @@
           {
             "name": "max_verifications",
             "description": "Only used for actions. Only for actions verified in the Developer Portal. Determines the maximum number of verifications that a user can perform for this action.",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "admin_dashboard_inventory",
+        "description": null,
+        "fields": [
+          {
+            "name": "active_api_keys",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_apps",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_teams",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleted_apps",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleted_teams",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "new_apps",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "new_teams",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "new_users",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pending_invites",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_users",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "admin_dashboard_inventory_bool_exp_bool_exp",
+        "description": "Boolean expression to filter rows from the logical model for \"admin_dashboard_inventory\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_dashboard_inventory_bool_exp_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "admin_dashboard_inventory_bool_exp_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_dashboard_inventory_bool_exp_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_api_keys",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_apps",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_teams",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleted_apps",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleted_teams",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "new_apps",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "new_teams",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "new_users",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pending_invites",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_users",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "admin_dashboard_inventory_enum_name",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "active_api_keys",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_apps",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_teams",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleted_apps",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleted_teams",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "new_apps",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "new_teams",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "new_users",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pending_invites",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_users",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "admin_dashboard_inventory_order_by",
+        "description": "Ordering options when selecting data from \"admin_dashboard_inventory\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "active_api_keys",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_apps",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_teams",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleted_apps",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleted_teams",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "new_apps",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "new_teams",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "new_users",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pending_invites",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_users",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "admin_dashboard_queue",
+        "description": null,
+        "fields": [
+          {
+            "name": "email",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner_email",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner_name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "admin_dashboard_queue_bool_exp_bool_exp",
+        "description": "Boolean expression to filter rows from the logical model for \"admin_dashboard_queue\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_dashboard_queue_bool_exp_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "admin_dashboard_queue_bool_exp_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_dashboard_queue_bool_exp_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "email",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner_email",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner_name",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_count",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "admin_dashboard_queue_enum_name",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "email",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner_email",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner_name",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_count",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "admin_dashboard_queue_order_by",
+        "description": "Ordering options when selecting data from \"admin_dashboard_queue\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "email",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner_email",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner_name",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_count",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
@@ -45865,53 +46996,6 @@
       },
       {
         "kind": "INPUT_OBJECT",
-        "name": "accept_team_invite_args",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "_invite_id",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_team_id",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_user_id",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
         "name": "merge_world_id_accounts_args",
         "description": null,
         "fields": null,
@@ -45962,6 +47046,123 @@
         "name": "mutation_root",
         "description": "mutation root",
         "fields": [
+          {
+            "name": "accept_team_invite",
+            "description": "execute VOLATILE function \"accept_team_invite\" which returns \"membership\"",
+            "args": [
+              {
+                "name": "args",
+                "description": "input parameters for function \"accept_team_invite\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "accept_team_invite_args",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "membership_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "membership_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "membership_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "membership",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "ban_app",
             "description": "Bans app by app_id",
@@ -50376,123 +51577,6 @@
               "kind": "OBJECT",
               "name": "InviteTeamMembersOutput",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "accept_team_invite",
-            "description": "execute VOLATILE function \"accept_team_invite\" which returns \"membership\"",
-            "args": [
-              {
-                "name": "args",
-                "description": "input parameters for function \"accept_team_invite\"",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "accept_team_invite_args",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "distinct_on",
-                "description": "distinct select on columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "membership_select_column",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "limit",
-                "description": "limit the number of rows returned",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "order_by",
-                "description": "sort the rows by one or more columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "membership_order_by",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": "filter the rows returned",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "membership_bool_exp",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "membership",
-                    "ofType": null
-                  }
-                }
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -63847,6 +64931,208 @@
             "deprecationReason": null
           },
           {
+            "name": "admin_dashboard_inventory",
+            "description": null,
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "admin_dashboard_inventory_enum_name",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "admin_dashboard_inventory_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_dashboard_inventory_bool_exp_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "admin_dashboard_inventory",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "admin_dashboard_queues",
+            "description": null,
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "admin_dashboard_queue_enum_name",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "admin_dashboard_queue_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_dashboard_queue_bool_exp_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "admin_dashboard_queue",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "api_key",
             "description": "fetch data from the table: \"api_key\"",
             "args": [
@@ -76230,6 +77516,208 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "action_v4",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "admin_dashboard_inventory",
+            "description": null,
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "admin_dashboard_inventory_enum_name",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "admin_dashboard_inventory_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_dashboard_inventory_bool_exp_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "admin_dashboard_inventory",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "admin_dashboard_queues",
+            "description": null,
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "admin_dashboard_queue_enum_name",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "admin_dashboard_queue_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_dashboard_queue_bool_exp_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "admin_dashboard_queue",
                     "ofType": null
                   }
                 }

--- a/web/graphql/graphql.ts
+++ b/web/graphql/graphql.ts
@@ -1668,6 +1668,142 @@ export type Action_Variance_Order_By = {
   max_verifications?: InputMaybe<Order_By>;
 };
 
+export type Admin_Dashboard_Inventory = {
+  __typename?: "admin_dashboard_inventory";
+  active_api_keys: Scalars["bigint"]["output"];
+  active_apps: Scalars["bigint"]["output"];
+  active_teams: Scalars["bigint"]["output"];
+  deleted_apps: Scalars["bigint"]["output"];
+  deleted_teams: Scalars["bigint"]["output"];
+  new_apps: Scalars["bigint"]["output"];
+  new_teams: Scalars["bigint"]["output"];
+  new_users: Scalars["bigint"]["output"];
+  pending_invites: Scalars["bigint"]["output"];
+  total_users: Scalars["bigint"]["output"];
+};
+
+/** Boolean expression to filter rows from the logical model for "admin_dashboard_inventory". All fields are combined with a logical 'AND'. */
+export type Admin_Dashboard_Inventory_Bool_Exp_Bool_Exp = {
+  _and?: InputMaybe<Array<Admin_Dashboard_Inventory_Bool_Exp_Bool_Exp>>;
+  _not?: InputMaybe<Admin_Dashboard_Inventory_Bool_Exp_Bool_Exp>;
+  _or?: InputMaybe<Array<Admin_Dashboard_Inventory_Bool_Exp_Bool_Exp>>;
+  active_api_keys?: InputMaybe<Bigint_Comparison_Exp>;
+  active_apps?: InputMaybe<Bigint_Comparison_Exp>;
+  active_teams?: InputMaybe<Bigint_Comparison_Exp>;
+  deleted_apps?: InputMaybe<Bigint_Comparison_Exp>;
+  deleted_teams?: InputMaybe<Bigint_Comparison_Exp>;
+  new_apps?: InputMaybe<Bigint_Comparison_Exp>;
+  new_teams?: InputMaybe<Bigint_Comparison_Exp>;
+  new_users?: InputMaybe<Bigint_Comparison_Exp>;
+  pending_invites?: InputMaybe<Bigint_Comparison_Exp>;
+  total_users?: InputMaybe<Bigint_Comparison_Exp>;
+};
+
+export enum Admin_Dashboard_Inventory_Enum_Name {
+  /** column name */
+  ActiveApiKeys = "active_api_keys",
+  /** column name */
+  ActiveApps = "active_apps",
+  /** column name */
+  ActiveTeams = "active_teams",
+  /** column name */
+  DeletedApps = "deleted_apps",
+  /** column name */
+  DeletedTeams = "deleted_teams",
+  /** column name */
+  NewApps = "new_apps",
+  /** column name */
+  NewTeams = "new_teams",
+  /** column name */
+  NewUsers = "new_users",
+  /** column name */
+  PendingInvites = "pending_invites",
+  /** column name */
+  TotalUsers = "total_users",
+}
+
+/** Ordering options when selecting data from "admin_dashboard_inventory". */
+export type Admin_Dashboard_Inventory_Order_By = {
+  active_api_keys?: InputMaybe<Order_By>;
+  active_apps?: InputMaybe<Order_By>;
+  active_teams?: InputMaybe<Order_By>;
+  deleted_apps?: InputMaybe<Order_By>;
+  deleted_teams?: InputMaybe<Order_By>;
+  new_apps?: InputMaybe<Order_By>;
+  new_teams?: InputMaybe<Order_By>;
+  new_users?: InputMaybe<Order_By>;
+  pending_invites?: InputMaybe<Order_By>;
+  total_users?: InputMaybe<Order_By>;
+};
+
+export type Admin_Dashboard_Queue = {
+  __typename?: "admin_dashboard_queue";
+  email?: Maybe<Scalars["String"]["output"]>;
+  id: Scalars["String"]["output"];
+  kind: Scalars["String"]["output"];
+  name?: Maybe<Scalars["String"]["output"]>;
+  owner_email?: Maybe<Scalars["String"]["output"]>;
+  owner_id?: Maybe<Scalars["String"]["output"]>;
+  owner_name?: Maybe<Scalars["String"]["output"]>;
+  team_id?: Maybe<Scalars["String"]["output"]>;
+  total_count: Scalars["bigint"]["output"];
+  updated_at?: Maybe<Scalars["timestamptz"]["output"]>;
+};
+
+/** Boolean expression to filter rows from the logical model for "admin_dashboard_queue". All fields are combined with a logical 'AND'. */
+export type Admin_Dashboard_Queue_Bool_Exp_Bool_Exp = {
+  _and?: InputMaybe<Array<Admin_Dashboard_Queue_Bool_Exp_Bool_Exp>>;
+  _not?: InputMaybe<Admin_Dashboard_Queue_Bool_Exp_Bool_Exp>;
+  _or?: InputMaybe<Array<Admin_Dashboard_Queue_Bool_Exp_Bool_Exp>>;
+  email?: InputMaybe<String_Comparison_Exp>;
+  id?: InputMaybe<String_Comparison_Exp>;
+  kind?: InputMaybe<String_Comparison_Exp>;
+  name?: InputMaybe<String_Comparison_Exp>;
+  owner_email?: InputMaybe<String_Comparison_Exp>;
+  owner_id?: InputMaybe<String_Comparison_Exp>;
+  owner_name?: InputMaybe<String_Comparison_Exp>;
+  team_id?: InputMaybe<String_Comparison_Exp>;
+  total_count?: InputMaybe<Bigint_Comparison_Exp>;
+  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+};
+
+export enum Admin_Dashboard_Queue_Enum_Name {
+  /** column name */
+  Email = "email",
+  /** column name */
+  Id = "id",
+  /** column name */
+  Kind = "kind",
+  /** column name */
+  Name = "name",
+  /** column name */
+  OwnerEmail = "owner_email",
+  /** column name */
+  OwnerId = "owner_id",
+  /** column name */
+  OwnerName = "owner_name",
+  /** column name */
+  TeamId = "team_id",
+  /** column name */
+  TotalCount = "total_count",
+  /** column name */
+  UpdatedAt = "updated_at",
+}
+
+/** Ordering options when selecting data from "admin_dashboard_queue". */
+export type Admin_Dashboard_Queue_Order_By = {
+  email?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  kind?: InputMaybe<Order_By>;
+  name?: InputMaybe<Order_By>;
+  owner_email?: InputMaybe<Order_By>;
+  owner_id?: InputMaybe<Order_By>;
+  owner_name?: InputMaybe<Order_By>;
+  team_id?: InputMaybe<Order_By>;
+  total_count?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+};
+
 /** columns and relationships of "api_key" */
 export type Api_Key = {
   __typename?: "api_key";
@@ -9369,6 +9505,8 @@ export type Query_Root = {
   action_v4_aggregate: Action_V4_Aggregate;
   /** fetch data from the table: "action_v4" using primary key columns */
   action_v4_by_pk?: Maybe<Action_V4>;
+  admin_dashboard_inventory: Array<Admin_Dashboard_Inventory>;
+  admin_dashboard_queues: Array<Admin_Dashboard_Queue>;
   /** fetch data from the table: "api_key" */
   api_key: Array<Api_Key>;
   /** fetch aggregated fields from the table: "api_key" */
@@ -9604,6 +9742,22 @@ export type Query_RootAction_V4_AggregateArgs = {
 
 export type Query_RootAction_V4_By_PkArgs = {
   id: Scalars["String"]["input"];
+};
+
+export type Query_RootAdmin_Dashboard_InventoryArgs = {
+  distinct_on?: InputMaybe<Array<Admin_Dashboard_Inventory_Enum_Name>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Admin_Dashboard_Inventory_Order_By>>;
+  where?: InputMaybe<Admin_Dashboard_Inventory_Bool_Exp_Bool_Exp>;
+};
+
+export type Query_RootAdmin_Dashboard_QueuesArgs = {
+  distinct_on?: InputMaybe<Array<Admin_Dashboard_Queue_Enum_Name>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Admin_Dashboard_Queue_Order_By>>;
+  where?: InputMaybe<Admin_Dashboard_Queue_Bool_Exp_Bool_Exp>;
 };
 
 export type Query_RootApi_KeyArgs = {
@@ -10919,6 +11073,8 @@ export type Subscription_Root = {
   action_v4_by_pk?: Maybe<Action_V4>;
   /** fetch data from the table in a streaming manner: "action_v4" */
   action_v4_stream: Array<Action_V4>;
+  admin_dashboard_inventory: Array<Admin_Dashboard_Inventory>;
+  admin_dashboard_queues: Array<Admin_Dashboard_Queue>;
   /** fetch data from the table: "api_key" */
   api_key: Array<Api_Key>;
   /** fetch aggregated fields from the table: "api_key" */
@@ -11215,6 +11371,22 @@ export type Subscription_RootAction_V4_StreamArgs = {
   batch_size: Scalars["Int"]["input"];
   cursor: Array<InputMaybe<Action_V4_Stream_Cursor_Input>>;
   where?: InputMaybe<Action_V4_Bool_Exp>;
+};
+
+export type Subscription_RootAdmin_Dashboard_InventoryArgs = {
+  distinct_on?: InputMaybe<Array<Admin_Dashboard_Inventory_Enum_Name>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Admin_Dashboard_Inventory_Order_By>>;
+  where?: InputMaybe<Admin_Dashboard_Inventory_Bool_Exp_Bool_Exp>;
+};
+
+export type Subscription_RootAdmin_Dashboard_QueuesArgs = {
+  distinct_on?: InputMaybe<Array<Admin_Dashboard_Queue_Enum_Name>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Admin_Dashboard_Queue_Order_By>>;
+  where?: InputMaybe<Admin_Dashboard_Queue_Bool_Exp_Bool_Exp>;
 };
 
 export type Subscription_RootApi_KeyArgs = {

--- a/web/scenes/Admin/graphql/server/fetch-admin-home.generated.ts
+++ b/web/scenes/Admin/graphql/server/fetch-admin-home.generated.ts
@@ -1,10 +1,9 @@
+/* eslint-disable */
 import * as Types from "@/graphql/graphql";
 
 import { GraphQLClient, RequestOptions } from "graphql-request";
 import gql from "graphql-tag";
-
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
-
 export type FetchAdminHomeQueryVariables = Types.Exact<{
   recentLimit: Types.Scalars["Int"]["input"];
 }>;
@@ -37,16 +36,30 @@ export type FetchAdminHomeQuery = {
     total_count: number;
     updated_at?: string | null;
   }>;
+  recent_teams: Array<{
+    __typename?: "team";
+    id: string;
+    name?: string | null;
+    created_at: string;
+    deleted_at?: string | null;
+  }>;
+  recent_users: Array<{
+    __typename?: "user";
+    id: string;
+    name: string;
+    email?: string | null;
+    created_at: string;
+  }>;
   recent_apps: Array<{
     __typename?: "app";
+    id: string;
+    name: string;
+    team_id: string;
     created_at: string;
     draft_metadata: Array<{
       __typename?: "app_metadata";
       verification_status: string;
     }>;
-    id: string;
-    name: string;
-    team_id: string;
     verified_metadata: Array<{
       __typename?: "app_metadata";
       verification_status: string;
@@ -58,20 +71,6 @@ export type FetchAdminHomeQuery = {
     name: string;
     updated_at: string;
     verification_status: string;
-  }>;
-  recent_teams: Array<{
-    __typename?: "team";
-    created_at: string;
-    deleted_at?: string | null;
-    id: string;
-    name?: string | null;
-  }>;
-  recent_users: Array<{
-    __typename?: "user";
-    created_at: string;
-    email?: string | null;
-    id: string;
-    name: string;
   }>;
 };
 
@@ -153,10 +152,15 @@ export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
   operationName: string,
   operationType?: string,
-  variables?: unknown,
+  variables?: any,
 ) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (action) => action();
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
 
 export function getSdk(
   client: GraphQLClient,
@@ -181,5 +185,4 @@ export function getSdk(
     },
   };
 }
-
 export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/graphql/server/fetch-admin-home.generated.ts
+++ b/web/scenes/Admin/graphql/server/fetch-admin-home.generated.ts
@@ -1,190 +1,52 @@
-/* eslint-disable */
 import * as Types from "@/graphql/graphql";
 
 import { GraphQLClient, RequestOptions } from "graphql-request";
 import gql from "graphql-tag";
+
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+
 export type FetchAdminHomeQueryVariables = Types.Exact<{
-  recentSince: Types.Scalars["timestamptz"]["input"];
   recentLimit: Types.Scalars["Int"]["input"];
 }>;
 
 export type FetchAdminHomeQuery = {
   __typename?: "query_root";
-  active_teams: {
-    __typename?: "team_aggregate";
-    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
-  };
-  deleted_teams: {
-    __typename?: "team_aggregate";
-    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
-  };
-  new_teams: {
-    __typename?: "team_aggregate";
-    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
-  };
-  total_users: {
-    __typename?: "user_aggregate";
-    aggregate?: { __typename?: "user_aggregate_fields"; count: number } | null;
-  };
-  new_users: {
-    __typename?: "user_aggregate";
-    aggregate?: { __typename?: "user_aggregate_fields"; count: number } | null;
-  };
-  active_apps: {
-    __typename?: "app_aggregate";
-    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
-  };
-  deleted_apps: {
-    __typename?: "app_aggregate";
-    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
-  };
-  new_apps: {
-    __typename?: "app_aggregate";
-    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
-  };
-  pending_invites: {
-    __typename?: "invite_aggregate";
-    aggregate?: {
-      __typename?: "invite_aggregate_fields";
-      count: number;
-    } | null;
-  };
-  active_api_keys: {
-    __typename?: "api_key_aggregate";
-    aggregate?: {
-      __typename?: "api_key_aggregate_fields";
-      count: number;
-    } | null;
-  };
-  teams_without_owner: Array<{
-    __typename?: "team";
-    id: string;
-    name?: string | null;
-    created_at: string;
+  inventory: Array<{
+    __typename?: "admin_dashboard_inventory";
+    active_api_keys: number;
+    active_apps: number;
+    active_teams: number;
+    deleted_apps: number;
+    deleted_teams: number;
+    new_apps: number;
+    new_teams: number;
+    new_users: number;
+    pending_invites: number;
+    total_users: number;
   }>;
-  teams_without_owner_count: {
-    __typename?: "team_aggregate";
-    aggregate?: { __typename?: "team_aggregate_fields"; count: number } | null;
-  };
-  users_without_teams: Array<{
-    __typename?: "user";
-    id: string;
-    name: string;
+  queues: Array<{
+    __typename?: "admin_dashboard_queue";
     email?: string | null;
-    created_at: string;
-  }>;
-  users_without_teams_count: {
-    __typename?: "user_aggregate";
-    aggregate?: { __typename?: "user_aggregate_fields"; count: number } | null;
-  };
-  apps_without_metadata: Array<{
-    __typename?: "app";
     id: string;
-    name: string;
-    team_id: string;
-    created_at: string;
-  }>;
-  apps_without_metadata_count: {
-    __typename?: "app_aggregate";
-    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
-  };
-  sole_owner_memberships: Array<{
-    __typename?: "membership";
-    user: {
-      __typename?: "user";
-      id: string;
-      name: string;
-      email?: string | null;
-    };
-    team: {
-      __typename?: "team";
-      id: string;
-      name?: string | null;
-      memberships_aggregate: {
-        __typename?: "membership_aggregate";
-        aggregate?: {
-          __typename?: "membership_aggregate_fields";
-          count: number;
-        } | null;
-      };
-    };
-  }>;
-  sole_owner_memberships_count: {
-    __typename?: "membership_aggregate";
-    aggregate?: {
-      __typename?: "membership_aggregate_fields";
-      count: number;
-    } | null;
-  };
-  apps_awaiting_review: Array<{
-    __typename?: "app";
-    id: string;
-    name: string;
-    team_id: string;
-    draft_metadata: Array<{
-      __typename?: "app_metadata";
-      name: string;
-      updated_at: string;
-      verification_status: string;
-    }>;
-    verified_metadata: Array<{
-      __typename?: "app_metadata";
-      name: string;
-      verified_at?: string | null;
-      verification_status: string;
-    }>;
-  }>;
-  apps_awaiting_review_count: {
-    __typename?: "app_aggregate";
-    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
-  };
-  apps_changes_requested: Array<{
-    __typename?: "app";
-    id: string;
-    name: string;
-    team_id: string;
-    draft_metadata: Array<{
-      __typename?: "app_metadata";
-      name: string;
-      updated_at: string;
-      verification_status: string;
-    }>;
-    verified_metadata: Array<{
-      __typename?: "app_metadata";
-      name: string;
-      verified_at?: string | null;
-      verification_status: string;
-    }>;
-  }>;
-  apps_changes_requested_count: {
-    __typename?: "app_aggregate";
-    aggregate?: { __typename?: "app_aggregate_fields"; count: number } | null;
-  };
-  recent_teams: Array<{
-    __typename?: "team";
-    id: string;
+    kind: string;
     name?: string | null;
-    created_at: string;
-    deleted_at?: string | null;
-  }>;
-  recent_users: Array<{
-    __typename?: "user";
-    id: string;
-    name: string;
-    email?: string | null;
-    created_at: string;
+    owner_email?: string | null;
+    owner_id?: string | null;
+    owner_name?: string | null;
+    team_id?: string | null;
+    total_count: number;
+    updated_at?: string | null;
   }>;
   recent_apps: Array<{
     __typename?: "app";
-    id: string;
-    name: string;
-    team_id: string;
     created_at: string;
     draft_metadata: Array<{
       __typename?: "app_metadata";
       verification_status: string;
     }>;
+    id: string;
+    name: string;
+    team_id: string;
     verified_metadata: Array<{
       __typename?: "app_metadata";
       verification_status: string;
@@ -197,263 +59,47 @@ export type FetchAdminHomeQuery = {
     updated_at: string;
     verification_status: string;
   }>;
+  recent_teams: Array<{
+    __typename?: "team";
+    created_at: string;
+    deleted_at?: string | null;
+    id: string;
+    name?: string | null;
+  }>;
+  recent_users: Array<{
+    __typename?: "user";
+    created_at: string;
+    email?: string | null;
+    id: string;
+    name: string;
+  }>;
 };
 
 export const FetchAdminHomeDocument = gql`
-  query FetchAdminHome($recentSince: timestamptz!, $recentLimit: Int!) {
-    active_teams: team_aggregate(where: { deleted_at: { _is_null: true } }) {
-      aggregate {
-        count
-      }
+  query FetchAdminHome($recentLimit: Int!) {
+    inventory: admin_dashboard_inventory {
+      active_api_keys
+      active_apps
+      active_teams
+      deleted_apps
+      deleted_teams
+      new_apps
+      new_teams
+      new_users
+      pending_invites
+      total_users
     }
-    deleted_teams: team_aggregate(where: { deleted_at: { _is_null: false } }) {
-      aggregate {
-        count
-      }
-    }
-    new_teams: team_aggregate(
-      where: {
-        deleted_at: { _is_null: true }
-        created_at: { _gte: $recentSince }
-      }
-    ) {
-      aggregate {
-        count
-      }
-    }
-    total_users: user_aggregate {
-      aggregate {
-        count
-      }
-    }
-    new_users: user_aggregate(where: { created_at: { _gte: $recentSince } }) {
-      aggregate {
-        count
-      }
-    }
-    active_apps: app_aggregate(where: { deleted_at: { _is_null: true } }) {
-      aggregate {
-        count
-      }
-    }
-    deleted_apps: app_aggregate(where: { deleted_at: { _is_null: false } }) {
-      aggregate {
-        count
-      }
-    }
-    new_apps: app_aggregate(
-      where: {
-        deleted_at: { _is_null: true }
-        created_at: { _gte: $recentSince }
-      }
-    ) {
-      aggregate {
-        count
-      }
-    }
-    pending_invites: invite_aggregate(
-      where: { expires_at: { _gte: "now()" } }
-    ) {
-      aggregate {
-        count
-      }
-    }
-    active_api_keys: api_key_aggregate(where: { is_active: { _eq: true } }) {
-      aggregate {
-        count
-      }
-    }
-    teams_without_owner: team(
-      where: {
-        _and: [
-          { deleted_at: { _is_null: true } }
-          { _not: { memberships: { role: { _eq: OWNER } } } }
-        ]
-      }
-      order_by: { created_at: desc }
-      limit: $recentLimit
-    ) {
-      id
-      name
-      created_at
-    }
-    teams_without_owner_count: team_aggregate(
-      where: {
-        _and: [
-          { deleted_at: { _is_null: true } }
-          { _not: { memberships: { role: { _eq: OWNER } } } }
-        ]
-      }
-    ) {
-      aggregate {
-        count
-      }
-    }
-    users_without_teams: user(
-      where: { _not: { memberships: {} } }
-      order_by: { created_at: desc }
-      limit: $recentLimit
-    ) {
-      id
-      name
+    queues: admin_dashboard_queues {
       email
-      created_at
-    }
-    users_without_teams_count: user_aggregate(
-      where: { _not: { memberships: {} } }
-    ) {
-      aggregate {
-        count
-      }
-    }
-    apps_without_metadata: app(
-      where: {
-        _and: [
-          { deleted_at: { _is_null: true } }
-          { _not: { app_metadata: {} } }
-        ]
-      }
-      order_by: { created_at: desc }
-      limit: $recentLimit
-    ) {
       id
+      kind
       name
+      owner_email
+      owner_id
+      owner_name
       team_id
-      created_at
-    }
-    apps_without_metadata_count: app_aggregate(
-      where: {
-        _and: [
-          { deleted_at: { _is_null: true } }
-          { _not: { app_metadata: {} } }
-        ]
-      }
-    ) {
-      aggregate {
-        count
-      }
-    }
-    sole_owner_memberships: membership(
-      where: {
-        role: { _eq: OWNER }
-        team: {
-          deleted_at: { _is_null: true }
-          memberships_aggregate: {
-            count: { filter: { role: { _eq: OWNER } }, predicate: { _eq: 1 } }
-          }
-        }
-      }
-      limit: $recentLimit
-    ) {
-      user {
-        id
-        name
-        email
-      }
-      team {
-        id
-        name
-        memberships_aggregate(where: { role: { _eq: OWNER } }) {
-          aggregate {
-            count
-          }
-        }
-      }
-    }
-    sole_owner_memberships_count: membership_aggregate(
-      where: {
-        role: { _eq: OWNER }
-        team: {
-          deleted_at: { _is_null: true }
-          memberships_aggregate: {
-            count: { filter: { role: { _eq: OWNER } }, predicate: { _eq: 1 } }
-          }
-        }
-      }
-    ) {
-      aggregate {
-        count
-      }
-    }
-    apps_awaiting_review: app(
-      where: {
-        deleted_at: { _is_null: true }
-        app_metadata: { verification_status: { _eq: "awaiting_review" } }
-      }
-      order_by: { created_at: desc }
-      limit: $recentLimit
-    ) {
-      id
-      name
-      team_id
-      draft_metadata: app_metadata(
-        where: { verification_status: { _neq: "verified" } }
-        order_by: { updated_at: desc }
-        limit: 1
-      ) {
-        name
-        updated_at
-        verification_status
-      }
-      verified_metadata: app_metadata(
-        where: { verification_status: { _eq: "verified" } }
-        order_by: { verified_at: desc }
-        limit: 1
-      ) {
-        name
-        verified_at
-        verification_status
-      }
-    }
-    apps_awaiting_review_count: app_aggregate(
-      where: {
-        deleted_at: { _is_null: true }
-        app_metadata: { verification_status: { _eq: "awaiting_review" } }
-      }
-    ) {
-      aggregate {
-        count
-      }
-    }
-    apps_changes_requested: app(
-      where: {
-        deleted_at: { _is_null: true }
-        app_metadata: { verification_status: { _eq: "changes_requested" } }
-      }
-      order_by: { created_at: desc }
-      limit: $recentLimit
-    ) {
-      id
-      name
-      team_id
-      draft_metadata: app_metadata(
-        where: { verification_status: { _neq: "verified" } }
-        order_by: { updated_at: desc }
-        limit: 1
-      ) {
-        name
-        updated_at
-        verification_status
-      }
-      verified_metadata: app_metadata(
-        where: { verification_status: { _eq: "verified" } }
-        order_by: { verified_at: desc }
-        limit: 1
-      ) {
-        name
-        verified_at
-        verification_status
-      }
-    }
-    apps_changes_requested_count: app_aggregate(
-      where: {
-        deleted_at: { _is_null: true }
-        app_metadata: { verification_status: { _eq: "changes_requested" } }
-      }
-    ) {
-      aggregate {
-        count
-      }
+      total_count
+      updated_at
     }
     recent_teams: team(order_by: { created_at: desc }, limit: $recentLimit) {
       id
@@ -507,15 +153,10 @@ export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
   operationName: string,
   operationType?: string,
-  variables?: any,
+  variables?: unknown,
 ) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (
-  action,
-  _operationName,
-  _operationType,
-  _variables,
-) => action();
+const defaultWrapper: SdkFunctionWrapper = (action) => action();
 
 export function getSdk(
   client: GraphQLClient,
@@ -540,4 +181,5 @@ export function getSdk(
     },
   };
 }
+
 export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/graphql/server/fetch-admin-home.gql
+++ b/web/scenes/Admin/graphql/server/fetch-admin-home.gql
@@ -1,249 +1,27 @@
-query FetchAdminHome($recentSince: timestamptz!, $recentLimit: Int!) {
-  active_teams: team_aggregate(where: { deleted_at: { _is_null: true } }) {
-    aggregate {
-      count
-    }
+query FetchAdminHome($recentLimit: Int!) {
+  inventory: admin_dashboard_inventory {
+    active_api_keys
+    active_apps
+    active_teams
+    deleted_apps
+    deleted_teams
+    new_apps
+    new_teams
+    new_users
+    pending_invites
+    total_users
   }
-  deleted_teams: team_aggregate(where: { deleted_at: { _is_null: false } }) {
-    aggregate {
-      count
-    }
-  }
-  new_teams: team_aggregate(
-    where: {
-      deleted_at: { _is_null: true }
-      created_at: { _gte: $recentSince }
-    }
-  ) {
-    aggregate {
-      count
-    }
-  }
-  total_users: user_aggregate {
-    aggregate {
-      count
-    }
-  }
-  new_users: user_aggregate(where: { created_at: { _gte: $recentSince } }) {
-    aggregate {
-      count
-    }
-  }
-  active_apps: app_aggregate(where: { deleted_at: { _is_null: true } }) {
-    aggregate {
-      count
-    }
-  }
-  deleted_apps: app_aggregate(where: { deleted_at: { _is_null: false } }) {
-    aggregate {
-      count
-    }
-  }
-  new_apps: app_aggregate(
-    where: {
-      deleted_at: { _is_null: true }
-      created_at: { _gte: $recentSince }
-    }
-  ) {
-    aggregate {
-      count
-    }
-  }
-  pending_invites: invite_aggregate(where: { expires_at: { _gte: "now()" } }) {
-    aggregate {
-      count
-    }
-  }
-  active_api_keys: api_key_aggregate(where: { is_active: { _eq: true } }) {
-    aggregate {
-      count
-    }
-  }
-  teams_without_owner: team(
-    where: {
-      _and: [
-        { deleted_at: { _is_null: true } }
-        { _not: { memberships: { role: { _eq: OWNER } } } }
-      ]
-    }
-    order_by: { created_at: desc }
-    limit: $recentLimit
-  ) {
-    id
-    name
-    created_at
-  }
-  teams_without_owner_count: team_aggregate(
-    where: {
-      _and: [
-        { deleted_at: { _is_null: true } }
-        { _not: { memberships: { role: { _eq: OWNER } } } }
-      ]
-    }
-  ) {
-    aggregate {
-      count
-    }
-  }
-  users_without_teams: user(
-    where: { _not: { memberships: {} } }
-    order_by: { created_at: desc }
-    limit: $recentLimit
-  ) {
-    id
-    name
+  queues: admin_dashboard_queues {
     email
-    created_at
-  }
-  users_without_teams_count: user_aggregate(
-    where: { _not: { memberships: {} } }
-  ) {
-    aggregate {
-      count
-    }
-  }
-  apps_without_metadata: app(
-    where: {
-      _and: [{ deleted_at: { _is_null: true } }, { _not: { app_metadata: {} } }]
-    }
-    order_by: { created_at: desc }
-    limit: $recentLimit
-  ) {
     id
+    kind
     name
+    owner_email
+    owner_id
+    owner_name
     team_id
-    created_at
-  }
-  apps_without_metadata_count: app_aggregate(
-    where: {
-      _and: [{ deleted_at: { _is_null: true } }, { _not: { app_metadata: {} } }]
-    }
-  ) {
-    aggregate {
-      count
-    }
-  }
-  sole_owner_memberships: membership(
-    where: {
-      role: { _eq: OWNER }
-      team: {
-        deleted_at: { _is_null: true }
-        memberships_aggregate: {
-          count: { filter: { role: { _eq: OWNER } }, predicate: { _eq: 1 } }
-        }
-      }
-    }
-    limit: $recentLimit
-  ) {
-    user {
-      id
-      name
-      email
-    }
-    team {
-      id
-      name
-      memberships_aggregate(where: { role: { _eq: OWNER } }) {
-        aggregate {
-          count
-        }
-      }
-    }
-  }
-  sole_owner_memberships_count: membership_aggregate(
-    where: {
-      role: { _eq: OWNER }
-      team: {
-        deleted_at: { _is_null: true }
-        memberships_aggregate: {
-          count: { filter: { role: { _eq: OWNER } }, predicate: { _eq: 1 } }
-        }
-      }
-    }
-  ) {
-    aggregate {
-      count
-    }
-  }
-  apps_awaiting_review: app(
-    where: {
-      deleted_at: { _is_null: true }
-      app_metadata: { verification_status: { _eq: "awaiting_review" } }
-    }
-    order_by: { created_at: desc }
-    limit: $recentLimit
-  ) {
-    id
-    name
-    team_id
-    draft_metadata: app_metadata(
-      where: { verification_status: { _neq: "verified" } }
-      order_by: { updated_at: desc }
-      limit: 1
-    ) {
-      name
-      updated_at
-      verification_status
-    }
-    verified_metadata: app_metadata(
-      where: { verification_status: { _eq: "verified" } }
-      order_by: { verified_at: desc }
-      limit: 1
-    ) {
-      name
-      verified_at
-      verification_status
-    }
-  }
-  apps_awaiting_review_count: app_aggregate(
-    where: {
-      deleted_at: { _is_null: true }
-      app_metadata: { verification_status: { _eq: "awaiting_review" } }
-    }
-  ) {
-    aggregate {
-      count
-    }
-  }
-  apps_changes_requested: app(
-    where: {
-      deleted_at: { _is_null: true }
-      app_metadata: { verification_status: { _eq: "changes_requested" } }
-    }
-    order_by: { created_at: desc }
-    limit: $recentLimit
-  ) {
-    id
-    name
-    team_id
-    draft_metadata: app_metadata(
-      where: { verification_status: { _neq: "verified" } }
-      order_by: { updated_at: desc }
-      limit: 1
-    ) {
-      name
-      updated_at
-      verification_status
-    }
-    verified_metadata: app_metadata(
-      where: { verification_status: { _eq: "verified" } }
-      order_by: { verified_at: desc }
-      limit: 1
-    ) {
-      name
-      verified_at
-      verification_status
-    }
-  }
-  apps_changes_requested_count: app_aggregate(
-    where: {
-      deleted_at: { _is_null: true }
-      app_metadata: { verification_status: { _eq: "changes_requested" } }
-    }
-  ) {
-    aggregate {
-      count
-    }
+    total_count
+    updated_at
   }
   recent_teams: team(order_by: { created_at: desc }, limit: $recentLimit) {
     id

--- a/web/scenes/Admin/server/fetch-home.ts
+++ b/web/scenes/Admin/server/fetch-home.ts
@@ -14,7 +14,7 @@ export type AdminMetadataStatus =
   | "unverified"
   | "verified";
 
-type HomeWorkflowApp = FetchAdminHomeQuery["apps_awaiting_review"][number];
+type RecentWorkflowApp = FetchAdminHomeQuery["recent_apps"][number];
 type WorkflowStatusSource = {
   draft_metadata: ReadonlyArray<{ verification_status: string }>;
   verified_metadata: ReadonlyArray<{ verification_status: string }>;
@@ -27,8 +27,26 @@ const metadataStatuses = new Set<AdminMetadataStatus>([
   "verified",
 ]);
 
-const getCount = (aggregate: { aggregate?: { count: number } | null }) =>
-  aggregate.aggregate?.count ?? 0;
+// Hasura returns bigint as string when STRINGIFY_NUMERIC_TYPES=true.
+const toCount = (value: number | string | null | undefined): number => {
+  const count = Number(value ?? 0);
+  return Number.isFinite(count) ? count : 0;
+};
+
+const getQueueCount = <Row extends { total_count: number | string }>(
+  rows: ReadonlyArray<Row>,
+) => toCount(rows[0]?.total_count);
+
+const getRequiredValue = <Value>(
+  value: Value | null | undefined,
+  field: string,
+): Value => {
+  if (value === null || value === undefined) {
+    throw new Error(`admin_dashboard_queues returned no ${field}`);
+  }
+
+  return value;
+};
 
 export const getWorkflowStatus = (
   app: WorkflowStatusSource,
@@ -42,84 +60,94 @@ export const getWorkflowStatus = (
     : null;
 };
 
-const mapWorkflowApp = (app: HomeWorkflowApp) => ({
+const mapRecentWorkflowApp = (app: RecentWorkflowApp) => ({
+  createdAt: app.created_at,
   id: app.id,
-  name:
-    app.draft_metadata[0]?.name ?? app.verified_metadata[0]?.name ?? app.name,
+  name: app.name,
   status: getWorkflowStatus(app),
   teamId: app.team_id,
-  updatedAt: app.draft_metadata[0]?.updated_at ?? null,
 });
 
 export const fetchAdminHome = async () => {
   const client = await getInternalDashboardGraphqlClient();
-  const recentSince = new Date(
-    Date.now() - 30 * 24 * 60 * 60 * 1000,
-  ).toISOString();
 
   try {
-    const data = await getSdk(client).FetchAdminHome({
-      recentLimit: 5,
-      recentSince,
-    });
-    const soleOwnerTeams = data.sole_owner_memberships.map((membership) => ({
-      id: membership.team.id,
-      name: membership.team.name ?? "Unnamed team",
-      owner: {
-        email: membership.user.email,
-        id: membership.user.id,
-        name: membership.user.name,
-      },
-    }));
+    const data = await getSdk(client).FetchAdminHome({ recentLimit: 5 });
+    const inventory = data.inventory[0];
+
+    if (!inventory) {
+      throw new Error("admin_dashboard_inventory returned no rows");
+    }
+
+    const getQueueRows = (kind: string) =>
+      data.queues.filter((queue) => queue.kind === kind);
+    const appsAwaitingReview = getQueueRows("apps_awaiting_review");
+    const appsChangesRequested = getQueueRows("apps_changes_requested");
+    const appsWithoutMetadata = getQueueRows("apps_without_metadata");
+    const teamsWithoutOwner = getQueueRows("teams_without_owner");
+    const soleOwnerTeams = getQueueRows("sole_owner_teams");
+    const usersWithoutTeams = getQueueRows("users_without_teams");
 
     return {
       inventory: {
-        activeApiKeys: getCount(data.active_api_keys),
-        activeApps: getCount(data.active_apps),
-        activeTeams: getCount(data.active_teams),
-        deletedApps: getCount(data.deleted_apps),
-        deletedTeams: getCount(data.deleted_teams),
-        newApps: getCount(data.new_apps),
-        newTeams: getCount(data.new_teams),
-        newUsers: getCount(data.new_users),
-        pendingInvites: getCount(data.pending_invites),
-        totalUsers: getCount(data.total_users),
+        activeApiKeys: toCount(inventory.active_api_keys),
+        activeApps: toCount(inventory.active_apps),
+        activeTeams: toCount(inventory.active_teams),
+        deletedApps: toCount(inventory.deleted_apps),
+        deletedTeams: toCount(inventory.deleted_teams),
+        newApps: toCount(inventory.new_apps),
+        newTeams: toCount(inventory.new_teams),
+        newUsers: toCount(inventory.new_users),
+        pendingInvites: toCount(inventory.pending_invites),
+        totalUsers: toCount(inventory.total_users),
       },
       queues: {
-        appsAwaitingReview: data.apps_awaiting_review.map(mapWorkflowApp),
-        appsChangesRequested: data.apps_changes_requested.map(mapWorkflowApp),
-        appsWithoutMetadata: data.apps_without_metadata.map((app) => ({
+        appsAwaitingReview: appsAwaitingReview.map((app) => ({
           id: app.id,
-          name: app.name,
-          teamId: app.team_id,
+          name: app.name ?? "Unnamed app",
+          teamId: getRequiredValue(app.team_id, "team_id"),
+          updatedAt: app.updated_at ?? null,
         })),
-        soleOwnerTeams,
-        teamsWithoutOwner: data.teams_without_owner.map((team) => ({
+        appsChangesRequested: appsChangesRequested.map((app) => ({
+          id: app.id,
+          name: app.name ?? "Unnamed app",
+          teamId: getRequiredValue(app.team_id, "team_id"),
+          updatedAt: app.updated_at ?? null,
+        })),
+        appsWithoutMetadata: appsWithoutMetadata.map((app) => ({
+          id: app.id,
+          name: app.name ?? "Unnamed app",
+          teamId: getRequiredValue(app.team_id, "team_id"),
+        })),
+        soleOwnerTeams: soleOwnerTeams.map((team) => ({
+          id: team.id,
+          name: team.name ?? "Unnamed team",
+          owner: {
+            email: team.owner_email,
+            id: getRequiredValue(team.owner_id, "owner_id"),
+            name: team.owner_name ?? "Unnamed user",
+          },
+        })),
+        teamsWithoutOwner: teamsWithoutOwner.map((team) => ({
           id: team.id,
           name: team.name ?? "Unnamed team",
         })),
-        usersWithoutTeams: data.users_without_teams.map((user) => ({
+        usersWithoutTeams: usersWithoutTeams.map((user) => ({
           email: user.email,
           id: user.id,
-          name: user.name,
+          name: user.name ?? "Unnamed user",
         })),
       },
       queueCounts: {
-        appsAwaitingReview: getCount(data.apps_awaiting_review_count),
-        appsChangesRequested: getCount(data.apps_changes_requested_count),
-        appsWithoutMetadata: getCount(data.apps_without_metadata_count),
-        soleOwnerTeams: getCount(data.sole_owner_memberships_count),
-        teamsWithoutOwner: getCount(data.teams_without_owner_count),
-        usersWithoutTeams: getCount(data.users_without_teams_count),
+        appsAwaitingReview: getQueueCount(appsAwaitingReview),
+        appsChangesRequested: getQueueCount(appsChangesRequested),
+        appsWithoutMetadata: getQueueCount(appsWithoutMetadata),
+        soleOwnerTeams: getQueueCount(soleOwnerTeams),
+        teamsWithoutOwner: getQueueCount(teamsWithoutOwner),
+        usersWithoutTeams: getQueueCount(usersWithoutTeams),
       },
       recent: {
-        apps: data.recent_apps.map((app) => ({
-          createdAt: app.created_at,
-          id: app.id,
-          name: app.name,
-          status: getWorkflowStatus(app),
-          teamId: app.team_id,
-        })),
+        apps: data.recent_apps.map(mapRecentWorkflowApp),
         metadata: data.recent_metadata.map((metadata) => ({
           appId: metadata.app_id,
           name: metadata.name,
@@ -140,7 +168,7 @@ export const fetchAdminHome = async () => {
           createdAt: user.created_at,
           email: user.email,
           id: user.id,
-          name: user.name,
+          name: user.name ?? "Unnamed user",
         })),
       },
     };

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-users.generated.ts
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-users.generated.ts
@@ -1,13 +1,13 @@
-/* eslint-disable */
 import * as Types from "@/graphql/graphql";
 
 import { GraphQLClient, RequestOptions } from "graphql-request";
 import gql from "graphql-tag";
+
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+
 export type FetchAdminUsersQueryVariables = Types.Exact<{
   includeCreatedAt: Types.Scalars["Boolean"]["input"];
   includeEmail: Types.Scalars["Boolean"]["input"];
-  includeTeamsCount: Types.Scalars["Boolean"]["input"];
   limit: Types.Scalars["Int"]["input"];
   offset: Types.Scalars["Int"]["input"];
   orderBy: Array<Types.User_Order_By> | Types.User_Order_By;
@@ -18,17 +18,10 @@ export type FetchAdminUsersQuery = {
   __typename?: "query_root";
   user: Array<{
     __typename?: "user";
+    created_at?: string;
+    email?: string | null;
     id: string;
     name: string;
-    email?: string | null;
-    created_at?: string;
-    memberships_aggregate?: {
-      __typename?: "membership_aggregate";
-      aggregate?: {
-        __typename?: "membership_aggregate_fields";
-        count: number;
-      } | null;
-    };
   }>;
   user_aggregate: {
     __typename?: "user_aggregate";
@@ -36,11 +29,22 @@ export type FetchAdminUsersQuery = {
   };
 };
 
+export type FetchAdminUserMembershipsQueryVariables = Types.Exact<{
+  userIds: Array<Types.Scalars["String"]["input"]>;
+}>;
+
+export type FetchAdminUserMembershipsQuery = {
+  __typename?: "query_root";
+  membership: Array<{
+    __typename?: "membership";
+    user_id: string;
+  }>;
+};
+
 export const FetchAdminUsersDocument = gql`
   query FetchAdminUsers(
     $includeCreatedAt: Boolean!
     $includeEmail: Boolean!
-    $includeTeamsCount: Boolean!
     $limit: Int!
     $offset: Int!
     $orderBy: [user_order_by!]!
@@ -51,11 +55,6 @@ export const FetchAdminUsersDocument = gql`
       name
       email @include(if: $includeEmail)
       created_at @include(if: $includeCreatedAt)
-      memberships_aggregate @include(if: $includeTeamsCount) {
-        aggregate {
-          count
-        }
-      }
     }
     user_aggregate(where: $where) {
       aggregate {
@@ -65,19 +64,22 @@ export const FetchAdminUsersDocument = gql`
   }
 `;
 
+export const FetchAdminUserMembershipsDocument = gql`
+  query FetchAdminUserMemberships($userIds: [String!]!) {
+    membership(where: { user_id: { _in: $userIds } }) {
+      user_id
+    }
+  }
+`;
+
 export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
   operationName: string,
   operationType?: string,
-  variables?: any,
+  variables?: unknown,
 ) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (
-  action,
-  _operationName,
-  _operationType,
-  _variables,
-) => action();
+const defaultWrapper: SdkFunctionWrapper = (action) => action();
 
 export function getSdk(
   client: GraphQLClient,
@@ -100,6 +102,23 @@ export function getSdk(
         variables,
       );
     },
+    FetchAdminUserMemberships(
+      variables: FetchAdminUserMembershipsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchAdminUserMembershipsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchAdminUserMembershipsQuery>(
+            FetchAdminUserMembershipsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchAdminUserMemberships",
+        "query",
+        variables,
+      );
+    },
   };
 }
+
 export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-users.generated.ts
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-users.generated.ts
@@ -1,10 +1,9 @@
+/* eslint-disable */
 import * as Types from "@/graphql/graphql";
 
 import { GraphQLClient, RequestOptions } from "graphql-request";
 import gql from "graphql-tag";
-
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
-
 export type FetchAdminUsersQueryVariables = Types.Exact<{
   includeCreatedAt: Types.Scalars["Boolean"]["input"];
   includeEmail: Types.Scalars["Boolean"]["input"];
@@ -18,10 +17,10 @@ export type FetchAdminUsersQuery = {
   __typename?: "query_root";
   user: Array<{
     __typename?: "user";
-    created_at?: string;
-    email?: string | null;
     id: string;
     name: string;
+    email?: string | null;
+    created_at?: string;
   }>;
   user_aggregate: {
     __typename?: "user_aggregate";
@@ -30,15 +29,14 @@ export type FetchAdminUsersQuery = {
 };
 
 export type FetchAdminUserMembershipsQueryVariables = Types.Exact<{
-  userIds: Array<Types.Scalars["String"]["input"]>;
+  userIds:
+    | Array<Types.Scalars["String"]["input"]>
+    | Types.Scalars["String"]["input"];
 }>;
 
 export type FetchAdminUserMembershipsQuery = {
   __typename?: "query_root";
-  membership: Array<{
-    __typename?: "membership";
-    user_id: string;
-  }>;
+  membership: Array<{ __typename?: "membership"; user_id: string }>;
 };
 
 export const FetchAdminUsersDocument = gql`
@@ -63,7 +61,6 @@ export const FetchAdminUsersDocument = gql`
     }
   }
 `;
-
 export const FetchAdminUserMembershipsDocument = gql`
   query FetchAdminUserMemberships($userIds: [String!]!) {
     membership(where: { user_id: { _in: $userIds } }) {
@@ -76,10 +73,15 @@ export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
   operationName: string,
   operationType?: string,
-  variables?: unknown,
+  variables?: any,
 ) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (action) => action();
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
 
 export function getSdk(
   client: GraphQLClient,
@@ -120,5 +122,4 @@ export function getSdk(
     },
   };
 }
-
 export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/users/graphql/server/fetch-admin-users.gql
+++ b/web/scenes/Admin/users/graphql/server/fetch-admin-users.gql
@@ -1,7 +1,6 @@
 query FetchAdminUsers(
   $includeCreatedAt: Boolean!
   $includeEmail: Boolean!
-  $includeTeamsCount: Boolean!
   $limit: Int!
   $offset: Int!
   $orderBy: [user_order_by!]!
@@ -12,15 +11,16 @@ query FetchAdminUsers(
     name
     email @include(if: $includeEmail)
     created_at @include(if: $includeCreatedAt)
-    memberships_aggregate @include(if: $includeTeamsCount) {
-      aggregate {
-        count
-      }
-    }
   }
   user_aggregate(where: $where) {
     aggregate {
       count
     }
+  }
+}
+
+query FetchAdminUserMemberships($userIds: [String!]!) {
+  membership(where: { user_id: { _in: $userIds } }) {
+    user_id
   }
 }

--- a/web/scenes/Admin/users/server/fetch-users.ts
+++ b/web/scenes/Admin/users/server/fetch-users.ts
@@ -205,12 +205,13 @@ export const createUsersOrderBy = (sort: UsersSort | null): User_Order_By[] => {
 const mapUserToTableRow = (
   user: FetchAdminUsersQuery["user"][number],
   columnVisibility: UserColumnVisibility,
+  teamsCountByUserId: ReadonlyMap<string, number>,
 ): UserTableRow => ({
   id: user.id,
   name: user.name ?? "Unnamed user",
   email: columnVisibility.email ? user.email : undefined,
   teamsCount: columnVisibility.teamsCount
-    ? user.memberships_aggregate?.aggregate?.count ?? 0
+    ? teamsCountByUserId.get(user.id) ?? 0
     : undefined,
   createdAt:
     columnVisibility.createdAt && user.created_at
@@ -247,17 +248,32 @@ export const fetchAdminUsersPage = async (
   const orderBy = createUsersOrderBy(sort);
 
   try {
-    const data = await getSdk(client).FetchAdminUsers({
+    const sdk = getSdk(client);
+    const data = await sdk.FetchAdminUsers({
       includeCreatedAt: columnVisibility.createdAt,
       includeEmail: columnVisibility.email,
-      includeTeamsCount: columnVisibility.teamsCount,
       limit,
       offset,
       orderBy,
       where,
     });
+    const teamsCountByUserId = new Map<string, number>();
+
+    if (columnVisibility.teamsCount && data.user.length > 0) {
+      const memberships = await sdk.FetchAdminUserMemberships({
+        userIds: data.user.map((user) => user.id),
+      });
+
+      for (const membership of memberships.membership) {
+        teamsCountByUserId.set(
+          membership.user_id,
+          (teamsCountByUserId.get(membership.user_id) ?? 0) + 1,
+        );
+      }
+    }
+
     const users = data.user.map((user) =>
-      mapUserToTableRow(user, columnVisibility),
+      mapUserToTableRow(user, columnVisibility, teamsCountByUserId),
     );
     const usersAmount = data.user_aggregate.aggregate?.count ?? users.length;
     const totalPages = getUsersTotalPages(usersAmount, limit);

--- a/web/tests/api/helpers/graphql.test.ts
+++ b/web/tests/api/helpers/graphql.test.ts
@@ -30,11 +30,13 @@ jest.mock("@/api/helpers/jwts", () => ({
 
 import {
   getInternalDashboardGraphqlClient,
+  internalDashboardGraphqlFetchPolicy,
   isRetryableOperation,
   makeGraphqlFetchWithRetry,
 } from "@/api/helpers/graphql";
 import { generateInternalDashboardJWT } from "@/api/helpers/jwts";
 import { AdminHasuraRole } from "@/lib/admin-auth/types";
+import { logger } from "@/lib/logger";
 
 // #region Test data
 const QUERY_BODY = JSON.stringify({
@@ -157,6 +159,30 @@ describe("graphqlFetchWithRetry", () => {
       }),
     ).rejects.toBeDefined();
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry an internal dashboard query on transport error", async () => {
+    fetchMock.mockRejectedValueOnce(transportError("ETIMEDOUT"));
+    const internalDashboardFetch = makeGraphqlFetchWithRetry(
+      fetchMock as unknown as typeof fetch,
+      internalDashboardGraphqlFetchPolicy,
+    );
+
+    await expect(
+      internalDashboardFetch("https://example.test/v1/graphql", {
+        method: "POST",
+        body: QUERY_BODY,
+      }),
+    ).rejects.toBeDefined();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "graphql transport request failed",
+      expect.objectContaining({
+        graphqlClient: "internal_dashboard",
+        operationName: "GetThing",
+      }),
+    );
   });
 
   it("does NOT retry on a 5xx HTTP response (fetch resolved, didn't throw)", async () => {

--- a/web/tests/unit/admin-home-fetch.test.ts
+++ b/web/tests/unit/admin-home-fetch.test.ts
@@ -179,9 +179,7 @@ describe("admin home fetch", () => {
     expect(home.inventory.activeTeams + home.inventory.deletedTeams).toBe(
       120602,
     );
-    expect(home.inventory.activeApps + home.inventory.deletedApps).toBe(
-      120610,
-    );
+    expect(home.inventory.activeApps + home.inventory.deletedApps).toBe(120610);
     expect(home.queueCounts.appsAwaitingReview).toBe(7);
   });
 

--- a/web/tests/unit/admin-home-fetch.test.ts
+++ b/web/tests/unit/admin-home-fetch.test.ts
@@ -1,15 +1,12 @@
 const mockFetchAdminHome = jest.fn();
 
 jest.mock("server-only", () => ({}));
-
 jest.mock("@/api/helpers/graphql", () => ({
-  getInternalDashboardGraphqlClient: jest.fn().mockResolvedValue({}),
+  getInternalDashboardGraphqlClient: async () => ({}),
 }));
-
 jest.mock("@/scenes/Admin/graphql/server/fetch-admin-home.generated", () => ({
   getSdk: () => ({ FetchAdminHome: mockFetchAdminHome }),
 }));
-
 jest.mock("@/lib/logger", () => ({
   logger: { error: jest.fn() },
 }));
@@ -20,80 +17,68 @@ import {
   getWorkflowStatus,
 } from "@/scenes/Admin/server/fetch-home";
 
-const aggregate = (count: number) => ({ aggregate: { count } });
-
 const createHomeResponse = () => ({
-  active_api_keys: aggregate(3),
-  active_apps: aggregate(7),
-  active_teams: aggregate(5),
-  apps_awaiting_review: [
+  inventory: [
     {
-      draft_metadata: [
-        {
-          name: "Waiting app",
-          updated_at: "2026-07-09T00:00:00.000Z",
-          verification_status: "awaiting_review",
-        },
-      ],
+      active_api_keys: 3,
+      active_apps: 7,
+      active_teams: 5,
+      deleted_apps: 2,
+      deleted_teams: 1,
+      new_apps: 4,
+      new_teams: 2,
+      new_users: 6,
+      pending_invites: 2,
+      total_users: 11,
+    },
+  ],
+  queues: [
+    {
       id: "app_waiting_review",
-      name: "Waiting source app",
+      kind: "apps_awaiting_review",
+      name: "Waiting app",
       team_id: "team_current",
-      verified_metadata: [],
+      total_count: 7,
+      updated_at: "2026-07-09T00:00:00.000Z",
     },
-  ],
-  apps_awaiting_review_count: aggregate(7),
-  apps_changes_requested: [
     {
-      draft_metadata: [
-        {
-          name: "Reviewed app",
-          updated_at: "2026-07-10T00:00:00.000Z",
-          verification_status: "changes_requested",
-        },
-      ],
       id: "app_changes_requested",
-      name: "Source app name",
+      kind: "apps_changes_requested",
+      name: "Reviewed app",
       team_id: "team_current",
-      verified_metadata: [
-        {
-          name: "Previously verified app",
-          verification_status: "verified",
-          verified_at: "2026-07-01T00:00:00.000Z",
-        },
-      ],
+      total_count: 8,
+      updated_at: "2026-07-10T00:00:00.000Z",
     },
-  ],
-  apps_changes_requested_count: aggregate(8),
-  apps_without_metadata: [
     {
-      created_at: "2026-07-01T00:00:00.000Z",
       id: "app_without_metadata",
+      kind: "apps_without_metadata",
       name: "Missing metadata",
       team_id: "team_current",
+      total_count: 9,
     },
-  ],
-  apps_without_metadata_count: aggregate(9),
-  deleted_apps: aggregate(2),
-  deleted_teams: aggregate(1),
-  new_apps: aggregate(4),
-  new_teams: aggregate(2),
-  new_users: aggregate(6),
-  sole_owner_memberships: [
     {
-      team: {
-        id: "team_sole_owner",
-        memberships_aggregate: aggregate(1),
-        name: "Sole owner team",
-      },
-      user: {
-        email: "owner@example.com",
-        id: "user_owner",
-        name: "Owner",
-      },
+      id: "team_without_owner",
+      kind: "teams_without_owner",
+      name: "No owner team",
+      total_count: 11,
+    },
+    {
+      id: "team_sole_owner",
+      kind: "sole_owner_teams",
+      name: "Sole owner team",
+      owner_email: "owner@example.com",
+      owner_id: "user_owner",
+      owner_name: "Owner",
+      total_count: 10,
+    },
+    {
+      email: "unassigned@example.com",
+      id: "user_without_team",
+      kind: "users_without_teams",
+      name: "Unassigned user",
+      total_count: 12,
     },
   ],
-  sole_owner_memberships_count: aggregate(10),
-  pending_invites: aggregate(2),
   recent_apps: [
     {
       created_at: "2026-07-10T00:00:00.000Z",
@@ -128,24 +113,6 @@ const createHomeResponse = () => ({
       name: "Recent user",
     },
   ],
-  teams_without_owner: [
-    {
-      created_at: "2026-07-09T00:00:00.000Z",
-      id: "team_without_owner",
-      name: "No owner team",
-    },
-  ],
-  teams_without_owner_count: aggregate(11),
-  total_users: aggregate(11),
-  users_without_teams: [
-    {
-      created_at: "2026-07-09T00:00:00.000Z",
-      email: "unassigned@example.com",
-      id: "user_without_team",
-      name: "Unassigned user",
-    },
-  ],
-  users_without_teams_count: aggregate(12),
 });
 
 beforeEach(() => {
@@ -153,34 +120,17 @@ beforeEach(() => {
 });
 
 describe("admin home fetch", () => {
-  it("uses the current draft metadata status and maps dashboard queues", async () => {
+  it("maps typed queue rows into the dashboard contract", async () => {
     mockFetchAdminHome.mockResolvedValue(createHomeResponse());
 
     const home = await fetchAdminHome();
 
-    expect(home.inventory).toEqual({
-      activeApiKeys: 3,
-      activeApps: 7,
-      activeTeams: 5,
-      deletedApps: 2,
-      deletedTeams: 1,
-      newApps: 4,
-      newTeams: 2,
-      newUsers: 6,
-      pendingInvites: 2,
-      totalUsers: 11,
-    });
+    expect(mockFetchAdminHome).toHaveBeenCalledWith({ recentLimit: 5 });
     expect(home.queues.appsAwaitingReview).toEqual([
       expect.objectContaining({ id: "app_waiting_review" }),
     ]);
-    expect(home.queues.appsChangesRequested).toEqual([
-      expect.objectContaining({ id: "app_changes_requested" }),
-    ]);
     expect(home.queues.soleOwnerTeams).toEqual([
       expect.objectContaining({ id: "team_sole_owner" }),
-    ]);
-    expect(home.queues.usersWithoutTeams).toEqual([
-      expect.objectContaining({ id: "user_without_team" }),
     ]);
     expect(home.queueCounts).toEqual({
       appsAwaitingReview: 7,
@@ -192,7 +142,50 @@ describe("admin home fetch", () => {
     });
   });
 
-  it("prioritizes the latest non-verified metadata over verified metadata", () => {
+  it("returns zero for an empty queue", async () => {
+    const response = createHomeResponse();
+    response.queues = response.queues.filter(
+      (queue) => queue.kind !== "apps_awaiting_review",
+    );
+    mockFetchAdminHome.mockResolvedValue(response);
+
+    const home = await fetchAdminHome();
+
+    expect(home.queueCounts.appsAwaitingReview).toBe(0);
+  });
+
+  it("coerces stringified bigint inventory counts before UI math", async () => {
+    const response = createHomeResponse();
+    response.inventory[0] = {
+      active_api_keys: "200" as unknown as number,
+      active_apps: "120510" as unknown as number,
+      active_teams: "120502" as unknown as number,
+      deleted_apps: "100" as unknown as number,
+      deleted_teams: "100" as unknown as number,
+      new_apps: "120500" as unknown as number,
+      new_teams: "120500" as unknown as number,
+      new_users: "120500" as unknown as number,
+      pending_invites: "300" as unknown as number,
+      total_users: "120506" as unknown as number,
+    };
+    response.queues[0] = {
+      ...response.queues[0],
+      total_count: "7" as unknown as number,
+    };
+    mockFetchAdminHome.mockResolvedValue(response);
+
+    const home = await fetchAdminHome();
+
+    expect(home.inventory.activeTeams + home.inventory.deletedTeams).toBe(
+      120602,
+    );
+    expect(home.inventory.activeApps + home.inventory.deletedApps).toBe(
+      120610,
+    );
+    expect(home.queueCounts.appsAwaitingReview).toBe(7);
+  });
+
+  it("prioritizes current draft metadata", () => {
     expect(
       getWorkflowStatus({
         draft_metadata: [{ verification_status: "changes_requested" }],

--- a/web/tests/unit/admin-users-fetch.test.ts
+++ b/web/tests/unit/admin-users-fetch.test.ts
@@ -1,21 +1,54 @@
+const getInternalDashboardGraphqlClient = jest.fn();
+const FetchAdminUserMemberships = jest.fn();
+const FetchAdminUsers = jest.fn();
+
 jest.mock("server-only", () => ({}));
 
 jest.mock("@/api/helpers/graphql", () => ({
-  getInternalDashboardGraphqlClient: jest.fn(),
+  getInternalDashboardGraphqlClient: () => getInternalDashboardGraphqlClient(),
 }));
 
 jest.mock(
   "@/scenes/Admin/users/graphql/server/fetch-admin-users.generated",
   () => ({
-    getSdk: jest.fn(),
+    getSdk: () => ({ FetchAdminUserMemberships, FetchAdminUsers }),
   }),
 );
 
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn() },
+}));
+
+import { DEFAULT_USER_COLUMN_VISIBILITY } from "@/components/AdminDashboard/Users/column-visibility";
+import { Order_By } from "@/graphql/graphql";
 import {
   createUsersOrderBy,
   createUsersWhere,
+  fetchAdminUsersPage,
 } from "@/scenes/Admin/users/server/fetch-users";
-import { Order_By } from "@/graphql/graphql";
+
+const createUsersResponse = () => ({
+  user: [
+    {
+      created_at: "2026-07-17T00:00:00.000Z",
+      email: "first@example.com",
+      id: "user_first",
+      name: "First",
+    },
+    {
+      created_at: "2026-07-16T00:00:00.000Z",
+      email: "second@example.com",
+      id: "user_second",
+      name: "Second",
+    },
+  ],
+  user_aggregate: { aggregate: { count: 2 } },
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getInternalDashboardGraphqlClient.mockResolvedValue({});
+});
 
 describe("admin users query mapping", () => {
   it("searches plain terms across name and email", () => {
@@ -48,5 +81,61 @@ describe("admin users query mapping", () => {
 
   it("returns no matches for an invalid date filter", () => {
     expect(createUsersWhere("created>=invalid")).toEqual({ id: { _in: [] } });
+  });
+});
+
+describe("fetchAdminUsersPage", () => {
+  it("batches visible team counts after selecting the users page", async () => {
+    FetchAdminUsers.mockResolvedValue(createUsersResponse());
+    FetchAdminUserMemberships.mockResolvedValue({
+      membership: [
+        { user_id: "user_first" },
+        { user_id: "user_first" },
+        { user_id: "user_second" },
+      ],
+    });
+
+    const result = await fetchAdminUsersPage({
+      columnVisibility: DEFAULT_USER_COLUMN_VISIBILITY,
+      limit: 300,
+      page: 1,
+      searchQuery: "",
+      sort: null,
+    });
+
+    expect(FetchAdminUsers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeCreatedAt: true,
+        includeEmail: true,
+        limit: 300,
+      }),
+    );
+    expect(FetchAdminUserMemberships).toHaveBeenCalledWith({
+      userIds: ["user_first", "user_second"],
+    });
+    expect(result.users).toEqual([
+      expect.objectContaining({ id: "user_first", teamsCount: 2 }),
+      expect.objectContaining({ id: "user_second", teamsCount: 1 }),
+    ]);
+  });
+
+  it("does not load memberships when the teams column is hidden", async () => {
+    FetchAdminUsers.mockResolvedValue(createUsersResponse());
+
+    const result = await fetchAdminUsersPage({
+      columnVisibility: {
+        ...DEFAULT_USER_COLUMN_VISIBILITY,
+        teamsCount: false,
+      },
+      limit: 300,
+      page: 1,
+      searchQuery: "",
+      sort: null,
+    });
+
+    expect(FetchAdminUserMemberships).not.toHaveBeenCalled();
+    expect(result.users[0]).toEqual(
+      expect.objectContaining({ teamsCount: undefined }),
+    );
   });
 });


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

This PR speeds up Admin Dashboard queries that were timing out / feeling slow on large data.

- Replace Admin Home inventory + “Needs attention” queues with Hasura Native Queries
  - Previous home query did a bunch of separate table aggregates / filtered lists
  - Native Queries run one SQL statement in Postgres and expose the result through Logical Models
  - `admin_dashboard_inventory` → counts for teams/apps/users + invites + API keys
  - `admin_dashboard_queues` → preview rows + `total_count` for each queue kind in one query
  - Recent apps/teams/users/metadata stay as normal GraphQL table queries
  - Coerce `bigint` counts with `Number(...)` because Hasura returns them as strings (`STRINGIFY_NUMERIC_TYPES`), otherwise UI does `"120502" + "100"` → `"120502100"`
- Add membership indexes used by those queue queries
- Fix Admin Users teams count: fetch memberships for page user IDs in a second query instead of `memberships_aggregate` per user
- Internal dashboard GraphQL client: no transport retries (these queries are expensive, fail fast) + better warn logs
- Add `web/app/admin/error.tsx` so a failed home load doesn’t break the whole admin shell

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.

---

<img width="2198" height="1349" alt="Screenshot 2026-07-17 at 16 17 09" src="https://github.com/user-attachments/assets/874588e4-66a8-4e49-ba0f-6777fd696ac6" />
