### PR TITLE
fix(portal): refetch app selector with matching variables after app delete

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Danger/page/DeleteModal/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Danger/page/DeleteModal/index.tsx
@@ -39,7 +39,9 @@ export const DeleteModal = (props: DeleteModalProps) => {
   const { openDeleteModal, setOpenDeleteModal, appName, appId, teamId } = props;
   const [deletingApp, setDeletingApp] = useState(false);
   const router = useRouter();
-  const { refetch: refetchApps } = useRefetchQueries(FetchAppsDocument);
+  const { refetch: refetchApps } = useRefetchQueries(FetchAppsDocument, {
+    teamId,
+  });
   const schema = createSchema(appName);
 
   const handleDeleteApp = async () => {

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/DeleteModal/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/DeleteModal/index.tsx
@@ -39,7 +39,9 @@ export const DeleteModal = (props: DeleteModalProps) => {
   const { openDeleteModal, setOpenDeleteModal, appName, appId, teamId } = props;
   const [deletingApp, setDeletingApp] = useState(false);
   const router = useRouter();
-  const { refetch: refetchApps } = useRefetchQueries(FetchAppsDocument);
+  const { refetch: refetchApps } = useRefetchQueries(FetchAppsDocument, {
+    teamId,
+  });
   const schema = createSchema(appName);
 
   const handleDeleteApp = async () => {


### PR DESCRIPTION
## Summary

- pass `{ teamId }` to `useRefetchQueries(FetchAppsDocument)` in both portals' app delete modals so the selector refetch actually fires

## Root cause

`useRefetchQueries` only refetches active queries whose variables JSON-match the ones passed to the hook. The delete modals passed no variables (which matches only `{}`), while every `FetchApps` consumer — Portal `AppSelector`, V3 `AppsDropdown`, V3 `SidebarNav`, the team apps page — runs the query with `{ teamId }`. The refetch silently matched nothing and resolved "successfully", so the deleted app kept being served from the Apollo cache until a hard reload. `CreateAppDialog` already passes `{ teamId }`, which is why creating an app refreshed the selector while deleting didn't.

## Validation

- `npx tsc --noEmit`
- `pnpm format:check`
- unit + api suites green
- local dev: deleted app vanishes from the dropdown immediately, no reload