### PR TITLE
Fix stale and broken portal links

### DIFF
--- a/web/components/ActionsHeader/index.tsx
+++ b/web/components/ActionsHeader/index.tsx
@@ -4,7 +4,7 @@ import { DecoratedButton } from "@/components/DecoratedButton";
 import { CaretIcon } from "@/components/Icons/CaretIcon";
 import { DocsIcon } from "@/components/Icons/DocsIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { DOCS_CLOUD_URL } from "@/lib/constants";
+import { DOCS_IDKIT_INTEGRATION_URL } from "@/lib/constants";
 import clsx from "clsx";
 import Link from "next/link";
 import posthog from "posthog-js";
@@ -36,7 +36,7 @@ export const ActionsHeader = memo(function ActionsHeader(
     displayText,
     backText,
     backUrl,
-    learnMoreUrl = DOCS_CLOUD_URL,
+    learnMoreUrl = DOCS_IDKIT_INTEGRATION_URL,
     isLoading = false,
     className,
     environment,

--- a/web/lib/constants.ts
+++ b/web/lib/constants.ts
@@ -48,7 +48,8 @@ export const FACE_SEQUENCER_STAGING =
 // ANCHOR: OIDC Base URL
 export const OIDC_BASE_URL = "https://id.worldcoin.org";
 export const DOCS_URL = "https://docs.world.org";
-export const DOCS_CLOUD_URL = "https://docs.world.org/id/cloud";
+export const DOCS_IDKIT_INTEGRATION_URL =
+  "https://docs.world.org/world-id/idkit/integrate";
 
 // ANCHOR: JWKs
 export const JWK_TIME_TO_LIVE = 30; // days; duration before a JWK is rotated
@@ -57,7 +58,7 @@ export const JWK_TTL_USABLE = 7; // days; duration before a JWK is rotated
 export const SIMULATOR_URL = "https://simulator.worldcoin.org";
 export const TELEGRAM_DEVELOPERS_GROUP_URL = "https://t.me/worldcoindevelopers";
 export const TELEGRAM_MATEO_URL = "https://t.me/MateoSauton";
-export const DISCORD_URL = "https://world.org/discord";
+export const DISCORD_URL = "https://discord.com/invite/worldcoin";
 export const WORLD_STATUS_URL = "https://status.world.org/";
 export const WORLD_PRIVACY_URL = "https://world.org/privacy";
 export const FAQ_URL = "https://world.org/faqs";

--- a/web/scenes/Onboarding/Home/page/index.tsx
+++ b/web/scenes/Onboarding/Home/page/index.tsx
@@ -178,7 +178,10 @@ const FOOTER_LINK_COLUMNS: FooterLink[][] = [
   ],
   [
     { href: "https://world.org/ecosystem", label: "Ecosystem" },
-    { href: "https://world.org/community", label: "Community" },
+    {
+      href: "https://world.org/community-operator",
+      label: "Community Operators",
+    },
   ],
   [
     { href: "https://docs.world.org", label: "Documentation" },
@@ -192,7 +195,6 @@ const FOOTER_LINK_COLUMNS: FooterLink[][] = [
   ],
   [
     { href: "https://whitepaper.world.org", label: "Whitepaper" },
-    { href: "https://world.org/events", label: "Events" },
     { href: "https://world.org/brand", label: "Brand Guidelines" },
     { href: "https://status.world.org", label: "Status" },
   ],

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
@@ -394,7 +394,7 @@ export const SetupForm = (props: LinksFormProps) => {
             rejected most of the time. Refer to{" "}
             <Link
               className="font-bold underline"
-              href="https://docs.world.org/mini-apps/notifications/how-to-send-notifications"
+              href="https://docs.world.org/mini-apps/commands/how-to-send-notifications"
             >
               docs
             </Link>{" "}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Notifications/page.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Notifications/page.tsx
@@ -251,7 +251,7 @@ export const NotificationsPage = () => {
             Send notifications to specific wallet addresses. Unverified apps are
             limited to 40 notifications per 4 hours.{" "}
             <a
-              href="https://docs.world.org/mini-apps/reference/api#send-notification"
+              href="https://docs.world.org/api-reference/developer-portal/send-notification"
               target="_blank"
               className="inline-block whitespace-nowrap underline"
               rel="noopener noreferrer"

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/index.tsx
@@ -1,7 +1,6 @@
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { DocsIcon } from "@/components/Icons/DocsIcon";
 import { GithubIcon } from "@/components/Icons/GithubIcon";
-import { WarningErrorIcon } from "@/components/Icons/WarningErrorIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import Image from "next/image";
 import { ClientInformationPage } from "./ClientInformation";
@@ -68,32 +67,6 @@ export const SignInWithWorldIdPage = async (
           </DecoratedButton>
         </div>
       </div>
-
-      <a
-        href="https://docs.world.org/world-id/sign-in/deprecation"
-        rel="noreferrer noopener"
-        target="_blank"
-        className="block w-full"
-      >
-        <div className="mt-6 mb-8 flex w-full items-center gap-3 rounded-xl border-2 border-orange-300 bg-orange-50 px-6 py-4 shadow-xs transition-all hover:bg-orange-100 hover:shadow-md">
-          <WarningErrorIcon className="h-full w-12 shrink-0 text-orange-600" />
-          <div className="grow">
-            <div className="text-base text-orange-800">
-              <div className="font-medium">
-                Sign in with World ID is sunsetting in{" "}
-                <span className="font-bold">December 2025</span>.
-              </div>
-              <div className="mt-1 font-medium">
-                New apps created after September 29, 2025 cannot enable this
-                feature.
-              </div>
-              <div className="mt-2 font-semibold text-orange-900 underline">
-                Read the full announcement →
-              </div>
-            </div>
-          </div>
-        </div>
-      </a>
 
       <hr className="my-4 w-full border-dashed text-grey-200" />
       <div className="grid max-w-[580px] grid-cols-1">

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Advanced/page/SetupForm/index.tsx
@@ -394,7 +394,7 @@ export const SetupForm = (props: LinksFormProps) => {
             rejected most of the time. Refer to{" "}
             <Link
               className="font-bold underline"
-              href="https://docs.world.org/mini-apps/notifications/how-to-send-notifications"
+              href="https://docs.world.org/mini-apps/commands/how-to-send-notifications"
             >
               docs
             </Link>{" "}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Notifications/page.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Notifications/page.tsx
@@ -256,7 +256,7 @@ export const NotificationsPage = () => {
             Send notifications to specific wallet addresses. Unverified apps are
             limited to 40 notifications per 4 hours.{" "}
             <a
-              href="https://docs.world.org/mini-apps/reference/api#send-notification"
+              href="https://docs.world.org/api-reference/developer-portal/send-notification"
               target="_blank"
               className="inline-block whitespace-nowrap underline"
               rel="noopener noreferrer"

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/index.tsx
@@ -1,7 +1,6 @@
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { DocsIcon } from "@/components/Icons/DocsIcon";
 import { GithubIcon } from "@/components/Icons/GithubIcon";
-import { WarningErrorIcon } from "@/components/Icons/WarningErrorIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import Image from "next/image";
 import { ClientInformationPage } from "./ClientInformation";
@@ -68,32 +67,6 @@ export const SignInWithWorldIdPage = async (
           </DecoratedButton>
         </div>
       </div>
-
-      <a
-        href="https://docs.world.org/world-id/sign-in/deprecation"
-        rel="noreferrer noopener"
-        target="_blank"
-        className="block w-full"
-      >
-        <div className="mt-6 mb-8 flex w-full items-center gap-3 rounded-xl border-2 border-orange-300 bg-orange-50 px-6 py-4 shadow-xs transition-all hover:bg-orange-100 hover:shadow-md">
-          <WarningErrorIcon className="h-full w-12 shrink-0 text-orange-600" />
-          <div className="grow">
-            <div className="text-base text-orange-800">
-              <div className="font-medium">
-                Sign in with World ID is sunsetting in{" "}
-                <span className="font-bold">December 2025</span>.
-              </div>
-              <div className="mt-1 font-medium">
-                New apps created after September 29, 2025 cannot enable this
-                feature.
-              </div>
-              <div className="mt-2 font-semibold text-orange-900 underline">
-                Read the full announcement →
-              </div>
-            </div>
-          </div>
-        </div>
-      </a>
 
       <hr className="my-4 w-full border-dashed text-grey-200" />
       <div className="grid max-w-[580px] grid-cols-1">


### PR DESCRIPTION
## Summary

- replace the broken homepage community destination and remove the obsolete Events footer link
- update Mini App notification docs, notification API reference, Discord, and default IDKit documentation links in both portal variants
- remove the expired Sign in with World ID deprecation banner whose announcement URL no longer exists
- rename the stale `DOCS_CLOUD_URL` constant to match its current IDKit destination

## Validation

- `pnpm format:check`
- `npx tsc --noEmit`
- `npx jest --no-cache tests/api tests/unit lib/compare-versions.unit.spec.ts lib/schema/schema.unit.spec.ts api/v2/minikit/send-notification/send-notification.schema.unit.spec.ts` — 155 suites / 1,100 tests passed
- confirmed all five replacement destinations return HTTP 200

## Test environment note

The unscoped `npx jest --no-cache` command also discovers integration and Playwright E2E suites. Locally, those service-dependent suites fail without Postgres/Hasura and when Playwright specs are invoked through Jest; the unit/API scope above is green.