### PR TITLE
docs(agents): drop the optical-centering and placeholder-copy directives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,29 +21,6 @@
 
 Always run formatting and type checks before committing. Make sure tests pass as well.
 
-After UI changes, remove generic or AI-sounding placeholder/example copy. Leave
-fields without placeholder text unless the product explicitly requires it.
-
-## Icons and glyph optical centering (required check when adding icons or badges)
-
-Any change that adds an icon, a numbered/lettered bubble, or a glyph beside a
-text label MUST be checked for optical centering — geometric centering is not
-enough, because flex centers the text's **line box**, not the glyph, and the
-World Pro font reserves descender space that digits/caps don't use:
-
-- **Icon beside cap-height text** → wrap it with `opticalIconClassName`
-  (exported from `web/scenes/PortalV3/common/Icon`); otherwise it reads ~1px low.
-- **Digit/cap glyph inside a fixed circle or pill** (stepper dots, count
-  badges) → wrap the glyph with `bubbleDigitClassName` from the same file;
-  otherwise it paints ~2.75px high at text-13. The class applies 0.12em, an
-  optical value chosen by eye — exact ink-centering (0.21em) reads too low.
-- Verify with `cd web && node scripts/check-optical-centering.mjs` — it
-  renders the bubble recipe with the real font and fails if the corrected
-  glyph drifts more than 0.15px from the circle's center. Run it whenever you
-  touch bubble markup, the correction offsets, or `WorldProMVP.ttf`.
-- Zoomed screenshots are the manual fallback: capture the element at 4x+ and
-  compare the ink's top/bottom gaps before calling the UI done.
-
 ## Pull request follow-up
 
 After pushing a branch with an open pull request, wait 5 minutes, then check the


### PR DESCRIPTION
Removes two directives from AGENTS.md:

- the **Icons and glyph optical centering** required-check section
- the **placeholder/example copy cleanup** note under Making Changes

Both were causing Codex to spawn noisy, low-value review comments on unrelated PRs. The optical-centering script itself (`web/scripts/check-optical-centering.mjs`) is unchanged and still available for anyone who wants to run it manually.