### PR TITLE
fix: Preserve sandbox environment in v4 verify responses

### DIFF
--- a/web/api/v4/verify/index.ts
+++ b/web/api/v4/verify/index.ts
@@ -142,9 +142,14 @@ export async function POST(
     const rpId = rpRegistration.rp_id;
     const appId = rpRegistration.app_id;
 
+    const verifierEnvironment =
+      parsedParams.environment === "sandbox"
+        ? "staging"
+        : parsedParams.environment;
+
     if (parsedParams.integrity_bundle) {
       const integrityResult = await verifyIntegrityBundle({
-        environment: parsedParams.environment,
+        environment: verifierEnvironment,
         integrityBundle: parsedParams.integrity_bundle,
         nonce: parsedParams.nonce!,
         protocolVersion: parsedParams.protocol_version as "3.0" | "4.0",

--- a/web/api/v4/verify/request-schema.ts
+++ b/web/api/v4/verify/request-schema.ts
@@ -185,13 +185,11 @@ export const schema = yup
     // We use this field to detect session proofs in custom validation
     session_id: yup.string().strict().optional(),
 
-    // Sandbox uses the staging verifier and storage partition.
+    // Sandbox is accepted as a distinct request environment and is
+    // normalized to staging only where verifier/storage environment is needed.
     environment: yup
       .string()
-      .transform((environment) =>
-        environment === "sandbox" ? "staging" : environment,
-      )
-      .oneOf(["production", "staging"])
+      .oneOf(["production", "staging", "sandbox"])
       .optional(),
 
     // Optional World App integrity attestation bundle. When present, it is
@@ -284,7 +282,7 @@ export interface UniquenessProofRequestV3 {
   nonce: string;
   action: string;
   action_description?: string;
-  environment?: "production" | "staging";
+  environment?: "production" | "staging" | "sandbox";
   integrity_bundle?: IntegrityBundle;
   responses: UniquenessProofResponseV3[];
 }
@@ -304,7 +302,7 @@ export interface UniquenessProofRequestV4 {
   nonce: string;
   action: string;
   action_description?: string;
-  environment?: "production" | "staging";
+  environment?: "production" | "staging" | "sandbox";
   integrity_bundle?: IntegrityBundle;
   responses: UniquenessProofResponseV4[];
 }
@@ -323,7 +321,7 @@ export interface SessionProofRequest {
   session_id: string;
   nonce: string;
   protocol_version: "4.0";
-  environment?: "production" | "staging";
+  environment?: "production" | "staging" | "sandbox";
   integrity_bundle?: IntegrityBundle;
   responses: SessionResponseItem[];
 }

--- a/web/api/v4/verify/session-proof/handler.ts
+++ b/web/api/v4/verify/session-proof/handler.ts
@@ -9,7 +9,7 @@ import { processSessionProof, SessionResult } from "./verify-util";
 type SessionProofSuccessResponse = {
   success: true;
   session_id: string;
-  environment: "production" | "staging";
+  environment: "production" | "staging" | "sandbox";
   results: SessionResult[];
   message: string;
 };
@@ -37,14 +37,17 @@ export async function handleSessionProofVerification(
     nonce: string;
     protocol_version: string;
     responses: SessionProofRequest["responses"];
-    environment?: "production" | "staging";
+    environment?: "production" | "staging" | "sandbox";
   },
 ): Promise<NextResponse<SessionProofResponse>> {
-  // Get verifier address based on requested environment (defaults to production)
+  // Get verifier address based on requested environment (defaults to production).
+  // Sandbox uses staging verifier but remains sandbox in the API response.
   const requestedEnvironment = parsedParams.environment ?? "production";
+  const verificationEnvironment =
+    requestedEnvironment === "sandbox" ? "staging" : requestedEnvironment;
 
   const verifierAddress =
-    requestedEnvironment === "staging"
+    verificationEnvironment === "staging"
       ? process.env.VERIFIER_CONTRACT_ADDRESS_STAGING
       : process.env.VERIFIER_CONTRACT_ADDRESS;
 
@@ -53,7 +56,7 @@ export async function handleSessionProofVerification(
       {
         success: false,
         code: "configuration_error",
-        detail: `Verifier contract address not configured for ${requestedEnvironment} environment.`,
+        detail: `Verifier contract address not configured for ${verificationEnvironment} environment.`,
       },
       { status: 400 },
     );

--- a/web/api/v4/verify/uniqueness-proof/handler.ts
+++ b/web/api/v4/verify/uniqueness-proof/handler.ts
@@ -66,12 +66,15 @@ export async function handleUniquenessProofVerification(
     nonce?: string;
     protocol_version: "3.0" | "4.0";
     responses: UniquenessProofResponseV3[] | UniquenessProofResponseV4[];
-    environment?: "production" | "staging";
+    environment?: "production" | "staging" | "sandbox";
   },
   req: NextRequest,
 ): Promise<NextResponse<UniquenessProofResponse | ErrorResponseBody>> {
-  // Resolve environment upfront: explicit request environment or default to "production"
-  const verificationEnvironment = parsedParams.environment ?? "production";
+  // Resolve sandbox to staging for verifier/storage while preserving the
+  // requested environment for API responses.
+  const requestedEnvironment = parsedParams.environment ?? "production";
+  const verificationEnvironment =
+    requestedEnvironment === "sandbox" ? "staging" : requestedEnvironment;
 
   // Fetch existing action filtered by environment
   let existingActionV4 = null;
@@ -229,7 +232,7 @@ export async function handleUniquenessProofVerification(
         rp_id: rpId,
         app_id: appId,
         action: parsedParams.action,
-        environment: actionV4.environment as string,
+        environment: requestedEnvironment,
         nullifier_reused: true,
         protocol_version: protocolVersion,
       },
@@ -242,7 +245,7 @@ export async function handleUniquenessProofVerification(
       action: parsedParams.action,
       metadata: {
         rp_id: rpId,
-        environment: actionV4.environment as string,
+        environment: requestedEnvironment,
         nullifier_reused: true,
         protocol_version: protocolVersion,
       },
@@ -254,7 +257,7 @@ export async function handleUniquenessProofVerification(
         action: actionV4.action,
         nullifier: normalizedNullifier,
         created_at: existingNullifier.created_at,
-        environment: actionV4.environment as string,
+        environment: requestedEnvironment,
         results: verificationResults,
         message: "Proof verified successfully (nullifier reuse)",
       },
@@ -289,7 +292,7 @@ export async function handleUniquenessProofVerification(
         rp_id: rpId,
         app_id: appId,
         action: parsedParams.action,
-        environment: actionV4.environment as string,
+        environment: requestedEnvironment,
         nullifier_reused: false,
         protocol_version: protocolVersion,
       },
@@ -302,7 +305,7 @@ export async function handleUniquenessProofVerification(
       action: parsedParams.action,
       metadata: {
         rp_id: rpId,
-        environment: actionV4.environment as string,
+        environment: requestedEnvironment,
         nullifier_reused: false,
         protocol_version: protocolVersion,
       },
@@ -314,7 +317,7 @@ export async function handleUniquenessProofVerification(
         action: actionV4.action,
         nullifier: normalizedNullifier,
         created_at: insertResult.insert_nullifier_v4_one.created_at,
-        environment: actionV4.environment as string,
+        environment: requestedEnvironment,
         results: verificationResults,
         message: "Proof verified successfully",
       },
@@ -332,7 +335,7 @@ export async function handleUniquenessProofVerification(
         action: parsedParams.action,
         metadata: {
           rp_id: rpId,
-          environment: actionV4.environment as string,
+          environment: requestedEnvironment,
           nullifier_reused: true,
           protocol_version: protocolVersion,
         },
@@ -343,7 +346,7 @@ export async function handleUniquenessProofVerification(
           success: true,
           action: actionV4.action,
           nullifier: normalizedNullifier,
-          environment: actionV4.environment as string,
+          environment: requestedEnvironment,
           results: verificationResults,
           message: "Proof verified successfully (nullifier reuse)",
         },

--- a/web/tests/api/v4/request-schema.test.ts
+++ b/web/tests/api/v4/request-schema.test.ts
@@ -28,7 +28,7 @@ describe("v4 verify request schema", () => {
     expect(parsed.responses[0]?.signal_hash).toBe("0x0");
   });
 
-  it('normalizes the "sandbox" environment to "staging"', async () => {
+  it('preserves the "sandbox" environment after schema validation', async () => {
     const parsed = await schema.validate({
       protocol_version: "4.0",
       nonce: "0x01",
@@ -45,7 +45,7 @@ describe("v4 verify request schema", () => {
       ],
     });
 
-    expect(parsed.environment).toBe("staging");
+    expect(parsed.environment).toBe("sandbox");
   });
 
   it("accepts optional top-level integrity_bundle", async () => {

--- a/web/tests/api/v4/verify.test.ts
+++ b/web/tests/api/v4/verify.test.ts
@@ -90,7 +90,7 @@ beforeEach(() => {
 
 // #region Integrity bundle environment
 describe("/api/v4/verify [integrity bundle]", () => {
-  it('treats the "sandbox" environment as "staging"', async () => {
+  it('normalizes "sandbox" only for integrity verification', async () => {
     const req = createRequest({
       protocol_version: "4.0",
       nonce: "1",
@@ -116,7 +116,7 @@ describe("/api/v4/verify [integrity bundle]", () => {
       expect.anything(),
       rpId,
       appId,
-      expect.objectContaining({ environment: "staging" }),
+      expect.objectContaining({ environment: "sandbox" }),
       req,
     );
     expect(mockHandleSessionProofVerification).not.toHaveBeenCalled();


### PR DESCRIPTION
### Motivation
- Schema-level transformation of `sandbox` → `staging` caused the API to mirror back `staging` even when callers explicitly requested `sandbox`, which is undesirable for API responses while still wanting staging verifier/storage behavior.

### Description
- `web/api/v4/verify/request-schema.ts`: accept `sandbox` as a valid top-level `environment` value instead of transforming it to `staging` during validation.
- `web/api/v4/verify/index.ts`: compute a `verifierEnvironment` that maps `sandbox` → `staging` and pass that to `verifyIntegrityBundle` so integrity verification uses staging behavior without mutating the parsed request environment.
- `web/api/v4/verify/uniqueness-proof/handler.ts`: introduce `requestedEnvironment` and `verificationEnvironment` (mapping `sandbox` → `staging`) and use `verificationEnvironment` for DB/verifier lookups while preserving `requestedEnvironment` in capture events and success responses.
- `web/api/v4/verify/session-proof/handler.ts`: apply the same pattern as uniqueness handler so session verification uses the staging verifier for `sandbox` but returns `sandbox` in the API response.

### Testing
- Ran unit tests `cd web && npx jest tests/api/v4/request-schema.test.ts tests/api/v4/verify.test.ts --runInBand` and both suites passed (2 suites, 6 tests total).
- Ran formatting check `cd web && pnpm format:check` and fixed formatting; final check passed.
- Ran type check `cd web && npx tsc --noEmit` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5b8fe37e7c8326b26480f0d999e3e4)