### PR TITLE
Wait for WLD approval to mine before submitting RP registration

### DIFF
--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -133,6 +133,7 @@ actions:
     definition:
       kind: synchronous
       handler: "{{NEXT_API_URL}}/hasura/register-rp"
+      timeout: 60
       headers:
         - name: Authorization
           value_from_env: INTERNAL_ENDPOINTS_SECRET
@@ -143,6 +144,7 @@ actions:
     definition:
       kind: synchronous
       handler: "{{NEXT_API_URL}}/hasura/rp-retry"
+      timeout: 60
       headers:
         - name: Authorization
           value_from_env: INTERNAL_ENDPOINTS_SECRET

--- a/web/api/helpers/rp-transactions.ts
+++ b/web/api/helpers/rp-transactions.ts
@@ -14,7 +14,9 @@ import {
 import {
   getERC20Allowance,
   getRpNonceFromContract,
+  getUserOperationReceipt,
   sendUserOperation,
+  UserOperationReceipt,
 } from "@/api/helpers/temporal-rpc";
 import {
   ADDRESS_ZERO,
@@ -94,6 +96,88 @@ async function submitWldApprovalTransaction(
   return result.operationHash;
 }
 
+// 15s nominal wait fits the register_rp Hasura action budget (60s explicit
+// timeout) even when the production staging duplicate runs a second wait.
+// The deadline bounds sleeps and poll starts; a poll already in flight may
+// overshoot by up to the RPC timeout.
+const APPROVAL_MINE_TIMEOUT_MS = 15_000;
+const APPROVAL_POLL_INITIAL_DELAY_MS = 1_000;
+const APPROVAL_POLL_MAX_DELAY_MS = 5_000;
+
+/**
+ * Waits for the WLD approval UserOperation to mine by polling for its
+ * receipt. Transient RPC failures are tolerated until the deadline — the
+ * approval is already in flight, so aborting on a poll error would fail a
+ * registration that is about to become valid. If the receipt never surfaces
+ * (dropped/replaced op, receipt API lag), falls back to reading the
+ * allowance directly: the allowance, not the specific operation, is the
+ * precondition the registration is simulated against. Single-caller poll
+ * against the internal bundler RPC, so capped exponential backoff without
+ * jitter is sufficient.
+ */
+async function waitForWldApprovalMined(
+  config: RpRegistryConfig,
+  approvalHash: string,
+  timeoutMs: number,
+): Promise<void> {
+  const startedAt = Date.now();
+  const deadline = startedAt + timeoutMs;
+  let delayMs = APPROVAL_POLL_INITIAL_DELAY_MS;
+  let failedPolls = 0;
+
+  for (;;) {
+    let receipt: UserOperationReceipt | null = null;
+    try {
+      receipt = await getUserOperationReceipt(approvalHash);
+    } catch (error) {
+      failedPolls += 1;
+      logger.warn("WLD approval receipt poll failed", {
+        approvalHash,
+        failedPolls,
+        error,
+      });
+    }
+
+    if (receipt) {
+      if (!receipt.success) {
+        throw new Error(
+          `WLD approval UserOperation reverted on-chain (operationHash: ${approvalHash})`,
+        );
+      }
+      logger.info("WLD approval mined", {
+        approvalHash,
+        transactionHash: receipt.receipt.transactionHash,
+        waitMs: Date.now() - startedAt,
+        failedPolls,
+      });
+      return;
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) break;
+    await new Promise((res) => setTimeout(res, Math.min(delayMs, remainingMs)));
+    delayMs = Math.min(delayMs * 2, APPROVAL_POLL_MAX_DELAY_MS);
+  }
+
+  const allowance = await getERC20Allowance(
+    config.safeAddress,
+    config.credentialSchemaIssuerRegistryAddress,
+    WLD_TOKEN_ADDRESS,
+  );
+  if (allowance >= MaxUint256) {
+    logger.info("WLD approval receipt not found but allowance is granted", {
+      approvalHash,
+      waitMs: Date.now() - startedAt,
+      failedPolls,
+    });
+    return;
+  }
+
+  throw new Error(
+    `WLD approval receipt not found and allowance not granted after ${timeoutMs}ms (operationHash: ${approvalHash}, failedPolls: ${failedPolls})`,
+  );
+}
+
 /**
  * Builds, signs, and submits a registerRp transaction for a given config.
  * Returns the operation hash on success.
@@ -126,8 +210,15 @@ export async function submitRegisterRpTransaction(
       safeAddress: config.safeAddress,
       spender: config.credentialSchemaIssuerRegistryAddress,
     });
-    // give a couple of seconds for the tx to mine
-    await new Promise((res) => setTimeout(res, 2000));
+
+    // The registration UserOp is simulated against current chain state, where
+    // the registry pulls the WLD fee via transferFrom — so the approval must
+    // be mined before registration is submitted, not merely accepted.
+    await waitForWldApprovalMined(
+      config,
+      approvalHash,
+      APPROVAL_MINE_TIMEOUT_MS,
+    );
   }
 
   const innerCalldata = buildRegisterRpCalldata(

--- a/web/tests/api/helpers/rp-transactions.test.ts
+++ b/web/tests/api/helpers/rp-transactions.test.ts
@@ -1,0 +1,197 @@
+import { submitRegisterRpTransaction } from "@/api/helpers/rp-transactions";
+import type { RpRegistryConfig } from "@/api/helpers/rp-utils";
+import type { KMSClient } from "@aws-sdk/client-kms";
+import { MaxUint256 } from "ethers";
+
+// #region Mocks
+const getERC20Allowance = jest.fn();
+const getUserOperationReceipt = jest.fn();
+const sendUserOperation = jest.fn();
+jest.mock("@/api/helpers/temporal-rpc", () => ({
+  getERC20Allowance: (...args: unknown[]) => getERC20Allowance(...args),
+  getRpNonceFromContract: jest.fn(),
+  getUserOperationReceipt: (...args: unknown[]) =>
+    getUserOperationReceipt(...args),
+  sendUserOperation: (...args: unknown[]) => sendUserOperation(...args),
+}));
+
+const signEthDigestWithKms = jest.fn();
+jest.mock("@/api/helpers/kms-eth", () => ({
+  signEthDigestWithKms: (...args: unknown[]) => signEthDigestWithKms(...args),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+// #endregion
+
+// #region Test Data
+const CONFIG: RpRegistryConfig = {
+  safeOwnerKmsKeyId: "test-kms-key-id",
+  contractAddress: `0x${"aa".repeat(20)}`,
+  safeAddress: `0x${"bb".repeat(20)}`,
+  entryPointAddress: `0x${"cc".repeat(20)}`,
+  safe4337ModuleAddress: `0x${"dd".repeat(20)}`,
+  kmsRegion: "us-east-1",
+  domainSeparator: `0x${"11".repeat(32)}`,
+  updateRpTypehash: `0x${"22".repeat(32)}`,
+  credentialSchemaIssuerRegistryAddress: `0x${"ee".repeat(20)}`,
+};
+
+const PARAMS = {
+  rpId: 123456789n,
+  managerAddress: `0x${"12".repeat(20)}`,
+  signerAddress: `0x${"34".repeat(20)}`,
+  appName: "Test App",
+  kmsClient: {} as KMSClient,
+};
+
+const APPROVAL_HASH = `0x${"a1".repeat(32)}`;
+const REGISTRATION_HASH = `0x${"b2".repeat(32)}`;
+
+const minedReceipt = (success: boolean) => ({
+  entryPoint: CONFIG.entryPointAddress,
+  userOpHash: APPROVAL_HASH,
+  sender: CONFIG.safeAddress,
+  nonce: "0x1",
+  actualGasUsed: "0x1",
+  actualGasCost: "0x1",
+  success,
+  logs: [],
+  receipt: {
+    transactionHash: `0x${"c3".repeat(32)}`,
+    transactionIndex: "0x0",
+    blockHash: `0x${"d4".repeat(32)}`,
+  },
+});
+// #endregion
+
+beforeEach(() => {
+  // resetAllMocks (not clearAllMocks) so per-test mockResolvedValueOnce
+  // queues never leak across tests.
+  jest.resetAllMocks();
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date("2026-07-21T12:00:00Z"));
+  signEthDigestWithKms.mockResolvedValue({
+    serialized: `0x${"56".repeat(65)}`,
+  });
+  // First sendUserOperation call is the approval, second the registration.
+  sendUserOperation
+    .mockResolvedValueOnce({ operationHash: APPROVAL_HASH })
+    .mockResolvedValueOnce({ operationHash: REGISTRATION_HASH });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// #region Allowance already granted
+describe("submitRegisterRpTransaction [allowance already granted]", () => {
+  it("skips approval and submits registration directly", async () => {
+    getERC20Allowance.mockResolvedValue(MaxUint256);
+
+    const hash = await submitRegisterRpTransaction(CONFIG, PARAMS);
+
+    expect(hash).toBe(APPROVAL_HASH); // first mock result = only submission
+    expect(sendUserOperation).toHaveBeenCalledTimes(1);
+    expect(getUserOperationReceipt).not.toHaveBeenCalled();
+  });
+});
+// #endregion
+
+// #region Approval required
+describe("submitRegisterRpTransaction [approval required]", () => {
+  beforeEach(() => {
+    getERC20Allowance.mockResolvedValue(0n);
+  });
+
+  it("waits for the approval to mine before submitting registration", async () => {
+    getUserOperationReceipt.mockResolvedValue(minedReceipt(true));
+
+    const hash = await submitRegisterRpTransaction(CONFIG, PARAMS);
+
+    expect(hash).toBe(REGISTRATION_HASH);
+    expect(sendUserOperation).toHaveBeenCalledTimes(2);
+    expect(getUserOperationReceipt).toHaveBeenCalledWith(APPROVAL_HASH);
+    // Registration must not be submitted until after the receipt arrived.
+    expect(getUserOperationReceipt.mock.invocationCallOrder[0]).toBeLessThan(
+      sendUserOperation.mock.invocationCallOrder[1],
+    );
+  });
+
+  it("polls until the receipt appears, then proceeds", async () => {
+    getUserOperationReceipt
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(minedReceipt(true));
+
+    const promise = submitRegisterRpTransaction(CONFIG, PARAMS);
+    // Two null polls -> 1s + 2s backoff before the third (mined) poll.
+    await jest.advanceTimersByTimeAsync(1_000);
+    await jest.advanceTimersByTimeAsync(2_000);
+    const hash = await promise;
+
+    expect(hash).toBe(REGISTRATION_HASH);
+    expect(getUserOperationReceipt).toHaveBeenCalledTimes(3);
+    expect(sendUserOperation).toHaveBeenCalledTimes(2);
+  });
+
+  it("tolerates a transient receipt-poll error and proceeds once mined", async () => {
+    getUserOperationReceipt
+      .mockRejectedValueOnce(new Error("upstream 502"))
+      .mockResolvedValue(minedReceipt(true));
+
+    const promise = submitRegisterRpTransaction(CONFIG, PARAMS);
+    await jest.advanceTimersByTimeAsync(1_000);
+    const hash = await promise;
+
+    expect(hash).toBe(REGISTRATION_HASH);
+    expect(getUserOperationReceipt).toHaveBeenCalledTimes(2);
+    expect(sendUserOperation).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws and does not submit registration when the approval reverts", async () => {
+    getUserOperationReceipt.mockResolvedValue(minedReceipt(false));
+
+    await expect(submitRegisterRpTransaction(CONFIG, PARAMS)).rejects.toThrow(
+      /approval UserOperation reverted/,
+    );
+    expect(sendUserOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows the capped backoff schedule and falls back to the allowance when the receipt never surfaces", async () => {
+    getERC20Allowance
+      .mockReset()
+      .mockResolvedValueOnce(0n) // initial gate: approval required
+      .mockResolvedValueOnce(MaxUint256); // fallback: approval mined meanwhile
+    getUserOperationReceipt.mockResolvedValue(null);
+
+    const promise = submitRegisterRpTransaction(CONFIG, PARAMS);
+    // Poll at t=0, then sleeps of 1s, 2s, 4s, 5s (cap), 3s (clamped to the
+    // 15s deadline) with a poll after each — 6 polls total.
+    for (const step of [1_000, 2_000, 4_000, 5_000, 3_000]) {
+      await jest.advanceTimersByTimeAsync(step);
+    }
+    const hash = await promise;
+
+    expect(hash).toBe(REGISTRATION_HASH);
+    expect(getUserOperationReceipt).toHaveBeenCalledTimes(6);
+    expect(sendUserOperation).toHaveBeenCalledTimes(2);
+    expect(getERC20Allowance).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws and does not submit registration when the receipt never surfaces and the allowance stays ungranted", async () => {
+    getERC20Allowance.mockReset().mockResolvedValue(0n);
+    getUserOperationReceipt.mockResolvedValue(null);
+
+    const promise = submitRegisterRpTransaction(CONFIG, PARAMS);
+    const assertion = expect(promise).rejects.toThrow(
+      /allowance not granted after 15000ms/,
+    );
+    await jest.advanceTimersByTimeAsync(15_000);
+    await assertion;
+
+    expect(sendUserOperation).toHaveBeenCalledTimes(1);
+  });
+});
+// #endregion


### PR DESCRIPTION
## What changed

- Replaced the fixed 2-second sleep after submitting the WLD approval UserOperation with a receipt poll (`waitForWldApprovalMined`): 1s→5s capped exponential backoff, 15s deadline, final sleep clamped to the deadline.
- Transient receipt-poll RPC errors are logged at warn and tolerated until the deadline instead of aborting the registration.
- If the receipt never surfaces (dropped/replaced op, receipt API lag), the wait falls back to re-reading the WLD allowance — the allowance, not the specific operation, is the precondition the registration is simulated against.
- A mined-but-reverted approval (`success: false`) aborts before the registration is submitted.
- Added an explicit `timeout: 60` to the `register_rp` and `retry_rp` Hasura actions (previously Hasura's default 30s, which the worst case — primary + production staging-duplicate waits — could exceed).

## Why

First-use managed registration race, introduced in #1810: `eth_sendUserOperation` returns on bundler **acceptance**, not mining, so on a fresh Safe/spender pair the registration was submitted ~2s after the approval and simulated against pre-approval chain state. The bundler rejected it, `submitManagedRpRegistration` deleted the claimed `rp_registration` row (correct slot-release behavior), and the user landed back on "Set up World ID" with a spurious failure. A retry succeeded because the approval had mined meanwhile — which also means the bug is dormant in any environment once one approval mines, and re-arms whenever the registry contract or Safe is redeployed (allowance is keyed to the (owner, spender) pair). This is what hit staging: reproduced there, with the `WLD approval UserOp submitted` → `Failed to submit registration transaction` log pair ~2s apart as the signature.

## Reliability notes

- All waits are bounded: 15s nominal poll deadline (in-flight poll may overshoot by up to the 10s RPC timeout), inside the explicit 60s action budget even with the production staging-duplicate leg.
- Failure semantics are unchanged: on genuine failure the slot is still released and `submission_error` returned, so retries keep working.
- Observability: per-poll-failure warn logs and mined/fallback info logs carry `approvalHash`, `waitMs`, and `failedPolls`, distinguishing receipt-poll errors, deadline expiry, and on-chain reverts for triage.
- Rollback: revert the commit; no schema or data migration. The Hasura action timeout requires metadata apply on deploy.

## Validation

- New suite `web/tests/api/helpers/rp-transactions.test.ts` (7 tests): skip-when-approved, mined-before-registration ordering, poll-until-mined, transient poll error tolerated, reverted approval aborts, pinned backoff schedule (1s/2s/4s/5s cap/clamp) with allowance fallback, and deadline + ungranted allowance failure.
- Existing `rp-registration-flows` and `register-rp` suites: 38 tests, unchanged, passing (45 total).
- `npx tsc --noEmit`, `pnpm format:check` — clean.
- Adversarially reviewed by three independent passes (correctness/concurrency, reliability budgets, test quality); all confirmed findings addressed in this revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)