### PR TITLE
test(ui): align cursor assertion with global rule

### DIFF
--- a/web/tests/unit/portal-v3-shell-dropdown-focus.test.tsx
+++ b/web/tests/unit/portal-v3-shell-dropdown-focus.test.tsx
@@ -5,8 +5,6 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { additionalColors } from "@/lib/additional-colors";
 import { colorAtom } from "@/scenes/common/layout/color-atom";
-import { HelpCenterMenu } from "@/scenes/PortalV3/layout/Shell/HelpCenterMenu";
-import { NavItem } from "@/scenes/PortalV3/layout/Shell/NavItem";
 import { TeamsDropdown } from "@/scenes/PortalV3/layout/Shell/TeamsDropdown";
 import { UserPopup } from "@/scenes/PortalV3/layout/Shell/UserPopup";
 import { act, fireEvent, render, screen } from "@testing-library/react";
@@ -52,31 +50,6 @@ describe("Portal v3 shell dropdown focus treatment", () => {
     for (const trigger of [teamTrigger, profileTrigger]) {
       expect(trigger).toHaveClass("focus-visible:bg-portal-border");
       expect(trigger).toHaveClass("focus-visible:ring-0");
-    }
-  });
-
-  it("uses a pointer cursor for interactive sidebar items", () => {
-    render(
-      <TooltipProvider>
-        <SidebarProvider>
-          <NavItem href="/world-id" label="World ID" />
-          <HelpCenterMenu />
-          <TeamsDropdown teams={[{ id: "team_1", name: "Example team" }]} />
-          <UserPopup
-            user={{ name: "Ada Lovelace", email: "ada@example.com" }}
-            color={null}
-          />
-        </SidebarProvider>
-      </TooltipProvider>,
-    );
-
-    for (const element of [
-      screen.getByRole("link", { name: "World ID" }),
-      screen.getByRole("button", { name: "Help center" }),
-      screen.getByRole("button", { name: "Switch team" }),
-      screen.getByRole("button", { name: "Account menu" }),
-    ]) {
-      expect(element).toHaveClass("cursor-pointer");
     }
   });
 


### PR DESCRIPTION
This PR aligns the Portal V3 shell unit test with the global pointer-cursor rule introduced in #2174.

- Removes the obsolete component-level `cursor-pointer` assertion.
- Removes imports used only by that stale test.
- Keeps production pointer behavior owned by `styles/globals.css`.
- Validates the focused regression test, all 115 unit suites / 584 tests, formatting, and TypeScript.