### PR TITLE
feat(proxy): add x-current-path header for admin routing and update P…

### DIFF
--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -215,6 +215,7 @@ const createSecurityHeadersResponse = (
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set("x-nonce", nonce);
   requestHeaders.set("content-security-policy", csp);
+  requestHeaders.set("x-current-path", pathname);
 
   const response = NextResponse.next({ request: { headers: requestHeaders } });
 
@@ -232,6 +233,7 @@ const createDashboardRewriteResponse = (request: NextRequest) => {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set("x-nonce", nonce);
   requestHeaders.set("content-security-policy", csp);
+  requestHeaders.set("x-current-path", "/admin");
 
   const response = NextResponse.rewrite(url, {
     request: { headers: requestHeaders },

--- a/web/scenes/Root/layout/index.tsx
+++ b/web/scenes/Root/layout/index.tsx
@@ -7,9 +7,9 @@ import { IBM_Plex_Mono, Rubik } from "next/font/google";
 import localFont from "next/font/local";
 import { headers } from "next/headers";
 import { Suspense } from "react";
+import "react-image-crop/dist/ReactCrop.css";
 import { SkeletonTheme } from "react-loading-skeleton";
 import "react-loading-skeleton/dist/skeleton.css";
-import "react-image-crop/dist/ReactCrop.css";
 import { Slide, ToastContainer } from "react-toastify";
 
 const rubik = Rubik({
@@ -84,7 +84,7 @@ export const RootLayout = async ({
   // from `web/proxy.ts` to framework and page scripts.
   const requestHeaders = await headers();
   const currentPath = requestHeaders.get("x-current-path");
-  const isAdminRequest =
+  const disableUserIdentification =
     currentPath === "/admin" || currentPath?.startsWith("/admin/");
 
   return (
@@ -98,7 +98,9 @@ export const RootLayout = async ({
         />
 
         <Auth0Provider>
-          <WithPostHogIdentifier isAdminRequest={isAdminRequest}>
+          <WithPostHogIdentifier
+            disableUserIdentification={disableUserIdentification}
+          >
             <SkeletonTheme baseColor="#F3F4F5" highlightColor="#EBECEF">
               <Provider>
                 <Suspense fallback={null}>

--- a/web/scenes/Root/layout/index.tsx
+++ b/web/scenes/Root/layout/index.tsx
@@ -82,7 +82,10 @@ export const RootLayout = async ({
 }>) => {
   // Force request-time rendering so Next can apply the per-request CSP nonce
   // from `web/proxy.ts` to framework and page scripts.
-  await headers();
+  const requestHeaders = await headers();
+  const currentPath = requestHeaders.get("x-current-path");
+  const isAdminRequest =
+    currentPath === "/admin" || currentPath?.startsWith("/admin/");
 
   return (
     <html lang="en" className={fontVariables}>
@@ -95,7 +98,7 @@ export const RootLayout = async ({
         />
 
         <Auth0Provider>
-          <WithPostHogIdentifier>
+          <WithPostHogIdentifier isAdminRequest={isAdminRequest}>
             <SkeletonTheme baseColor="#F3F4F5" highlightColor="#EBECEF">
               <Provider>
                 <Suspense fallback={null}>

--- a/web/scenes/Root/providers/providers.tsx
+++ b/web/scenes/Root/providers/providers.tsx
@@ -3,10 +3,12 @@
 import { useUser } from "@auth0/nextjs-auth0/client";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
+import { usePathname } from "next/navigation";
 import React, { useEffect } from "react";
 
 interface WithPostHogProps {
   children: React.ReactNode;
+  isAdminRequest?: boolean;
 }
 interface HasuraUserData {
   posthog_id: string;
@@ -32,7 +34,7 @@ if (typeof window !== "undefined" && !isPostHogDisabled) {
   });
 }
 
-const WithPostHogIdentifier: React.FC<WithPostHogProps> = ({ children }) => {
+const PostHogUserIdentifier: React.FC<WithPostHogProps> = ({ children }) => {
   const { user } = useUser();
 
   useEffect(() => {
@@ -55,10 +57,33 @@ const WithPostHogIdentifier: React.FC<WithPostHogProps> = ({ children }) => {
     }
   }, [user]);
 
+  return children;
+};
+
+const WithPostHogIdentifier: React.FC<WithPostHogProps> = ({
+  children,
+  isAdminRequest = false,
+}) => {
+  const pathname = usePathname();
+  const isAdminPage =
+    pathname === "/admin" ||
+    pathname?.startsWith("/admin/") ||
+    (isAdminRequest && pathname === "/");
+
+  useEffect(() => {
+    if (isAdminPage) {
+      posthog.reset();
+    }
+  }, [isAdminPage]);
+
   return (
-    <>
-      <PostHogProvider client={posthog}>{children}</PostHogProvider>
-    </>
+    <PostHogProvider client={posthog}>
+      {isAdminPage ? (
+        children
+      ) : (
+        <PostHogUserIdentifier>{children}</PostHogUserIdentifier>
+      )}
+    </PostHogProvider>
   );
 };
 

--- a/web/scenes/Root/providers/providers.tsx
+++ b/web/scenes/Root/providers/providers.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useUser } from "@auth0/nextjs-auth0/client";
+import { usePathname } from "next/navigation";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
-import { usePathname } from "next/navigation";
 import React, { useEffect } from "react";
 
 interface WithPostHogProps {
   children: React.ReactNode;
-  isAdminRequest?: boolean;
+  disableUserIdentification?: boolean;
 }
 interface HasuraUserData {
   posthog_id: string;
@@ -62,23 +62,23 @@ const PostHogUserIdentifier: React.FC<WithPostHogProps> = ({ children }) => {
 
 const WithPostHogIdentifier: React.FC<WithPostHogProps> = ({
   children,
-  isAdminRequest = false,
+  disableUserIdentification = false,
 }) => {
   const pathname = usePathname();
-  const isAdminPage =
+  const shouldDisableUserIdentification =
     pathname === "/admin" ||
     pathname?.startsWith("/admin/") ||
-    (isAdminRequest && pathname === "/");
+    (disableUserIdentification && pathname === "/");
 
   useEffect(() => {
-    if (isAdminPage) {
+    if (shouldDisableUserIdentification) {
       posthog.reset();
     }
-  }, [isAdminPage]);
+  }, [shouldDisableUserIdentification]);
 
   return (
     <PostHogProvider client={posthog}>
-      {isAdminPage ? (
+      {shouldDisableUserIdentification ? (
         children
       ) : (
         <PostHogUserIdentifier>{children}</PostHogUserIdentifier>

--- a/web/tests/unit/proxy-auth-origin.test.ts
+++ b/web/tests/unit/proxy-auth-origin.test.ts
@@ -256,6 +256,9 @@ describe("proxy [admin pages]", () => {
       "clipboard-write=(self)",
     );
     expect(res.headers.get("x-current-path")).toBe("/admin");
+    expect(res.headers.get("x-middleware-request-x-current-path")).toBe(
+      "/admin",
+    );
   });
 
   it("redirects admin pages without authentication evidence", async () => {
@@ -319,6 +322,9 @@ describe("proxy [internal dashboard host]", () => {
       "clipboard-write=(self)",
     );
     expect(res.headers.get("x-current-path")).toBe("/admin");
+    expect(res.headers.get("x-middleware-request-x-current-path")).toBe(
+      "/admin",
+    );
   });
 
   it("matches the dashboard host via x-forwarded-host, normalizing port and extra proxies", async () => {

--- a/web/tests/unit/root-posthog-provider.test.tsx
+++ b/web/tests/unit/root-posthog-provider.test.tsx
@@ -1,0 +1,100 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+const mockUsePathname = jest.fn();
+const mockUseUser = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+jest.mock("@auth0/nextjs-auth0/client", () => ({
+  useUser: () => mockUseUser(),
+}));
+
+jest.mock("posthog-js", () => ({
+  __esModule: true,
+  default: {
+    init: jest.fn(),
+    reset: jest.fn(),
+    has_opted_out_capturing: jest.fn(() => false),
+    has_opted_in_capturing: jest.fn(() => false),
+    opt_out_capturing: jest.fn(),
+    opt_in_capturing: jest.fn(),
+    identify: jest.fn(),
+  },
+}));
+
+jest.mock("posthog-js/react", () => ({
+  PostHogProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import WithPostHogIdentifier from "@/scenes/Root/providers/providers";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUsePathname.mockReturnValue("/teams/team_1/apps");
+  mockUseUser.mockReturnValue({ user: null });
+});
+
+describe("root PostHog provider", () => {
+  it("loads the Auth0 user on portal pages", () => {
+    render(
+      <WithPostHogIdentifier>
+        <div>Portal content</div>
+      </WithPostHogIdentifier>,
+    );
+
+    expect(screen.getByText("Portal content")).toBeInTheDocument();
+    expect(mockUseUser).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["/admin", "/admin/users"])(
+    "does not load the Auth0 user on %s",
+    (pathname) => {
+      mockUsePathname.mockReturnValue(pathname);
+
+      render(
+        <WithPostHogIdentifier>
+          <div>Admin content</div>
+        </WithPostHogIdentifier>,
+      );
+
+      expect(screen.getByText("Admin content")).toBeInTheDocument();
+      expect(mockUseUser).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not load the Auth0 user for an admin host root rewrite", () => {
+    mockUsePathname.mockReturnValue("/");
+
+    render(
+      <WithPostHogIdentifier isAdminRequest>
+        <div>Admin content</div>
+      </WithPostHogIdentifier>,
+    );
+
+    expect(screen.getByText("Admin content")).toBeInTheDocument();
+    expect(mockUseUser).not.toHaveBeenCalled();
+  });
+
+  it("loads the Auth0 user after leaving an admin host root rewrite", () => {
+    mockUsePathname.mockReturnValue("/");
+    const { rerender } = render(
+      <WithPostHogIdentifier isAdminRequest>
+        <div>Content</div>
+      </WithPostHogIdentifier>,
+    );
+
+    mockUsePathname.mockReturnValue("/teams/team_1/apps");
+    rerender(
+      <WithPostHogIdentifier isAdminRequest>
+        <div>Content</div>
+      </WithPostHogIdentifier>,
+    );
+
+    expect(mockUseUser).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/tests/unit/root-posthog-provider.test.tsx
+++ b/web/tests/unit/root-posthog-provider.test.tsx
@@ -71,7 +71,7 @@ describe("root PostHog provider", () => {
     mockUsePathname.mockReturnValue("/");
 
     render(
-      <WithPostHogIdentifier isAdminRequest>
+      <WithPostHogIdentifier disableUserIdentification>
         <div>Admin content</div>
       </WithPostHogIdentifier>,
     );
@@ -83,14 +83,14 @@ describe("root PostHog provider", () => {
   it("loads the Auth0 user after leaving an admin host root rewrite", () => {
     mockUsePathname.mockReturnValue("/");
     const { rerender } = render(
-      <WithPostHogIdentifier isAdminRequest>
+      <WithPostHogIdentifier disableUserIdentification>
         <div>Content</div>
       </WithPostHogIdentifier>,
     );
 
     mockUsePathname.mockReturnValue("/teams/team_1/apps");
     rerender(
-      <WithPostHogIdentifier isAdminRequest>
+      <WithPostHogIdentifier disableUserIdentification>
         <div>Content</div>
       </WithPostHogIdentifier>,
     );


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

This PR prevents admin pages from periodically requesting Auth0 `/api/auth/profile` and receiving `401` responses. Admin pages use separate authentication, but the global PostHog provider previously mounted Auth0 `useUser()` for every route.

- Mounts Auth0 user identification only outside `/admin`.
- Keeps the PostHog provider available and resets its identity on admin pages.
- Passes the resolved route path through the proxy to handle dashboard-host root rewrites.
- Keeps existing admin authorization checks unchanged.
- Adds regression coverage for admin routes, root rewrites, client navigation, and proxy path forwarding.

Tested with:

- `pnpm exec jest tests/unit/root-posthog-provider.test.tsx tests/unit/proxy-auth-origin.test.ts --runInBand` — 29 tests passed.
- Prettier check for all changed files.

## Checklist

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.