### PR TITLE
Forward Zoom Pulse notification metadata

### DIFF
--- a/web/api/v2/minikit/send-notification/index.ts
+++ b/web/api/v2/minikit/send-notification/index.ts
@@ -377,6 +377,12 @@ export const POST = async (req: NextRequest) => {
           miniAppPath: mini_app_path,
           teamId: teamId,
           localisations: (parsedParams as SendNotificationBodyV2).localisations,
+          ...((parsedParams as SendNotificationBodyV2).template_key !==
+            undefined && {
+            templateKey: (parsedParams as SendNotificationBodyV2).template_key,
+            templateArgs: (parsedParams as SendNotificationBodyV2)
+              .template_args,
+          }),
           ...(draft_id !== undefined && { draftId: draft_id }),
         };
 

--- a/web/api/v2/minikit/send-notification/schema.ts
+++ b/web/api/v2/minikit/send-notification/schema.ts
@@ -6,6 +6,7 @@ import {
 import * as yup from "yup";
 
 const USERNAME_SPECIAL_STRING = "${username}";
+const PULSE_ZOOM_DEEP_FACE_TEMPLATE_KEY = "pulse_zoom_deep_face";
 
 const isProduction = process.env.NEXT_PUBLIC_APP_ENV === "production";
 
@@ -141,6 +142,19 @@ export const sendNotificationBodySchemaV2 = yup
         },
       ),
     draft_id: yup.string().optional(),
+    template_key: yup
+      .string()
+      .oneOf([PULSE_ZOOM_DEEP_FACE_TEMPLATE_KEY])
+      .strict()
+      .optional(),
+    template_args: yup
+      .object({
+        app_name: yup.string().oneOf(["Zoom"]).strict().required(),
+        is_self: yup.string().oneOf(["yes", "no"]).strict().required(),
+      })
+      .noUnknown()
+      .strict()
+      .optional(),
     localisations: yup
       .array()
       .of(
@@ -175,4 +189,11 @@ export const sendNotificationBodySchemaV2 = yup
         return Boolean(value?.find(({ language }) => language === "en"));
       }),
   })
+  .test(
+    "pulse-template-pair",
+    "template_key and template_args must be provided together",
+    (value) =>
+      (value?.template_key === undefined) ===
+      (value?.template_args === undefined),
+  )
   .noUnknown();

--- a/web/tests/api/v2/send-notification.test.ts
+++ b/web/tests/api/v2/send-notification.test.ts
@@ -207,6 +207,33 @@ describe("/api/v2/minikit/send-notification [success cases]", () => {
     expect(res.status).toBe(200);
   });
 
+  it("forwards Zoom Pulse template metadata to app-backend", async () => {
+    const mockReq = new NextRequest(
+      "http://localhost:3000/api/v2/minikit/send-notification",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${validApiKey}`,
+        },
+        body: JSON.stringify({
+          ...v2RequestBody,
+          template_key: "pulse_zoom_deep_face",
+          template_args: { app_name: "Zoom", is_self: "yes" },
+        }),
+      },
+    );
+
+    const res = await POST(mockReq);
+
+    expect(res.status).toBe(200);
+    const [, options] = mockSignedFetcher.mock.calls[0] as any;
+    expect(JSON.parse(options.body)).toMatchObject({
+      templateKey: "pulse_zoom_deep_face",
+      templateArgs: { app_name: "Zoom", is_self: "yes" },
+    });
+  });
+
   it("prioritizes a verified Mini App over an external draft", async () => {
     GetAppMetadata.mockResolvedValue({
       app_metadata: [
@@ -329,6 +356,32 @@ describe("/api/v2/minikit/send-notification [error cases]", () => {
     expect((await res.json()).detail).toBe(
       "Neither localisations nor title and message are specified",
     );
+  });
+
+  it("rejects incomplete Pulse template metadata", async () => {
+    mockSignedFetcher.mockClear();
+    const mockReq = new NextRequest(
+      "http://localhost:3000/api/v2/minikit/send-notification",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${validApiKey}`,
+        },
+        body: JSON.stringify({
+          ...v2RequestBody,
+          template_key: "pulse_zoom_deep_face",
+        }),
+      },
+    );
+
+    const res = await POST(mockReq);
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).detail).toBe(
+      "template_key and template_args must be provided together",
+    );
+    expect(mockSignedFetcher).not.toHaveBeenCalled();
   });
 
   it("returns 404 if api key not exists", async () => {


### PR DESCRIPTION
## Summary
- accept the Zoom Deep Face Pulse template metadata on the v2 MiniKit notification route;
- restrict the public contract to `pulse_zoom_deep_face` and its required `app_name`/`is_self` arguments;
- translate snake_case API fields to the camelCase app-backend contract while leaving existing Braze localisations intact.