### PR TITLE
Optimize syntax highlighting bundle

### DIFF
--- a/web/components/CodeBlock/index.tsx
+++ b/web/components/CodeBlock/index.tsx
@@ -1,8 +1,11 @@
 import clsx from "clsx";
 import { ComponentProps, memo, useCallback } from "react";
-import SyntaxHighlighter from "react-syntax-highlighter";
+import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
+import javascript from "react-syntax-highlighter/dist/esm/languages/hljs/javascript";
 import { atomOneLight } from "react-syntax-highlighter/dist/esm/styles/hljs";
 import { PreTag } from "./PreTag";
+
+SyntaxHighlighter.registerLanguage("javascript", javascript);
 
 export const CodeBlock = memo(function CodeBlock(
   props: {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/CodeBlock/CodeDisplays/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/CodeBlock/CodeDisplays/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { Button } from "@/components/Button";
-import { CodeBlock } from "@/components/CodeBlock";
 import { DisclosureButton } from "@/components/DisclosureButton";
 import { DisclosurePanel } from "@/components/DisclosurePanel";
 import { CopyIcon } from "@/components/Icons/CopyIcon";
@@ -8,10 +7,16 @@ import { MinusIcon } from "@/components/Icons/MinusIcon";
 import { PlusIcon } from "@/components/Icons/PlusIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { Disclosure } from "@headlessui/react";
+import dynamic from "next/dynamic";
 import { useParams } from "next/navigation";
 import posthog from "posthog-js";
 import { useCallback } from "react";
 import { toast } from "react-toastify";
+
+const CodeBlock = dynamic(
+  () => import("@/components/CodeBlock").then((module) => module.CodeBlock),
+  { ssr: false },
+);
 
 type CodeDisplayComponentProps = {
   buttonText: string;
@@ -55,12 +60,14 @@ export const CodeDisplayComponent = (props: CodeDisplayComponentProps) => {
               isOpen={open}
             >
               <div className="grid w-full justify-items-end">
-                <CodeBlock
-                  code={panelText}
-                  language="javascript"
-                  theme={"neutral"}
-                  className="w-full text-xs text-grey-700"
-                />
+                {open && (
+                  <CodeBlock
+                    code={panelText}
+                    language="javascript"
+                    theme={"neutral"}
+                    className="w-full text-xs text-grey-700"
+                  />
+                )}
                 <Button
                   type="button"
                   onClick={copyAction}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/CodeBlock/CodeDisplays/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/ActionId/Settings/TryAction/CodeBlock/CodeDisplays/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { Button } from "@/components/Button";
-import { CodeBlock } from "@/components/CodeBlock";
 import { DisclosureButton } from "@/components/DisclosureButton";
 import { DisclosurePanel } from "@/components/DisclosurePanel";
 import { CopyIcon } from "@/components/Icons/CopyIcon";
@@ -8,10 +7,16 @@ import { MinusIcon } from "@/components/Icons/MinusIcon";
 import { PlusIcon } from "@/components/Icons/PlusIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { Disclosure } from "@headlessui/react";
+import dynamic from "next/dynamic";
 import { useParams } from "next/navigation";
 import posthog from "posthog-js";
 import { useCallback } from "react";
 import { toast } from "react-toastify";
+
+const CodeBlock = dynamic(
+  () => import("@/components/CodeBlock").then((module) => module.CodeBlock),
+  { ssr: false },
+);
 
 type CodeDisplayComponentProps = {
   buttonText: string;
@@ -55,12 +60,14 @@ export const CodeDisplayComponent = (props: CodeDisplayComponentProps) => {
               isOpen={open}
             >
               <div className="grid w-full justify-items-end">
-                <CodeBlock
-                  code={panelText}
-                  language="javascript"
-                  theme={"neutral"}
-                  className="w-full text-xs text-grey-700"
-                />
+                {open && (
+                  <CodeBlock
+                    code={panelText}
+                    language="javascript"
+                    theme={"neutral"}
+                    className="w-full text-xs text-grey-700"
+                  />
+                )}
                 <Button
                   type="button"
                   onClick={copyAction}


### PR DESCRIPTION
## Summary

- switch the shared syntax highlighter to the light build with only JavaScript registered
- lazy-load the code block in both portal implementations
- avoid requesting the highlighter until the disclosure is opened

## Why

The default import bundled every highlight.js language and added 885.5 KiB parsed / 288.1 KiB gzip to both action-settings routes.

## Impact

The replacement is shared async chunks totaling 44.6 KiB parsed / 15.1 KiB gzip. The highlighter is no longer part of initial route JavaScript.

## Validation

- `pnpm format:check`
- `npx tsc --noEmit`
- 121 unit/API suites, 804 tests
- `pnpm build`