### PR TITLE
fix(portal): hide team-scoped sidebar items on team-less routes

### DIFF
--- a/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
@@ -92,74 +92,82 @@ export const SidebarNav = (props: {
 
   return (
     <nav className="no-scrollbar flex flex-1 flex-col overflow-y-auto px-4 pt-[27px]">
-      <div className="grid gap-2">
-        <NavItem
-          label="World ID"
-          href={worldIdHref}
-          active={worldIdActive}
-          icon={<NavIcon name="nav-world-id" active={worldIdActive} />}
-        />
-
-        {appId ? (
-          <>
+      {/* Team-scoped items: without a team in the route (e.g. /profile) these
+          links could only bounce to an arbitrary first team, so hide them. */}
+      {teamId ? (
+        <>
+          <div className="grid gap-2">
             <NavItem
-              label="Configuration"
-              href={configurationHref}
-              active={configurationActive}
-              icon={
-                <NavIcon
-                  name="nav-configuration"
+              label="World ID"
+              href={worldIdHref}
+              active={worldIdActive}
+              icon={<NavIcon name="nav-world-id" active={worldIdActive} />}
+            />
+
+            {appId ? (
+              <>
+                <NavItem
+                  label="Configuration"
+                  href={configurationHref}
                   active={configurationActive}
-                />
-              }
-            />
-            <NavItem
-              label="Mini App"
-              href={miniAppHref}
-              active={miniAppActive}
-              current={false}
-              icon={<NavIcon name="nav-mini-app" active={miniAppActive} />}
-            />
-            {miniAppActive && ids ? (
-              <div className="ml-5 grid gap-1 border-l border-portal-border pl-2">
-                <NavItem
-                  label="Permissions"
-                  href={urls.miniAppPermissions(ids)}
-                  active={miniAppPermissionsActive}
-                  className="h-9 rounded-8 pr-3 pl-3 text-12"
-                  icon={<LockIcon className="size-3.5" />}
+                  icon={
+                    <NavIcon
+                      name="nav-configuration"
+                      active={configurationActive}
+                    />
+                  }
                 />
                 <NavItem
-                  label="Transactions"
-                  href={urls.miniAppTransactions(ids)}
-                  active={miniAppTransactionsActive}
-                  className="h-9 rounded-8 pr-3 pl-3 text-12"
-                  icon={<WalletIcon className="size-3.5" />}
+                  label="Mini App"
+                  href={miniAppHref}
+                  active={miniAppActive}
+                  current={false}
+                  icon={<NavIcon name="nav-mini-app" active={miniAppActive} />}
                 />
-                <NavItem
-                  label="Notifications"
-                  href={urls.miniAppNotifications(ids)}
-                  active={miniAppNotificationsActive}
-                  className="h-9 rounded-8 pr-3 pl-3 text-12"
-                  icon={<SendIcon className="size-3.5" />}
-                />
-              </div>
+                {miniAppActive && ids ? (
+                  <div className="ml-5 grid gap-1 border-l border-portal-border pl-2">
+                    <NavItem
+                      label="Permissions"
+                      href={urls.miniAppPermissions(ids)}
+                      active={miniAppPermissionsActive}
+                      className="h-9 rounded-8 pr-3 pl-3 text-12"
+                      icon={<LockIcon className="size-3.5" />}
+                    />
+                    <NavItem
+                      label="Transactions"
+                      href={urls.miniAppTransactions(ids)}
+                      active={miniAppTransactionsActive}
+                      className="h-9 rounded-8 pr-3 pl-3 text-12"
+                      icon={<WalletIcon className="size-3.5" />}
+                    />
+                    <NavItem
+                      label="Notifications"
+                      href={urls.miniAppNotifications(ids)}
+                      active={miniAppNotificationsActive}
+                      className="h-9 rounded-8 pr-3 pl-3 text-12"
+                      icon={<SendIcon className="size-3.5" />}
+                    />
+                  </div>
+                ) : null}
+              </>
             ) : null}
-          </>
-        ) : null}
-      </div>
+          </div>
 
-      <div className="my-2 h-px w-full">
-        <Icon name="nav-separator" className="h-px w-full" />
-      </div>
+          <div className="my-2 h-px w-full">
+            <Icon name="nav-separator" className="h-px w-full" />
+          </div>
+        </>
+      ) : null}
 
       <div className="grid gap-2">
-        <NavItem
-          label="Team settings"
-          href={teamSettingsHref}
-          active={settingsActive}
-          icon={<NavIcon name="nav-settings" active={settingsActive} />}
-        />
+        {teamId ? (
+          <NavItem
+            label="Team settings"
+            href={teamSettingsHref}
+            active={settingsActive}
+            icon={<NavIcon name="nav-settings" active={settingsActive} />}
+          />
+        ) : null}
         <HelpCenterMenu />
         {configurationDangerHref ? (
           <NavItem

--- a/web/tests/unit/pv3-sidebar-section-nav.test.tsx
+++ b/web/tests/unit/pv3-sidebar-section-nav.test.tsx
@@ -224,7 +224,8 @@ describe("v3 SidebarNav [no app selected]", () => {
 });
 // #endregion
 
-// Team-less links fall back to /teams.
+// Team-scoped links disappear without a team in the route: they could only
+// bounce to an arbitrary first team, which is disorienting on /profile.
 // #region team-less pages
 describe("v3 SidebarNav [team-less pages]", () => {
   beforeEach(() => {
@@ -233,19 +234,25 @@ describe("v3 SidebarNav [team-less pages]", () => {
     usePathname.mockReturnValue("/profile");
   });
 
-  it("routes World ID to the /teams landing when the route has no teamId", () => {
+  it("hides World ID when the route has no teamId", () => {
     renderSidebar();
-    expect(link("World ID")).toHaveAttribute("href", "/teams");
-    expect(isCurrent("World ID")).toBe(false);
+    expect(
+      screen.queryByRole("link", { name: "World ID" }),
+    ).not.toBeInTheDocument();
   });
 
-  it("routes Team settings to the /teams landing rather than a dead link", () => {
+  it("hides Team settings when the route has no teamId", () => {
     renderSidebar();
-    expect(link("Team settings")).toHaveAttribute("href", "/teams");
+    expect(
+      screen.queryByRole("link", { name: "Team settings" }),
+    ).not.toBeInTheDocument();
   });
 
-  it("keeps the sandbox button visible without a teamId", () => {
+  it("keeps Help center and the sandbox button visible without a teamId", () => {
     renderSidebar();
+    expect(
+      screen.getByRole("button", { name: /Help center/i }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /World ID Sandbox/i }),
     ).toBeInTheDocument();


### PR DESCRIPTION
## Why

On `/profile` there is no team in the route (and none shown in the header), but the sidebar still renders **World ID** and **Team settings**. Both fall back to the `/teams` landing, which redirects to the *first* team — so clicking either silently drops you onto an arbitrary team's World ID page. With no team context, "which team's settings?" and "which World ID?" have no answer, so the links shouldn't be there.

## What

- `SidebarNav` now renders the team-scoped items — **World ID** (plus its separator) and **Team settings** — only when the route has a `teamId`. The bulk of the diff is re-indentation from wrapping the existing World ID / app block in that conditional; no item inside it changed.
- On team-less routes the sidebar keeps **Help center** and the **World ID Sandbox** button, which don't need team context.
- The app-scoped items (Configuration, Mini App, Danger zone) were already hidden on `/profile` because the remembered app is team-keyed.

## Testing

- Updated the existing `[team-less pages]` tests, which pinned the old fallback-to-`/teams` hrefs, to assert the items are hidden and Help center / Sandbox remain: `pv3-sidebar-section-nav.test.tsx` — 17/17 pass
- `tsc --noEmit` and `pnpm format:check` pass