### PR TITLE
fix(portal): deleting the last team no longer strands the user or kicks them to the landing page

### DIFF
--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -109,6 +109,15 @@ const checkRouteRolesRestrictions = (
   const urlSegments = pathname.split("/");
   const teamId = urlSegments[2];
 
+  // No membership in the URL's team (deleted/foreign) → send home; a member with the wrong role still gets the 401.
+  const isTeamMember = Boolean(
+    user?.hasura?.memberships?.some((m) => m.team?.id === teamId),
+  );
+  const restrictedRouteResponse = () =>
+    isTeamMember
+      ? NextResponse.rewrite(new URL("/unauthorized", request.url))
+      : NextResponse.redirect(new URL("/", request.url));
+
   // Route Subset Restriction
   const ownerOnlyRoutes = [
     "/teams/[a-zA-Z0-9_]+/apps/[a-zA-Z0-9_]+/configuration/danger$",
@@ -123,7 +132,7 @@ const checkRouteRolesRestrictions = (
 
   if (ownerOnlyRoutes.some((route) => pathname.match(route))) {
     if (!checkUserPermissions(user, teamId, [Role_Enum.Owner])) {
-      return NextResponse.rewrite(new URL("/unauthorized", request.url));
+      return restrictedRouteResponse();
     }
   }
 
@@ -134,7 +143,7 @@ const checkRouteRolesRestrictions = (
       : [Role_Enum.Owner];
 
     if (!checkUserPermissions(user, teamId, validRoles)) {
-      return NextResponse.rewrite(new URL("/unauthorized", request.url));
+      return restrictedRouteResponse();
     }
   }
 
@@ -142,7 +151,7 @@ const checkRouteRolesRestrictions = (
     if (
       !checkUserPermissions(user, teamId, [Role_Enum.Owner, Role_Enum.Admin])
     ) {
-      return NextResponse.rewrite(new URL("/unauthorized", request.url));
+      return restrictedRouteResponse();
     }
   }
   return false;

--- a/web/scenes/Onboarding/CreateTeam/layout/CloseButton/index.tsx
+++ b/web/scenes/Onboarding/CreateTeam/layout/CloseButton/index.tsx
@@ -5,7 +5,7 @@ import { CloseIcon } from "@/components/Icons/CloseIcon";
 import { Auth0SessionUser } from "@/lib/types";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { useRouter } from "next/navigation";
-import { Fragment, useCallback, useMemo, useRef } from "react";
+import { Fragment, useCallback, useMemo, useState } from "react";
 
 type Props = {
   href?: string;
@@ -22,10 +22,10 @@ export const CloseButton = (props: Props) => {
     [auth0User?.hasura?.memberships],
   );
 
-  // Latch hidden once the session resolves to no teams: the post-create session refresh lands before navigation finishes and would otherwise flash the X back in.
-  const sawNoTeams = useRef(false);
-  if (!isLoading && !hasTeams) {
-    sawNoTeams.current = true;
+  // Latch hidden once the session resolves to no teams: the post-create session refresh lands before navigation finishes and would otherwise flash the X back in. A failed profile fetch also reports `isLoading: false`, so latch only on a session we actually read.
+  const [sawNoTeams, setSawNoTeams] = useState(false);
+  if (!isLoading && auth0User && !hasTeams && !sawNoTeams) {
+    setSawNoTeams(true);
   }
 
   const closeCreateTeam = useCallback(() => {
@@ -36,7 +36,7 @@ export const CloseButton = (props: Props) => {
     return router.back();
   }, [router, props.href]);
 
-  if (sawNoTeams.current || !hasTeams) {
+  if (sawNoTeams || !hasTeams) {
     return null;
   }
 

--- a/web/scenes/Onboarding/CreateTeam/layout/CloseButton/index.tsx
+++ b/web/scenes/Onboarding/CreateTeam/layout/CloseButton/index.tsx
@@ -3,44 +3,50 @@
 import { Button } from "@/components/Button";
 import { CloseIcon } from "@/components/Icons/CloseIcon";
 import { Auth0SessionUser } from "@/lib/types";
-import { urls } from "@/lib/urls";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { useRouter } from "next/navigation";
-import { Fragment, useCallback, useMemo } from "react";
+import { Fragment, useCallback, useMemo, useRef } from "react";
 
 type Props = {
   href?: string;
 };
+
+// Only rendered when the user has a team to return to — closing with no teams used to strand users on the logged-out landing page.
 export const CloseButton = (props: Props) => {
-  const { user } = useUser() as Auth0SessionUser;
+  const { user, isLoading } = useUser();
+  const auth0User = (user ?? undefined) as Auth0SessionUser["user"];
   const router = useRouter();
-  const hasUser = useMemo(() => Boolean(user?.hasura?.id), [user?.hasura?.id]);
+
+  const hasTeams = useMemo(
+    () => (auth0User?.hasura?.memberships?.length ?? 0) > 0,
+    [auth0User?.hasura?.memberships],
+  );
+
+  // Latch hidden once the session resolves to no teams: the post-create session refresh lands before navigation finishes and would otherwise flash the X back in.
+  const sawNoTeams = useRef(false);
+  if (!isLoading && !hasTeams) {
+    sawNoTeams.current = true;
+  }
 
   const closeCreateTeam = useCallback(() => {
-    if (!hasUser) {
-      return router.push(urls.logout());
-    }
-
     if (props.href) {
       return router.push(props.href);
     }
 
     return router.back();
-  }, [hasUser, router, props.href]);
+  }, [router, props.href]);
+
+  if (sawNoTeams.current || !hasTeams) {
+    return null;
+  }
 
   return (
     <Fragment>
-      {hasUser && (
-        <Button type="button" onClick={closeCreateTeam} className="flex">
-          <CloseIcon />
-        </Button>
-      )}
+      <Button type="button" onClick={closeCreateTeam} className="flex">
+        <CloseIcon />
+      </Button>
 
-      {!hasUser && (
-        <Button href={urls.logout()} className="flex">
-          <CloseIcon />
-        </Button>
-      )}
+      <span className="text-grey-200">|</span>
     </Fragment>
   );
 };

--- a/web/scenes/Onboarding/CreateTeam/layout/index.tsx
+++ b/web/scenes/Onboarding/CreateTeam/layout/index.tsx
@@ -13,8 +13,6 @@ export const CreateTeamLayout = (props: { children: ReactNode }) => {
             <div className="flex items-center gap-x-3">
               <CloseButton />
 
-              <span className="text-grey-200">|</span>
-
               <Typography variant={TYPOGRAPHY.M4}>Create a new team</Typography>
             </div>
 

--- a/web/scenes/Portal/Teams/TeamId/Apps/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/page/index.tsx
@@ -1,6 +1,7 @@
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { Auth0SessionUser } from "@/lib/types";
 import { auth0 } from "@/lib/auth0";
+import { urls } from "@/lib/urls";
 import { redirect } from "next/navigation";
 import { AppsPageClient } from "./AppsPageClient";
 import { getSdk as getInitialAppSdk } from "./graphql/server/apps.generated";
@@ -28,8 +29,9 @@ export const AppsPage = async (props: AppPage) => {
   // If user tries to access another team's app, redirect to the their own.
   if (!memberships.find((m) => m.team?.id === teamId)) {
     const redirectTeamId = memberships[0]?.team?.id;
+    // No teams left (e.g. last one just deleted): send to onboarding instead of logging out.
     return redirect(
-      redirectTeamId ? `/teams/${redirectTeamId}/apps` : "/api/auth/logout",
+      redirectTeamId ? `/teams/${redirectTeamId}/apps` : urls.createTeam(),
     );
   }
 

--- a/web/scenes/Portal/common/DeleteTeamDialog/index.tsx
+++ b/web/scenes/Portal/common/DeleteTeamDialog/index.tsx
@@ -13,7 +13,7 @@ import { useMeQuery } from "@/scenes/common/me-query/client";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { usePathname, useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import * as yup from "yup";
@@ -42,7 +42,7 @@ export const DeleteTeamDialog = (props: DeleteTeamDialogProps) => {
   const router = useRouter();
   const path = usePathname();
   const { user: auth0User } = useUser() as Auth0SessionUser;
-  const [deleteFinished, setDeleteFinished] = useState(false);
+  const { invalidate } = useUser();
 
   const {
     register,
@@ -56,12 +56,12 @@ export const DeleteTeamDialog = (props: DeleteTeamDialogProps) => {
 
   const onClose = useCallback(() => {
     reset();
-    setDeleteFinished(false);
     props.onClose(false);
-  }, [props, reset, setDeleteFinished]);
+  }, [props, reset]);
 
-  const { user, loading, refetch } = useMeQuery();
+  const { refetch } = useMeQuery();
 
+  // Post-delete flow lives here, not in an effect: the settings page unmounts this dialog when canWrite collapses, but an async handler keeps running.
   const submit = useCallback(async () => {
     if (!team?.id || !auth0User?.hasura?.id) {
       return toast.error("Error deleting team. Try again later");
@@ -70,42 +70,46 @@ export const DeleteTeamDialog = (props: DeleteTeamDialogProps) => {
     try {
       const result = await deleteTeamServerSide(team.id);
 
-      if (result.success) {
-        await refetch();
-        toast.success("Team deleted!");
-        setDeleteFinished(true);
-      } else {
-        toast.error(result.message || "Error deleting team");
+      if (!result.success) {
+        return toast.error(result.message || "Error deleting team");
       }
+
+      const refetched = await refetch();
+      const membershipsCount = refetched?.data?.user_by_pk?.memberships?.length;
+
+      // Refresh session claims before navigating — server guards read memberships from the cookie.
+      try {
+        const res = await fetch("/api/update-session", { method: "POST" });
+        if (res.ok) {
+          await invalidate();
+        }
+      } catch {
+        // Best effort — the next me-query pass heals the session.
+      }
+
+      toast.success("Team deleted!");
+
+      if (typeof membershipsCount === "number" && membershipsCount === 0) {
+        return router.push(urls.createTeam());
+      }
+
+      if (path !== urls.profileTeams()) {
+        return router.push(urls.profileTeams());
+      }
+
+      onClose();
     } catch (e) {
       console.error("Delete Team Dialog: ", e);
       toast.error("Error deleting team");
     }
-  }, [team?.id, auth0User?.hasura?.id, refetch]);
-
-  useEffect(() => {
-    if (!deleteFinished || loading) {
-      return;
-    }
-
-    const membershipsCount = user.memberships?.length;
-
-    if (typeof membershipsCount === "number" && membershipsCount === 0) {
-      return router.push(urls.createTeam());
-    }
-
-    if (path !== urls.profileTeams()) {
-      return router.push(urls.profileTeams());
-    }
-
-    onClose();
   }, [
-    deleteFinished,
-    loading,
-    onClose,
-    path,
+    team?.id,
+    auth0User?.hasura?.id,
+    refetch,
+    invalidate,
     router,
-    user.memberships?.length,
+    path,
+    onClose,
   ]);
 
   return (

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/page/index.tsx
@@ -1,6 +1,7 @@
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { auth0 } from "@/lib/auth0";
 import { Auth0SessionUser } from "@/lib/types";
+import { urls } from "@/lib/urls";
 import { getSdk as getInitialAppSdk } from "@/scenes/Portal/Teams/TeamId/Apps/page/graphql/server/apps.generated";
 import { redirect } from "next/navigation";
 import { AppsPageClient } from "./AppsPageClient";
@@ -24,8 +25,9 @@ export const AppsPage = async (props: AppsPageProps) => {
   if (!memberships.find((membership) => membership.team?.id === teamId)) {
     const redirectTeamId = memberships[0]?.team?.id;
 
+    // No teams left (e.g. last one just deleted): send to onboarding instead of logging out.
     return redirect(
-      redirectTeamId ? `/teams/${redirectTeamId}/apps` : "/api/auth/logout",
+      redirectTeamId ? `/teams/${redirectTeamId}/apps` : urls.createTeam(),
     );
   }
 

--- a/web/scenes/PortalV3/common/DeleteTeamDialog/index.tsx
+++ b/web/scenes/PortalV3/common/DeleteTeamDialog/index.tsx
@@ -13,7 +13,7 @@ import { useMeQuery } from "@/scenes/common/me-query/client";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { usePathname, useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import * as yup from "yup";
@@ -42,7 +42,7 @@ export const DeleteTeamDialog = (props: DeleteTeamDialogProps) => {
   const router = useRouter();
   const path = usePathname();
   const { user: auth0User } = useUser() as Auth0SessionUser;
-  const [deleteFinished, setDeleteFinished] = useState(false);
+  const { invalidate } = useUser();
 
   const {
     register,
@@ -56,12 +56,12 @@ export const DeleteTeamDialog = (props: DeleteTeamDialogProps) => {
 
   const onClose = useCallback(() => {
     reset();
-    setDeleteFinished(false);
     props.onClose(false);
-  }, [props, reset, setDeleteFinished]);
+  }, [props, reset]);
 
-  const { user, loading, refetch } = useMeQuery();
+  const { refetch } = useMeQuery();
 
+  // Post-delete flow lives here, not in an effect: the settings page unmounts this dialog when canWrite collapses, but an async handler keeps running.
   const submit = useCallback(async () => {
     if (!team?.id || !auth0User?.hasura?.id) {
       return toast.error("Error deleting team. Try again later");
@@ -70,42 +70,46 @@ export const DeleteTeamDialog = (props: DeleteTeamDialogProps) => {
     try {
       const result = await deleteTeamServerSide(team.id);
 
-      if (result.success) {
-        await refetch();
-        toast.success("Team deleted!");
-        setDeleteFinished(true);
-      } else {
-        toast.error(result.message || "Error deleting team");
+      if (!result.success) {
+        return toast.error(result.message || "Error deleting team");
       }
+
+      const refetched = await refetch();
+      const membershipsCount = refetched?.data?.user_by_pk?.memberships?.length;
+
+      // Refresh session claims before navigating — server guards read memberships from the cookie.
+      try {
+        const res = await fetch("/api/update-session", { method: "POST" });
+        if (res.ok) {
+          await invalidate();
+        }
+      } catch {
+        // Best effort — the next me-query pass heals the session.
+      }
+
+      toast.success("Team deleted!");
+
+      if (typeof membershipsCount === "number" && membershipsCount === 0) {
+        return router.push(urls.createTeam());
+      }
+
+      if (path !== urls.profileTeams()) {
+        return router.push(urls.profileTeams());
+      }
+
+      onClose();
     } catch (e) {
       console.error("Delete Team Dialog: ", e);
       toast.error("Error deleting team");
     }
-  }, [team?.id, auth0User?.hasura?.id, refetch]);
-
-  useEffect(() => {
-    if (!deleteFinished || loading) {
-      return;
-    }
-
-    const membershipsCount = user.memberships?.length;
-
-    if (typeof membershipsCount === "number" && membershipsCount === 0) {
-      return router.push(urls.createTeam());
-    }
-
-    if (path !== urls.profileTeams()) {
-      return router.push(urls.profileTeams());
-    }
-
-    onClose();
   }, [
-    deleteFinished,
-    loading,
-    onClose,
-    path,
+    team?.id,
+    auth0User?.hasura?.id,
+    refetch,
+    invalidate,
     router,
-    user.memberships?.length,
+    path,
+    onClose,
   ]);
 
   return (

--- a/web/scenes/PortalV3/common/DeleteTeamDialog/index.tsx
+++ b/web/scenes/PortalV3/common/DeleteTeamDialog/index.tsx
@@ -97,6 +97,8 @@ export const DeleteTeamDialog = (props: DeleteTeamDialogProps) => {
         return router.push(urls.profileTeams());
       }
 
+      // Already on the teams page: no navigation to re-render the session-fed sidebar, so force it.
+      router.refresh();
       onClose();
     } catch (e) {
       console.error("Delete Team Dialog: ", e);

--- a/web/tests/unit/apps-page-no-team-redirect.test.tsx
+++ b/web/tests/unit/apps-page-no-team-redirect.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+
+// #region Mocks
+const getSession = jest.fn();
+jest.mock("@/lib/auth0", () => ({
+  auth0: { getSession: (...args: unknown[]) => getSession(...args) },
+}));
+
+const redirect = jest.fn();
+jest.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => redirect(...args),
+}));
+
+jest.mock("@/api/helpers/graphql", () => ({
+  getAPIServiceGraphqlClient: jest.fn().mockResolvedValue({}),
+}));
+
+const InitialApp = jest.fn();
+jest.mock(
+  "../../scenes/Portal/Teams/TeamId/Apps/page/graphql/server/apps.generated",
+  () => ({
+    getSdk: () => ({ InitialApp }),
+  }),
+);
+
+jest.mock(
+  "../../scenes/PortalV3/Teams/TeamId/Apps/page/AppsPageClient",
+  () => ({
+    AppsPageClient: () => <div data-testid="v3-apps-client" />,
+  }),
+);
+jest.mock("../../scenes/Portal/Teams/TeamId/Apps/page/AppsPageClient", () => ({
+  AppsPageClient: () => <div data-testid="v2-apps-client" />,
+}));
+// #endregion
+
+import { AppsPage as AppsPageV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/page";
+import { AppsPage as AppsPageV2 } from "@/scenes/Portal/Teams/TeamId/Apps/page";
+
+// #region Test Data
+const props = (teamId: string) => ({
+  params: Promise.resolve({ teamId }),
+});
+
+const sessionWithMemberships = (teamIds: string[]) => ({
+  user: {
+    hasura: {
+      id: "usr_1",
+      memberships: teamIds.map((id) => ({ team: { id } })),
+    },
+  },
+});
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  InitialApp.mockResolvedValue({ app: [] });
+});
+
+// #region Users with no team land on onboarding, not logout
+describe.each([
+  ["v3", AppsPageV3],
+  ["v2", AppsPageV2],
+])("/teams/[teamId]/apps [%s, membership guard]", (_version, AppsPage) => {
+  it("redirects a user with zero memberships to create-team", async () => {
+    getSession.mockResolvedValue(sessionWithMemberships([]));
+
+    await AppsPage(props("team_1"));
+
+    expect(redirect).toHaveBeenCalledWith("/create-team");
+    expect(InitialApp).not.toHaveBeenCalled();
+  });
+
+  it("redirects a member of another team to their own team's apps", async () => {
+    getSession.mockResolvedValue(sessionWithMemberships(["team_mine"]));
+
+    await AppsPage(props("team_foreign"));
+
+    expect(redirect).toHaveBeenCalledWith("/teams/team_mine/apps");
+    expect(InitialApp).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect a member of the requested team", async () => {
+    getSession.mockResolvedValue(sessionWithMemberships(["team_1"]));
+
+    const result = await AppsPage(props("team_1"));
+
+    expect(redirect).not.toHaveBeenCalled();
+    expect(InitialApp).toHaveBeenCalledWith({ teamId: "team_1" });
+    expect(result).toBeTruthy();
+  });
+});
+// #endregion

--- a/web/tests/unit/create-team-close-button.test.tsx
+++ b/web/tests/unit/create-team-close-button.test.tsx
@@ -69,6 +69,24 @@ describe("CloseButton", () => {
     expect(screen.getByRole("button")).toBeInTheDocument();
   });
 
+  it("does not latch hidden when the profile fetch fails", () => {
+    // useUser reports `user: null, isLoading: false` on any failed /api/auth/profile
+    // fetch, and SWR keeps that state across its retry backoff.
+    useUser.mockReturnValue({
+      user: null,
+      isLoading: false,
+      error: new Error("Unauthorized"),
+    });
+
+    const { container, rerender } = render(<CloseButton />);
+    expect(container).toBeEmptyDOMElement();
+
+    useUser.mockReturnValue(sessionState([{ team: { id: "team_1" } }]));
+    rerender(<CloseButton />);
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
   it("renders the X and divider for a user with teams and navigates back", () => {
     useUser.mockReturnValue(sessionState([{ team: { id: "team_1" } }]));
 

--- a/web/tests/unit/create-team-close-button.test.tsx
+++ b/web/tests/unit/create-team-close-button.test.tsx
@@ -1,0 +1,95 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+const back = jest.fn();
+const push = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ back, push }),
+}));
+
+const useUser = jest.fn();
+jest.mock("@auth0/nextjs-auth0/client", () => ({
+  useUser: () => useUser(),
+}));
+// #endregion
+
+import { CloseButton } from "@/scenes/Onboarding/CreateTeam/layout/CloseButton";
+
+// #region Test Data
+const sessionState = (
+  memberships: { team: { id: string } }[],
+  isLoading = false,
+) => ({
+  user: {
+    hasura: { id: "usr_1", memberships },
+  },
+  isLoading,
+});
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// #region CloseButton branches
+describe("CloseButton", () => {
+  it("renders nothing when the user has no teams", () => {
+    useUser.mockReturnValue(sessionState([]));
+
+    const { container } = render(<CloseButton />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("stays hidden when a team appears mid-visit (create-team submit)", () => {
+    // The post-create session refresh must not flash the X back in while navigation is pending.
+    useUser.mockReturnValue(sessionState([]));
+
+    const { container, rerender } = render(<CloseButton />);
+
+    useUser.mockReturnValue(sessionState([{ team: { id: "team_new" } }]));
+    rerender(<CloseButton />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("does not latch hidden while the session is still loading", () => {
+    // The pre-hydration frame (no user yet) must not trip the latch for users who do have teams.
+    useUser.mockReturnValue({ user: undefined, isLoading: true });
+
+    const { container, rerender } = render(<CloseButton />);
+    expect(container).toBeEmptyDOMElement();
+
+    useUser.mockReturnValue(sessionState([{ team: { id: "team_1" } }]));
+    rerender(<CloseButton />);
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("renders the X and divider for a user with teams and navigates back", () => {
+    useUser.mockReturnValue(sessionState([{ team: { id: "team_1" } }]));
+
+    render(<CloseButton />);
+
+    expect(screen.getByText("|")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(back).toHaveBeenCalledTimes(1);
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("prefers an explicit href over history back", () => {
+    useUser.mockReturnValue(sessionState([{ team: { id: "team_1" } }]));
+
+    render(<CloseButton href="/profile/teams" />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(push).toHaveBeenCalledWith("/profile/teams");
+    expect(back).not.toHaveBeenCalled();
+  });
+});
+// #endregion

--- a/web/tests/unit/delete-team-dialog-navigation.test.tsx
+++ b/web/tests/unit/delete-team-dialog-navigation.test.tsx
@@ -9,9 +9,10 @@ jest.mock("react-toastify", () => ({
 }));
 
 const push = jest.fn();
+const refresh = jest.fn();
 let pathname = "/teams/team_1/settings";
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push }),
+  useRouter: () => ({ push, refresh }),
   usePathname: () => pathname,
 }));
 
@@ -106,6 +107,17 @@ describe("DeleteTeamDialog [post-delete navigation]", () => {
     await confirmAndSubmit();
 
     await waitFor(() => expect(push).toHaveBeenCalledWith("/profile/teams"));
+  });
+
+  it("refreshes the session-fed sidebar when already on the teams page", async () => {
+    pathname = "/profile/teams";
+    refetch.mockResolvedValue(refetchResultWithMemberships(2));
+
+    renderDialog();
+    await confirmAndSubmit();
+
+    await waitFor(() => expect(refresh).toHaveBeenCalled());
+    expect(push).not.toHaveBeenCalled();
   });
 
   it("still navigates when the session refresh fails", async () => {

--- a/web/tests/unit/delete-team-dialog-navigation.test.tsx
+++ b/web/tests/unit/delete-team-dialog-navigation.test.tsx
@@ -1,0 +1,157 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+jest.mock("react-toastify", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const push = jest.fn();
+let pathname = "/teams/team_1/settings";
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => pathname,
+}));
+
+const invalidate = jest.fn();
+jest.mock("@auth0/nextjs-auth0/client", () => ({
+  useUser: () => ({
+    user: { hasura: { id: "usr_1" } },
+    invalidate,
+  }),
+}));
+
+const refetch = jest.fn();
+jest.mock("@/scenes/common/me-query/client", () => ({
+  useMeQuery: () => ({ refetch }),
+}));
+
+const deleteTeamServerSide = jest.fn();
+jest.mock("@/scenes/common/common/DeleteTeamDialog/server", () => ({
+  deleteTeamServerSide: (...args: unknown[]) => deleteTeamServerSide(...args),
+}));
+
+// Render the dialog contents without Headless UI's portal/transition machinery.
+jest.mock("@/components/Dialog", () => ({
+  Dialog: ({ children, open }: React.PropsWithChildren<{ open: boolean }>) =>
+    open ? <div>{children}</div> : null,
+}));
+jest.mock("@/components/DialogOverlay", () => ({
+  DialogOverlay: () => null,
+}));
+jest.mock("@/components/DialogPanel", () => ({
+  DialogPanel: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+// #endregion
+
+import { DeleteTeamDialog } from "@/scenes/PortalV3/common/DeleteTeamDialog";
+
+// #region Test Data
+const team = { id: "team_1", name: "My team" };
+
+const refetchResultWithMemberships = (count: number) => ({
+  data: {
+    user_by_pk: {
+      id: "usr_1",
+      memberships: Array.from({ length: count }, (_, i) => ({
+        role: "OWNER",
+        team: { id: `team_${i + 1}`, name: `Team ${i + 1}` },
+      })),
+    },
+  },
+});
+
+const renderDialog = () =>
+  render(<DeleteTeamDialog open onClose={jest.fn()} team={team} />);
+
+const confirmAndSubmit = async () => {
+  fireEvent.change(screen.getByRole("textbox"), {
+    target: { value: "DELETE" },
+  });
+  const submitButton = screen.getByRole("button", { name: "Delete team" });
+  await waitFor(() => expect(submitButton).toBeEnabled());
+  fireEvent.click(submitButton);
+};
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  pathname = "/teams/team_1/settings";
+  deleteTeamServerSide.mockResolvedValue({ success: true });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+});
+
+// #region Post-delete navigation
+describe("DeleteTeamDialog [post-delete navigation]", () => {
+  it("deletes, refreshes the session, and navigates to create-team when no teams remain", async () => {
+    refetch.mockResolvedValue(refetchResultWithMemberships(0));
+
+    renderDialog();
+    await confirmAndSubmit();
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/create-team"));
+    expect(deleteTeamServerSide).toHaveBeenCalledWith("team_1");
+    expect(global.fetch).toHaveBeenCalledWith("/api/update-session", {
+      method: "POST",
+    });
+    expect(invalidate).toHaveBeenCalled();
+  });
+
+  it("navigates to profile teams when other teams remain", async () => {
+    refetch.mockResolvedValue(refetchResultWithMemberships(2));
+
+    renderDialog();
+    await confirmAndSubmit();
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/profile/teams"));
+  });
+
+  it("still navigates when the session refresh fails", async () => {
+    refetch.mockResolvedValue(refetchResultWithMemberships(0));
+    (global.fetch as jest.Mock).mockRejectedValue(new Error("offline"));
+
+    renderDialog();
+    await confirmAndSubmit();
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/create-team"));
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate when the delete fails", async () => {
+    deleteTeamServerSide.mockResolvedValue({ success: false, message: "nope" });
+
+    renderDialog();
+    await confirmAndSubmit();
+
+    await waitFor(() => expect(deleteTeamServerSide).toHaveBeenCalled());
+    expect(refetch).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+});
+// #endregion
+
+// #region Unmount race (team settings page revokes canWrite mid-flow)
+describe("DeleteTeamDialog [unmounted before delete resolves]", () => {
+  it("completes the redirect even after the dialog unmounts", async () => {
+    let resolveRefetch!: (value: unknown) => void;
+    refetch.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRefetch = resolve;
+      }),
+    );
+
+    const { unmount } = renderDialog();
+    await confirmAndSubmit();
+
+    await waitFor(() => expect(deleteTeamServerSide).toHaveBeenCalled());
+
+    // The settings page unmounts the dialog once canWrite collapses — before the refetch resolves.
+    unmount();
+    resolveRefetch(refetchResultWithMemberships(0));
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/create-team"));
+  });
+});
+// #endregion

--- a/web/tests/unit/proxy-auth-origin.test.ts
+++ b/web/tests/unit/proxy-auth-origin.test.ts
@@ -218,16 +218,16 @@ describe("proxy [protected route role restrictions]", () => {
     );
   });
 
-  it("keeps another team's settings restricted for a member", async () => {
+  it("sends another team's settings to the root for a non-member", async () => {
+    // No membership in the URL's team at all → home (root routes onward) instead of a dead-end 401.
     process.env.PORTAL_V3_EMAILS = "member@example.com";
     const req = new NextRequest(
       `${CANONICAL}/teams/team_abcdef0123456789/settings`,
     );
     const res = await proxy(req);
 
-    expect(res.headers.get("x-middleware-rewrite")).toBe(
-      `${CANONICAL}/unauthorized`,
-    );
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(`${CANONICAL}/`);
   });
 
   it("keeps owner-only team routes restricted for a member", async () => {


### PR DESCRIPTION
### Motivation
Deleting your only team from **Team settings** (sidebar) left the portal in a dead end: the success toast fired but you stayed on the deleted team's page, refreshing gave a bare **401 | Unauthorized**, and follow-up navigation logged you out onto the marketing landing page. The onboarding screen had the same failure in miniature: with no team, the header **X** was a logout link (mid-signup) or a history-back onto the logged-out landing page — and it flashed back in briefly right after submitting the create-team form.

### Description
- `scenes/{Portal,PortalV3}/common/DeleteTeamDialog`: the post-delete sequence (delete → refetch memberships → refresh session cookie → navigate) now runs entirely in the submit handler instead of a `useEffect`. The settings page unmounts the dialog the moment `canWrite` collapses after the session refresh, so the pending effect never ran — an async handler keeps executing after unmount. Zero teams left → `/create-team`; otherwise → `/profile/teams` as before.
- `scenes/{Portal,PortalV3}/Teams/TeamId/Apps/page`: the membership guard sent zero-membership users to `/api/auth/logout`; they now go to `/create-team` with the session intact. Foreign-team access still redirects to your own team; no session still logs out.
- `scenes/Onboarding/CreateTeam/layout/CloseButton`: the X only renders when the user has a team to return to, and latches hidden once the session resolves to no teams — the post-create session refresh lands before navigation finishes and would otherwise flash it back in (clickable, straight to the landing page).
- `proxy.ts`: a role-restricted team URL for a team the user has **no membership in at all** (just deleted, or someone else's) redirects to `/` — the root page routes to their first team or `/create-team` — instead of rewriting to the dead-end `/unauthorized`. A member with an insufficient role still gets the 401. Split into its own commit since it changes shared middleware behavior.

### Testing
- New suites: `create-team-close-button`, `apps-page-no-team-redirect` (both portal versions), `delete-team-dialog-navigation` (including a regression test that unmounts the dialog mid-flow); `proxy-auth-origin` updated for the new non-member redirect. Full unit run: 87 suites / 365 tests green; `npx tsc --noEmit` and `pnpm format:check` clean.
- Verified live against local Hasura: create team → delete from Team settings → lands on `/create-team` logged in; deleted-team URL redirects home instead of 401; a DOM observer across the create-team submit confirmed the X never reappears.