### PR TITLE
fix(world-id): check on-chain signer before promoting RP to registered

### DIFF
--- a/web/api/helpers/rp-utils.ts
+++ b/web/api/helpers/rp-utils.ts
@@ -65,6 +65,38 @@ export function normalizeAddress(address: string): string {
   return `0x${address}`;
 }
 
+/**
+ * Whether an on-chain RP reading may be trusted as authoritative for the
+ * Portal's stored registration, judged by the signer.
+ *
+ * Returns true when there is no expected signer to compare against
+ * (self-managed mode — the developer owns the on-chain signer, so on-chain is
+ * authoritative by definition), or when the on-chain signer matches the
+ * Portal's expected `signer_address`.
+ *
+ * Returns false when a managed RP's on-chain signer does NOT match the expected
+ * signer. That happens (a) mid-signer-rotation, before the on-chain update
+ * settles, or (b) when a party other than the Portal won the permissionless
+ * on-chain `register()` for this rp_id — e.g. after a failed managed
+ * registration someone else registered the same rp_id with their own signer.
+ * In case (b), trusting the on-chain "registered"/"active" reading would
+ * promote the Portal row to `registered` and bind the app's verified branding
+ * to a foreign OPRF signer (impersonation), so callers must preserve the stored
+ * status instead of writing the on-chain state back.
+ */
+export function canTrustOnChainSigner(
+  onChainSigner: string,
+  expectedSigner: string | null | undefined,
+): boolean {
+  if (!expectedSigner) {
+    return true;
+  }
+  return (
+    normalizeAddress(onChainSigner).toLowerCase() ===
+    normalizeAddress(expectedSigner).toLowerCase()
+  );
+}
+
 // =============================================================================
 // Configuration
 // =============================================================================

--- a/web/api/v4/rp-status/[rp_id]/index.ts
+++ b/web/api/v4/rp-status/[rp_id]/index.ts
@@ -1,9 +1,9 @@
 import { errorResponse } from "@/api/helpers/errors";
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import {
+  canTrustOnChainSigner,
   isValidRpId,
   mapOnChainToDbStatus,
-  normalizeAddress,
   parseRpId,
   RpRegistrationStatus,
 } from "@/api/helpers/rp-utils";
