### PR TITLE
feat(portal): restyle World ID Sandbox tile and pin it to the sidebar bottom

### DIFF
--- a/web/public/images/portal-v3/icons/world-id-sandbox-app-icon.svg
+++ b/web/public/images/portal-v3/icons/world-id-sandbox-app-icon.svg
@@ -1,9 +1,10 @@
 <!-- Flat rendering of world-app-ios WorldID/AppIcons/WorldID-sandbox.icon
-     (Icon Composer bundle: white auto background, purple circle at group
-     scale 1.24, white Union glyph). Keep in sync if the app icon changes. -->
+     (Icon Composer bundle: white auto background, circle at group scale 1.24,
+     white Union glyph). Circle deliberately recolored to World ID blue
+     (portal-blue) for the portal; keep geometry in sync if the icon changes. -->
 <svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
   <rect width="1024" height="1024" rx="229" fill="#FFFFFF"/>
-  <circle cx="512" cy="512" r="383" fill="#9260F7"/>
+  <circle cx="512" cy="512" r="383" fill="#007CFB"/>
   <g transform="translate(316.73 297.48) scale(1.24)">
     <path d="M314.542 115.718L187.515 199.4V345.388H128.688V200.506L0 115.718L32.9688 68.8311L157.268 148.92L281.566 68.8311L314.542 115.718ZM158.066 0C181.849 9.59062e-05 202.426 19.2837 202.426 43.0664C202.426 66.849 181.849 86.1327 158.066 86.1328C134.284 86.1328 113.707 66.8491 113.707 43.0664C113.707 19.2771 134.284 0 158.066 0Z" fill="#FFFFFF"/>
   </g>

--- a/web/scenes/PortalV3/layout/Shell/SandboxButton.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SandboxButton.tsx
@@ -165,37 +165,27 @@ export const SandboxButton = (props: {
         onClick={openDialog}
         aria-haspopup="dialog"
         className={clsx(
-          "group relative flex shrink-0 cursor-pointer items-center gap-x-3 overflow-hidden rounded-[10px] bg-grey-900 p-3 text-left outline-hidden transition-shadow hover:shadow-portal-card focus-visible:ring-2 focus-visible:ring-grey-300 focus-visible:ring-offset-2 focus-visible:ring-offset-portal-canvas",
+          "group flex shrink-0 cursor-pointer items-center gap-x-3 rounded-[10px] border border-portal-border px-3 py-2 text-left outline-hidden transition-colors hover:bg-portal-border focus-visible:ring-2 focus-visible:ring-grey-300 focus-visible:ring-offset-2 focus-visible:ring-offset-portal-canvas",
           props.className,
         )}
       >
-        {/* Static halftone ground, echoing the landing hero mark. */}
-        <div
-          aria-hidden
-          className="absolute inset-0 [background-image:radial-gradient(circle,rgba(255,255,255,0.2)_1px,transparent_1.5px)] [background-size:10px_10px]"
-        />
-        {/* Soft glow in the sandbox icon's purple, anchoring it on the halftone. */}
-        <div
-          aria-hidden
-          className="absolute inset-0 [background-image:radial-gradient(circle_at_12%_50%,rgba(146,96,247,0.4),transparent_45%)]"
-        />
         {/* The sandbox build's actual app icon, so banner → TestFlight →
                 home screen all show the same mark. */}
         <Icon
           name="world-id-sandbox-app-icon"
-          className="relative size-10 shrink-0 drop-shadow-md"
+          className="size-9 shrink-0 drop-shadow-sm"
         />
-        <span className="relative grid min-w-0 flex-1 gap-y-0.5">
-          <span className="font-world text-13 font-medium text-white">
+        <span className="grid min-w-0 flex-1 gap-y-0.5">
+          <span className="font-world text-13 font-medium text-portal-text">
             World ID Sandbox
           </span>
-          <span className="font-world text-11 text-grey-400">
+          <span className="font-world text-11 text-portal-muted">
             Install the test build
           </span>
         </span>
         <span
           aria-hidden
-          className="relative pr-0.5 font-world text-13 text-grey-400 transition-transform duration-200 group-hover:translate-x-0.5"
+          className="-mr-[5px] font-world text-13 text-portal-subtle transition-transform duration-200 group-hover:translate-x-0.5"
         >
           →
         </span>
@@ -255,7 +245,7 @@ export const SandboxButton = (props: {
               <div className="rounded-12 bg-grey-50 px-4 py-3">
                 <Typography variant={TYPOGRAPHY.R4} className="text-grey-700">
                   The Android build is distributed as a Google Play internal
-                  test — your Google account email must be approved before the
+                  test. Your Google account email must be approved before the
                   link works.
                 </Typography>
 

--- a/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
@@ -176,10 +176,12 @@ export const SidebarNav = (props: {
         ) : null}
       </div>
 
-      <SandboxButton
-        className="mt-6 w-full"
-        initialRequest={props.initialSandboxRequest}
-      />
+      <div className="mt-auto pt-6 pb-3">
+        <SandboxButton
+          className="-ml-1 w-[calc(100%_+_8px)]"
+          initialRequest={props.initialSandboxRequest}
+        />
+      </div>
     </nav>
   );
 };


### PR DESCRIPTION
## What

Reworks the World ID Sandbox entry tile in the PortalV3 sidebar:

- **Placement**: pinned to the bottom of the sidebar nav, above the account chip (was inline below the nav items).
- **Style**: the black halftone/glow treatment is gone. The tile is now a quiet outline card — transparent background, `portal-border` outline (same gray as the nav separator), nav-item hover fill, dark title / muted subtitle.
- **Icon**: the sandbox app icon's circle mark is recolored from purple to World ID blue (`#007CFB`, the `portal-blue` token). The install dialog header shares the SVG, so it follows automatically.
- **Geometry**: symmetric 12px side insets (slightly wider than nav rows), height trimmed 64→56px, arrow aligned to the same vertical axis as the team/user chevrons.
- **Copy**: the Android dialog's em-dash sentence is split into two sentences.

## Screenshots

| Tile (sidebar bottom) | Install dialog (Android) |
|---|---|
| transparent outline card, blue mark | dash-free copy |

## Testing

- `tsc --noEmit` clean
- `pnpm test:unit` 451 passed, `pnpm test:api` 509 passed
- `pnpm format:check` clean
- Visually verified in the browser (tile geometry measured: 12px symmetric insets, arrow centered on the chevron axis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)