### PR TITLE
fix(config): Apollo 4 refetch -> straight query for showcase images on config page 

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/hook/use-image.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/hook/use-image.tsx
@@ -154,17 +154,8 @@ export const useImage = () => {
       );
     }
 
-    // Re-execute (not refetch): refetch throws if the lazy query has never
-    // run, and callers invoke uploadViaPresignedPost before any getImage.
-    await getUploadedImage({
-      variables: {
-        app_id: appId,
-        image_type: imageType,
-        content_type_ending: file.type.split("/")[1],
-        team_id: teamId,
-        locale: locale,
-      },
-    });
+    // No post-upload request needed: S3's 2xx above is the upload
+    // confirmation, and callers fetch the display URL via getImage themselves.
   };
 
   return {

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/hook/use-image.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/hook/use-image.tsx
@@ -14,9 +14,10 @@ export class ImageValidationError extends Error {
 }
 
 export const useImage = () => {
-  const [getUploadedImage, { refetch }] = useLazyQuery(
-    GetUploadedImageDocument,
-  );
+  // network-only: presigned URLs expire, so a cached result is never useful.
+  const [getUploadedImage] = useLazyQuery(GetUploadedImageDocument, {
+    fetchPolicy: "network-only",
+  });
 
   const getImage = async (
     fileType: string, // png, jpeg
@@ -153,12 +154,16 @@ export const useImage = () => {
       );
     }
 
-    await refetch({
-      app_id: appId,
-      image_type: imageType,
-      content_type_ending: file.type.split("/")[1],
-      team_id: teamId,
-      locale: locale,
+    // Re-execute (not refetch): refetch throws if the lazy query has never
+    // run, and callers invoke uploadViaPresignedPost before any getImage.
+    await getUploadedImage({
+      variables: {
+        app_id: appId,
+        image_type: imageType,
+        content_type_ending: file.type.split("/")[1],
+        team_id: teamId,
+        locale: locale,
+      },
     });
   };
 

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/hook/use-image.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/hook/use-image.tsx
@@ -207,17 +207,8 @@ export const useImage = () => {
       );
     }
 
-    // Re-execute (not refetch): refetch throws if the lazy query has never
-    // run, and callers invoke uploadViaPresignedPost before any getImage.
-    await getUploadedImage({
-      variables: {
-        app_id: appId,
-        image_type: imageType,
-        content_type_ending: file.type.split("/")[1],
-        team_id: teamId,
-        locale: locale,
-      },
-    });
+    // No post-upload request needed: S3's 2xx above is the upload
+    // confirmation, and callers fetch the display URL via getImage themselves.
   };
 
   return {

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/hook/use-image.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/hook/use-image.tsx
@@ -106,9 +106,10 @@ export const useCroppedImageUpload = (params: {
 };
 
 export const useImage = () => {
-  const [getUploadedImage, { refetch }] = useLazyQuery(
-    GetUploadedImageDocument,
-  );
+  // network-only: presigned URLs expire, so a cached result is never useful.
+  const [getUploadedImage] = useLazyQuery(GetUploadedImageDocument, {
+    fetchPolicy: "network-only",
+  });
 
   const getImage = async (
     fileType: string, // png, jpeg
@@ -206,12 +207,16 @@ export const useImage = () => {
       );
     }
 
-    await refetch({
-      app_id: appId,
-      image_type: imageType,
-      content_type_ending: file.type.split("/")[1],
-      team_id: teamId,
-      locale: locale,
+    // Re-execute (not refetch): refetch throws if the lazy query has never
+    // run, and callers invoke uploadViaPresignedPost before any getImage.
+    await getUploadedImage({
+      variables: {
+        app_id: appId,
+        image_type: imageType,
+        content_type_ending: file.type.split("/")[1],
+        team_id: teamId,
+        locale: locale,
+      },
     });
   };
 

--- a/web/tests/unit/use-image-upload.test.tsx
+++ b/web/tests/unit/use-image-upload.test.tsx
@@ -1,0 +1,125 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { renderHook } from "@testing-library/react";
+import { ReactNode } from "react";
+
+// #region Mocks
+jest.mock("posthog-js", () => ({
+  __esModule: true,
+  default: { capture: jest.fn() },
+}));
+
+jest.mock("react-toastify", () => ({
+  toast: Object.assign(jest.fn(), { error: jest.fn() }),
+}));
+
+// lib/utils transitively imports IDKit/ox, which needs TextEncoder (absent in
+// jsdom). The hook only uses tryParseJSON; mock it faithfully.
+jest.mock("@/lib/utils", () => ({
+  tryParseJSON: (input: string) => {
+    try {
+      return JSON.parse(input);
+    } catch {
+      return null;
+    }
+  },
+}));
+// #endregion
+
+import { UploadImageDocument } from "@/scenes/common/Teams/TeamId/Apps/AppId/Configuration/hook/graphql/client/upload-image.generated";
+import { useImage } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/hook/use-image";
+
+// #region Test Data
+const variables = {
+  app_id: "app_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+  image_type: "showcase_img_1",
+  content_type_ending: "png",
+  team_id: "team_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+  locale: "en",
+};
+
+// Deliberately the ONLY mock: the optimal upload flow makes exactly one
+// GraphQL request (the presigned-POST signing). Any reintroduced post-upload
+// request (the old refetch / trailing GetUploadedImage) finds no mock,
+// rejects, and fails this test.
+const mocks = [
+  {
+    request: { query: UploadImageDocument, variables },
+    result: {
+      data: {
+        upload_image: {
+          url: "https://s3.test/upload",
+          stringifiedFields: JSON.stringify({ key: "some-key" }),
+        },
+      },
+    },
+  },
+];
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <MockedProvider mocks={mocks}>{children}</MockedProvider>
+);
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // The presigned POST goes straight to S3; stub it as a success.
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue({ ok: true, text: async () => "" }) as never;
+});
+
+// #region upload flow
+describe("useImage.uploadViaPresignedPost", () => {
+  it("completes on a fresh hook instance with a single signing request", async () => {
+    // Regression 1: the flow used to end with refetch() on the never-executed
+    // GetUploadedImage lazy query — Apollo 4 throws "refetch cannot be called
+    // before executing the query", crashing every first upload.
+    // Regression 2: its replacement re-requested the download URL and threw
+    // away the result, so a failed redundant request reported upload failure
+    // AFTER S3 had accepted the file.
+    const { result } = renderHook(() => useImage(), { wrapper });
+
+    const file = new File(["binary"], "showcase.png", { type: "image/png" });
+
+    await expect(
+      result.current.uploadViaPresignedPost(
+        file,
+        variables.app_id,
+        variables.team_id,
+        variables.image_type,
+        variables.locale,
+      ),
+    ).resolves.not.toThrow();
+
+    // The S3 POST itself must have happened — it is the upload confirmation.
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://s3.test/upload",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("rejects when S3 refuses the upload", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      text: async () => "expired policy",
+    });
+
+    const { result } = renderHook(() => useImage(), { wrapper });
+    const file = new File(["binary"], "showcase.png", { type: "image/png" });
+
+    await expect(
+      result.current.uploadViaPresignedPost(
+        file,
+        variables.app_id,
+        variables.team_id,
+        variables.image_type,
+        variables.locale,
+      ),
+    ).rejects.toThrow("Failed to upload file: 403");
+  });
+});
+// #endregion


### PR DESCRIPTION
## What and Why
- replace refetch() with a call to the actual function because refetch() throws when a lazy query had never been executed yet. both callers in that page upload before calling get image, so the query its needed hasn't been executed

- remove extra getImage call after initial uploadImageVia.. cause it already checked with getImage within the method
- 