### PR TITLE
fix supported countries alert icon alignment

### DIFF
--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/CountriesSection.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/AppStore/components/FormSections/CountriesSection.tsx
@@ -2,6 +2,7 @@ import { AlertIcon } from "@/components/Icons/AlertIcon";
 import { SelectMultiple } from "@/components/SelectMultiple";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { formCountriesList } from "@/lib/languages";
+import { opticalIconClassName } from "@/scenes/PortalV3/common/Icon";
 import Image from "next/image";
 import { useMemo, useState } from "react";
 import { Control, Controller, FieldErrors } from "react-hook-form";
@@ -31,7 +32,7 @@ export const CountriesSection = ({
     >
       <div className="flex items-center gap-3 rounded-[10px] bg-system-warning-100 p-5">
         <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-system-warning-600">
-          <AlertIcon className="size-4 text-white" />
+          <AlertIcon className={`${opticalIconClassName} size-4 text-white`} />
         </div>
         <Typography
           variant={TYPOGRAPHY.B3}


### PR DESCRIPTION
## Summary
- optically lift the Supported Countries warning icon by reusing `opticalIconClassName`
- keep the correction scoped to this banner instead of changing `AlertIcon` globally

## Why
The triangular glyph is geometrically centered inside its circular badge, but its visual weight makes it read low. Reusing the existing shared optical offset brings it into visual alignment without adding a new magic value or affecting unrelated alert icons.

## Validation
- `npx tsc --noEmit`
- `pnpm format:check`
- `node scripts/check-optical-centering.mjs`
- `npx jest tests/unit lib/schema --runInBand` (115 suites, 584 tests)