@@ -113,6 +113,13 @@ export async function GET(
   // Fetch production on-chain state
   let productionStatus: string;
   let productionInitialized = false;
+  // Whether the on-chain production reading is authoritative for this row — see
+  // canTrustOnChainSigner. Mirrors the staging check below: a managed RP is only
+  // promoted to the on-chain status when the on-chain signer matches the
+  // Portal's expected signer, so a foreign on-chain register()/rotation can't
+  // flip the row to `registered` and bind the app's branding to a foreign
+  // OPRF signer.
+  let canTrustOnChainProduction = false;
   try {
     const onChainRp = await getRpFromContract(
       numericRpId,
@@ -121,10 +128,32 @@ export async function GET(
     productionInitialized = onChainRp.initialized;
 
     if (onChainRp.initialized) {
-      productionStatus = mapOnChainToDbStatus(
-        onChainRp.initialized,
-        onChainRp.active,
+      canTrustOnChainProduction = canTrustOnChainSigner(
+        onChainRp.signer,
+        dbRecord.signer_address,
       );
+
+      if (canTrustOnChainProduction) {
+        productionStatus = mapOnChainToDbStatus(
+          onChainRp.initialized,
+          onChainRp.active,
+        );
+      } else {
+        // On-chain signer differs from the Portal's expected signer. Preserve
+        // the DB status instead of promoting — for a managed RP this is either
+        // an in-flight signer rotation or a foreign takeover of the rp_id.
+        productionStatus = currentDbStatus;
+        logger.warn(
+          "On-chain RP signer does not match expected signer; preserving DB status",
+          {
+            rpId,
+            mode: dbRecord.mode,
+            dbStatus: currentDbStatus,
+            expectedSigner: dbRecord.signer_address,
+            onChainSigner: onChainRp.signer,
+          },
+        );
+      }
     } else {
       // Not initialized on-chain — use DB status (tracks production)
       productionStatus = currentDbStatus;
@@ -147,12 +176,9 @@ export async function GET(
   let stagingStatus: string | null = null;
   let stagingInitialized = false;
   let stagingRpcSucceeded = false;
-  // Whether to treat on-chain as authoritative for staging. True when we
-  // have no DB signer to compare (self-managed mode), or when the on-chain
-  // signer matches the DB signer (rotation has settled). False during a
-  // rotation in flight, after a failed rotation, or while a retry is
-  // pending — in those cases the on-chain "registered" reading is
-  // misleading and we must preserve the DB staging_status.
+  // Whether to treat the on-chain staging reading as authoritative — see
+  // canTrustOnChainSigner. Preserves the DB staging_status during/after a
+  // signer rotation or a foreign takeover.
   let canTrustOnChainStaging = false;
   if (stagingContractAddress) {
     try {
@@ -164,11 +190,10 @@ export async function GET(
       stagingInitialized = stagingOnChainRp.initialized;
 
       if (stagingOnChainRp.initialized) {
-        const expectedSigner = dbRecord.signer_address;
-        canTrustOnChainStaging =
-          !expectedSigner ||
-          normalizeAddress(stagingOnChainRp.signer).toLowerCase() ===
-            normalizeAddress(expectedSigner).toLowerCase();
+        canTrustOnChainStaging = canTrustOnChainSigner(
+          stagingOnChainRp.signer,
+          dbRecord.signer_address,
+        );
 
         const onChainMappedStatus = mapOnChainToDbStatus(
           stagingOnChainRp.initialized,
@@ -194,10 +219,13 @@ export async function GET(
   const isPastGracePeriod = ageMs > PENDING_TIMEOUT_MS;
 
   // Sync DB status based on production contract only (never for deleted apps —
-  // see isAppDeleted above).
+  // see isAppDeleted above). Only when the on-chain reading is trusted (signer
+  // matches, or self-managed with no expected signer) — otherwise a foreign
+  // on-chain register()/rotation would clobber the row into `registered`.
   if (
     !isAppDeleted &&
     productionInitialized &&
+    canTrustOnChainProduction &&
     productionStatus !== currentDbStatus
   ) {
     try {

--- a/web/api/v4/rp-status/[rp_id]/index.ts
+++ b/web/api/v4/rp-status/[rp_id]/index.ts
@@ -217,6 +217,11 @@ export async function GET(
 
   const ageMs = Date.now() - new Date(dbRecord.created_at).getTime();
   const isPastGracePeriod = ageMs > PENDING_TIMEOUT_MS;
+  // updated_at-based grace, for cases where a fresh retry or an in-flight signer
+  // rotation must reset the clock (both bump updated_at): the staging timeout and
+  // the untrusted-initialized production timeout below.
+  const isPastGracePeriodSinceUpdate =
+    Date.now() - new Date(dbRecord.updated_at).getTime() > PENDING_TIMEOUT_MS;
 
   // Sync DB status based on production contract only (never for deleted apps —
   // see isAppDeleted above). Only when the on-chain reading is trusted (signer
@@ -304,19 +309,56 @@ export async function GET(
     }
   }
 
+  // Timeout: a managed RP that is initialized on-chain but by a signer the
+  // Portal doesn't recognize can never become a trusted `registered` — either a
+  // foreign party won the permissionless on-chain register() for this rp_id, or
+  // a signer rotation never settled. The `!productionInitialized` guard above
+  // can't catch this (it IS initialized), so without this the row is wedged in
+  // `pending` forever, polling endlessly and never exposing the retry path. Fail
+  // it once past grace. Use the updated_at clock so an in-flight rotation — which
+  // bumps updated_at and settles within seconds — is never prematurely failed.
+  if (
+    !isAppDeleted &&
+    productionInitialized &&
+    !canTrustOnChainProduction &&
+    currentDbStatus === RpRegistrationStatus.Pending &&
+    isPastGracePeriodSinceUpdate &&
+    dbRecord.mode === "managed"
+  ) {
+    logger.warn(
+      "RP untrusted-initialized past grace — transitioning to failed",
+      {
+        rpId,
+        updatedAt: dbRecord.updated_at,
+        operation_hash: dbRecord.operation_hash ?? "null",
+      },
+    );
+
+    try {
+      await getUpdateRpStatusSdk(client).UpdateRpStatus({
+        rp_id: rpId,
+        status: RpRegistrationStatus.Failed,
+      });
+      productionStatus = RpRegistrationStatus.Failed;
+    } catch (error) {
+      logger.error("Failed to update untrusted-initialized RP status in DB", {
+        rpId,
+        error,
+      });
+    }
+  }
+
   // Staging timeout: if staging is not initialized after the grace period,
   // transition to failed so the user gets a retry button and polling stops.
   // Only apply when the RPC call succeeded — a transient RPC failure should
   // not permanently mark a healthy staging registration as failed.
-  // Use updated_at (not created_at) so a fresh staging retry resets the clock.
-  const stagingAgeMs = Date.now() - new Date(dbRecord.updated_at).getTime();
-  const isStagingPastGracePeriod = stagingAgeMs > PENDING_TIMEOUT_MS;
+  // Uses the updated_at clock so a fresh staging retry resets the grace period.
   if (
     !isAppDeleted &&
     stagingContractAddress &&
     stagingRpcSucceeded &&
     !stagingInitialized &&
-    isStagingPastGracePeriod &&
+    isPastGracePeriodSinceUpdate &&
     dbRecord.mode === "managed"
   ) {
     stagingStatus = RpRegistrationStatus.Failed;

--- a/web/api/v4/rp-status/[rp_id]/index.ts
+++ b/web/api/v4/rp-status/[rp_id]/index.ts
@@ -8,6 +8,7 @@ import {
   RpRegistrationStatus,
 } from "@/api/helpers/rp-utils";
 import { getRpFromContract } from "@/api/helpers/temporal-rpc";
+import { USER_OP_MAX_VALIDITY_MS } from "@/api/helpers/user-operation";
 import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
 import { getSdk as getGetRpRegistrationSdk } from "./graphql/get-rp-registration.generated";
@@ -217,11 +218,18 @@ export async function GET(
 
   const ageMs = Date.now() - new Date(dbRecord.created_at).getTime();
   const isPastGracePeriod = ageMs > PENDING_TIMEOUT_MS;
-  // updated_at-based grace, for cases where a fresh retry or an in-flight signer
-  // rotation must reset the clock (both bump updated_at): the staging timeout and
-  // the untrusted-initialized production timeout below.
-  const isPastGracePeriodSinceUpdate =
-    Date.now() - new Date(dbRecord.updated_at).getTime() > PENDING_TIMEOUT_MS;
+  // updated_at-based grace windows. updated_at is bumped by a fresh retry or an
+  // in-flight signer rotation, so both restart these clocks.
+  const updatedAgeMs = Date.now() - new Date(dbRecord.updated_at).getTime();
+  //  - staging timeout: same short grace as production.
+  const isPastGracePeriodSinceUpdate = updatedAgeMs > PENDING_TIMEOUT_MS;
+  //  - untrusted-initialized production timeout: a managed registration/rotation
+  //    UserOp stays includable on-chain for USER_OP_MAX_VALIDITY_MS, so an
+  //    unsettled op is only provably dead once that window plus the settlement
+  //    margin has elapsed. Failing sooner would race a rotation that can still
+  //    land, then cache `failed` for an hour over a trusted `registered`.
+  const isPastUserOpValidityWindow =
+    updatedAgeMs > USER_OP_MAX_VALIDITY_MS + PENDING_TIMEOUT_MS;
 
   // Sync DB status based on production contract only (never for deleted apps —
   // see isAppDeleted above). Only when the on-chain reading is trusted (signer
@@ -314,15 +322,16 @@ export async function GET(
   // foreign party won the permissionless on-chain register() for this rp_id, or
   // a signer rotation never settled. The `!productionInitialized` guard above
   // can't catch this (it IS initialized), so without this the row is wedged in
-  // `pending` forever, polling endlessly and never exposing the retry path. Fail
-  // it once past grace. Use the updated_at clock so an in-flight rotation — which
-  // bumps updated_at and settles within seconds — is never prematurely failed.
+  // `pending` forever, polling endlessly and never exposing the retry path. Only
+  // fail it once the UserOp validity window has elapsed: before that an in-flight
+  // signer rotation could still land, and failing early would cache `failed` for
+  // an hour over what then becomes a trusted `registered`.
   if (
     !isAppDeleted &&
     productionInitialized &&
     !canTrustOnChainProduction &&
     currentDbStatus === RpRegistrationStatus.Pending &&
-    isPastGracePeriodSinceUpdate &&
+    isPastUserOpValidityWindow &&
     dbRecord.mode === "managed"
   ) {
     logger.warn(

--- a/web/tests/api/v4/rp-status.test.ts
+++ b/web/tests/api/v4/rp-status.test.ts
@@ -227,6 +227,85 @@ describe("/api/v4/rp-status [pending timeout]", () => {
 });
 // #endregion
 
+// #region Production signer verification (rp_id takeover protection)
+describe("/api/v4/rp-status [production signer verification]", () => {
+  it("does not promote a managed RP to registered when the on-chain signer is foreign", async () => {
+    // The security case: a managed registration failed, leaving the rp_id row
+    // in `failed` while the RP is unregistered on-chain. An attacker then wins
+    // the permissionless on-chain register() for the same rp_id with their OWN
+    // signer. rp-status must NOT adopt that on-chain "registered" reading — that
+    // would flip the row to `registered` and let proof-context serve the app's
+    // verified branding bound to the attacker's OPRF signer. (Same guard also
+    // keeps an in-flight signer rotation from prematurely reading as registered.)
+    GetRpRegistration.mockResolvedValue({
+      rp_registration_by_pk: makeDbRecord({
+        status: "failed",
+        mode: "managed",
+        signer_address: "0xExpectedSigner",
+        created_at: new Date().toISOString(),
+      }),
+    });
+
+    getRpFromContractMock.mockImplementation(
+      (_rpId: unknown, contractAddress: string) => {
+        if (contractAddress === productionContract) {
+          // Attacker registered on-chain with a different signer.
+          return {
+            initialized: true,
+            active: true,
+            signer: "0xAttackerSigner",
+          };
+        }
+        return { initialized: false, active: false };
+      },
+    );
+
+    const res = await GET(createRequest(), ctx);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    // Status stays `failed`; the untrusted on-chain reading is not adopted...
+    expect(body.production_status).toBe("failed");
+    // ...and never written back to the DB.
+    expect(UpdateRpStatus).not.toHaveBeenCalled();
+  });
+
+  it("promotes a self-managed RP to registered for any on-chain signer (no expected signer to check)", async () => {
+    // Self-managed RPs have no Portal-stored signer to compare against — the
+    // developer owns the on-chain signer — so the on-chain reading stays
+    // authoritative and a completed on-chain registration flips it to registered.
+    GetRpRegistration.mockResolvedValue({
+      rp_registration_by_pk: makeDbRecord({
+        status: "pending",
+        mode: "self_managed",
+        signer_address: null,
+        created_at: new Date().toISOString(),
+      }),
+    });
+
+    getRpFromContractMock.mockResolvedValue({
+      initialized: true,
+      active: true,
+      signer: "0xDeveloperOwnedSigner",
+    });
+
+    UpdateRpStatus.mockResolvedValue({
+      update_rp_registration_by_pk: { rp_id: rpId },
+    });
+
+    const res = await GET(createRequest(), ctx);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.production_status).toBe("registered");
+    expect(UpdateRpStatus).toHaveBeenCalledWith({
+      rp_id: rpId,
+      status: RpRegistrationStatus.Registered,
+    });
+  });
+});
+// #endregion
+
 // #region Staging status is derived from on-chain, not DB
 describe("/api/v4/rp-status [staging timeout]", () => {
   it("reports staging as pending when production initialized first but within grace period", async () => {
@@ -241,7 +320,7 @@ describe("/api/v4/rp-status [staging timeout]", () => {
     getRpFromContractMock.mockImplementation(
       (_rpId: unknown, contractAddress: string) => {
         if (contractAddress === productionContract) {
-          return { initialized: true, active: true };
+          return { initialized: true, active: true, signer: "0x1234" };
         }
         return { initialized: false, active: false };
       },
@@ -269,7 +348,7 @@ describe("/api/v4/rp-status [staging timeout]", () => {
     getRpFromContractMock.mockImplementation(
       (_rpId: unknown, contractAddress: string) => {
         if (contractAddress === productionContract) {
-          return { initialized: true, active: true };
+          return { initialized: true, active: true, signer: "0x1234" };
         }
         return { initialized: false, active: false };
       },
@@ -305,7 +384,7 @@ describe("/api/v4/rp-status [staging DB sync]", () => {
     getRpFromContractMock.mockImplementation(
       (_rpId: unknown, contractAddress: string) => {
         if (contractAddress === productionContract) {
-          return { initialized: true, active: true };
+          return { initialized: true, active: true, signer: "0x1234" };
         }
         return { initialized: true, active: true, signer: "0x1234" };
       },
@@ -366,7 +445,7 @@ describe("/api/v4/rp-status [staging DB sync]", () => {
     getRpFromContractMock.mockImplementation(
       (_rpId: unknown, contractAddress: string) => {
         if (contractAddress === productionContract) {
-          return { initialized: true, active: true };
+          return { initialized: true, active: true, signer: "0x1234" };
         }
         return { initialized: true, active: true, signer: "0xoldSigner" };
       },
@@ -425,7 +504,7 @@ describe("/api/v4/rp-status [staging DB sync]", () => {
     getRpFromContractMock.mockImplementation(
       (_rpId: unknown, contractAddress: string) => {
         if (contractAddress === productionContract) {
-          return { initialized: true, active: true };
+          return { initialized: true, active: true, signer: "0x1234" };
         }
         return { initialized: true, active: true, signer: "0xoldSigner" };
       },
@@ -453,7 +532,7 @@ describe("/api/v4/rp-status [staging DB sync]", () => {
     getRpFromContractMock.mockImplementation(
       (_rpId: unknown, contractAddress: string) => {
         if (contractAddress === productionContract) {
-          return { initialized: true, active: true };
+          return { initialized: true, active: true, signer: "0x1234" };
         }
         return { initialized: false, active: false };
       },
@@ -482,7 +561,7 @@ describe("/api/v4/rp-status [staging DB sync]", () => {
     getRpFromContractMock.mockImplementation(
       (_rpId: unknown, contractAddress: string) => {
         if (contractAddress === productionContract) {
-          return { initialized: true, active: true };
+          return { initialized: true, active: true, signer: "0x1234" };
         }
         // Staging RPC throws — transient error
         throw new Error("RPC timeout");
@@ -514,7 +593,7 @@ describe("/api/v4/rp-status [staging DB sync]", () => {
     getRpFromContractMock.mockImplementation(
       (_rpId: unknown, contractAddress: string) => {
         if (contractAddress === productionContract) {
-          return { initialized: true, active: true };
+          return { initialized: true, active: true, signer: "0x1234" };
         }
         // Staging not yet initialized (retry tx still in flight)
         return { initialized: false, active: false };

--- a/web/tests/api/v4/rp-status.test.ts
+++ b/web/tests/api/v4/rp-status.test.ts
@@ -303,6 +303,85 @@ describe("/api/v4/rp-status [production signer verification]", () => {
       status: RpRegistrationStatus.Registered,
     });
   });
+
+  it("times out a managed RP wedged pending by a foreign on-chain signer once past grace", async () => {
+    // Foreign takeover of the rp_id: the row is still `pending` (the Portal's
+    // registration never completed) but on-chain it's initialized+active under a
+    // signer we don't recognize. It can never become a trusted `registered`, so
+    // past the grace period it must flip to `failed` — otherwise the dashboard
+    // polls forever with no retry path. updated_at is old (no rotation in flight).
+    const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    GetRpRegistration.mockResolvedValue({
+      rp_registration_by_pk: makeDbRecord({
+        status: "pending",
+        mode: "managed",
+        signer_address: "0xExpectedSigner",
+        created_at: tenMinutesAgo,
+        updated_at: tenMinutesAgo,
+      }),
+    });
+
+    getRpFromContractMock.mockImplementation(
+      (_rpId: unknown, contractAddress: string) => {
+        if (contractAddress === productionContract) {
+          return {
+            initialized: true,
+            active: true,
+            signer: "0xAttackerSigner",
+          };
+        }
+        return { initialized: false, active: false };
+      },
+    );
+
+    UpdateRpStatus.mockResolvedValue({
+      update_rp_registration_by_pk: { rp_id: rpId },
+    });
+
+    const res = await GET(createRequest(), ctx);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.production_status).toBe("failed");
+    expect(UpdateRpStatus).toHaveBeenCalledWith({
+      rp_id: rpId,
+      status: RpRegistrationStatus.Failed,
+    });
+  });
+
+  it("does not time out a signer rotation in flight (recent updated_at) despite the mismatch", async () => {
+    // Rotation just submitted: status=pending, DB signer already the NEW key,
+    // on-chain still the OLD key (tx not yet mined) → signer mismatch. The row
+    // was created long ago but updated_at is recent, so it must stay `pending`
+    // and resolve to `registered` once the tx lands — not be prematurely failed.
+    const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const oneMinuteAgo = new Date(Date.now() - 1 * 60 * 1000).toISOString();
+    GetRpRegistration.mockResolvedValue({
+      rp_registration_by_pk: makeDbRecord({
+        status: "pending",
+        mode: "managed",
+        signer_address: "0xNewSigner",
+        created_at: tenMinutesAgo,
+        updated_at: oneMinuteAgo,
+      }),
+    });
+
+    getRpFromContractMock.mockImplementation(
+      (_rpId: unknown, contractAddress: string) => {
+        if (contractAddress === productionContract) {
+          return { initialized: true, active: true, signer: "0xOldSigner" };
+        }
+        return { initialized: false, active: false };
+      },
+    );
+
+    const res = await GET(createRequest(), ctx);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.production_status).toBe("pending");
+    expect(UpdateRpStatus).not.toHaveBeenCalled();
+  });
 });
 // #endregion
 

--- a/web/tests/api/v4/rp-status.test.ts
+++ b/web/tests/api/v4/rp-status.test.ts
@@ -304,20 +304,21 @@ describe("/api/v4/rp-status [production signer verification]", () => {
     });
   });
 
-  it("times out a managed RP wedged pending by a foreign on-chain signer once past grace", async () => {
+  it("times out a managed RP wedged pending by a foreign on-chain signer once the UserOp window elapses", async () => {
     // Foreign takeover of the rp_id: the row is still `pending` (the Portal's
     // registration never completed) but on-chain it's initialized+active under a
-    // signer we don't recognize. It can never become a trusted `registered`, so
-    // past the grace period it must flip to `failed` — otherwise the dashboard
-    // polls forever with no retry path. updated_at is old (no rotation in flight).
-    const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    // signer we don't recognize. It can never become a trusted `registered`, and
+    // enough time has passed since the last write (> UserOp validity + margin)
+    // that any in-flight op is provably dead, so it must flip to `failed` —
+    // otherwise the dashboard polls forever with no retry path.
+    const fortyMinutesAgo = new Date(Date.now() - 40 * 60 * 1000).toISOString();
     GetRpRegistration.mockResolvedValue({
       rp_registration_by_pk: makeDbRecord({
         status: "pending",
         mode: "managed",
         signer_address: "0xExpectedSigner",
-        created_at: tenMinutesAgo,
-        updated_at: tenMinutesAgo,
+        created_at: fortyMinutesAgo,
+        updated_at: fortyMinutesAgo,
       }),
     });
 
@@ -349,20 +350,21 @@ describe("/api/v4/rp-status [production signer verification]", () => {
     });
   });
 
-  it("does not time out a signer rotation in flight (recent updated_at) despite the mismatch", async () => {
-    // Rotation just submitted: status=pending, DB signer already the NEW key,
-    // on-chain still the OLD key (tx not yet mined) → signer mismatch. The row
-    // was created long ago but updated_at is recent, so it must stay `pending`
-    // and resolve to `registered` once the tx lands — not be prematurely failed.
+  it("does not fail a signer rotation still within its UserOp validity window", async () => {
+    // Rotation submitted ~10 min ago: status=pending, DB signer already the NEW
+    // key, on-chain still the OLD key (op not yet mined) → signer mismatch. This
+    // is past the short 5-min grace but well within the 30-min UserOp validity
+    // window, so the op can still land — the row must stay `pending`, NOT be
+    // failed (which would then be cached for an hour over a trusted registered).
+    const fortyMinutesAgo = new Date(Date.now() - 40 * 60 * 1000).toISOString();
     const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
-    const oneMinuteAgo = new Date(Date.now() - 1 * 60 * 1000).toISOString();
     GetRpRegistration.mockResolvedValue({
       rp_registration_by_pk: makeDbRecord({
         status: "pending",
         mode: "managed",
         signer_address: "0xNewSigner",
-        created_at: tenMinutesAgo,
-        updated_at: oneMinuteAgo,
+        created_at: fortyMinutesAgo,
+        updated_at: tenMinutesAgo,
       }),
     });
 


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Fixes H1 #3869823. The v4 `rp-status` production reconciliation path promoted a managed RP to `registered` from on-chain `initialized && active` alone, without comparing the on-chain signer to the Portal's stored `signer_address` — a check the staging path in the same file already performed — so after a failed managed registration, whoever won the permissionless on-chain `register()` for that `rp_id` with their own signer could flip the row to `registered` and make `proof-context` serve the legitimate app's verified branding bound to an attacker-controlled OPRF signer (impersonation). This PR extracts the signer-trust logic into a shared `canTrustOnChainSigner` helper used by both the production and staging paths (so they can't silently diverge again), preserves the DB status and logs a warning on mismatch, and gates the DB writeback on the trust flag. Existing `rp-status` tests were updated to include the on-chain `signer` the real RPC always returns, and two tests were added: one asserting a foreign on-chain signer is not promoted (the takeover case), and one confirming self-managed RPs (no expected signer) still promote.

Note: this prevents future poisoning but does not auto-heal a row already at `registered` from a prior exploit (mismatch preserves the stored status, matching the staging path); the new warning log surfaces any such mismatches for follow-up.

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
