### PR TITLE
fix(config): image upload survives mid-autosave form remounts — keep wizard step, persist metadata, show success toast

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
@@ -155,8 +155,9 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
 
         if (isMountedRef.current) {
           onChange(newUrls);
-          onUploadSuccess?.();
         }
+        // Parent toast / bookkeeping — must not be skipped on remount mid-upload.
+        onUploadSuccess?.();
       } catch (error) {
         console.error("error uploading image:", error);
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
@@ -139,21 +139,24 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
           isLocalized ? locale : undefined,
         );
 
-        // check if component is still mounted/valid before updating
-        if (!isMountedRef.current) {
-          return;
-        }
-
+        // S3 has the file from here on — the remaining steps are bookkeeping
+        // and must run even if this instance unmounts mid-flight (the form
+        // provider is keyed on metadata id + view mode and can remount during
+        // autosave). Persistence is ownerless; only UI updates are gated.
         const extractedPath =
           extractImagePathWithExtensionFromActualUrl(imageUrl);
         const newUrls =
           maxImages === 1 ? [extractedPath] : [...value, extractedPath];
 
         await onAutosave(newUrls);
+        // Writes into the shared Apollo cache, so a remounted successor
+        // instance watching the same query re-renders with the new image.
         await onRefetchImages();
-        onChange(newUrls);
 
-        onUploadSuccess?.();
+        if (isMountedRef.current) {
+          onChange(newUrls);
+          onUploadSuccess?.();
+        }
       } catch (error) {
         console.error("error uploading image:", error);
 

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
@@ -139,8 +139,9 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
 
         if (isMountedRef.current) {
           onChange(newUrls);
-          onUploadSuccess?.();
         }
+        // Parent toast / bookkeeping — must not be skipped on remount mid-upload.
+        onUploadSuccess?.();
         return true;
       } catch (error) {
         console.error("error uploading image:", error);

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/AppStore/ImageForm/ImageUploadField.tsx
@@ -114,6 +114,11 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
           abortController.signal,
         );
 
