### PR TITLE
fix(e2e): align create-team existing-user fixture

### DIFF
--- a/tests/api/helpers/hasura.ts
+++ b/tests/api/helpers/hasura.ts
@@ -254,14 +254,21 @@ const createTestUserIdentifiers = () => {
 };
 
 // Helper for creating test user
-export const createTestUser = async (email: string, teamId?: string) => {
+export const createTestUser = async (
+  email: string,
+  teamId?: string,
+  auth0Id?: string,
+) => {
   try {
-    const { auth0Id, ironcladId, worldIdNullifier } =
-      createTestUserIdentifiers();
+    const {
+      auth0Id: generatedAuth0Id,
+      ironcladId,
+      worldIdNullifier,
+    } = createTestUserIdentifiers();
     const response = (await adminGraphqlClient.request(CREATE_USER_MUTATION, {
       object: {
         email,
-        auth0Id,
+        auth0Id: auth0Id ?? generatedAuth0Id,
         ...(teamId && { team_id: teamId }),
         ironclad_id: ironcladId,
         world_id_nullifier: worldIdNullifier,

--- a/tests/api/specs/dev-portal-helpers/create-team.spec.ts
+++ b/tests/api/specs/dev-portal-helpers/create-team.spec.ts
@@ -25,13 +25,18 @@ describe("Dev Portal Helpers API Endpoints", () => {
 
     it("Create team successfully for existing user", async () => {
       const userEmail = `qa+${NAME_SLUG}+${Date.now()}@toolsforhumanity.com`;
-      const testUserId = await createTestUser(userEmail);
+
+      // The endpoint determines whether the user exists by looking up the
+      // session's Auth0 ID in Hasura, so the fixture must use the same ID.
+      const uniqueAuth0Id = `auth0|test_existing_user_${Date.now()}`;
+      const testUserId = await createTestUser(
+        userEmail,
+        undefined,
+        uniqueAuth0Id,
+      );
 
       // Add cleanup functions
       cleanUpFunctions.push(async () => await deleteTestUser(testUserId));
-
-      // Generate unique auth0Id to prevent constraint violations
-      const uniqueAuth0Id = `auth0|test_existing_user_${Date.now()}`;
 
       const existingUserSession = await createAppSession({
         user: {


### PR DESCRIPTION
This PR fixes the create-team e2e fixture after the endpoint began deriving existing-user state from Hasura.

- creates the Hasura test user with the same Auth0 ID used by the test session
- preserves generated Auth0 IDs for all existing helper callers
- keeps the existing-user `/teams/:id` and new-user `/teams/:id/apps/` branches distinct
- validates with API-test lint, formatting, typecheck, and `git diff --check`
- leaves the live focused e2e to CI because local execution lacks the CI `AUTH0_SECRET` and staging Hasura access