### PR TITLE
fix(portal): repair the MCP setup flow end to end

### DIFF
--- a/web/api/mcp/index.ts
+++ b/web/api/mcp/index.ts
@@ -1670,6 +1670,20 @@ export const POST = async (req: NextRequest) => {
     );
   }
 
+  // Must sit ahead of the notification check: null/arrays/primitives parse
+  // cleanly, then either throw reading `.id` or get mistaken for notifications.
+  if (
+    typeof message !== "object" ||
+    message === null ||
+    Array.isArray(message)
+  ) {
+    return jsonRpcError(
+      null,
+      new McpError("Invalid JSON-RPC request.", -32600),
+      400,
+    );
+  }
+
   if (message.id === undefined) {
     return new NextResponse(null, { status: 202 });
   }
@@ -1693,17 +1707,20 @@ export const POST = async (req: NextRequest) => {
   }
 };
 
+// A 200 here reads as an SSE stream to the MCP SDK, which then reconnects
+// ~1/sec forever against an attempt counter it never increments.
 export const GET = async () =>
-  NextResponse.json({
-    name: "world-developer-portal",
-    transport: "streamable-http",
-    endpoint: "/api/mcp",
+  new NextResponse(null, {
+    status: 405,
+    headers: {
+      Allow: "POST, OPTIONS",
+    },
   });
 
 export const OPTIONS = async () =>
   new NextResponse(null, {
     status: 204,
     headers: {
-      Allow: "GET, POST, OPTIONS",
+      Allow: "POST, OPTIONS",
     },
   });

--- a/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields/index.tsx
@@ -5,36 +5,15 @@ import { CopyIcon } from "@/components/Icons/CopyIcon";
 import { ExternalLinkIcon } from "@/components/Icons/ExternalLinkIcon";
 import { LockIcon } from "@/components/Icons/LockIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import {
+  getMcpEndpoint,
+  getProviderSnippets,
+  PROVIDERS,
+  type ProviderId,
+} from "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/mcp-snippets";
 import clsx from "clsx";
 import { useMemo, useState } from "react";
 import { toast } from "react-toastify";
-
-const MCP_SERVER_NAME = "worldcoin-developer-portal";
-const MCP_ENDPOINT = "https://developer.world.org/api/mcp";
-const MCP_API_KEY_ENV_VAR = "WORLD_DEVELOPER_API_KEY";
-
-type ProviderId =
-  | "codex"
-  | "claude"
-  | "cursor"
-  | "windsurf"
-  | "chatgpt"
-  | "zed";
-
-type Provider = {
-  id: ProviderId;
-  name: string;
-  setupLabel: string;
-};
-
-type ProviderSnippet = {
-  command: string;
-  rawConfig: string;
-};
-
-const shellQuote = (value: string) => `'${value.replace(/'/g, "'\\''")}'`;
-const envReference = (name: string) => `\${${name}}`;
-const tomlString = (value: string) => JSON.stringify(value);
 
 const getApiKeyPreview = (apiKey: string) => {
   if (apiKey.length <= 34) {
@@ -43,161 +22,6 @@ const getApiKeyPreview = (apiKey: string) => {
 
   return `${apiKey.slice(0, 18)}...${apiKey.slice(-12)}`;
 };
-
-export const getClaudeMcpCommand = (apiKey: string) =>
-  `claude mcp add ${MCP_SERVER_NAME} ${MCP_ENDPOINT} --transport http --scope project --header "Authorization: Bearer ${apiKey}"`;
-
-export const getCodexMcpCommand = (apiKey: string) =>
-  `codex mcp add ${MCP_SERVER_NAME} --env ${MCP_API_KEY_ENV_VAR}=${shellQuote(apiKey)} -- npx -y mcp-remote ${MCP_ENDPOINT} --transport http-only --header 'Authorization:Bearer ${envReference(MCP_API_KEY_ENV_VAR)}'`;
-
-const getClaudeJsonConfig = (apiKey: string) =>
-  JSON.stringify(
-    {
-      mcpServers: {
-        [MCP_SERVER_NAME]: {
-          type: "http",
-          url: MCP_ENDPOINT,
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-          },
-        },
-      },
-    },
-    null,
-    2,
-  );
-
-const getCursorJsonConfig = (apiKey: string) =>
-  JSON.stringify(
-    {
-      mcpServers: {
-        [MCP_SERVER_NAME]: {
-          url: MCP_ENDPOINT,
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-          },
-        },
-      },
-    },
-    null,
-    2,
-  );
-
-const getWindsurfJsonConfig = (apiKey: string) =>
-  JSON.stringify(
-    {
-      mcpServers: {
-        [MCP_SERVER_NAME]: {
-          serverUrl: MCP_ENDPOINT,
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-          },
-        },
-      },
-    },
-    null,
-    2,
-  );
-
-const getChatGptConnectorConfig = (apiKey: string) =>
-  [
-    `Name: World Developer Portal`,
-    `URL: ${MCP_ENDPOINT}`,
-    `Authorization: Bearer ${apiKey}`,
-  ].join("\n");
-
-const getZedJsonConfig = (apiKey: string) =>
-  JSON.stringify(
-    {
-      context_servers: {
-        [MCP_SERVER_NAME]: {
-          url: MCP_ENDPOINT,
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-          },
-        },
-      },
-    },
-    null,
-    2,
-  );
-
-const getProviderSnippets = (
-  apiKey: string,
-): Record<ProviderId, ProviderSnippet> => {
-  const claudeJsonConfig = getClaudeJsonConfig(apiKey);
-  const cursorJsonConfig = getCursorJsonConfig(apiKey);
-  const windsurfJsonConfig = getWindsurfJsonConfig(apiKey);
-  const chatGptConnectorConfig = getChatGptConnectorConfig(apiKey);
-  const zedJsonConfig = getZedJsonConfig(apiKey);
-
-  return {
-    codex: {
-      command: getCodexMcpCommand(apiKey),
-      rawConfig: [
-        `[mcp_servers.${MCP_SERVER_NAME}]`,
-        `command = "npx"`,
-        `args = ["-y", "mcp-remote", ${tomlString(MCP_ENDPOINT)}, "--transport", "http-only", "--header", ${tomlString(`Authorization:Bearer ${envReference(MCP_API_KEY_ENV_VAR)}`)}]`,
-        "",
-        `[mcp_servers.${MCP_SERVER_NAME}.env]`,
-        `${MCP_API_KEY_ENV_VAR} = ${tomlString(apiKey)}`,
-      ].join("\n"),
-    },
-    claude: {
-      command: getClaudeMcpCommand(apiKey),
-      rawConfig: claudeJsonConfig,
-    },
-    cursor: {
-      command: cursorJsonConfig,
-      rawConfig: cursorJsonConfig,
-    },
-    windsurf: {
-      command: windsurfJsonConfig,
-      rawConfig: windsurfJsonConfig,
-    },
-    chatgpt: {
-      command: chatGptConnectorConfig,
-      rawConfig: chatGptConnectorConfig,
-    },
-    zed: {
-      command: zedJsonConfig,
-      rawConfig: zedJsonConfig,
-    },
-  };
-};
-
-const PROVIDERS: Provider[] = [
-  {
-    id: "codex",
-    name: "Codex",
-    setupLabel: "Run in your terminal",
-  },
-  {
-    id: "claude",
-    name: "Claude",
-    setupLabel: "Run in your terminal",
-  },
-  {
-    id: "cursor",
-    name: "Cursor",
-    setupLabel: "Paste into .cursor/mcp.json",
-  },
-  {
-    id: "windsurf",
-    name: "Windsurf",
-    setupLabel: "Paste into MCP config",
-  },
-  {
-    id: "chatgpt",
-    name: "ChatGPT",
-    setupLabel: "Use as connector config",
-  },
-  {
-    id: "zed",
-    name: "Zed",
-    setupLabel: "Paste into settings.json",
-  },
-];
 
 const CopyControl = (props: {
   fieldName: string;
@@ -230,6 +54,7 @@ const CopyControl = (props: {
           "size-8 rounded-12": variant === "icon",
         },
       )}
+      aria-label={variant === "icon" ? `Copy ${fieldName}` : undefined}
       onClick={copyToClipboard}
     >
       <Icon className="size-4" />
@@ -250,15 +75,8 @@ const SnippetText = (props: { value: string; isRawConfig: boolean }) => {
   }
 
   const firstSpace = value.indexOf(" ");
-  const firstEquals = value.indexOf("=");
-  const splitAt =
-    firstSpace === -1
-      ? firstEquals
-      : firstEquals === -1
-        ? firstSpace
-        : Math.min(firstSpace, firstEquals);
-  const firstToken = splitAt === -1 ? value : value.slice(0, splitAt);
-  const rest = splitAt === -1 ? "" : value.slice(splitAt);
+  const firstToken = firstSpace === -1 ? value : value.slice(0, firstSpace);
+  const rest = firstSpace === -1 ? "" : value.slice(firstSpace);
 
   return (
     <pre className="min-w-0 overflow-x-auto font-ibm text-xs leading-5 whitespace-pre text-grey-900 md:text-sm">
@@ -275,7 +93,11 @@ export const ApiKeySecretFields = (props: { apiKey: string }) => {
   const apiKeyPreview = getApiKeyPreview(apiKey);
   const [selectedProvider, setSelectedProvider] = useState<ProviderId>("codex");
   const [showRawConfig, setShowRawConfig] = useState(false);
-  const snippets = useMemo(() => getProviderSnippets(apiKey), [apiKey]);
+  // Only ever rendered post-mutation inside CreateKeyModal, so `window` exists.
+  const snippets = useMemo(
+    () => getProviderSnippets(apiKey, getMcpEndpoint(window.location.origin)),
+    [apiKey],
+  );
   const provider = PROVIDERS.find((item) => item.id === selectedProvider)!;
   const snippet = snippets[selectedProvider];
   const snippetValue = showRawConfig ? snippet.rawConfig : snippet.command;

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/index.tsx
@@ -69,6 +69,13 @@ export const WorldIdPage = (props: {
   const enableWorldId4Requested = searchParams.get("enableWorldId4") === "true";
   const createActionRequested = searchParams.get("createAction") === "true";
 
+  // Seeds useState below: the sync effect runs post-paint, so a deep link would
+  // otherwise paint Actions for one frame.
+  const requestedTab: WorldIdTab =
+    searchParams.get("tab") === "world-id-4-0" || enableWorldId4Requested
+      ? "world-id-4-0"
+      : "actions";
+
   const consumeSearchParams = useCallback(
     (...names: string[]) => {
       if (!names.some((name) => searchParams.has(name))) return;
@@ -83,11 +90,7 @@ export const WorldIdPage = (props: {
     [pathname, router, searchParams],
   );
 
-  const [tab, setTab] = useState<WorldIdTab>(
-    props.searchParams.tab === "world-id-4-0" || enableWorldId4Requested
-      ? "world-id-4-0"
-      : "actions",
-  );
+  const [tab, setTab] = useState<WorldIdTab>(requestedTab);
   const [createAfterSetup, setCreateAfterSetup] = useState(
     createActionRequested && props.canManageWorldId,
   );
@@ -95,6 +98,7 @@ export const WorldIdPage = (props: {
   const [reconciledRpStatus, setReconciledRpStatus] = useState<{
     rpId: string;
     status: RpRegistrationStatus;
+    serverStatus: unknown;
   } | null>(null);
 
   const selectTab = useCallback(
@@ -137,11 +141,6 @@ export const WorldIdPage = (props: {
     [selectTab],
   );
 
-  const requestedTab: WorldIdTab =
-    searchParams.get("tab") === "world-id-4-0" || enableWorldId4Requested
-      ? "world-id-4-0"
-      : "actions";
-
   useEffect(() => {
     setTab(requestedTab);
   }, [requestedTab]);
@@ -151,6 +150,8 @@ export const WorldIdPage = (props: {
     {
       variables: { app_id: appId },
       skip: !appId,
+      fetchPolicy: "cache-and-network",
+      nextFetchPolicy: "cache-first",
     },
   );
 
@@ -158,8 +159,11 @@ export const WorldIdPage = (props: {
   const rp = app?.rp_registration?.[0];
   const hasResolvedApp = Boolean(app);
   const hasRpRegistration = Boolean(rp);
+  // Optimistic status holds only until the server reports something new.
   const effectiveRpStatus =
-    reconciledRpStatus && reconciledRpStatus.rpId === rp?.rp_id
+    reconciledRpStatus &&
+    reconciledRpStatus.rpId === rp?.rp_id &&
+    reconciledRpStatus.serverStatus === rp?.status
       ? reconciledRpStatus.status
       : rp?.status;
   const hasActiveRp = effectiveRpStatus === RpRegistrationStatus.Registered;
@@ -212,15 +216,38 @@ export const WorldIdPage = (props: {
   const handleRpChanged = useCallback(
     (status?: RpRegistrationStatus) => {
       if (status && rp) {
-        setReconciledRpStatus({ rpId: rp.rp_id, status });
+        setReconciledRpStatus({
+          rpId: rp.rp_id,
+          status,
+          serverStatus: rp.status,
+        });
       }
       refetchOverview();
     },
     [refetchOverview, rp],
   );
 
-  // Tabs and search are real during load — only the data-backed cards are skeletons.
-  if (loading) {
+  // RP/action changes land out-of-band (MCP, another tab); revalidate on return.
+  useEffect(() => {
+    if (!appId) return;
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible") return;
+      refetchOverview();
+    };
+    const handleFocus = () => refetchOverview();
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("focus", handleFocus);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", handleFocus);
+    };
+  }, [appId, refetchOverview]);
+
+  // Skeletons are first-load only; a background refetch keeps `data`.
+  if (loading && !data) {
     return (
       <SizingWrapper className="flex flex-col gap-8 py-8">
         <div className="flex flex-col gap-6">

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/page/AppsPageClient.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/page/AppsPageClient.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import { Button } from "@/components/Button";
-import { urls } from "@/lib/urls";
+import { Role_Enum } from "@/graphql/graphql";
+import { Auth0SessionUser } from "@/lib/types";
+import { checkUserPermissions } from "@/lib/utils";
 import { Icon } from "@/scenes/PortalV3/common/Icon";
+import { useUser } from "@auth0/nextjs-auth0/client";
+import clsx from "clsx";
 import dynamic from "next/dynamic";
 import { ReactNode, useState } from "react";
 
@@ -10,6 +14,14 @@ const CreateAppDialogV4 = dynamic(() =>
   import("@/scenes/PortalV3/layout/CreateAppDialog/index-v4").then(
     (module) => module.CreateAppDialogV4,
   ),
+);
+
+const CreateKeyModal = dynamic(
+  () =>
+    import(
+      "@/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/CreateKeyModal"
+    ).then((module) => module.CreateKeyModal),
+  { loading: () => null },
 );
 
 const actionButtonClassName =
@@ -49,15 +61,34 @@ const ActionCard = (props: {
   </section>
 );
 
-export const AppsPageClient = (props: { teamId: string }) => {
+export const AppsPageClient = (props: {
+  teamId: string;
+  initialIsOwner?: boolean;
+}) => {
   const [createAppOpen, setCreateAppOpen] = useState(false);
   // Keep mounted after first open to preserve transitions and state.
   const [dialogMounted, setDialogMounted] = useState(false);
+  const [createKeyOpen, setCreateKeyOpen] = useState(false);
+  const [keyDialogMounted, setKeyDialogMounted] = useState(false);
+  const { user } = useUser() as Auth0SessionUser;
+
+  // useUser resolves client-side; fall back to the server's answer until it does.
+  const isOwner = user
+    ? checkUserPermissions(user, props.teamId, [Role_Enum.Owner])
+    : Boolean(props.initialIsOwner);
 
   return (
     <>
       {dialogMounted ? (
         <CreateAppDialogV4 open={createAppOpen} onClose={setCreateAppOpen} />
+      ) : null}
+
+      {keyDialogMounted ? (
+        <CreateKeyModal
+          teamId={props.teamId}
+          isOpen={createKeyOpen}
+          setIsOpen={setCreateKeyOpen}
+        />
       ) : null}
 
       <div className="px-6 py-10 lg:px-10">
@@ -70,7 +101,12 @@ export const AppsPageClient = (props: { teamId: string }) => {
           </p>
         </div>
 
-        <div className="mt-10 grid max-w-[1176px] gap-[22px] xl:grid-cols-2">
+        <div
+          className={clsx(
+            "mt-10 grid max-w-[1176px] gap-[22px]",
+            isOwner && "xl:grid-cols-2",
+          )}
+        >
           <ActionCard
             icon={<Icon name="card-toolkit" className="size-7" />}
             iconClassName="bg-portal-blue"
@@ -90,20 +126,26 @@ export const AppsPageClient = (props: { teamId: string }) => {
             </Button>
           </ActionCard>
 
-          <ActionCard
-            icon={<Icon name="card-wand" className="size-7" />}
-            iconClassName="bg-portal-purple"
-            title="Set up MCP via API key"
-            description="Connect Codex, Claude, or any MCP client to build and manage your app via natural language."
-            badge="New"
-          >
-            <Button
-              href={urls.teamSettings({ team_id: props.teamId })}
-              className={actionButtonClassName}
+          {isOwner ? (
+            <ActionCard
+              icon={<Icon name="card-wand" className="size-7" />}
+              iconClassName="bg-portal-purple"
+              title="Set up MCP via API key"
+              description="Connect Codex, Claude, or any MCP client to build and manage your app via natural language."
+              badge="New"
             >
-              Create API key
-            </Button>
-          </ActionCard>
+              <Button
+                type="button"
+                onClick={() => {
+                  setKeyDialogMounted(true);
+                  setCreateKeyOpen(true);
+                }}
+                className={actionButtonClassName}
+              >
+                Create API key
+              </Button>
+            </ActionCard>
+          ) : null}
         </div>
       </div>
     </>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/page/AppsPageClient.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/page/AppsPageClient.tsx
@@ -5,10 +5,12 @@ import { Role_Enum } from "@/graphql/graphql";
 import { Auth0SessionUser } from "@/lib/types";
 import { checkUserPermissions } from "@/lib/utils";
 import { Icon } from "@/scenes/PortalV3/common/Icon";
+import { FetchAppsDocument } from "@/scenes/common/layout/AppSelector/graphql/client/fetch-apps.generated";
+import { useLazyQuery } from "@apollo/client/react";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import clsx from "clsx";
 import dynamic from "next/dynamic";
-import { ReactNode, useState } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 
 const CreateAppDialogV4 = dynamic(() =>
   import("@/scenes/PortalV3/layout/CreateAppDialog/index-v4").then(
@@ -23,6 +25,9 @@ const CreateKeyModal = dynamic(
     ).then((module) => module.CreateKeyModal),
   { loading: () => null },
 );
+
+// Collapses Chrome's visibilitychange+focus double-fire on a tab return.
+const RETURN_CHECK_MIN_INTERVAL_MS = 1_000;
 
 const actionButtonClassName =
   "inline-flex h-10 items-center justify-center rounded-8 bg-portal-ink px-4 font-world text-13 font-medium leading-none text-white transition-colors hover:bg-portal-ink-hover focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-grey-300 focus-visible:ring-offset-2";
@@ -76,6 +81,60 @@ export const AppsPageClient = (props: {
   const isOwner = user
     ? checkUserPermissions(user, props.teamId, [Role_Enum.Owner])
     : Boolean(props.initialIsOwner);
+
+  // The cache holds this page's zero-app answer; only the network can see one
+  // created out-of-band (MCP) while the user was in their terminal.
+  const [fetchApps] = useLazyQuery(FetchAppsDocument, {
+    fetchPolicy: "network-only",
+  });
+  const lastCheckAt = useRef(0);
+  const keyDialogWasOpen = useRef(false);
+
+  useEffect(() => {
+    // A navigation must never yank the one-shot key secret off screen.
+    if (createKeyOpen) {
+      keyDialogWasOpen.current = true;
+      return;
+    }
+
+    const checkForApp = async () => {
+      if (Date.now() - lastCheckAt.current < RETURN_CHECK_MIN_INTERVAL_MS) {
+        return;
+      }
+      lastCheckAt.current = Date.now();
+
+      const result = await fetchApps({
+        variables: { teamId: props.teamId },
+      }).catch(() => null);
+      const appId = result?.data?.app?.[0]?.id;
+      if (!appId) return;
+
+      // Hard nav on purpose (CreateAppDialogV4 precedent): re-renders the
+      // session-rendered shell and keeps routing server-owned.
+      window.location.replace(`/teams/${props.teamId}/apps/${appId}`);
+    };
+
+    // Likeliest MCP path: the app was created while the secret was on screen,
+    // so the dialog closing is the only signal left.
+    if (keyDialogWasOpen.current) {
+      keyDialogWasOpen.current = false;
+      void checkForApp();
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible") return;
+      void checkForApp();
+    };
+    const handleFocus = () => void checkForApp();
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("focus", handleFocus);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", handleFocus);
+    };
+  }, [createKeyOpen, fetchApps, props.teamId]);
 
   return (
     <>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/page/index.tsx
@@ -1,4 +1,5 @@
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { Role_Enum } from "@/graphql/graphql";
 import { auth0 } from "@/lib/auth0";
 import { Auth0SessionUser } from "@/lib/types";
 import { urls } from "@/lib/urls";
@@ -38,5 +39,13 @@ export const AppsPage = async (props: AppsPageProps) => {
     return redirect(`/teams/${teamId}/apps/${app[0].id}/world-id-4-0`);
   }
 
-  return <AppsPageClient teamId={teamId} />;
+  return (
+    <AppsPageClient
+      teamId={teamId}
+      initialIsOwner={memberships.some(
+        (membership) =>
+          membership.team?.id === teamId && membership.role === Role_Enum.Owner,
+      )}
+    />
+  );
 };

--- a/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeySecretFields/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeySecretFields/index.tsx
@@ -5,36 +5,15 @@ import { CopyIcon } from "@/components/Icons/CopyIcon";
 import { ExternalLinkIcon } from "@/components/Icons/ExternalLinkIcon";
 import { LockIcon } from "@/components/Icons/LockIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import {
+  getMcpEndpoint,
+  getProviderSnippets,
+  PROVIDERS,
+  type ProviderId,
+} from "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/mcp-snippets";
 import clsx from "clsx";
 import { useMemo, useState } from "react";
 import { toast } from "react-toastify";
-
-const MCP_SERVER_NAME = "worldcoin-developer-portal";
-const MCP_ENDPOINT = "https://developer.world.org/api/mcp";
-const MCP_API_KEY_ENV_VAR = "WORLD_DEVELOPER_API_KEY";
-
-type ProviderId =
-  | "codex"
-  | "claude"
-  | "cursor"
-  | "windsurf"
-  | "chatgpt"
-  | "zed";
-
-type Provider = {
-  id: ProviderId;
-  name: string;
-  setupLabel: string;
-};
-
-type ProviderSnippet = {
-  command: string;
-  rawConfig: string;
-};
-
-const shellQuote = (value: string) => `'${value.replace(/'/g, "'\\''")}'`;
-const envReference = (name: string) => `\${${name}}`;
-const tomlString = (value: string) => JSON.stringify(value);
 
 const getApiKeyPreview = (apiKey: string) => {
   if (apiKey.length <= 34) {
@@ -43,161 +22,6 @@ const getApiKeyPreview = (apiKey: string) => {
 
   return `${apiKey.slice(0, 18)}...${apiKey.slice(-12)}`;
 };
-
-export const getClaudeMcpCommand = (apiKey: string) =>
-  `claude mcp add ${MCP_SERVER_NAME} ${MCP_ENDPOINT} --transport http --scope project --header "Authorization: Bearer ${apiKey}"`;
-
-export const getCodexMcpCommand = (apiKey: string) =>
-  `codex mcp add ${MCP_SERVER_NAME} --env ${MCP_API_KEY_ENV_VAR}=${shellQuote(apiKey)} -- npx -y mcp-remote ${MCP_ENDPOINT} --transport http-only --header 'Authorization:Bearer ${envReference(MCP_API_KEY_ENV_VAR)}'`;
-
-const getClaudeJsonConfig = (apiKey: string) =>
-  JSON.stringify(
-    {
-      mcpServers: {
-        [MCP_SERVER_NAME]: {
-          type: "http",
-          url: MCP_ENDPOINT,
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-          },
-        },
-      },
-    },
-    null,
-    2,
-  );
-
-const getCursorJsonConfig = (apiKey: string) =>
-  JSON.stringify(
-    {
-      mcpServers: {
-        [MCP_SERVER_NAME]: {
-          url: MCP_ENDPOINT,
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-          },
-        },
-      },
-    },
-    null,
-    2,
-  );
-
-const getWindsurfJsonConfig = (apiKey: string) =>
-  JSON.stringify(
-    {
-      mcpServers: {
-        [MCP_SERVER_NAME]: {
-          serverUrl: MCP_ENDPOINT,
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-          },
-        },
-      },
-    },
-    null,
-    2,
-  );
-
-const getChatGptConnectorConfig = (apiKey: string) =>
-  [
-    `Name: World Developer Portal`,
-    `URL: ${MCP_ENDPOINT}`,
-    `Authorization: Bearer ${apiKey}`,
-  ].join("\n");
-
-const getZedJsonConfig = (apiKey: string) =>
-  JSON.stringify(
-    {
-      context_servers: {
-        [MCP_SERVER_NAME]: {
-          url: MCP_ENDPOINT,
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-          },
-        },
-      },
-    },
-    null,
-    2,
-  );
-
-const getProviderSnippets = (
-  apiKey: string,
-): Record<ProviderId, ProviderSnippet> => {
-  const claudeJsonConfig = getClaudeJsonConfig(apiKey);
-  const cursorJsonConfig = getCursorJsonConfig(apiKey);
-  const windsurfJsonConfig = getWindsurfJsonConfig(apiKey);
-  const chatGptConnectorConfig = getChatGptConnectorConfig(apiKey);
-  const zedJsonConfig = getZedJsonConfig(apiKey);
-
-  return {
-    codex: {
-      command: getCodexMcpCommand(apiKey),
-      rawConfig: [
-        `[mcp_servers.${MCP_SERVER_NAME}]`,
-        `command = "npx"`,
-        `args = ["-y", "mcp-remote", ${tomlString(MCP_ENDPOINT)}, "--transport", "http-only", "--header", ${tomlString(`Authorization:Bearer ${envReference(MCP_API_KEY_ENV_VAR)}`)}]`,
-        "",
-        `[mcp_servers.${MCP_SERVER_NAME}.env]`,
-        `${MCP_API_KEY_ENV_VAR} = ${tomlString(apiKey)}`,
-      ].join("\n"),
-    },
-    claude: {
-      command: getClaudeMcpCommand(apiKey),
-      rawConfig: claudeJsonConfig,
-    },
-    cursor: {
-      command: cursorJsonConfig,
-      rawConfig: cursorJsonConfig,
-    },
-    windsurf: {
-      command: windsurfJsonConfig,
-      rawConfig: windsurfJsonConfig,
-    },
-    chatgpt: {
-      command: chatGptConnectorConfig,
-      rawConfig: chatGptConnectorConfig,
-    },
-    zed: {
-      command: zedJsonConfig,
-      rawConfig: zedJsonConfig,
-    },
-  };
-};
-
-const PROVIDERS: Provider[] = [
-  {
-    id: "codex",
-    name: "Codex",
-    setupLabel: "Run in your terminal",
-  },
-  {
-    id: "claude",
-    name: "Claude",
-    setupLabel: "Run in your terminal",
-  },
-  {
-    id: "cursor",
-    name: "Cursor",
-    setupLabel: "Paste into .cursor/mcp.json",
-  },
-  {
-    id: "windsurf",
-    name: "Windsurf",
-    setupLabel: "Paste into MCP config",
-  },
-  {
-    id: "chatgpt",
-    name: "ChatGPT",
-    setupLabel: "Use as connector config",
-  },
-  {
-    id: "zed",
-    name: "Zed",
-    setupLabel: "Paste into settings.json",
-  },
-];
 
 const CopyControl = (props: {
   fieldName: string;
@@ -230,6 +54,7 @@ const CopyControl = (props: {
           "size-8 rounded-12": variant === "icon",
         },
       )}
+      aria-label={variant === "icon" ? `Copy ${fieldName}` : undefined}
       onClick={copyToClipboard}
     >
       <Icon className="size-4" />
@@ -250,15 +75,8 @@ const SnippetText = (props: { value: string; isRawConfig: boolean }) => {
   }
 
   const firstSpace = value.indexOf(" ");
-  const firstEquals = value.indexOf("=");
-  const splitAt =
-    firstSpace === -1
-      ? firstEquals
-      : firstEquals === -1
-        ? firstSpace
-        : Math.min(firstSpace, firstEquals);
-  const firstToken = splitAt === -1 ? value : value.slice(0, splitAt);
-  const rest = splitAt === -1 ? "" : value.slice(splitAt);
+  const firstToken = firstSpace === -1 ? value : value.slice(0, firstSpace);
+  const rest = firstSpace === -1 ? "" : value.slice(firstSpace);
 
   return (
     <pre className="min-w-0 overflow-x-auto font-ibm text-xs leading-5 whitespace-pre text-grey-900 md:text-sm">
@@ -275,7 +93,11 @@ export const ApiKeySecretFields = (props: { apiKey: string }) => {
   const apiKeyPreview = getApiKeyPreview(apiKey);
   const [selectedProvider, setSelectedProvider] = useState<ProviderId>("codex");
   const [showRawConfig, setShowRawConfig] = useState(false);
-  const snippets = useMemo(() => getProviderSnippets(apiKey), [apiKey]);
+  // Only ever rendered post-mutation inside CreateKeyModal, so `window` exists.
+  const snippets = useMemo(
+    () => getProviderSnippets(apiKey, getMcpEndpoint(window.location.origin)),
+    [apiKey],
+  );
   const provider = PROVIDERS.find((item) => item.id === selectedProvider)!;
   const snippet = snippets[selectedProvider];
   const snippetValue = showRawConfig ? snippet.rawConfig : snippet.command;

--- a/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeyTable/ApiKeyRow/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeyTable/ApiKeyRow/index.tsx
@@ -17,6 +17,7 @@ import clsx from "clsx";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "react-toastify";
 import { ApiKeySecretModal } from "../../ApiKeySecretModal";
+import { RotateKeyModal } from "../RotateKeyModal";
 import { FetchKeysDocument } from "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/graphql/client/fetch-keys.generated";
 import { Status } from "./Status";
 import { ResetApiKeyDocument } from "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/graphql/client/reset-api-key.generated";
@@ -30,6 +31,7 @@ export const ApiKeyRow = (props: {
 }) => {
   const { apiKey, index, teamId, openViewDetails, openDeleteKeyModal } = props;
   const [resetKey, setResetKey] = useState<string | null>(null);
+  const [rotateOpen, setRotateOpen] = useState(false);
   const timeAgo = formatDistanceToNowStrict(new Date(apiKey.created_at), {
     addSuffix: true,
   });
@@ -45,9 +47,9 @@ export const ApiKeyRow = (props: {
   const [resetApiKeyMutation, { loading }] = useMutation(ResetApiKeyDocument);
 
   const resetAPIKey = useCallback(
-    async (apiKeyId: string) => {
+    async (apiKeyId: string): Promise<boolean> => {
       if (loading) {
-        return;
+        return false;
       }
 
       try {
@@ -63,15 +65,20 @@ export const ApiKeyRow = (props: {
           throw result;
         }
 
-        toast.success("API key was reset");
-
+        // The rotation already committed server-side and has no rollback, so a
+        // missing secret is not the same failure as the mutation not running.
         if (!result.data?.reset_api_key?.api_key) {
-          throw new Error("No API key returned");
+          throw new Error("ROTATED_WITHOUT_SECRET");
         }
 
+        toast.success("API key was reset");
         setResetKey(result.data.reset_api_key.api_key);
+        return true;
       } catch (error) {
-        let errorText = "Error occurred while resetting API key.";
+        let errorText =
+          error instanceof Error && error.message === "ROTATED_WITHOUT_SECRET"
+            ? "Key was rotated but the new secret could not be shown. Rotate again to get a new key."
+            : "Error occurred while resetting API key.";
 
         if (CombinedGraphQLErrors.is(error)) {
           for (let graphQLError of error.errors) {
@@ -85,6 +92,7 @@ export const ApiKeyRow = (props: {
         }
 
         toast.error(errorText);
+        return false;
       }
     },
     [loading, resetApiKeyMutation, teamId],
@@ -98,6 +106,16 @@ export const ApiKeyRow = (props: {
         onClose={() => setResetKey(null)}
         title="API Key"
         description="Your new API key is ready. Save it now because you won't be able to see it again."
+      />
+
+      <RotateKeyModal
+        isOpen={rotateOpen}
+        name={apiKey.name}
+        loading={loading}
+        setIsOpen={setRotateOpen}
+        onConfirm={async () => {
+          if (await resetAPIKey(apiKey.id)) setRotateOpen(false);
+        }}
       />
 
       <div
@@ -160,55 +178,53 @@ export const ApiKeyRow = (props: {
         </div>
 
         <div className="max-md:col-start-4 max-md:col-end-5 max-md:row-start-1 max-md:row-end-3 max-md:pl-2 md:table-cell md:border-b md:border-grey-200 md:pr-2 md:pl-4 md:align-middle">
-          <div
-            key={`api_key_${index}_5`}
-            className={clsx("flex w-full justify-end", {
-              hidden: !isEnoughPermissions,
-            })}
-          >
-            <Dropdown>
-              <Dropdown.Button>
-                <MoreVerticalIcon />
-              </Dropdown.Button>
+          {/* Every item here is OWNER-only in Hasura; don't ship dead DOM. */}
+          {isEnoughPermissions ? (
+            <div key={`api_key_${index}_5`} className="flex w-full justify-end">
+              <Dropdown>
+                <Dropdown.Button>
+                  <MoreVerticalIcon />
+                </Dropdown.Button>
 
-              <Dropdown.List align="end" heading={apiKey.name} hideBackButton>
-                <Dropdown.ListItem asChild>
-                  <button onClick={() => openViewDetails(apiKey)}>
-                    <Dropdown.ListItemIcon asChild>
-                      <EditIcon />
-                    </Dropdown.ListItemIcon>
+                <Dropdown.List align="end" heading={apiKey.name} hideBackButton>
+                  <Dropdown.ListItem asChild>
+                    <button onClick={() => openViewDetails(apiKey)}>
+                      <Dropdown.ListItemIcon asChild>
+                        <EditIcon />
+                      </Dropdown.ListItemIcon>
 
-                    <Dropdown.ListItemText>Edit Key</Dropdown.ListItemText>
-                  </button>
-                </Dropdown.ListItem>
+                      <Dropdown.ListItemText>Edit Key</Dropdown.ListItemText>
+                    </button>
+                  </Dropdown.ListItem>
 
-                <Dropdown.ListItem asChild>
-                  <button onClick={() => resetAPIKey(apiKey.id)}>
-                    <Dropdown.ListItemIcon asChild>
-                      <KeyIcon />
-                    </Dropdown.ListItemIcon>
+                  <Dropdown.ListItem asChild>
+                    <button onClick={() => setRotateOpen(true)}>
+                      <Dropdown.ListItemIcon asChild>
+                        <KeyIcon />
+                      </Dropdown.ListItemIcon>
 
-                    <Dropdown.ListItemText>Reset key</Dropdown.ListItemText>
-                  </button>
-                </Dropdown.ListItem>
+                      <Dropdown.ListItemText>Rotate key</Dropdown.ListItemText>
+                    </button>
+                  </Dropdown.ListItem>
 
-                <Dropdown.ListItem asChild>
-                  <button onClick={() => openDeleteKeyModal(apiKey)}>
-                    <Dropdown.ListItemIcon
-                      className="text-system-error-600"
-                      asChild
-                    >
-                      <TrashIcon />
-                    </Dropdown.ListItemIcon>
+                  <Dropdown.ListItem asChild>
+                    <button onClick={() => openDeleteKeyModal(apiKey)}>
+                      <Dropdown.ListItemIcon
+                        className="text-system-error-600"
+                        asChild
+                      >
+                        <TrashIcon />
+                      </Dropdown.ListItemIcon>
 
-                    <Dropdown.ListItemText className="text-system-error-600">
-                      Remove key
-                    </Dropdown.ListItemText>
-                  </button>
-                </Dropdown.ListItem>
-              </Dropdown.List>
-            </Dropdown>
-          </div>
+                      <Dropdown.ListItemText className="text-system-error-600">
+                        Remove key
+                      </Dropdown.ListItemText>
+                    </button>
+                  </Dropdown.ListItem>
+                </Dropdown.List>
+              </Dropdown>
+            </div>
+          ) : null}
         </div>
       </div>
     </>

--- a/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeyTable/RotateKeyModal/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeyTable/RotateKeyModal/index.tsx
@@ -1,0 +1,72 @@
+import { CircleIconContainer } from "@/components/CircleIconContainer";
+import { DecoratedButton } from "@/components/DecoratedButton";
+import { Dialog } from "@/components/Dialog";
+import { DialogOverlay } from "@/components/DialogOverlay";
+import { DialogPanel } from "@/components/DialogPanel";
+import { WarningErrorIcon } from "@/components/Icons/WarningErrorIcon";
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
+
+type RotateKeyModalProps = {
+  isOpen: boolean;
+  name?: string;
+  loading: boolean;
+  onConfirm: () => void;
+  setIsOpen: (isOpen: boolean) => void;
+};
+
+export const RotateKeyModal = (props: RotateKeyModalProps) => {
+  const { isOpen, name, loading, onConfirm, setIsOpen } = props;
+
+  return (
+    <Dialog open={isOpen} onClose={() => setIsOpen(false)}>
+      <DialogOverlay />
+
+      <DialogPanel>
+        <div className="grid grid-cols-1 justify-items-center gap-y-8 px-2 md:w-full md:max-w-100">
+          <CircleIconContainer variant={"error"}>
+            <WarningErrorIcon className="w-6" />
+          </CircleIconContainer>
+
+          <div className="grid w-full grid-cols-1 items-center justify-items-center gap-y-4 text-center">
+            <Typography variant={TYPOGRAPHY.H6}>Are you sure?</Typography>
+
+            {/* Consequence stays in one trailing text node so getByText can match it. */}
+            <Typography variant={TYPOGRAPHY.R3} className="text-grey-500">
+              Rotating{" "}
+              <div className="inline-flex">
+                <Typography
+                  variant={TYPOGRAPHY.M3}
+                  className="max-w-52 truncate text-grey-900"
+                >
+                  {name}
+                </Typography>
+              </div>{" "}
+              will stop working immediately anywhere it is already deployed, and
+              the new key is shown only once.
+            </Typography>
+          </div>
+
+          <div className="grid w-full gap-x-4 gap-y-2 md:grid-cols-2">
+            <DecoratedButton
+              className="order-2 md:order-1"
+              type="button"
+              variant="danger"
+              disabled={loading}
+              onClick={onConfirm}
+            >
+              Rotate key
+            </DecoratedButton>
+
+            <DecoratedButton
+              className="order-1 whitespace-nowrap"
+              type="button"
+              onClick={() => setIsOpen(false)}
+            >
+              Keep current key
+            </DecoratedButton>
+          </div>
+        </div>
+      </DialogPanel>
+    </Dialog>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/McpSetup/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/McpSetup/index.tsx
@@ -1,0 +1,89 @@
+"use client";
+import { CopyIcon } from "@/components/Icons/CopyIcon";
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import {
+  getMcpEndpoint,
+  getProviderSnippets,
+  PROVIDERS,
+  type ProviderId,
+} from "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/mcp-snippets";
+import clsx from "clsx";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "react-toastify";
+
+const KEY_PLACEHOLDER = "YOUR_API_KEY";
+
+export const McpSetup = () => {
+  // Origin is unknown during SSR; correct on mount rather than hydrate a wrong one.
+  const [endpoint, setEndpoint] = useState(() => getMcpEndpoint(undefined));
+  useEffect(() => setEndpoint(getMcpEndpoint(window.location.origin)), []);
+
+  const [providerId, setProviderId] = useState<ProviderId>("claude");
+
+  // The real key is shown once at creation; this section never handles one.
+  const snippets = useMemo(
+    () => getProviderSnippets(KEY_PLACEHOLDER, endpoint),
+    [endpoint],
+  );
+  const command = snippets[providerId].command;
+
+  return (
+    <section className="order-2 grid gap-y-3 md:pb-8">
+      <Typography variant={TYPOGRAPHY.M4} className="text-grey-400 uppercase">
+        MCP endpoint
+      </Typography>
+
+      <code className="font-ibm text-sm break-all text-grey-900">
+        {endpoint}
+      </code>
+
+      <div className="flex flex-wrap gap-1.5">
+        {PROVIDERS.map((item) => {
+          const isSelected = item.id === providerId;
+
+          return (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={isSelected}
+              onClick={() => setProviderId(item.id)}
+              className={clsx(
+                "flex h-9 items-center rounded-full border px-3 text-grey-500 transition-colors hover:border-blue-150 hover:bg-blue-50 hover:text-grey-900 focus-visible:ring-2 focus-visible:ring-blue-150 focus-visible:outline-hidden",
+                {
+                  "border-blue-150 bg-blue-50 text-grey-900": isSelected,
+                  "border-transparent bg-grey-0": !isSelected,
+                },
+              )}
+            >
+              <Typography variant={TYPOGRAPHY.M5}>{item.name}</Typography>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="grid min-h-12 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-12 bg-grey-0 px-3 py-2 shadow-button">
+        <pre className="min-w-0 overflow-x-auto font-ibm text-xs leading-5 whitespace-pre text-grey-900">
+          <code>{command}</code>
+        </pre>
+
+        <button
+          type="button"
+          aria-label="Copy MCP setup command"
+          className="flex size-8 shrink-0 items-center justify-center rounded-12 text-blue-500 transition-colors hover:text-grey-900 focus-visible:ring-2 focus-visible:ring-blue-150 focus-visible:outline-hidden"
+          onClick={() =>
+            navigator.clipboard
+              .writeText(command)
+              .then(() => toast.success("Setup command copied to clipboard"))
+              .catch(() =>
+                toast.error(
+                  "Couldn't copy — select the command and copy it manually",
+                ),
+              )
+          }
+        >
+          <CopyIcon className="size-4" />
+        </button>
+      </div>
+    </section>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/index.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import Skeleton from "react-loading-skeleton";
 import { ApiKeysTable } from "./ApiKeyTable";
 import { CreateKeyModal } from "./CreateKeyModal";
+import { McpSetup } from "./McpSetup";
 import { FetchKeysDocument } from "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/graphql/client/fetch-keys.generated";
 import { useQuery } from "@apollo/client/react";
 
@@ -51,7 +52,7 @@ export const ApiKeys = (props: { teamId?: string; canWrite: boolean }) => {
       ) : null}
 
       {!loading && apiKeys?.length === 0 ? (
-        <div className="grid grid-cols-1 justify-items-center gap-y-8 pt-12">
+        <div className="order-2 grid grid-cols-1 justify-items-center gap-y-8 pt-12">
           <div className="grid justify-items-center gap-y-5">
             <Typography variant={TYPOGRAPHY.H6}>No API keys found</Typography>
 
@@ -95,6 +96,8 @@ export const ApiKeys = (props: { teamId?: string; canWrite: boolean }) => {
           )}
         </div>
       )}
+
+      <McpSetup />
     </Section>
   );
 };

--- a/web/scenes/common/Teams/TeamId/Team/ApiKeys/page/mcp-snippets.ts
+++ b/web/scenes/common/Teams/TeamId/Team/ApiKeys/page/mcp-snippets.ts
@@ -1,0 +1,192 @@
+const MCP_SERVER_NAME = "worldcoin-developer-portal";
+const MCP_API_KEY_ENV_VAR = "WORLD_DEVELOPER_API_KEY";
+const MCP_PATH = "/api/mcp";
+
+export type ProviderId =
+  | "codex"
+  | "claude"
+  | "cursor"
+  | "windsurf"
+  | "chatgpt"
+  | "zed";
+
+export type Provider = {
+  id: ProviderId;
+  name: string;
+  setupLabel: string;
+};
+
+export type ProviderSnippet = {
+  command: string;
+  rawConfig: string;
+};
+
+const shellQuote = (value: string) => `'${value.replace(/'/g, "'\\''")}'`;
+const envReference = (name: string) => `\${${name}}`;
+const tomlString = (value: string) => JSON.stringify(value);
+
+// Renders inside the useMemo that shows a one-shot secret, so it must never
+// throw: "" and "null" are real origins and would blow up `new URL`.
+export const getMcpEndpoint = (origin?: string | null): string => {
+  if (!origin || origin === "null") {
+    return MCP_PATH;
+  }
+
+  return `${origin.replace(/\/+$/, "")}${MCP_PATH}`;
+};
+
+const getClaudeMcpCommand = (apiKey: string, endpoint: string) =>
+  `claude mcp add ${MCP_SERVER_NAME} ${endpoint} --transport http --header "Authorization: Bearer ${apiKey}"`;
+
+const getCodexMcpCommand = (apiKey: string, endpoint: string) =>
+  `codex mcp add ${MCP_SERVER_NAME} --env ${MCP_API_KEY_ENV_VAR}=${shellQuote(apiKey)} -- npx -y mcp-remote ${endpoint} --transport http-only --header 'Authorization:Bearer ${envReference(MCP_API_KEY_ENV_VAR)}'`;
+
+const getClaudeJsonConfig = (apiKey: string, endpoint: string) =>
+  JSON.stringify(
+    {
+      mcpServers: {
+        [MCP_SERVER_NAME]: {
+          type: "http",
+          url: endpoint,
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+const getCursorJsonConfig = (apiKey: string, endpoint: string) =>
+  JSON.stringify(
+    {
+      mcpServers: {
+        [MCP_SERVER_NAME]: {
+          url: endpoint,
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+const getWindsurfJsonConfig = (apiKey: string, endpoint: string) =>
+  JSON.stringify(
+    {
+      mcpServers: {
+        [MCP_SERVER_NAME]: {
+          serverUrl: endpoint,
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+const getChatGptConnectorConfig = (apiKey: string, endpoint: string) =>
+  [
+    `Name: World Developer Portal`,
+    `URL: ${endpoint}`,
+    `Authorization: Bearer ${apiKey}`,
+  ].join("\n");
+
+const getZedJsonConfig = (apiKey: string, endpoint: string) =>
+  JSON.stringify(
+    {
+      context_servers: {
+        [MCP_SERVER_NAME]: {
+          url: endpoint,
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+export const getProviderSnippets = (
+  apiKey: string,
+  endpoint: string,
+): Record<ProviderId, ProviderSnippet> => {
+  const claudeJsonConfig = getClaudeJsonConfig(apiKey, endpoint);
+  const cursorJsonConfig = getCursorJsonConfig(apiKey, endpoint);
+  const windsurfJsonConfig = getWindsurfJsonConfig(apiKey, endpoint);
+  const chatGptConnectorConfig = getChatGptConnectorConfig(apiKey, endpoint);
+  const zedJsonConfig = getZedJsonConfig(apiKey, endpoint);
+
+  return {
+    codex: {
+      command: getCodexMcpCommand(apiKey, endpoint),
+      rawConfig: [
+        `[mcp_servers.${MCP_SERVER_NAME}]`,
+        `command = "npx"`,
+        `args = ["-y", "mcp-remote", ${tomlString(endpoint)}, "--transport", "http-only", "--header", ${tomlString(`Authorization:Bearer ${envReference(MCP_API_KEY_ENV_VAR)}`)}]`,
+        "",
+        `[mcp_servers.${MCP_SERVER_NAME}.env]`,
+        `${MCP_API_KEY_ENV_VAR} = ${tomlString(apiKey)}`,
+      ].join("\n"),
+    },
+    claude: {
+      command: getClaudeMcpCommand(apiKey, endpoint),
+      rawConfig: claudeJsonConfig,
+    },
+    cursor: {
+      command: cursorJsonConfig,
+      rawConfig: cursorJsonConfig,
+    },
+    windsurf: {
+      command: windsurfJsonConfig,
+      rawConfig: windsurfJsonConfig,
+    },
+    chatgpt: {
+      command: chatGptConnectorConfig,
+      rawConfig: chatGptConnectorConfig,
+    },
+    zed: {
+      command: zedJsonConfig,
+      rawConfig: zedJsonConfig,
+    },
+  };
+};
+
+export const PROVIDERS: Provider[] = [
+  {
+    id: "codex",
+    name: "Codex",
+    setupLabel: "Run in your terminal",
+  },
+  {
+    id: "claude",
+    name: "Claude",
+    setupLabel: "Run in your terminal",
+  },
+  {
+    id: "cursor",
+    name: "Cursor",
+    setupLabel: "Paste into .cursor/mcp.json",
+  },
+  {
+    id: "windsurf",
+    name: "Windsurf",
+    setupLabel: "Paste into MCP config",
+  },
+  {
+    id: "chatgpt",
+    name: "ChatGPT",
+    setupLabel: "Use as connector config",
+  },
+  {
+    id: "zed",
+    name: "Zed",
+    setupLabel: "Paste into settings.json",
+  },
+];

--- a/web/tests/api/mcp.test.ts
+++ b/web/tests/api/mcp.test.ts
@@ -1,5 +1,5 @@
 import { generateHashedSecret } from "@/api/helpers/utils";
-import { POST } from "@/api/mcp";
+import { GET, OPTIONS, POST } from "@/api/mcp";
 import { logger } from "@/lib/logger";
 import { generateRpIdString } from "@/lib/rp";
 import { NextRequest } from "next/server";
@@ -2108,3 +2108,92 @@ describe("/api/mcp", () => {
     );
   });
 });
+
+// #region Transport
+// createRequest JSON.stringifies an object, so malformed envelopes need a raw
+// body. Auth header stays valid so a 400 can only mean "bad shape", not "bad key".
+const rawRequest = (body: string) =>
+  new NextRequest("http://localhost:3000/api/mcp", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${validApiKey}`,
+    },
+    body,
+  });
+
+describe("/api/mcp [transport]", () => {
+  it("rejects GET with 405 and advertises only POST and OPTIONS", async () => {
+    const res = await GET();
+
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("POST, OPTIONS");
+    // A 200 here makes the MCP SDK treat the JSON body as an SSE stream and
+    // reconnect ~1/sec forever, so the handshake descriptor must be gone.
+    expect(await res.text()).not.toMatch(/"transport"\s*:\s*"streamable-http"/);
+  });
+
+  it("advertises only POST and OPTIONS from OPTIONS", async () => {
+    const res = await OPTIONS();
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Allow")).toBe("POST, OPTIONS");
+    expect(await res.text()).toBe("");
+    expect(
+      String(res.headers.get("Access-Control-Allow-Methods")),
+    ).not.toContain("GET");
+  });
+
+  it("returns an invalid-request error for a literal null body", async () => {
+    const res = await POST(rawRequest("null"));
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = await res.json();
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.id).toBeNull();
+    expect(body.error.code).toBe(-32600);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an invalid-request error for a JSON-RPC batch array", async () => {
+    const res = await POST(
+      rawRequest(JSON.stringify([{ jsonrpc: "2.0", id: 1, method: "ping" }])),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32600);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("returns an invalid-request error for a primitive body", async () => {
+    const res = await POST(rawRequest('"tools/list"'));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32600);
+  });
+
+  it("returns method-not-found, not a transport error, when method is missing", async () => {
+    const res = await POST(createRequest({ jsonrpc: "2.0", id: 1 }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(1);
+    expect(body.error.code).toBe(-32601);
+  });
+
+  it("answers ping with an empty result and echoes a string id", async () => {
+    const res = await POST(
+      createRequest({ jsonrpc: "2.0", id: "abc-1", method: "ping" }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe("abc-1");
+    expect(body.result).toEqual({});
+  });
+});
+// #endregion

--- a/web/tests/unit/api-key-rotate-confirm.test.tsx
+++ b/web/tests/unit/api-key-rotate-confirm.test.tsx
@@ -1,0 +1,357 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act } from "react";
+import { CombinedGraphQLErrors } from "@apollo/client";
+import { Role_Enum } from "@/graphql/graphql";
+import { ApiKeyRow } from "@/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeyTable/ApiKeyRow";
+
+// #region Mocks
+// The real I/O boundary. The stateful wrapper below drives `loading` from it.
+const resetApiKeyMock = jest.fn();
+
+// Stateful tuple on purpose: ApiKeyRow's `if (loading) return false` guard reads
+// this value, so a flat [fn, { loading: false }] would turn the in-flight case
+// into a tautology. `React` is out of scope inside a jest.mock factory.
+jest.mock("@apollo/client/react", () => {
+  const React = require("react");
+  return {
+    useMutation: () => {
+      const [loading, setLoading] = React.useState(false);
+      const mutate = React.useCallback((...args: unknown[]) => {
+        setLoading(true);
+        return resetApiKeyMock(...args).finally(() => setLoading(false));
+      }, []);
+      return [mutate, { loading }];
+    },
+  };
+});
+
+// ApiKeyRow reads user.hasura.memberships directly, so mocking
+// checkUserPermissions would have no effect -- the session itself is the gate.
+let mockSession: unknown;
+jest.mock("@auth0/nextjs-auth0/client", () => ({
+  useUser: () => ({ user: mockSession }),
+}));
+
+const toastSuccess = jest.fn();
+const toastError = jest.fn();
+jest.mock("react-toastify", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+// Flattened Radix primitives (precedent: portal-v3-apps-dropdown.test.tsx).
+// Item must NOT be a <button>: Dropdown.ListItem forwards `asChild`, and the
+// real menu entries are <button onClick> children. A <div role="menuitem">
+// wrapper never receives their click -- events bubble up, not down -- so every
+// activation below goes through the inner button.
+jest.mock("@radix-ui/react-dropdown-menu", () => ({
+  Root: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  Trigger: ({ children, ...props }: React.ComponentProps<"button">) => (
+    <button {...props}>{children}</button>
+  ),
+  Portal: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  Content: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  Item: ({
+    children,
+    onSelect,
+    asChild,
+    ...props
+  }: React.ComponentProps<"div"> & {
+    onSelect?: () => void;
+    asChild?: boolean;
+  }) => (
+    <div role="menuitem" onClick={onSelect} {...props}>
+      {children}
+    </div>
+  ),
+}));
+
+// Headless UI portal/transition machinery is not the subject. Rendering the
+// open dialog as role="dialog" is what makes within(dialog) scoping work.
+jest.mock("@/components/Dialog", () => ({
+  Dialog: ({ open, children }: React.PropsWithChildren<{ open: boolean }>) =>
+    open ? <div role="dialog">{children}</div> : null,
+}));
+jest.mock("@/components/DialogOverlay", () => ({ DialogOverlay: () => null }));
+jest.mock("@/components/DialogPanel", () => ({
+  DialogPanel: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
+// Keeps this file off ApiKeySecretFields (clipboard + window.location).
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeySecretModal",
+  () => ({
+    ApiKeySecretModal: ({ isOpen }: { isOpen: boolean }) => (
+      <div data-testid="secret-modal" data-open={String(isOpen)} />
+    ),
+  }),
+);
+
+jest.mock(
+  "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/graphql/client/reset-api-key.generated",
+  () => ({ ResetApiKeyDocument: { __mockDoc: "resetApiKey" } }),
+);
+jest.mock(
+  "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/graphql/client/fetch-keys.generated",
+  () => ({ FetchKeysDocument: { __mockDoc: "fetchKeys" } }),
+);
+// CombinedGraphQLErrors stays real -- it comes from the @apollo/client root,
+// a different specifier from the mocked /react subpath, and case 8 depends on
+// its actual shape narrowing.
+// #endregion
+
+// #region Test Data
+const sessionWithRole = (role: string) => ({
+  hasura: { memberships: [{ role, team: { id: "team_1" } }] },
+});
+
+const API_KEY = {
+  __typename: "api_key" as const,
+  id: "key_1",
+  team_id: "team_1",
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+  is_active: true,
+  name: "prod-mcp",
+};
+
+const NEW_SECRET = { data: { reset_api_key: { api_key: "api_NEWSECRET" } } };
+
+const openViewDetails = jest.fn();
+const openDeleteKeyModal = jest.fn();
+
+const renderRow = () =>
+  render(
+    <ApiKeyRow
+      apiKey={API_KEY}
+      index={0}
+      teamId="team_1"
+      openViewDetails={openViewDetails}
+      openDeleteKeyModal={openDeleteKeyModal}
+    />,
+  );
+
+// The real control inside the menu row -- see the Radix stub comment.
+const menuButton = (name: RegExp) =>
+  within(screen.getByRole("menuitem", { name })).getByRole("button");
+
+const dialog = () => screen.getByRole("dialog");
+// Query by accessible name, never by index: DeleteKeyModal (and this modal)
+// put the destructive button first in source and reorder it with CSS.
+const confirmButton = () =>
+  within(dialog()).getByRole("button", { name: /^rotate key$/i });
+const cancelButton = () =>
+  within(dialog()).getByRole("button", { name: /cancel|keep/i });
+
+const secretModal = () => screen.getByTestId("secret-modal");
+
+const openConfirm = () => {
+  renderRow();
+  fireEvent.click(menuButton(/rotate key/i));
+};
+
+const clickConfirm = async () => {
+  await act(async () => {
+    fireEvent.click(confirmButton());
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSession = sessionWithRole(Role_Enum.Owner);
+  // The mocked useMutation calls .finally on this, so it must be a promise.
+  resetApiKeyMock.mockResolvedValue(NEW_SECRET);
+});
+// #endregion
+
+// #region Confirmation gate
+describe("ApiKeyRow rotate [confirmation gate]", () => {
+  it("opens a confirmation and mutates nothing when Rotate key is chosen", () => {
+    openConfirm();
+
+    // The whole point of the change: choosing the menu item is not the rotation.
+    expect(resetApiKeyMock).not.toHaveBeenCalled();
+
+    const confirm = dialog();
+    // Names which key, and names the consequence.
+    expect(within(confirm).getByText(/prod-mcp/)).toBeInTheDocument();
+    expect(
+      within(confirm).getByText(
+        /will stop working|stop working|become invalid/i,
+      ),
+    ).toBeInTheDocument();
+
+    // The rename, scoped to the menu so the confirm button cannot mask it.
+    expect(
+      screen.queryByRole("menuitem", { name: /^reset key$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("rotates exactly once and reveals the new secret when confirmed", async () => {
+    openConfirm();
+    await clickConfirm();
+
+    expect(resetApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(resetApiKeyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: { id: "key_1", team_id: "team_1" },
+        // The tagged FetchKeysDocument: the row refetches the key list, not
+        // some other document.
+        refetchQueries: [{ __mockDoc: "fetchKeys" }],
+      }),
+    );
+    expect(toastSuccess).toHaveBeenCalledWith("API key was reset");
+    expect(secretModal()).toHaveAttribute("data-open", "true");
+    // Both open at once would trap focus behind two overlays.
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("does not rotate when the confirmation is cancelled", () => {
+    openConfirm();
+
+    fireEvent.click(cancelButton());
+
+    expect(resetApiKeyMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(menuButton(/rotate key/i)).toBeInTheDocument();
+  });
+
+  it("locks the confirm control while a rotation is in flight", async () => {
+    let resolveMutation!: (value: unknown) => void;
+    resetApiKeyMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveMutation = resolve;
+      }),
+    );
+
+    openConfirm();
+    // No await between the two clicks -- this is the double-click a user makes
+    // when the first one appears to do nothing. Rotating twice burns the key
+    // that was just copied.
+    fireEvent.click(confirmButton());
+    fireEvent.click(confirmButton());
+
+    expect(resetApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(confirmButton()).toBeDisabled();
+
+    await act(async () => {
+      resolveMutation(NEW_SECRET);
+    });
+
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(secretModal()).toHaveAttribute("data-open", "true");
+  });
+});
+// #endregion
+
+// #region Failure paths
+describe("ApiKeyRow rotate [failures]", () => {
+  it("surfaces an error and leaves no secret modal open when the rotation rejects", async () => {
+    resetApiKeyMock.mockRejectedValue(new Error("network down"));
+
+    openConfirm();
+    await clickConfirm();
+
+    expect(toastError).toHaveBeenCalledWith(
+      "Error occurred while resetting API key.",
+    );
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(secretModal()).toHaveAttribute("data-open", "false");
+    // The in-flight lock must release on failure, and the dialog must stay open
+    // so the user can retry -- the classic set-before-await/clear-on-success brick.
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(confirmButton()).toBeEnabled();
+  });
+
+  it("treats a resolved-with-error result as a failure", async () => {
+    // Different branch from the reject: Boolean(result?.error).
+    resetApiKeyMock.mockResolvedValue({ error: new Error("gql") });
+
+    openConfirm();
+    await clickConfirm();
+
+    expect(toastError).toHaveBeenCalledWith(
+      "Error occurred while resetting API key.",
+    );
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(secretModal()).toHaveAttribute("data-open", "false");
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("does not report success when the rotation returns no secret", async () => {
+    // The mutation already committed server-side and has no rollback, so this
+    // is not the same failure as the mutation never running.
+    resetApiKeyMock.mockResolvedValue({ data: { reset_api_key: null } });
+
+    openConfirm();
+    await clickConfirm();
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith(
+      expect.stringMatching(/could not be shown/i),
+    );
+    expect(secretModal()).toHaveAttribute("data-open", "false");
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("explains that the key must be active on an inactive-key permission error", async () => {
+    resetApiKeyMock.mockRejectedValue(
+      new CombinedGraphQLErrors({
+        data: null,
+        errors: [{ message: "User does not have sufficient permissions." }],
+      }),
+    );
+
+    openConfirm();
+    await clickConfirm();
+
+    expect(toastError).toHaveBeenCalledWith("API key must be active to reset.");
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+});
+// #endregion
+
+// #region Permissions and sibling actions
+describe("ApiKeyRow menu [permissions]", () => {
+  it("renders no rotate control at all for a non-owner", () => {
+    mockSession = sessionWithRole(Role_Enum.Admin);
+    renderRow();
+
+    // A render guard, not a Tailwind `hidden` class: jsdom loads no stylesheet,
+    // so a CSS gate is untestable and ships dead OWNER-only DOM to non-owners.
+    expect(
+      screen.queryByRole("menuitem", { name: /rotate key/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /remove key/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /edit key/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /rotate key/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("still invokes the Edit key and Remove key callbacks", () => {
+    renderRow();
+
+    fireEvent.click(menuButton(/edit key/i));
+    expect(openViewDetails).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "key_1" }),
+    );
+
+    fireEvent.click(menuButton(/remove key/i));
+    expect(openDeleteKeyModal).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "key_1" }),
+    );
+
+    expect(resetApiKeyMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+// #endregion

--- a/web/tests/unit/api-key-secret-fields.test.tsx
+++ b/web/tests/unit/api-key-secret-fields.test.tsx
@@ -1,0 +1,161 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react";
+import { ApiKeySecretFields } from "@/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeySecretFields";
+import { ApiKeySecretFields as ApiKeySecretFieldsV2 } from "@/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields";
+
+// #region Mocks
+const toastSuccess = jest.fn();
+jest.mock("react-toastify", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: jest.fn(),
+  },
+}));
+// #endregion
+
+// #region Test Data
+const V3_COMPONENT =
+  "@/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeySecretFields";
+const V2_COMPONENT =
+  "@/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields";
+
+const SHORT_KEY = "api_short";
+// Shape of a real key: "api_" + base64 of 88 bytes, padding stripped.
+const REAL_KEY = `api_${"a".repeat(118)}`;
+
+const originalLocation = window.location;
+const writeText = jest.fn();
+let xhrOpen: jest.SpyInstance;
+
+const snippetText = (container: HTMLElement) =>
+  container.querySelector("pre")!.textContent ?? "";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  Object.defineProperty(window, "location", {
+    value: new URL("https://staging.example.test:8443/teams/team_1/settings"),
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+  global.fetch = jest.fn();
+  xhrOpen = jest.spyOn(XMLHttpRequest.prototype, "open");
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    value: originalLocation,
+    writable: true,
+    configurable: true,
+  });
+  jest.restoreAllMocks();
+});
+// #endregion
+
+// #region Endpoint
+describe("ApiKeySecretFields [endpoint]", () => {
+  it("renders the endpoint for the browser's current origin", () => {
+    const { container } = render(<ApiKeySecretFields apiKey={SHORT_KEY} />);
+
+    expect(snippetText(container)).toContain(
+      "https://staging.example.test:8443/api/mcp",
+    );
+    expect(snippetText(container)).not.toContain("developer.world.org");
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(xhrOpen).not.toHaveBeenCalled();
+  });
+
+  it("renders byte-identical snippets in both portals", () => {
+    const v3 = render(<ApiKeySecretFields apiKey={SHORT_KEY} />);
+    const v3Text = snippetText(v3.container);
+    cleanup();
+
+    const v2 = render(<ApiKeySecretFieldsV2 apiKey={SHORT_KEY} />);
+    expect(snippetText(v2.container)).toBe(v3Text);
+  });
+});
+// #endregion
+
+// #region Provider switching
+describe("ApiKeySecretFields [providers]", () => {
+  it("resets the raw-config view when the provider changes", () => {
+    render(<ApiKeySecretFields apiKey={SHORT_KEY} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw config" }));
+    // Cursor, not Claude: codex and claude share a setupLabel.
+    fireEvent.click(screen.getByRole("button", { name: "Cursor" }));
+
+    expect(screen.getByRole("button", { name: "Raw config" })).toBeVisible();
+    expect(screen.getByText("Paste into .cursor/mcp.json")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Cursor" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Codex" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("swaps the codex CLI command for the TOML block", () => {
+    const { container } = render(<ApiKeySecretFields apiKey={SHORT_KEY} />);
+
+    expect(snippetText(container).startsWith("codex mcp add")).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw config" }));
+
+    expect(snippetText(container)).toContain(
+      "[mcp_servers.worldcoin-developer-portal]",
+    );
+    expect(snippetText(container)).not.toContain("codex mcp add");
+  });
+});
+// #endregion
+
+// #region Module boundary
+describe("ApiKeySecretFields [module boundary]", () => {
+  it("keeps snippet generation in exactly one module", () => {
+    expect(Object.keys(require(V3_COMPONENT)).sort()).toEqual([
+      "ApiKeySecretFields",
+    ]);
+    expect(Object.keys(require(V2_COMPONENT)).sort()).toEqual([
+      "ApiKeySecretFields",
+    ]);
+    expect(
+      Object.keys(
+        require("@/scenes/common/Teams/TeamId/Team/ApiKeys/page/mcp-snippets"),
+      ).sort(),
+    ).toEqual(["PROVIDERS", "getMcpEndpoint", "getProviderSnippets"].sort());
+  });
+});
+// #endregion
+
+// #region Copy controls
+describe("ApiKeySecretFields [copy]", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("copies whichever snippet view is showing", () => {
+    render(<ApiKeySecretFields apiKey={SHORT_KEY} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw config" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy Codex config" }));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0][0]).toContain("[mcp_servers.");
+    expect(writeText.mock.calls[0][0]).not.toContain("codex mcp add");
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Codex config copied to clipboard",
+    );
+  });
+});
+// #endregion

--- a/web/tests/unit/create-key-modal-snippet.test.tsx
+++ b/web/tests/unit/create-key-modal-snippet.test.tsx
@@ -1,0 +1,99 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { CreateKeyModal } from "@/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/CreateKeyModal";
+
+// #region Mocks
+// The only path that reaches ApiKeySecretFields in production: card -> modal ->
+// success screen. File 6 stubs this modal, so the endpoint bug is invisible there.
+jest.mock(
+  "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/CreateKeyModal/graphql/client/create-key.generated",
+  () => ({ InsertKeyDocument: { __doc: "insert" } }),
+);
+jest.mock(
+  "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/ApiKeyTable/ApiKeyRow/graphql/client/reset-api-key.generated",
+  () => ({ ResetApiKeyDocument: { __doc: "reset" } }),
+);
+jest.mock(
+  "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/graphql/client/fetch-keys.generated",
+  () => ({ FetchKeysDocument: { __doc: "fetch" } }),
+);
+
+jest.mock("@apollo/client/react", () => ({
+  useMutation: (document: { __doc?: string }) => [
+    jest.fn(async () =>
+      document?.__doc === "insert"
+        ? { data: { insert_api_key_one: { id: "key_1" } } }
+        : { data: { reset_api_key: { api_key: "api_TESTSECRET" } } },
+    ),
+    { loading: false },
+  ],
+}));
+
+// Headless UI portal/transition machinery is not the subject.
+jest.mock("@/components/Dialog", () => ({
+  Dialog: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+jest.mock("@/components/DialogOverlay", () => ({
+  DialogOverlay: () => null,
+}));
+jest.mock("@/components/DialogPanel", () => ({
+  DialogPanel: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
+jest.mock("react-toastify", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+// #endregion
+
+const originalLocation = window.location;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Object.defineProperty(window, "location", {
+    value: new URL("https://staging.developer.world.org/teams/team_1/settings"),
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: jest.fn() },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    value: originalLocation,
+    writable: true,
+    configurable: true,
+  });
+});
+
+// #region Seam
+describe("CreateKeyModal -> ApiKeySecretFields", () => {
+  it("shows an origin-correct MCP command on the success screen", async () => {
+    const { container } = render(
+      <CreateKeyModal teamId="team_1" isOpen setIsOpen={jest.fn()} />,
+    );
+
+    // Input renders `label` as a bare <legend>, so query by placeholder.
+    fireEvent.change(screen.getByPlaceholderText("api_key_123"), {
+      target: { value: "mcp" },
+    });
+    fireEvent.submit(container.querySelector("form")!);
+
+    await waitFor(() =>
+      expect(container.querySelector("pre")).toBeInTheDocument(),
+    );
+
+    expect(container.querySelector("pre")!.textContent).toContain(
+      "https://staging.developer.world.org/api/mcp",
+    );
+    expect(document.body.textContent).not.toContain(
+      "https://developer.world.org/api/mcp",
+    );
+    expect(document.body.textContent).not.toContain("--scope project");
+  });
+});
+// #endregion

--- a/web/tests/unit/mcp-persistent-section.test.tsx
+++ b/web/tests/unit/mcp-persistent-section.test.tsx
@@ -1,0 +1,279 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { ApiKeys } from "@/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys";
+import {
+  getMcpEndpoint,
+  getProviderSnippets,
+} from "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/mcp-snippets";
+
+// #region Mocks
+// mcp-snippets stays REAL — it is the seam under test (case 9 compares the
+// rendered command against it byte for byte).
+const fetchKeysMock = jest.fn();
+const mutateMock = jest.fn();
+jest.mock("@apollo/client/react", () => ({
+  useQuery: (doc: { __mockDoc?: string }) =>
+    doc?.__mockDoc === "fetchKeys"
+      ? fetchKeysMock()
+      : { data: undefined, loading: false },
+  useMutation: () => [mutateMock, { loading: false }],
+}));
+
+jest.mock(
+  "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/graphql/client/fetch-keys.generated",
+  () => ({ FetchKeysDocument: { __mockDoc: "fetchKeys" } }),
+);
+
+// Both stubs are covered by files 6-7 and both drag in useUser, Radix and
+// ApiKeySecretFields, which this file has no business rendering.
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeyTable",
+  () => ({
+    ApiKeysTable: () => <div data-testid="api-key-table" />,
+  }),
+);
+
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/CreateKeyModal",
+  () => ({
+    CreateKeyModal: (props: { isOpen?: boolean }) => (
+      <div data-testid="create-key-modal" data-open={String(props.isOpen)} />
+    ),
+  }),
+);
+
+jest.mock("react-toastify", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const push = jest.fn();
+const replace = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push, replace }),
+  usePathname: () => "/teams/team_1/settings",
+  useSearchParams: () => new URLSearchParams(),
+}));
+// #endregion
+
+// #region Test Data
+const ORIGIN = "https://staging.developer.world.org";
+
+const makeKey = (over: Partial<{ id: string; name: string }> = {}) => ({
+  __typename: "api_key" as const,
+  id: over.id ?? "key_1",
+  name: over.name ?? "prod-mcp",
+  created_at: "2024-01-01T00:00:00.000Z",
+  is_active: true,
+  team: { __typename: "team" as const, id: "team_1", name: "Team" },
+});
+
+const originalLocation = window.location;
+const writeText = jest.fn();
+let xhrOpen: jest.SpyInstance;
+
+const setLocation = (origin: string) =>
+  Object.defineProperty(window, "location", {
+    value: new URL(`${origin}/teams/team_1/settings`),
+    writable: true,
+    configurable: true,
+  });
+
+const renderSection = (
+  query: { data?: unknown; loading: boolean },
+  canWrite = true,
+) => {
+  fetchKeysMock.mockReturnValue(query);
+  return render(<ApiKeys teamId="team_1" canWrite={canWrite} />);
+};
+
+// Exactly one <pre> lives in this tree (McpSetup's snippet block).
+const snippetEl = (container: HTMLElement) => container.querySelector("pre")!;
+const snippetText = (container: HTMLElement) =>
+  snippetEl(container).textContent ?? "";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchKeysMock.mockReset();
+
+  setLocation(ORIGIN);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+  writeText.mockResolvedValue(undefined);
+  // whatwg-fetch's polyfill is real and XHR-backed; without our own spies the
+  // "transmits nothing" assertions would either throw or hit the network.
+  global.fetch = jest.fn();
+  navigator.sendBeacon = jest.fn();
+  xhrOpen = jest.spyOn(XMLHttpRequest.prototype, "open");
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    value: originalLocation,
+    writable: true,
+    configurable: true,
+  });
+  jest.restoreAllMocks();
+});
+// #endregion
+
+// #region Renders in every branch of the section
+describe("ApiKeys section [MCP block presence]", () => {
+  it("renders the MCP setup block when the team has zero API keys", () => {
+    const { container } = renderSection({
+      data: { api_key: [] },
+      loading: false,
+    });
+
+    expect(screen.getByText("No API keys found")).toBeInTheDocument();
+    expect(screen.getByText(`${ORIGIN}/api/mcp`)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /codex/i })).toBeInTheDocument();
+    expect(snippetText(container)).toContain(`${ORIGIN}/api/mcp`);
+  });
+
+  it("renders the MCP setup block when the team already has API keys", () => {
+    renderSection({ data: { api_key: [makeKey()] }, loading: false });
+
+    expect(screen.getByTestId("api-key-table")).toBeInTheDocument();
+    expect(screen.getByText(`${ORIGIN}/api/mcp`)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /codex/i })).toBeInTheDocument();
+  });
+
+  it("renders the MCP setup block while the keys query is loading", () => {
+    renderSection({ data: undefined, loading: true });
+
+    expect(screen.getByText(`${ORIGIN}/api/mcp`)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /codex/i })).toBeInTheDocument();
+    expect(screen.queryByTestId("api-key-table")).not.toBeInTheDocument();
+  });
+});
+// #endregion
+
+// #region Endpoint
+describe("ApiKeys section [MCP endpoint]", () => {
+  // Two origins in one file: a module-scope `const ENDPOINT = getMcpEndpoint(...)`
+  // is evaluated once per file and would pass the first row and fail the second.
+  it.each([
+    "https://staging.developer.world.org",
+    "https://developer.world.org",
+  ])("derives the endpoint from origin %s", (origin) => {
+    setLocation(origin);
+    const { container } = renderSection({
+      data: { api_key: [] },
+      loading: false,
+    });
+
+    expect(screen.getByText(`${origin}/api/mcp`)).toBeInTheDocument();
+    expect(snippetText(container)).toContain(`${origin}/api/mcp`);
+  });
+});
+// #endregion
+
+// #region MCP command
+describe("ApiKeys section [MCP command]", () => {
+  it("renders a placeholder where the key goes, never a real secret", () => {
+    const { container } = renderSection({
+      data: { api_key: [] },
+      loading: false,
+    });
+
+    const text = snippetText(container);
+    expect(text).toMatch(/YOUR_API_KEY/);
+    expect(text).not.toMatch(/Bearer\s*$/m);
+    expect(text).not.toMatch(/Bearer\s+"/);
+  });
+
+  it("offers no way to enter an API key", () => {
+    const { container } = renderSection({
+      data: { api_key: [] },
+      loading: false,
+    });
+
+    // The section deliberately never handles a user's key: no input to type
+    // one into, and nothing that could carry one off the page.
+    expect(container.querySelectorAll("input")).toHaveLength(0);
+    expect(container.querySelectorAll("textarea")).toHaveLength(0);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(xhrOpen).not.toHaveBeenCalled();
+    expect(navigator.sendBeacon).not.toHaveBeenCalled();
+    expect(mutateMock).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("keeps the placeholder when the provider changes", () => {
+    const { container } = renderSection({
+      data: { api_key: [] },
+      loading: false,
+    });
+
+    expect(snippetText(container)).toMatch(/^claude mcp add /);
+
+    fireEvent.click(screen.getByRole("button", { name: /cursor/i }));
+    const cursorText = snippetText(container);
+
+    expect(() => JSON.parse(cursorText)).not.toThrow();
+    expect(
+      JSON.parse(cursorText).mcpServers["worldcoin-developer-portal"].headers
+        .Authorization,
+    ).toBe("Bearer YOUR_API_KEY");
+  });
+
+  it("renders a command produced by the shared snippet module", () => {
+    const { container } = renderSection({
+      data: { api_key: [] },
+      loading: false,
+    });
+
+    expect(snippetEl(container).textContent).toBe(
+      getProviderSnippets("YOUR_API_KEY", getMcpEndpoint(ORIGIN)).claude
+        .command,
+    );
+    expect(snippetText(container)).not.toContain("--scope project");
+  });
+
+  it("copies the placeholder command", async () => {
+    renderSection({ data: { api_key: [] }, loading: false });
+
+    // The copy control's accessible name is provider-independent by design —
+    // any provider name in it collides with the picker's getByRole queries.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /copy/i }));
+    });
+
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining("YOUR_API_KEY"),
+    );
+    expect(writeText.mock.calls[0][0]).toContain(`${ORIGIN}/api/mcp`);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+// #endregion
+
+// #region Read-only viewers
+describe("ApiKeys section [canWrite=false]", () => {
+  it("still shows the MCP block to a non-writing viewer who has keys", () => {
+    renderSection({ data: { api_key: [makeKey()] }, loading: false }, false);
+
+    expect(screen.getByText(`${ORIGIN}/api/mcp`)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /codex/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /copy/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /new key/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("create-key-modal")).not.toBeInTheDocument();
+  });
+
+  it("still shows the MCP block to a non-writing viewer with no keys", () => {
+    renderSection({ data: { api_key: [] }, loading: false }, false);
+
+    expect(screen.getByText(`${ORIGIN}/api/mcp`)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /codex/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /create new key/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+// #endregion

--- a/web/tests/unit/mcp-setup-entry-point.test.tsx
+++ b/web/tests/unit/mcp-setup-entry-point.test.tsx
@@ -1,0 +1,247 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { AppsPageClient } from "@/scenes/PortalV3/Teams/TeamId/Apps/page/AppsPageClient";
+import { Role_Enum } from "@/graphql/graphql";
+
+// #region Mocks
+// Session boundary. Mutable so a test can pick the role, or drop the user
+// entirely to exercise the SSR fallback.
+let mockSession: unknown;
+jest.mock("@auth0/nextjs-auth0/client", () => ({
+  useUser: () => ({ user: mockSession }),
+}));
+
+// Real @/lib/utils transitively pulls in idkit/ox, which needs TextEncoder.
+// This is a faithful reimplementation of checkUserPermissions wrapped in a spy
+// -- NOT a constant `true`, which would erase the branch under test.
+const checkUserPermissionsMock = jest.fn(
+  (user: any, teamId: string, roles: string[]) => {
+    const membership = user?.hasura?.memberships?.find(
+      (m: any) => m.team?.id === teamId,
+    );
+    return membership ? roles.includes(membership.role) : false;
+  },
+);
+jest.mock("@/lib/utils", () => ({
+  checkUserPermissions: (
+    ...args: Parameters<typeof checkUserPermissionsMock>
+  ) => checkUserPermissionsMock(...args),
+}));
+
+// Prop-discriminating dialog stub. AppsPageClient dynamics two different
+// dialogs; a single undifferentiated stub would make the independent-state
+// case unwritable. CreateAppDialogV4 takes open/onClose, CreateKeyModal takes
+// isOpen/setIsOpen -- "isOpen" is the discriminator.
+const DialogStub = (props: any) => {
+  const isKeyModal = "isOpen" in props;
+  return (
+    <div
+      data-testid={isKeyModal ? "create-key-modal" : "create-app-dialog"}
+      data-open={String(isKeyModal ? props.isOpen : props.open)}
+      data-team-id={props.teamId}
+    >
+      {/* Distinct testids: the mirror half of the independence case has both
+          dialogs mounted at once, so a shared label would be ambiguous. */}
+      <button
+        type="button"
+        data-testid={isKeyModal ? "close-key-dialog" : "close-app-dialog"}
+        onClick={() =>
+          isKeyModal ? props.setIsOpen(false) : props.onClose(false)
+        }
+      >
+        close-dialog
+      </button>
+    </div>
+  );
+};
+
+jest.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => (props: any) => <DialogStub {...props} />,
+}));
+
+// Belt-and-braces: keeps the suite honest if CreateKeyModal is ever imported
+// statically instead of through next/dynamic.
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/CreateKeyModal",
+  () => ({
+    CreateKeyModal: (props: any) => <DialogStub {...props} />,
+  }),
+);
+
+// AppsPageClient does not import next/navigation today. The mock exists so the
+// "never navigates" assertions stay writable (and keep failing loudly) if
+// someone reintroduces a router push.
+const push = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => "/teams/team_1/apps",
+  useParams: () => ({ teamId: "team_1" }),
+}));
+// #endregion
+
+// #region Test Data
+const sessionWithRole = (role: string) => ({
+  hasura: { memberships: [{ role, team: { id: "team_1" } }] },
+});
+
+// @/components/Button returns null when given neither href nor type
+// (components/Button/index.tsx:29), so a CTA written without type="button"
+// silently disappears. Querying by *role* is the tripwire -- do not relax
+// these to getByText.
+const createKeyButton = () =>
+  screen.queryByRole("button", { name: /create api key/i });
+const createKeyLink = () =>
+  screen.queryByRole("link", { name: /create api key/i });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSession = sessionWithRole(Role_Enum.Owner);
+});
+// #endregion
+
+// #region CTA opens the dialog in place
+describe("AppsPageClient MCP card [in-place dialog]", () => {
+  it("opens the create-key dialog instead of navigating to team settings", () => {
+    render(<AppsPageClient teamId="team_1" />);
+
+    // The regression was a <Button href> -- Button renders a NextLink whenever
+    // href is truthy, so a revert fails here without touching the router.
+    expect(createKeyLink()).toBeNull();
+
+    fireEvent.click(createKeyButton()!);
+
+    const modal = screen.getByTestId("create-key-modal");
+    expect(modal).toHaveAttribute("data-open", "true");
+    expect(modal).toHaveAttribute("data-team-id", "team_1");
+    expect(createKeyLink()).toBeNull();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("does not mount either dialog until its button is clicked", () => {
+    render(<AppsPageClient teamId="team_1" />);
+
+    expect(screen.queryByTestId("create-key-modal")).toBeNull();
+    expect(screen.queryByTestId("create-app-dialog")).toBeNull();
+  });
+
+  it("keeps the dialog mounted after it closes and reopens it", () => {
+    render(<AppsPageClient teamId="team_1" />);
+
+    fireEvent.click(createKeyButton()!);
+    fireEvent.click(screen.getByTestId("close-key-dialog"));
+
+    // Still in the DOM: {open && <Modal/>} would unmount mid-transition and
+    // lose the form state the user already typed.
+    expect(screen.getByTestId("create-key-modal")).toHaveAttribute(
+      "data-open",
+      "false",
+    );
+
+    fireEvent.click(createKeyButton()!);
+    expect(screen.getByTestId("create-key-modal")).toHaveAttribute(
+      "data-open",
+      "true",
+    );
+  });
+
+  it("controls the create-key and create-app dialogs independently", () => {
+    render(<AppsPageClient teamId="team_1" />);
+
+    fireEvent.click(createKeyButton()!);
+    expect(screen.getByTestId("create-key-modal")).toHaveAttribute(
+      "data-open",
+      "true",
+    );
+    expect(screen.queryByTestId("create-app-dialog")).toBeNull();
+
+    // Mirror half runs in the same render, after the key modal has mounted --
+    // on a fresh render the lazy mount makes the attribute unassertable.
+    fireEvent.click(screen.getByTestId("close-key-dialog"));
+    fireEvent.click(screen.getByTestId("button-create-new-app"));
+
+    expect(screen.getByTestId("create-app-dialog")).toHaveAttribute(
+      "data-open",
+      "true",
+    );
+    expect(screen.getByTestId("create-key-modal")).toHaveAttribute(
+      "data-open",
+      "false",
+    );
+  });
+});
+// #endregion
+
+// #region Permission matrix
+describe("AppsPageClient MCP card [permissions]", () => {
+  it("gives an Owner an enabled create control gated on the Owner role", () => {
+    render(<AppsPageClient teamId="team_1" />);
+
+    expect(createKeyButton()).toBeEnabled();
+    expect(checkUserPermissionsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "team_1",
+      [Role_Enum.Owner],
+    );
+  });
+
+  describe.each([[Role_Enum.Admin], [Role_Enum.Member]])(
+    "as %s",
+    (role: Role_Enum) => {
+      it("cannot reach the create-key dialog from the MCP card", () => {
+        mockSession = sessionWithRole(role);
+        render(<AppsPageClient teamId="team_1" />);
+
+        // Implementation-agnostic: passes whether PR4 hides or disables.
+        const button = createKeyButton();
+        if (button) {
+          fireEvent.click(button);
+        }
+
+        expect(screen.queryByTestId("create-key-modal")).toBeNull();
+        // No anchor escape hatch: a disabled href becomes href="" on a still
+        // clickable anchor (components/Button/index.tsx:19).
+        expect(createKeyLink()).toBeNull();
+        // An over-broad gate must not blank the welcome page for non-Owners.
+        expect(screen.getByTestId("button-create-new-app")).toBeInTheDocument();
+      });
+    },
+  );
+});
+// #endregion
+
+// #region SSR fallback
+// useUser() is an SWR fetch with no SSR seed, so a purely client-side gate pops
+// the primary CTA in after a round-trip. These cases cover the window before
+// the session resolves, where only initialIsOwner can answer.
+describe("AppsPageClient MCP card [unresolved session]", () => {
+  beforeEach(() => {
+    mockSession = undefined;
+  });
+
+  it("renders the MCP card from the server's answer when the user is an owner", () => {
+    render(<AppsPageClient teamId="team_1" initialIsOwner />);
+
+    expect(createKeyButton()).toBeInTheDocument();
+    // The fallback must not consult the (absent) client session.
+    expect(checkUserPermissionsMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["explicitly false", false],
+    ["omitted", undefined],
+  ])(
+    "hides the MCP card when the server's answer is %s",
+    (_label: string, initialIsOwner: boolean | undefined) => {
+      render(
+        <AppsPageClient teamId="team_1" initialIsOwner={initialIsOwner} />,
+      );
+
+      expect(createKeyButton()).toBeNull();
+      expect(createKeyLink()).toBeNull();
+      expect(screen.getByTestId("button-create-new-app")).toBeInTheDocument();
+    },
+  );
+});
+// #endregion

--- a/web/tests/unit/mcp-setup-entry-point.test.tsx
+++ b/web/tests/unit/mcp-setup-entry-point.test.tsx
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { AppsPageClient } from "@/scenes/PortalV3/Teams/TeamId/Apps/page/AppsPageClient";
 import { Role_Enum } from "@/graphql/graphql";
 
@@ -79,6 +79,18 @@ jest.mock("next/navigation", () => ({
   usePathname: () => "/teams/team_1/apps",
   useParams: () => ({ teamId: "team_1" }),
 }));
+
+// The return-path app check. fetchAppsMock is module-level so every render
+// gets the same execute identity -- the component's effect depends on it.
+const fetchAppsMock = jest.fn();
+const useLazyQueryMock = jest.fn();
+jest.mock("@apollo/client/react", () => ({
+  useLazyQuery: (...args: unknown[]) => useLazyQueryMock(...args),
+}));
+jest.mock(
+  "@/scenes/common/layout/AppSelector/graphql/client/fetch-apps.generated",
+  () => ({ FetchAppsDocument: { __mockDoc: "fetchApps" } }),
+);
 // #endregion
 
 // #region Test Data
@@ -95,9 +107,30 @@ const createKeyButton = () =>
 const createKeyLink = () =>
   screen.queryByRole("link", { name: /create api key/i });
 
+const originalLocation = window.location;
+const locationReplace = jest.fn();
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockSession = sessionWithRole(Role_Enum.Owner);
+  // Same array every render: a fresh tuple would re-run the return-path effect.
+  useLazyQueryMock.mockReturnValue([fetchAppsMock, { loading: false }]);
+  // A bare jest.fn() would hand checkForApp undefined to .catch and turn every
+  // key-dialog close in the older regions into an unhandled rejection.
+  fetchAppsMock.mockResolvedValue({ data: { app: [] } });
+  Object.defineProperty(window, "location", {
+    value: { replace: locationReplace },
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    value: originalLocation,
+    writable: true,
+    configurable: true,
+  });
 });
 // #endregion
 
@@ -243,5 +276,150 @@ describe("AppsPageClient MCP card [unresolved session]", () => {
       expect(screen.getByTestId("button-create-new-app")).toBeInTheDocument();
     },
   );
+});
+// #endregion
+
+// #region MCP return path
+// The first app can be created out-of-band (MCP) while the user sits on this
+// page, and the redirect to it lives server-side only -- these triggers are
+// the page's sole way to ever learn the app exists.
+describe("AppsPageClient [MCP return path]", () => {
+  const APP_RESULT = { data: { app: [{ id: "app_123" }] } };
+
+  beforeEach(() => {
+    // Modern fake timers patch Date.now, which drives the throttle.
+    jest.useFakeTimers();
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  const tabReturn = async () => {
+    await act(async () => {
+      fireEvent(document, new Event("visibilitychange"));
+    });
+  };
+
+  it("configures the app check to bypass the cache", () => {
+    render(<AppsPageClient teamId="team_1" />);
+
+    // cache-first would re-serve this page's own zero-app answer forever --
+    // the exact silent staleness under test.
+    expect(useLazyQueryMock).toHaveBeenCalledWith(
+      { __mockDoc: "fetchApps" },
+      { fetchPolicy: "network-only" },
+    );
+    // Mount alone must not fire a check; the server just answered "zero".
+    expect(fetchAppsMock).not.toHaveBeenCalled();
+  });
+
+  it("stays put when the tab returns and the team still has no apps", async () => {
+    render(<AppsPageClient teamId="team_1" />);
+
+    await tabReturn();
+
+    expect(fetchAppsMock).toHaveBeenCalledTimes(1);
+    expect(fetchAppsMock).toHaveBeenCalledWith({
+      variables: { teamId: "team_1" },
+    });
+    expect(locationReplace).not.toHaveBeenCalled();
+    expect(createKeyButton()).toBeInTheDocument();
+  });
+
+  it("hard-navigates to an app created out-of-band when the tab returns", async () => {
+    fetchAppsMock.mockResolvedValue(APP_RESULT);
+    render(<AppsPageClient teamId="team_1" />);
+
+    await tabReturn();
+
+    expect(locationReplace).toHaveBeenCalledWith("/teams/team_1/apps/app_123");
+    // Hard nav by design: a router.push would keep the session-rendered shell
+    // (apps dropdown, sidebar) stale.
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("collapses the visibilitychange+focus double-fire into one check", async () => {
+    render(<AppsPageClient teamId="team_1" />);
+
+    // Chrome fires both events on one tab return.
+    await act(async () => {
+      fireEvent(document, new Event("visibilitychange"));
+      fireEvent(window, new Event("focus"));
+    });
+    expect(fetchAppsMock).toHaveBeenCalledTimes(1);
+
+    // A later, genuine return checks again once the throttle lapses.
+    await act(async () => {
+      jest.advanceTimersByTime(1_001);
+    });
+    await act(async () => {
+      fireEvent(window, new Event("focus"));
+    });
+    expect(fetchAppsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses checks while the key secret is on screen and checks on close", async () => {
+    fetchAppsMock.mockResolvedValue(APP_RESULT);
+    render(<AppsPageClient teamId="team_1" />);
+
+    fireEvent.click(createKeyButton()!);
+    await act(async () => {
+      fireEvent(window, new Event("focus"));
+      fireEvent(document, new Event("visibilitychange"));
+    });
+
+    // Navigating now would destroy the one-shot secret.
+    expect(fetchAppsMock).not.toHaveBeenCalled();
+    expect(locationReplace).not.toHaveBeenCalled();
+
+    // The likeliest MCP sequence ends here: the agent created the app while
+    // the secret was on screen, so the close is the last signal there is.
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("close-key-dialog"));
+    });
+
+    expect(fetchAppsMock).toHaveBeenCalledTimes(1);
+    expect(locationReplace).toHaveBeenCalledWith("/teams/team_1/apps/app_123");
+  });
+
+  it("ignores a visibilitychange that fires while the tab is hidden", async () => {
+    render(<AppsPageClient teamId="team_1" />);
+
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      configurable: true,
+    });
+    await tabReturn();
+
+    expect(fetchAppsMock).not.toHaveBeenCalled();
+  });
+
+  it("removes both listeners on unmount", () => {
+    const docAdd = jest.spyOn(document, "addEventListener");
+    const docRemove = jest.spyOn(document, "removeEventListener");
+    const winAdd = jest.spyOn(window, "addEventListener");
+    const winRemove = jest.spyOn(window, "removeEventListener");
+
+    const view = render(<AppsPageClient teamId="team_1" />);
+
+    const visHandler = docAdd.mock.calls.find(
+      ([type]) => type === "visibilitychange",
+    )![1];
+    const focusHandler = winAdd.mock.calls.find(
+      ([type]) => type === "focus",
+    )![1];
+
+    view.unmount();
+
+    expect(docRemove).toHaveBeenCalledWith("visibilitychange", visHandler);
+    expect(winRemove).toHaveBeenCalledWith("focus", focusHandler);
+  });
 });
 // #endregion

--- a/web/tests/unit/mcp-snippets.test.ts
+++ b/web/tests/unit/mcp-snippets.test.ts
@@ -1,0 +1,249 @@
+import {
+  getMcpEndpoint,
+  getProviderSnippets,
+  PROVIDERS,
+  type ProviderId,
+} from "@/scenes/common/Teams/TeamId/Team/ApiKeys/page/mcp-snippets";
+import { execFileSync } from "node:child_process";
+
+// #region Test Data
+const KEY = "api_TESTKEY";
+// Host must be disjoint from production: "staging-developer.world.org" would
+// *contain* "developer.world.org" and red-fail case 7 against correct code.
+const ENDPOINT = "https://staging.example.test:8443/api/mcp";
+const SERVER_NAME = "worldcoin-developer-portal";
+
+const snippetsFor = (apiKey = KEY, endpoint = ENDPOINT) =>
+  getProviderSnippets(apiKey, endpoint);
+
+const allStrings = (apiKey = KEY, endpoint = ENDPOINT) =>
+  Object.values(snippetsFor(apiKey, endpoint)).flatMap((snippet) => [
+    snippet.command,
+    snippet.rawConfig,
+  ]);
+// #endregion
+
+// #region getMcpEndpoint
+describe("getMcpEndpoint()", () => {
+  it("appends the MCP path to a bare origin", () => {
+    expect(getMcpEndpoint("https://staging.example.test")).toBe(
+      "https://staging.example.test/api/mcp",
+    );
+  });
+
+  it.each([
+    ["https://x.test/", "https://x.test/api/mcp"],
+    ["https://x.test//", "https://x.test/api/mcp"],
+    ["http://localhost:3000", "http://localhost:3000/api/mcp"],
+    ["https://x.test:8443/", "https://x.test:8443/api/mcp"],
+  ])(
+    "collapses trailing slashes and keeps scheme and port (%s)",
+    (origin, expected) => {
+      const result = getMcpEndpoint(origin);
+
+      expect(result).toBe(expected);
+      // An unanchored /\/+/g would mangle "https://" into "https:/".
+      expect(result).not.toContain("//api");
+    },
+  );
+
+  it.each([["" as const], ["null" as const], [undefined]])(
+    "degrades to a relative path rather than throwing on a degenerate origin (%s)",
+    (origin) => {
+      expect(() => getMcpEndpoint(origin)).not.toThrow();
+
+      const result = getMcpEndpoint(origin);
+      expect(result).toBe("/api/mcp");
+      expect(result).not.toContain("null/api/mcp");
+      expect(result).not.toContain("undefined");
+    },
+  );
+
+  it("passes a worldcoin.org origin through instead of canonicalising it", () => {
+    expect(getMcpEndpoint("https://developer.worldcoin.org")).toBe(
+      "https://developer.worldcoin.org/api/mcp",
+    );
+  });
+});
+// #endregion
+
+// #region Module hygiene
+describe("mcp-snippets module", () => {
+  it("does not read window at import time", () => {
+    expect(typeof globalThis.window).toBe("undefined");
+    expect(() =>
+      require("@/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeySecretFields"),
+    ).not.toThrow();
+    expect(() =>
+      require("@/scenes/Portal/Teams/TeamId/Team/ApiKeys/page/ApiKeySecretFields"),
+    ).not.toThrow();
+  });
+
+  it("returns exactly the provider ids declared in PROVIDERS", () => {
+    expect(Object.keys(snippetsFor()).sort()).toEqual(
+      PROVIDERS.map((provider) => provider.id).sort(),
+    );
+  });
+});
+// #endregion
+
+// #region Endpoint threading
+describe("provider snippets — endpoint", () => {
+  it.each(PROVIDERS.map((provider) => provider.id))(
+    "embeds the supplied endpoint exactly once (%s)",
+    (id) => {
+      const snippet = snippetsFor()[id as ProviderId];
+
+      expect(snippet.command.split(ENDPOINT).length - 1).toBe(1);
+      expect(snippet.rawConfig.split(ENDPOINT).length - 1).toBe(1);
+    },
+  );
+
+  it("never leaks a hardcoded production host", () => {
+    const joined = allStrings().join("\n");
+
+    expect(joined).not.toContain("developer.world.org");
+    // With the .org — MCP_SERVER_NAME is "worldcoin-developer-portal".
+    expect(joined).not.toContain("worldcoin.org");
+    expect(joined).not.toContain("undefined");
+  });
+});
+// #endregion
+
+// #region Codex
+describe("codex snippets", () => {
+  it("matches the shape verified against codex-cli and mcp-remote", () => {
+    expect(snippetsFor().codex.command).toBe(
+      "codex mcp add worldcoin-developer-portal --env WORLD_DEVELOPER_API_KEY='api_TESTKEY' -- npx -y mcp-remote https://staging.example.test:8443/api/mcp --transport http-only --header 'Authorization:Bearer ${WORLD_DEVELOPER_API_KEY}'",
+    );
+  });
+
+  it("keeps the raw key out of the header", () => {
+    const key = "api_a$b`c;d";
+    const command = snippetsFor(key).codex.command;
+
+    expect(command).toContain(
+      "--header 'Authorization:Bearer ${WORLD_DEVELOPER_API_KEY}'",
+    );
+    // Double quotes would let the user's shell expand the var at add-time.
+    expect(command).not.toContain('"Authorization:Bearer');
+    // A space after the colon makes mcp-remote's header regex drop the scheme.
+    expect(command).not.toContain("Authorization: Bearer ${");
+    expect(command.slice(command.indexOf("--header"))).not.toContain(key);
+  });
+
+  it("survives a real POSIX shell and agrees with its own TOML argv", () => {
+    const key = "api_ab'cd";
+    const command = snippetsFor(key).codex.command;
+
+    const quoted = command
+      .slice(command.indexOf("--env WORLD_DEVELOPER_API_KEY=") + 30)
+      .split(" -- ")[0];
+    expect(quoted).toBe("'api_ab'\\''cd'");
+    expect(
+      execFileSync("/bin/sh", ["-c", `printf %s ${quoted}`]).toString(),
+    ).toBe(key);
+
+    // Round-trip the CLI tail through the shell rather than splitting on
+    // spaces — the header value legitimately contains one.
+    const argv = execFileSync("/bin/sh", [
+      "-c",
+      `printf '%s\n' ${command.split(" -- ")[1]}`,
+    ])
+      .toString()
+      .split("\n")
+      .filter(Boolean);
+
+    const argsLine = snippetsFor(key)
+      .codex.rawConfig.split("\n")
+      .find((line) => line.startsWith("args = "))!;
+    const tomlArgs = JSON.parse(argsLine.slice("args = ".length));
+
+    expect(argv).toEqual(["npx", ...tomlArgs]);
+  });
+
+  it("emits parseable TOML holding the key exactly once", () => {
+    const rawConfig = snippetsFor().codex.rawConfig;
+    const lines = rawConfig.split("\n");
+
+    expect(lines[0]).toBe(`[mcp_servers.${SERVER_NAME}]`);
+    expect(lines[1]).toBe('command = "npx"');
+    expect(lines[4]).toBe(`[mcp_servers.${SERVER_NAME}.env]`);
+
+    const argsLine = lines[2];
+    expect(JSON.parse(argsLine.slice("args = ".length))).toEqual([
+      "-y",
+      "mcp-remote",
+      ENDPOINT,
+      "--transport",
+      "http-only",
+      "--header",
+      "Authorization:Bearer ${WORLD_DEVELOPER_API_KEY}",
+    ]);
+    expect(argsLine).not.toContain(KEY);
+
+    expect(
+      JSON.parse(lines[5].slice("WORLD_DEVELOPER_API_KEY = ".length)),
+    ).toBe(KEY);
+    expect(rawConfig.indexOf(KEY)).toBe(rawConfig.lastIndexOf(KEY));
+  });
+});
+// #endregion
+
+// #region Claude
+describe("claude snippets", () => {
+  it("no longer writes a live secret into a committed .mcp.json", () => {
+    const command = snippetsFor().claude.command;
+
+    expect(command).not.toContain("--scope");
+    expect(command).toBe(
+      'claude mcp add worldcoin-developer-portal https://staging.example.test:8443/api/mcp --transport http --header "Authorization: Bearer api_TESTKEY"',
+    );
+  });
+
+  it("emits an http-typed server entry", () => {
+    expect(JSON.parse(snippetsFor().claude.rawConfig)).toEqual({
+      mcpServers: {
+        [SERVER_NAME]: {
+          type: "http",
+          url: ENDPOINT,
+          headers: { Authorization: `Bearer ${KEY}` },
+        },
+      },
+    });
+  });
+});
+// #endregion
+
+// #region Other providers
+describe("JSON provider snippets", () => {
+  const headers = { Authorization: `Bearer ${KEY}` };
+
+  it.each([
+    ["cursor", { mcpServers: { [SERVER_NAME]: { url: ENDPOINT, headers } } }],
+    [
+      "windsurf",
+      { mcpServers: { [SERVER_NAME]: { serverUrl: ENDPOINT, headers } } },
+    ],
+    ["zed", { context_servers: { [SERVER_NAME]: { url: ENDPOINT, headers } } }],
+  ])("keeps its own schema (%s)", (id, expected) => {
+    const snippet = snippetsFor()[id as ProviderId];
+    const parsed = JSON.parse(snippet.rawConfig);
+
+    expect(parsed).toEqual(expected);
+    expect(snippet.command).toBe(snippet.rawConfig);
+  });
+
+  it("renders the chatgpt connector as three labelled lines", () => {
+    const lines = snippetsFor().chatgpt.rawConfig.split("\n");
+
+    expect(lines).toEqual([
+      "Name: World Developer Portal",
+      `URL: ${ENDPOINT}`,
+      `Authorization: Bearer ${KEY}`,
+    ]);
+    // ChatGPT does not normalize the URL; a trailing slash 404s the handshake.
+    expect(lines[1].slice("URL: ".length)).toBe(ENDPOINT);
+  });
+});
+// #endregion

--- a/web/tests/unit/pv3-world-id-page-freshness.test.tsx
+++ b/web/tests/unit/pv3-world-id-page-freshness.test.tsx
@@ -1,0 +1,361 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { WorldIdPage } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page";
+
+// #region Mocks
+// This tree renders clean in jsdom with no TextEncoder shim, even though
+// BanMessageDialog is a static import. Revisit if that import graph grows.
+const useQueryMock = jest.fn();
+const refetch = jest.fn();
+jest.mock("@apollo/client/react", () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}));
+
+jest.mock(
+  "@/scenes/common/Teams/TeamId/Apps/AppId/WorldId/page/graphql/client/get-world-id-overview.generated",
+  () => ({ GetWorldIdOverviewDocument: { __mockDoc: "worldIdOverview" } }),
+);
+
+let searchParams = new URLSearchParams();
+const replace = jest.fn((url: string) => {
+  // The page re-derives requestedTab/createActionRequested from
+  // useSearchParams() every render; an inert replace freezes the funnel.
+  searchParams = new URLSearchParams(url.split("?")[1] ?? "");
+});
+const push = jest.fn();
+const refresh = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push, refresh }),
+  usePathname: () => "/teams/team_1/apps/app_1/world-id-4-0",
+  useSearchParams: () => searchParams,
+}));
+
+let gridMounts = 0;
+let registerMounts = 0;
+
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionsGrid",
+  () => ({
+    ActionsGrid: (props: {
+      initialDialogOpen?: boolean;
+      onActionsChanged?: () => void;
+    }) => {
+      React.useEffect(() => {
+        gridMounts += 1;
+      }, []);
+      return (
+        <div
+          data-testid="actions-grid"
+          data-dialog-open={String(Boolean(props.initialDialogOpen))}
+        >
+          <button type="button" onClick={() => props.onActionsChanged?.()}>
+            actions-changed
+          </button>
+        </div>
+      );
+    },
+  }),
+);
+
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionCard/Skeleton",
+  () => ({
+    ActionCardSkeleton: () => <div data-testid="action-skeleton" />,
+  }),
+);
+
+jest.mock("@/components/Skeletons", () => ({
+  SkeletonForm: () => <div data-testid="skeleton-form" />,
+}));
+
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/WorldId40Pane",
+  () => ({
+    WorldId40Pane: (props: {
+      initialStatus?: string;
+      onRpChanged?: (status?: string) => void;
+    }) => (
+      <div data-testid="world-id-pane" data-status={props.initialStatus}>
+        <button type="button" onClick={() => props.onRpChanged?.("registered")}>
+          rp-registered
+        </button>
+        <button type="button" onClick={() => props.onRpChanged?.()}>
+          rp-refetch-only
+        </button>
+      </div>
+    ),
+  }),
+);
+
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/RegisterRpEmptyState",
+  () => ({
+    RegisterRpEmptyState: (props: { initialOpen?: boolean }) => {
+      React.useEffect(() => {
+        registerMounts += 1;
+      }, []);
+      return (
+        <div
+          data-testid="register-rp"
+          data-open={String(Boolean(props.initialOpen))}
+        />
+      );
+    },
+  }),
+);
+// #endregion
+
+// #region Test Data
+const makeData = (
+  over: {
+    status?: string;
+    rp?: boolean;
+    banned?: boolean;
+    legacy?: boolean;
+    app?: unknown[];
+  } = {},
+) => ({
+  app: over.app ?? [
+    {
+      id: "app_1",
+      is_staging: false,
+      is_banned: over.banned ?? false,
+      rp_registration:
+        over.rp === false
+          ? []
+          : [
+              {
+                rp_id: "rp_0123456789abcdef",
+                status: over.status ?? "registered",
+                staging_status: null,
+                mode: "managed",
+                created_at: "2026-01-01T00:00:00Z",
+              },
+            ],
+    },
+  ],
+  action: over.legacy ? [{ id: "a_1" }] : [],
+  action_v4: [{ id: "av_1", action: "vote", description: "Vote" }],
+});
+
+const el = (over?: Partial<React.ComponentProps<typeof WorldIdPage>>) => (
+  <WorldIdPage
+    params={{ teamId: "team_1", appId: "app_1" }}
+    searchParams={{}}
+    canManageWorldId
+    {...over}
+  />
+);
+
+const setQuery = (result: Record<string, unknown>) =>
+  useQueryMock.mockReturnValue({ error: undefined, refetch, ...result });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  gridMounts = 0;
+  registerMounts = 0;
+  searchParams = new URLSearchParams();
+  useQueryMock.mockReset();
+  // refetchOverview calls .catch() on the result.
+  refetch.mockResolvedValue({});
+  Object.defineProperty(document, "visibilityState", {
+    value: "visible",
+    configurable: true,
+  });
+});
+
+afterEach(() => jest.restoreAllMocks());
+// #endregion
+
+// #region Loading boundary
+describe("WorldIdPage [loading boundary]", () => {
+  it("renders skeleton cards on first load when no data has arrived", () => {
+    setQuery({ data: undefined, loading: true });
+    render(el());
+
+    expect(screen.queryAllByTestId("action-skeleton")).toHaveLength(2);
+    expect(screen.queryByTestId("actions-grid")).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
+  });
+
+  it("keeps real content during a background refetch and never remounts the grid", () => {
+    const data = makeData({ banned: true, legacy: true });
+    setQuery({ data, loading: false });
+    const view = render(el());
+
+    expect(screen.getByTestId("actions-grid")).toBeInTheDocument();
+    expect(gridMounts).toBe(1);
+
+    setQuery({ data: { ...data }, loading: true });
+    view.rerender(el());
+
+    expect(screen.queryAllByTestId("action-skeleton")).toHaveLength(0);
+    expect(screen.getByTestId("actions-grid")).toBeInTheDocument();
+    expect(screen.getByText(/was banned/)).toBeInTheDocument();
+    expect(screen.getByText("Legacy Actions")).toBeInTheDocument();
+
+    setQuery({ data: { ...data }, loading: false });
+    view.rerender(el());
+    expect(gridMounts).toBe(1);
+
+    expect(useQueryMock.mock.calls[0][1]).toEqual({
+      variables: { app_id: "app_1" },
+      skip: false,
+      fetchPolicy: "cache-and-network",
+      nextFetchPolicy: "cache-first",
+    });
+  });
+
+  it("does not flash the form skeleton when a World ID pane is cached", () => {
+    searchParams = new URLSearchParams("tab=world-id-4-0");
+    setQuery({ data: makeData(), loading: true });
+    render(el());
+
+    expect(screen.queryByTestId("skeleton-form")).not.toBeInTheDocument();
+    expect(screen.getByTestId("world-id-pane")).toBeInTheDocument();
+  });
+});
+// #endregion
+
+// #region Optimistic status
+describe("WorldIdPage [optimistic status]", () => {
+  it("lets a background refetch override an optimistic status for the same RP", () => {
+    searchParams = new URLSearchParams("tab=world-id-4-0");
+    setQuery({ data: makeData({ status: "pending" }), loading: false });
+    const view = render(el());
+
+    fireEvent.click(screen.getByText("rp-registered"));
+
+    setQuery({ data: makeData({ status: "failed" }), loading: false });
+    view.rerender(el());
+
+    expect(screen.getByTestId("world-id-pane")).toHaveAttribute(
+      "data-status",
+      "failed",
+    );
+  });
+});
+// #endregion
+
+// #region Revalidation
+describe("WorldIdPage [revalidation]", () => {
+  it("refetches when the tab becomes visible again, and not on mount", () => {
+    setQuery({ data: makeData(), loading: false });
+    render(el());
+
+    expect(refetch).not.toHaveBeenCalled();
+
+    const search = screen.getByPlaceholderText(/search/i);
+    search.focus();
+    fireEvent.change(search, { target: { value: "hello" } });
+
+    act(() => {
+      fireEvent(document, new Event("visibilitychange"));
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(refetch).toHaveBeenCalledWith();
+    // Freshness comes from Apollo, not an RSC refresh — that reintroduces the flash.
+    expect(refresh).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+
+    const after = screen.getByPlaceholderText(/search/i) as HTMLInputElement;
+    expect(after.value).toBe("hello");
+    expect(document.activeElement).toBe(after);
+  });
+
+  it("ignores a visibilitychange that fires while the tab is hidden", () => {
+    setQuery({ data: makeData(), loading: false });
+    render(el());
+
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      configurable: true,
+    });
+    act(() => {
+      fireEvent(document, new Event("visibilitychange"));
+    });
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("refetches on window focus", () => {
+    setQuery({ data: makeData(), loading: false });
+    render(el());
+
+    act(() => {
+      fireEvent(window, new Event("focus"));
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes both listeners on unmount", () => {
+    const docAdd = jest.spyOn(document, "addEventListener");
+    const docRemove = jest.spyOn(document, "removeEventListener");
+    const winAdd = jest.spyOn(window, "addEventListener");
+    const winRemove = jest.spyOn(window, "removeEventListener");
+
+    setQuery({ data: makeData(), loading: false });
+    const view = render(el());
+
+    const visHandler = docAdd.mock.calls.find(
+      ([type]) => type === "visibilitychange",
+    )![1];
+    const focusHandler = winAdd.mock.calls.find(
+      ([type]) => type === "focus",
+    )![1];
+
+    view.unmount();
+
+    expect(docRemove).toHaveBeenCalledWith("visibilitychange", visHandler);
+    expect(winRemove).toHaveBeenCalledWith("focus", focusHandler);
+  });
+
+  it("registers the listeners once and does not re-subscribe on every render", () => {
+    const docAdd = jest.spyOn(document, "addEventListener");
+    const winAdd = jest.spyOn(window, "addEventListener");
+
+    const data = makeData();
+    setQuery({ data, loading: false });
+    const view = render(el());
+
+    setQuery({ data: { ...data }, loading: false });
+    view.rerender(el());
+    setQuery({ data: { ...data }, loading: false });
+    view.rerender(el());
+
+    expect(
+      docAdd.mock.calls.filter(([type]) => type === "visibilitychange"),
+    ).toHaveLength(1);
+    expect(winAdd.mock.calls.filter(([type]) => type === "focus")).toHaveLength(
+      1,
+    );
+
+    act(() => {
+      fireEvent(document, new Event("visibilitychange"));
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refetch a skipped query when the app id is missing", () => {
+    setQuery({ data: undefined, loading: false });
+    render(el({ params: { teamId: "team_1" } }));
+
+    expect(useQueryMock.mock.calls[0][1]).toMatchObject({
+      variables: { app_id: "" },
+      skip: true,
+    });
+
+    act(() => {
+      fireEvent(document, new Event("visibilitychange"));
+      fireEvent(window, new Event("focus"));
+    });
+
+    expect(refetch).not.toHaveBeenCalled();
+    expect(screen.getByText("404")).toBeInTheDocument();
+  });
+});
+// #endregion


### PR DESCRIPTION
A user on staging generated an MCP setup command, ran it, and nothing worked. This fixes why, plus three adjacent breaks found along the way.

## The root cause

**API keys are per-deployment; the portal hardcoded a production URL.** `MCP_ENDPOINT` was `https://developer.world.org/api/mcp` regardless of which portal you were on. A staging key resolved against staging's Hasura and is verified with an HMAC keyed on staging's `GENERAL_SECRET_KEY`, so it cannot authenticate against production. `authenticate()` runs before the method switch, so even `initialize` failed — the handshake died and no tool ever ran.

Confirmed empirically with the reporter's key: `developer.world.org` → `{"code":-32001,"message":"API key is not valid."}`; `staging-developer.world.org` → full handshake, 11 tools.

**The command itself was correct.** Verified against shipped mcp-remote 0.1.38 and codex-cli 0.144.5: the single-quoted key, the literal unexpanded `${WORLD_DEVELOPER_API_KEY}` in the header (mcp-remote substitutes it, not the shell), the missing space in `Authorization:Bearer`, and `--transport http-only` are all right. Only the hostname was wrong. Tests pin all four so nobody "fixes" them.

## What else was broken

**An existing-key user had no path to the command at all.** `ApiKeySecretFields` only mounts in post-mutation modals; the key row renders non-interactive `Reset to view` text, and the only route back was Reset key — Owner-only, in a `⋮` menu, and it invalidates the key you already deployed. The word "MCP" only appeared when you had zero keys.

**The CTA was a link.** `href={urls.teamSettings(...)}` — no key created, no dialog, no deep link. And the card lives only on the zero-apps page, removed by the redirect the moment any app exists, including one MCP creates.

**Nothing refetched.** Default `cache-first` on a window-scoped Apollo client, a shell that never remounts, and no invalidation signal anywhere. An MCP-created RP stayed invisible until a hard reload.

**A silent runaway poll, not previously noticed.** `GET /api/mcp` returned 200 with a handshake descriptor. The SDK only special-cases 405, so a 200 fell into a reconnect scheduler whose attempt counter is hardcoded to 0 — ~1 req/sec, forever, per connected client, no error emitted. Reproduced against a stub with the real SDK. mcp-remote bundles identical logic, so the command we hand out triggers it.

**The zero-apps page never learns the app exists.** The new in-place flow parks the user on `/teams/:id/apps` while an agent creates their first app out-of-band, but the redirect to that app runs only in the server component (`InitialApp`) — the page had no app query, no focus listener, and no `router.refresh()`, so the welcome state survived until a hard reload. Found in review.

## Commits

Reviewable independently, in landing order:

| | |
|---|---|
| `2a4e073c` | GET → 405, `Allow` header, JSON-RPC envelope guard |
| `27d56bad` | origin-derived endpoint + snippet dedup, drop `--scope project` |
| `df7832c8` | World ID freshness |
| `1477f0fa` | entry point, Owner gate, rotate confirmation, persistent section |
| `8d394209` | zero-apps page detects the MCP-created first app and hard-navigates |

## Notes for review

**The dedup is the point of commit 2.** The two `ApiKeySecretFields` copies were byte-identical. `fa3b8403` shows the failure mode: it fixed `getClaudeMcpCommand` in both trees and left `getCodexMcpCommand`, the next function in both hunks, untouched. Snippet generation now lives in one pure module, and a test asserts each component exports only `["ApiKeySecretFields"]`.

**`--scope project` removed.** `.mcp.json` is designed to be checked into version control, so the old command told users to commit a live secret.

**`cache-and-network` needs the `loading && !data` guard in the same commit.** Alone it makes every warm-cache mount paint a skeleton where `cache-first` painted content — strictly worse.

**Load characteristic:** Chrome fires both `visibilitychange` and `focus` on a tab return, so one return can put two requests on the wire. Apollo dedups the observable so the user sees one loading cycle. No throttle by design; a timestamp ref is the cheap mitigation if it shows up.

**The return check hard-navigates on purpose.** A soft `router.refresh()` relying on the server `redirect()` was rejected: its failure mode is the same silent staleness this fixes, and jsdom can't catch it — a mocked router passes forever. `CreateAppDialogV4` already uses `window.location.replace` after portal-native creation, and the hard nav re-renders the session-rendered shell for free. Unlike the WorldIdPage refetch, lazy executions get no Apollo observable dedup, so this one ships with a 1s timestamp throttle from the start. Checks are suppressed while the create-key modal is open — a navigation must not destroy the one-shot secret — and run once on close, the likeliest moment the MCP-created app already exists. A split-screen session that never blurs the tab still fires neither event; same accepted limitation as the WorldIdPage freshness work.

**Owner gate is seeded server-side.** `useUser` resolves via a client fetch with no SSR seed, so a client-only check would pop the primary CTA in after a round-trip.

**The persistent section never handles a user's key** — it renders a `YOUR_API_KEY` placeholder. An earlier draft had a paste-your-key field; that was removed deliberately, and a test asserts the section renders zero `input`/`textarea` elements.

## Deliberately out of scope

- **ChatGPT provider tab** — hands out `Authorization: Bearer …` as "connector config", but ChatGPT connectors support only OAuth or no-auth, with no field for a customer-supplied token. Product decision; unchanged here.
- **OAuth / `.well-known` metadata.** Don't ship a bare 401 without it — mcp-remote always attaches an auth provider, so it would pop a browser window and hang rather than failing fast. Today's `200` + `-32001` is the better of the two until the metadata exists.
- **CORS on `/api/mcp`** — every advertised client is a native/Node process; `Access-Control-Allow-Origin: *` on a bearer-authenticated endpoint would be a regression.
- **v2 `ClientPage`** has the same navigate-away CTA, deferred.
- **v2 twins of the rotate/persistent-section work** — PortalV3 is the shipping surface.

## Testing

**1051 unit + api tests pass; `tsc --noEmit` clean.** 69 new cases, ~2,000 test lines.

Verified live against a local server, not only mocks: `GET` → 405 with `Allow: POST, OPTIONS`, `null` body → `400`/`-32600`, full MCP handshake, `tools/list` → 11 tools, and `create_app` writing a real row.

Two mutation checks on the freshness work: reverting `loading && !data` reddens 4 cases; deleting the revalidation effect reddens a different 4. The PR4 suites were mutation-tested too — 12 independent mutations to `AppsPageClient`, all 12 killed. The return-path region likewise: guard inversion, throttle removal, dropped navigation, and cache-first each redden their targeted case, 4/4 killed.

The codex command test shells out to `/bin/sh` and proves the CLI form and the TOML config produce identical argv — the two forms that had already drifted once.

## Not verified

The `mcp-remote` + Codex client path was driven as raw JSON-RPC, not through the actual CLI. And the UI was not exercised in a signed-in browser — the freshness behaviour is covered by the mutation-tested suite, not a visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