+        // S3 has the file from here on — the remaining steps are bookkeeping
+        // and must run even if this component instance unmounts mid-flight
+        // (the form provider is keyed on metadata id + view mode and can
+        // remount during autosave). Persistence is ownerless; only UI
+        // updates below are gated on being mounted.
         const imageUrl = await getImage(
           fileTypeEnding,
           appId,
@@ -122,21 +127,20 @@ export const ImageUploadField = (props: ImageUploadFieldProps) => {
           isLocalized ? locale : undefined,
         );
 
-        // check if component is still mounted/valid before updating
-        if (!isMountedRef.current) {
-          return false;
-        }
-
         const extractedPath =
           extractImagePathWithExtensionFromActualUrl(imageUrl);
         const newUrls =
           maxImages === 1 ? [extractedPath] : [...value, extractedPath];
 
         await onAutosave(newUrls);
+        // Writes into the shared Apollo cache, so a remounted successor
+        // instance watching the same query re-renders with the new image.
         await onRefetchImages();
-        onChange(newUrls);
 
-        onUploadSuccess?.();
+        if (isMountedRef.current) {
+          onChange(newUrls);
+          onUploadSuccess?.();
+        }
         return true;
       } catch (error) {
         console.error("error uploading image:", error);

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/page.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/page.tsx
@@ -70,6 +70,8 @@ type ConfigurationContentProps = {
   app: FetchAppMetadataQuery["app"][0];
   appMetadata: FetchAppMetadataQuery["app"][0]["app_metadata"][0];
   teamName: string;
+  activeStep: AppStoreWizardStep;
+  setActiveStep: (step: AppStoreWizardStep) => void;
 };
 
 const stepActionClassName =
@@ -281,6 +283,8 @@ const ConfigurationContent = ({
   app,
   appMetadata,
   teamName,
+  activeStep,
+  setActiveStep,
 }: ConfigurationContentProps) => {
   const basicInfoRef = useRef<BasicInformationHandle>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -291,16 +295,16 @@ const ConfigurationContent = ({
       ? optimisticIsMiniApp
       : appMetadata.app_mode === "mini-app";
   const steps = useMemo(() => getAppStoreWizardSteps(isMiniApp), [isMiniApp]);
-  const [activeStep, setActiveStep] = useState<AppStoreWizardStep>(
-    AppStoreWizardStep.BASIC,
-  );
 
-  const handleStepChange = useCallback((step: AppStoreWizardStep) => {
-    setActiveStep(step);
-    requestAnimationFrame(() => {
-      scrollContainerRef.current?.scrollTo?.({ top: 0, behavior: "smooth" });
-    });
-  }, []);
+  const handleStepChange = useCallback(
+    (step: AppStoreWizardStep) => {
+      setActiveStep(step);
+      requestAnimationFrame(() => {
+        scrollContainerRef.current?.scrollTo?.({ top: 0, behavior: "smooth" });
+      });
+    },
+    [setActiveStep],
+  );
 
   // Seed the optimistic mode atom from the row before using it for later
   // in-place mode changes. Until this row is synced, derive the first render
@@ -456,6 +460,12 @@ export const AppProfilePage = ({ params }: AppProfilePageProps) => {
   const appId = (params?.appId || routeParams?.appId) as `app_${string}`;
   const teamId = (params?.teamId || routeParams?.teamId) as `team_${string}`;
   const [viewMode, setViewMode] = useAtom(viewModeAtom);
+  // Lives here — ABOVE the keyed AppStoreFormProvider — so a provider remount
+  // (metadata row change / view switch mid-autosave) can't yank the user back
+  // to the first wizard step.
+  const [activeStep, setActiveStep] = useState<AppStoreWizardStep>(
+    AppStoreWizardStep.BASIC,
+  );
 
   const {
     data,
@@ -587,6 +597,8 @@ export const AppProfilePage = ({ params }: AppProfilePageProps) => {
             app={app}
             appMetadata={appMetadata}
             teamName={teamName}
+            activeStep={activeStep}
+            setActiveStep={setActiveStep}
           />
         </SizingWrapper>
       </SaveStatusProvider>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/page.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/page.tsx
@@ -462,10 +462,15 @@ export const AppProfilePage = ({ params }: AppProfilePageProps) => {
   const [viewMode, setViewMode] = useAtom(viewModeAtom);
   // Lives here — ABOVE the keyed AppStoreFormProvider — so a provider remount
   // (metadata row change / view switch mid-autosave) can't yank the user back
-  // to the first wizard step.
+  // to the first wizard step. Reset only when the route app changes; do not
+  // key this on appMetadata.id or the lift would be pointless.
   const [activeStep, setActiveStep] = useState<AppStoreWizardStep>(
     AppStoreWizardStep.BASIC,
   );
+
+  useEffect(() => {
+    setActiveStep(AppStoreWizardStep.BASIC);
+  }, [appId]);
 
   const {
     data,


### PR DESCRIPTION
### Motivation
  Follow-up to #2125 → #2139. Fixing the Apollo 4 `refetch` crash let the image
  upload flow run further than it ever had, exposing a second latent bug: the
  AppStoreFormProvider` is keyed on `${appMetadata.id}-${viewMode}` (both
 portals), so the form can remount mid-upload when its own autosave/refetch
 changes that identity. `ImageUploadField` bailed on unmount *before*
persistence, so on staging an upload would: kick the user back to the first
wizard step, skip the metadata autosave + image refetch + success toast, and
leave the preview stale until a hard refresh — while S3 already had the file.

### Description
- `scenes/PortalV3/.../Configuration/page.tsx`: lift the wizard `activeStep`
  state out of `ConfigurationContent` into `AppProfilePage`, above the keyed
  provider boundary — a provider remount can no longer reset the user to the
  first step. (v3-only: v2 has no wizard.)
- `scenes/PortalV3/.../ImageForm/ImageUploadField.tsx` and the v2 copy
  (`scenes/Portal/...`): restructure `uploadAcceptedImage` so that once S3 has
  accepted the file, persistence (`onAutosave`, `onRefetchImages`) always runs
  — persistence is ownerless; only UI updates (`onChange`,
  `onUploadSuccess`) remain gated on the instance still being mounted. The
  refetch writes into the shared Apollo cache, so a remounted successor
  instance re-renders with the new image immediately, and the mutation's
  `onCompleted` success toast now fires reliably.
- v2 is included deliberately: it has the identical keyed provider
  (`page.tsx:105`) and identical bail, so the defect was reachable on the
  production path — same-defect-in-both-trees gets parity-fixed.

Known limitation (intentionally out of scope): these changes make the upload
flow *robust against* the remount rather than preventing it. Why the key
churns during a save is still undiagnosed — tracked separately; the fix there
is likely keying on `app_id + viewMode` instead of the metadata row id.

### Testing
- `npx jest tests/unit/use-image-upload.test.tsx tests/unit/pv3-config-redesign.test.tsx`
  — 18/18 pass (the upload suite pins the single-request flow and rejects on
  S3 refusal; any reintroduced post-upload request fails it by construction).
- `npx tsc --noEmit` clean, `pnpm format:check` clean.
- Manual repro on staging pending deploy: upload a showcase image → expect
  success toast, preview appears without refresh, wizard stays on the
  Store listing step.
  wizard step, skip the metadata autosave + image refetch + success toast, and
  leave the preview stale until a hard refresh — while S3 already had the file.

  ### Description
  - `scenes/PortalV3/.../Configuration/page.tsx`: lift the wizard `activeStep`
    state out of `ConfigurationContent` into `AppProfilePage`, above the keyed
    provider boundary — a provider remount can no longer reset the user to the
    first step. (v3-only: v2 has no wizard.)
  - `scenes/PortalV3/.../ImageForm/ImageUploadField.tsx` and the v2 copy
    (`scenes/Portal/...`): restructure `uploadAcceptedImage` so that once S3 has
    accepted the file, persistence (`onAutosave`, `onRefetchImages`) always runs
    — persistence is ownerless; only UI updates (`onChange`,
    `onUploadSuccess`) remain gated on the instance still being mounted. The
    refetch writes into the shared Apollo cache, so a remounted successor
    instance re-renders with the new image immediately, and the mutation's
    `onCompleted` success toast now fires reliably.
  - v2 is included deliberately: it has the identical keyed provider
    (`page.tsx:105`) and identical bail, so the defect was reachable on the
    production path — same-defect-in-both-trees gets parity-fixed.

  Known limitation (intentionally out of scope): these changes make the upload
  flow *robust against* the remount rather than preventing it. Why the key