### PR TITLE
feat(portal): enable v3 for tools for humanity emails

### DIFF
--- a/web/lib/feature-flags/portal-v3/flag.ts
+++ b/web/lib/feature-flags/portal-v3/flag.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+const WHITELISTED_EMAIL_DOMAINS = ["toolsforhumanity.com"] as const;
+
 /**
  * Global switch: "true" turns v3 on for everyone in the current environment;
  * any other value (unset, "1", "false") is off — fail-safe to v2. Leave it
@@ -10,8 +12,9 @@ export const isPortalV3Enabled = (): boolean =>
 
 /**
  * Per-user v3 activation by email. v3 is on when the global switch is on, or
- * when the user's email is in the PORTAL_V3_EMAILS allow-list (comma-separated,
- * case-insensitive). No email -> off.
+ * when the user's email domain is hardcoded above or the full email is in the
+ * PORTAL_V3_EMAILS allow-list (comma-separated, case-insensitive). No email ->
+ * off.
  */
 export const isPortalV3EnabledForEmail = (email?: string | null): boolean => {
   if (isPortalV3Enabled()) {
@@ -20,9 +23,17 @@ export const isPortalV3EnabledForEmail = (email?: string | null): boolean => {
   if (!email) {
     return false;
   }
+  const normalizedEmail = email.toLowerCase();
+  if (
+    WHITELISTED_EMAIL_DOMAINS.some((domain) =>
+      normalizedEmail.endsWith(`@${domain}`),
+    )
+  ) {
+    return true;
+  }
   const allow = (process.env.PORTAL_V3_EMAILS ?? "")
     .split(",")
     .map((e) => e.trim().toLowerCase())
     .filter(Boolean);
-  return allow.includes(email.toLowerCase());
+  return allow.includes(normalizedEmail);
 };

--- a/web/tests/e2e/helpers/test.ts
+++ b/web/tests/e2e/helpers/test.ts
@@ -40,7 +40,7 @@ export const test = base.extend<{}, { workerStorageState: string }>({
         .fill(process.env.TEST_USER_PASSWORD);
       await page.locator("[name='submit']").click();
 
-      await expect(page.getByText("Build your first project")).toBeVisible();
+      await expect(page).toHaveURL(/\/teams\/team_[a-f0-9]+\/apps$/);
 
       // Save storage state of the authenticated browser
       await page.context().storageState({ path: fileName });

--- a/web/tests/e2e/specs/app.spec.ts
+++ b/web/tests/e2e/specs/app.spec.ts
@@ -8,16 +8,18 @@ test.describe("App", () => {
   });
 
   test("Create an App", async ({ page }) => {
+    test.slow();
     qase.id(2);
 
     const appName = "World Test!";
 
     await page.goto("/");
     await expect(page.getByText("Let's create your first app.")).toBeVisible();
-    await page.waitForLoadState("networkidle");
     await page.getByTestId("button-create-new-app").click();
 
-    await expect(page.getByText("Setup your app")).toBeVisible();
+    await expect(page.getByText("Setup your app")).toBeVisible({
+      timeout: 90_000,
+    });
     await expect(page.getByTestId("button-create-app")).toBeDisabled();
 
     await page.fill("[data-testid='input-app-name']", appName);

--- a/web/tests/e2e/specs/app.spec.ts
+++ b/web/tests/e2e/specs/app.spec.ts
@@ -13,8 +13,8 @@ test.describe("App", () => {
     const appName = "World Test!";
 
     await page.goto("/");
-    await expect(page.getByText("Build your first project")).toBeVisible();
-    await page.click("[data-testid='button-create-an-app']");
+    await expect(page.getByText("Let's create your first app.")).toBeVisible();
+    await page.getByTestId("button-create-new-app").click();
 
     await expect(page.getByText("Setup your app")).toBeVisible();
     await expect(page.getByTestId("button-create-app")).toBeDisabled();
@@ -24,9 +24,9 @@ test.describe("App", () => {
     await page.getByTestId("button-create-app").click();
 
     await expect(page).toHaveURL(
-      new RegExp(`/teams/${constants.teamId}/apps/app_[a-f0-9]+$`),
+      new RegExp(`/teams/${constants.teamId}/apps/app_[a-f0-9]+/world-id-4-0$`),
     );
-    await expect(page.getByText("Overview")).toBeVisible();
+    await expect(page.getByText("Set up World ID")).toBeVisible();
     await expect(page.getByText(appName)).toBeVisible();
   });
 });

--- a/web/tests/e2e/specs/app.spec.ts
+++ b/web/tests/e2e/specs/app.spec.ts
@@ -14,6 +14,7 @@ test.describe("App", () => {
 
     await page.goto("/");
     await expect(page.getByText("Let's create your first app.")).toBeVisible();
+    await page.waitForLoadState("networkidle");
     await page.getByTestId("button-create-new-app").click();
 
     await expect(page.getByText("Setup your app")).toBeVisible();
@@ -26,7 +27,9 @@ test.describe("App", () => {
     await expect(page).toHaveURL(
       new RegExp(`/teams/${constants.teamId}/apps/app_[a-f0-9]+/world-id-4-0$`),
     );
-    await expect(page.getByText("Set up World ID")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Create action" }),
+    ).toBeVisible();
     await expect(page.getByText(appName)).toBeVisible();
   });
 });

--- a/web/tests/unit/portal-v3-flag.test.ts
+++ b/web/tests/unit/portal-v3-flag.test.ts
@@ -18,6 +18,7 @@ describe("isPortalV3EnabledForEmail", () => {
     expect(isPortalV3EnabledForEmail("DEVELOPER@TOOLSFORHUMANITY.COM")).toBe(
       true,
     );
+    expect(isPortalV3EnabledForEmail("developer@example.com")).toBe(false);
     expect(isPortalV3EnabledForEmail("developer@nottoolsforhumanity.com")).toBe(
       false,
     );

--- a/web/tests/unit/portal-v3-flag.test.ts
+++ b/web/tests/unit/portal-v3-flag.test.ts
@@ -8,6 +8,21 @@ afterEach(() => {
 });
 
 describe("isPortalV3EnabledForEmail", () => {
+  it("enables the hardcoded email domains without environment configuration", () => {
+    delete process.env.LOCAL_DEV_PORTAL_V3_ENABLED;
+    delete process.env.PORTAL_V3_EMAILS;
+
+    expect(isPortalV3EnabledForEmail("developer@toolsforhumanity.com")).toBe(
+      true,
+    );
+    expect(isPortalV3EnabledForEmail("DEVELOPER@TOOLSFORHUMANITY.COM")).toBe(
+      true,
+    );
+    expect(isPortalV3EnabledForEmail("developer@nottoolsforhumanity.com")).toBe(
+      false,
+    );
+  });
+
   it("enables allow-listed emails only", () => {
     delete process.env.LOCAL_DEV_PORTAL_V3_ENABLED;
     process.env.PORTAL_V3_EMAILS = "ada@example.com";


### PR DESCRIPTION
This PR enables Portal v3 for all authenticated users whose email ends with `@toolsforhumanity.com`.

- Adds `toolsforhumanity.com` to the hardcoded `WHITELISTED_EMAIL_DOMAINS` list.
- Preserves the existing local global switch and `PORTAL_V3_EMAILS` per-address allowlist.
- Covers case-insensitive domain matching and rejects lookalike domains.
- Validates the change with focused Jest, TypeScript, formatting, and diff checks.