### PR TITLE
fix(portal): polish sidebar account menu

### DIFF
--- a/web/scenes/PortalV3/layout/Shell/HelpCenterMenu.tsx
+++ b/web/scenes/PortalV3/layout/Shell/HelpCenterMenu.tsx
@@ -75,7 +75,7 @@ export const HelpCenterMenu = () => {
           <SidebarMenuButton
             aria-label="Help center"
             title="Help center"
-            className="h-10 rounded-[10px] px-3 font-world text-13 leading-none text-portal-muted hover:bg-portal-border hover:text-portal-text"
+            className="h-10 cursor-pointer rounded-[10px] px-3 font-world text-13 leading-none text-portal-muted hover:bg-portal-border hover:text-portal-text"
           >
             <Icon
               name="nav-help"

--- a/web/scenes/PortalV3/layout/Shell/NavItem.tsx
+++ b/web/scenes/PortalV3/layout/Shell/NavItem.tsx
@@ -34,7 +34,7 @@ export const NavItem = (props: {
         isActive={active}
         tooltip={label}
         className={cn(
-          "h-10 rounded-[10px] px-3 font-world text-13 leading-none font-normal text-portal-muted hover:bg-portal-border hover:text-portal-text data-[active=true]:border data-[active=true]:border-portal-border data-[active=true]:bg-white data-[active=true]:text-portal-text data-[active=true]:shadow-portal-card",
+          "h-10 cursor-pointer rounded-[10px] px-3 font-world text-13 leading-none font-normal text-portal-muted hover:bg-portal-border hover:text-portal-text data-[active=true]:border data-[active=true]:border-portal-border data-[active=true]:bg-white data-[active=true]:text-portal-text data-[active=true]:shadow-portal-card",
           className,
         )}
       >

--- a/web/scenes/PortalV3/layout/Shell/SearchableSwitcher.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SearchableSwitcher.tsx
@@ -178,7 +178,7 @@ export const SearchableSwitcher = <T extends SwitcherItem>(
                   aria-current={isSelected ? "page" : undefined}
                   onClick={() => setPopoverOpen(false)}
                   className={cn(
-                    "flex h-10 items-center gap-2 rounded-8 px-3 font-world text-13 font-medium text-portal-text outline-none hover:bg-grey-50 focus-visible:bg-grey-50",
+                    "flex h-10 cursor-pointer items-center gap-2 rounded-8 px-3 font-world text-13 font-medium text-portal-text outline-none hover:bg-grey-50 focus-visible:bg-grey-50",
                     isSelected && "bg-grey-50",
                   )}
                 >

--- a/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
@@ -185,7 +185,7 @@ export const SidebarNav = (props: {
                                 asChild
                                 size="sm"
                                 isActive={item.active}
-                                className="h-9 px-3 font-world text-portal-muted hover:bg-portal-border hover:text-portal-text data-[active=true]:bg-white data-[active=true]:text-portal-text [&>svg]:text-current"
+                                className="h-9 cursor-pointer px-3 font-world text-portal-muted hover:bg-portal-border hover:text-portal-text data-[active=true]:bg-white data-[active=true]:text-portal-text [&>svg]:text-current"
                               >
                                 <Link
                                   href={item.href}

--- a/web/scenes/PortalV3/layout/Shell/UserPopup.tsx
+++ b/web/scenes/PortalV3/layout/Shell/UserPopup.tsx
@@ -12,7 +12,6 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  useSidebar,
 } from "@/components/ui/sidebar";
 import { urls } from "@/lib/urls";
 import { Color } from "@/scenes/common/Profile/types";
@@ -70,7 +69,6 @@ export const UserPopup = (props: { user: PortalUser; color: Color | null }) => {
   const { user } = props;
   const selectedColor = useAtomValue(colorAtom);
   const color = selectedColor ?? props.color;
-  const { isMobile } = useSidebar();
 
   return (
     <SidebarMenu>
@@ -81,7 +79,7 @@ export const UserPopup = (props: { user: PortalUser; color: Color | null }) => {
               size="lg"
               aria-label="Account menu"
               title={user.name}
-              className="text-portal-text hover:bg-portal-border focus-visible:bg-portal-border focus-visible:ring-0 data-open:bg-portal-border"
+              className="cursor-pointer text-portal-text hover:bg-portal-border focus-visible:bg-portal-border focus-visible:ring-0 data-open:bg-portal-border"
             >
               <UserAvatar name={user.name} color={color} />
               <span className="min-w-0 flex-1 truncate font-world text-13 leading-none font-medium group-data-[collapsible=icon]:hidden">
@@ -92,10 +90,10 @@ export const UserPopup = (props: { user: PortalUser; color: Color | null }) => {
           </DropdownMenuTrigger>
 
           <DropdownMenuContent
-            side={isMobile ? "bottom" : "right"}
-            align="end"
-            sideOffset={12}
-            className="w-64 border border-portal-border font-world"
+            side="top"
+            align="start"
+            sideOffset={8}
+            className="w-(--radix-dropdown-menu-trigger-width) border border-portal-border font-world"
           >
             {accountLinks.map((item) => (
               <DropdownMenuItem key={item.href} asChild className={itemClass}>

--- a/web/scenes/PortalV3/layout/index.tsx
+++ b/web/scenes/PortalV3/layout/index.tsx
@@ -1,5 +1,6 @@
 import { fetchSandboxAccessRequest } from "@/api/v2/sandbox-access-request/server/fetch-sandbox-access-request";
 import { auth0 } from "@/lib/auth0";
+import { isWorldUser } from "@/lib/is-world-user";
 import { logger } from "@/lib/logger";
 import { Auth0SessionUser } from "@/lib/types";
 import { ReactNode } from "react";
@@ -30,7 +31,10 @@ export const PortalLayout = async (props: { children: ReactNode }) => {
 
   return (
     <PortalShell
-      user={{ name: user?.name, email: user?.email }}
+      user={{
+        name: user && isWorldUser(user) ? "Anonymous user" : user?.name,
+        email: user?.email,
+      }}
       teams={teams}
       sandboxRequest={sandboxRequest}
     >

--- a/web/tests/unit/portal-v3-apps-dropdown.test.tsx
+++ b/web/tests/unit/portal-v3-apps-dropdown.test.tsx
@@ -109,10 +109,12 @@ it("shows the route app and links app rows directly to World ID", () => {
   renderDropdown();
 
   expect(trigger()).toHaveTextContent("My App");
-  expect(screen.getByRole("link", { name: /My App/ })).toHaveAttribute(
+  const appLink = screen.getByRole("link", { name: /My App/ });
+  expect(appLink).toHaveAttribute(
     "href",
     "/teams/team_1/apps/app_1/world-id-4-0",
   );
+  expect(appLink).toHaveClass("cursor-pointer");
 });
 
 it("remembers the route app on team-scoped routes", () => {

--- a/web/tests/unit/portal-v3-portal-layout.test.tsx
+++ b/web/tests/unit/portal-v3-portal-layout.test.tsx
@@ -20,6 +20,7 @@ jest.mock("@/lib/logger", () => ({
 // Stub the shell so we test only PortalLayout's session -> shell wiring.
 jest.mock("@/scenes/PortalV3/layout/Shell", () => ({
   PortalShell: (props: {
+    user: { name?: string | null };
     teams: { id: string }[];
     sandboxRequest: { email: string } | null;
     children: React.ReactNode;
@@ -28,6 +29,7 @@ jest.mock("@/scenes/PortalV3/layout/Shell", () => ({
       data-testid="shell"
       data-team-count={props.teams.length}
       data-sandbox-email={props.sandboxRequest?.email}
+      data-user-name={props.user.name}
     >
       {props.children}
     </div>
@@ -44,6 +46,7 @@ beforeEach(() => {
 it("mounts the shell with teams from the session", async () => {
   getSession.mockResolvedValue({
     user: {
+      sub: "auth0|ada",
       name: "Ada",
       email: "ada@example.com",
       hasura: { memberships: [{ team: { id: "team_1", name: "Acme" } }] },
@@ -57,6 +60,7 @@ it("mounts the shell with teams from the session", async () => {
 it("hydrates the user's sandbox request into the shell", async () => {
   getSession.mockResolvedValue({
     user: {
+      sub: "auth0|ada",
       name: "Ada",
       email: "ada@example.com",
       hasura: { id: "usr_abc123", memberships: [] },
@@ -74,5 +78,22 @@ it("hydrates the user's sandbox request into the shell", async () => {
   expect(screen.getByTestId("shell")).toHaveAttribute(
     "data-sandbox-email",
     "tester@gmail.com",
+  );
+});
+
+it("labels World ID sessions without exposing their nullifier-like name", async () => {
+  getSession.mockResolvedValue({
+    user: {
+      sub: "oauth2|worldcoin|0xabc123",
+      name: "0xabc123",
+      hasura: { id: "usr_world_id", memberships: [] },
+    },
+  });
+
+  render(await PortalLayout({ children: null }));
+
+  expect(screen.getByTestId("shell")).toHaveAttribute(
+    "data-user-name",
+    "Anonymous user",
   );
 });

--- a/web/tests/unit/portal-v3-shell-dropdown-focus.test.tsx
+++ b/web/tests/unit/portal-v3-shell-dropdown-focus.test.tsx
@@ -2,11 +2,14 @@
 
 import "@testing-library/jest-dom";
 import { SidebarProvider } from "@/components/ui/sidebar";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { additionalColors } from "@/lib/additional-colors";
 import { colorAtom } from "@/scenes/common/layout/color-atom";
+import { HelpCenterMenu } from "@/scenes/PortalV3/layout/Shell/HelpCenterMenu";
+import { NavItem } from "@/scenes/PortalV3/layout/Shell/NavItem";
 import { TeamsDropdown } from "@/scenes/PortalV3/layout/Shell/TeamsDropdown";
 import { UserPopup } from "@/scenes/PortalV3/layout/Shell/UserPopup";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { createStore, Provider } from "jotai";
 
 // #region Mocks
@@ -30,13 +33,15 @@ jest.mock("@/hooks/use-mobile", () => ({
 describe("Portal v3 shell dropdown focus treatment", () => {
   it("uses a clean background cue instead of a persistent focus ring", () => {
     render(
-      <SidebarProvider>
-        <TeamsDropdown teams={[{ id: "team_1", name: "Example team" }]} />
-        <UserPopup
-          user={{ name: "Ada Lovelace", email: "ada@example.com" }}
-          color={null}
-        />
-      </SidebarProvider>,
+      <TooltipProvider>
+        <SidebarProvider>
+          <TeamsDropdown teams={[{ id: "team_1", name: "Example team" }]} />
+          <UserPopup
+            user={{ name: "Ada Lovelace", email: "ada@example.com" }}
+            color={null}
+          />
+        </SidebarProvider>
+      </TooltipProvider>,
     );
 
     const teamTrigger = screen.getByRole("button", { name: "Switch team" });
@@ -50,17 +55,65 @@ describe("Portal v3 shell dropdown focus treatment", () => {
     }
   });
 
+  it("uses a pointer cursor for interactive sidebar items", () => {
+    render(
+      <TooltipProvider>
+        <SidebarProvider>
+          <NavItem href="/world-id" label="World ID" />
+          <HelpCenterMenu />
+          <TeamsDropdown teams={[{ id: "team_1", name: "Example team" }]} />
+          <UserPopup
+            user={{ name: "Ada Lovelace", email: "ada@example.com" }}
+            color={null}
+          />
+        </SidebarProvider>
+      </TooltipProvider>,
+    );
+
+    for (const element of [
+      screen.getByRole("link", { name: "World ID" }),
+      screen.getByRole("button", { name: "Help center" }),
+      screen.getByRole("button", { name: "Switch team" }),
+      screen.getByRole("button", { name: "Account menu" }),
+    ]) {
+      expect(element).toHaveClass("cursor-pointer");
+    }
+  });
+
+  it("opens the profile menu directly above the profile row", async () => {
+    render(
+      <TooltipProvider>
+        <SidebarProvider>
+          <UserPopup
+            user={{ name: "Ada Lovelace", email: "ada@example.com" }}
+            color={null}
+          />
+        </SidebarProvider>
+      </TooltipProvider>,
+    );
+
+    fireEvent.keyDown(screen.getByRole("button", { name: "Account menu" }), {
+      key: "ArrowDown",
+    });
+
+    const menu = await screen.findByRole("menu");
+    expect(menu).toHaveAttribute("data-side", "top");
+    expect(menu).toHaveClass("w-(--radix-dropdown-menu-trigger-width)");
+  });
+
   it("updates the profile avatar when the profile color changes", () => {
     const store = createStore();
 
     render(
       <Provider store={store}>
-        <SidebarProvider>
-          <UserPopup
-            user={{ name: "Ada Lovelace", email: "ada@example.com" }}
-            color={additionalColors.pink}
-          />
-        </SidebarProvider>
+        <TooltipProvider>
+          <SidebarProvider>
+            <UserPopup
+              user={{ name: "Ada Lovelace", email: "ada@example.com" }}
+              color={additionalColors.pink}
+            />
+          </SidebarProvider>
+        </TooltipProvider>
       </Provider>,
     );
 

--- a/web/tests/unit/pv3-sidebar-section-nav.test.tsx
+++ b/web/tests/unit/pv3-sidebar-section-nav.test.tsx
@@ -84,6 +84,7 @@ describe("v3 SidebarNav [navigation hierarchy]", () => {
     renderSidebar();
 
     expect(link("World ID")).toBeInTheDocument();
+    expect(link("World ID")).toHaveClass("cursor-pointer");
     expect(
       screen.queryByRole("link", { name: "Dashboard" }),
     ).not.toBeInTheDocument();
@@ -135,6 +136,7 @@ describe("v3 SidebarNav [active section]", () => {
     expect(link("World ID")).toBeInTheDocument();
     expect(link("Permissions")).toHaveAttribute("aria-current", "page");
     expect(link("Permissions")).toHaveAttribute("data-active", "true");
+    expect(link("Permissions")).toHaveClass("cursor-pointer");
     expect(link("Permissions").querySelector("svg")).toHaveClass(
       "lucide-lock-keyhole",
     );


### PR DESCRIPTION
This PR polishes the Portal V3 shadcn sidebar account experience.

- Shows `Anonymous user` for World ID-authenticated sessions without exposing nullifier-like names.
- Adds pointer cursors to interactive sidebar controls and switcher rows.
- Opens the shadcn profile menu directly above the account row and matches its width.
- Adds focused regression coverage; 32 tests, TypeScript, and formatting pass.