### PR TITLE
feat(portal): improve team navigation

### DIFF
--- a/web/api/login-callback/index.ts
+++ b/web/api/login-callback/index.ts
@@ -25,6 +25,7 @@ import {
 } from "./graphql/accept-team-invite.generated";
 
 import { logger } from "@/lib/logger";
+import { isPortalV3EnabledForEmail } from "@/lib/feature-flags/portal-v3/flag";
 import { Auth0User } from "@/lib/types";
 import { urls } from "@/lib/urls";
 import { isEmailUser } from "../helpers/is-email-user";
@@ -325,7 +326,9 @@ export const loginCallback = async (req: NextRequest) => {
     }
   }
 
-  // If a user just accepted an invite, redirect them to that teams page.
+  // Portal V2 keeps its original first-team apps destination. Only V3 uses
+  // the cross-device latest-team resolver.
+  const isPortalV3 = isPortalV3EnabledForEmail(auth0User.email);
   const teamId = team_id_from_invite ?? user?.memberships[0]?.team.id;
   let url: string = urls.profile();
   const rawReturnTo = req.nextUrl.searchParams.get("returnTo");
@@ -347,7 +350,15 @@ export const loginCallback = async (req: NextRequest) => {
     url = returnTo;
   }
 
-  if (!returnTo && teamId) {
+  if (!returnTo && isPortalV3 && team_id_from_invite) {
+    url = urls.teams({ team_id: team_id_from_invite });
+  }
+
+  if (!returnTo && isPortalV3 && !team_id_from_invite && teamId) {
+    url = urls.dashboard();
+  }
+
+  if (!returnTo && !isPortalV3 && teamId) {
     url = urls.apps({ team_id: teamId });
   }
 

--- a/web/app/(portal)/dashboard/page.tsx
+++ b/web/app/(portal)/dashboard/page.tsx
@@ -1,17 +1,17 @@
 import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { generateMetaTitle } from "@/lib/genarate-title";
 import { urls } from "@/lib/urls";
-import { TeamsPage } from "@/scenes/Portal/Teams/page";
+import { DashboardPage } from "@/scenes/PortalV3/Dashboard/page";
 import { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 export const metadata: Metadata = {
-  title: generateMetaTitle({ left: "Teams" }),
+  title: generateMetaTitle({ left: "Dashboard" }),
 };
 
 export default function Page() {
   return pickPortalVersion(
-    () => redirect(urls.dashboard()),
-    () => TeamsPage(),
+    () => DashboardPage(),
+    () => redirect(urls.teams({})),
   );
 }

--- a/web/app/(portal)/teams/[teamId]/(team)/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/(team)/page.tsx
@@ -1,9 +1,8 @@
 import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { generateMetaTitle } from "@/lib/genarate-title";
-import { urls } from "@/lib/urls";
 import { TeamIdPage } from "@/scenes/Portal/Teams/TeamId/Team/page";
+import { TeamIdPage as TeamIdPageV3 } from "@/scenes/PortalV3/Teams/TeamId/Team/page";
 import { Metadata } from "next";
-import { redirect } from "next/navigation";
 
 export const metadata: Metadata = {
   title: generateMetaTitle({ left: "Overview" }),
@@ -18,7 +17,7 @@ export default async function Page(props: {
     props.searchParams,
   ]);
   return pickPortalVersion(
-    () => redirect(urls.apps({ team_id: params.teamId })),
+    () => <TeamIdPageV3 params={params} searchParams={searchParams} />,
     () => <TeamIdPage params={params} searchParams={searchParams} />,
   );
 }

--- a/web/app/(portal)/teams/[teamId]/apps/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/page.tsx
@@ -1,8 +1,9 @@
 import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
 import { generateMetaTitle } from "@/lib/genarate-title";
+import { urls } from "@/lib/urls";
 import { AppsPage } from "@/scenes/Portal/Teams/TeamId/Apps/page";
-import { AppsPage as AppsPageV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/page";
 import { Metadata } from "next";
+import { redirect } from "next/navigation";
 
 export const metadata: Metadata = {
   title: generateMetaTitle({ left: "Apps" }),
@@ -11,8 +12,14 @@ export const metadata: Metadata = {
 type Props = { params: Promise<Record<string, string>> };
 
 export default async function Page(props: Props) {
+  const params = await props.params;
+
   return pickPortalVersion(
-    () => <AppsPageV3 params={props.params} />,
-    () => <AppsPage params={props.params} />,
+    () => {
+      // Portal V3 has one canonical team overview. Keep this legacy apps URL
+      // working for bookmarks and old links without maintaining duplicate UI.
+      return redirect(urls.teams({ team_id: params.teamId }));
+    },
+    () => <AppsPage params={Promise.resolve(params)} />,
   );
 }

--- a/web/components/ui/dropdown-menu.tsx
+++ b/web/components/ui/dropdown-menu.tsx
@@ -218,9 +218,11 @@ function DropdownMenuSubTrigger({
   className,
   inset,
   children,
+  chevronClassName,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
   inset?: boolean;
+  chevronClassName?: string;
 }) {
   return (
     <DropdownMenuPrimitive.SubTrigger
@@ -233,7 +235,7 @@ function DropdownMenuSubTrigger({
       {...props}
     >
       {children}
-      <ChevronRightIcon className="ml-auto" />
+      <ChevronRightIcon className={cn("ml-auto", chevronClassName)} />
     </DropdownMenuPrimitive.SubTrigger>
   );
 }

--- a/web/lib/urls.ts
+++ b/web/lib/urls.ts
@@ -65,6 +65,8 @@ export const urls = {
 
   createTeam: (): "/create-team" => "/create-team",
 
+  dashboard: (): "/dashboard" => "/dashboard",
+
   signInWorldId: (params: { team_id: string; app_id?: string }): string =>
     `/teams/${params.team_id}/apps/${params.app_id}/sign-in-with-world-id`,
 

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -158,6 +158,7 @@ const checkRouteRolesRestrictions = (
 };
 
 const protectedMatchers = [
+  /^\/dashboard$/,
   /^\/teams(\/|$)/,
   /^\/create-team$/,
   /^\/profile(\/|$)/,
@@ -417,6 +418,7 @@ export const config = {
   matcher: [
     "/",
     "/api/auth/:path*",
+    "/dashboard",
     "/teams/:path*",
     "/create-team",
     "/profile/:path*",

--- a/web/scenes/PortalV3/Dashboard/page/index.tsx
+++ b/web/scenes/PortalV3/Dashboard/page/index.tsx
@@ -1,0 +1,37 @@
+import { auth0 } from "@/lib/auth0";
+import { Auth0SessionUser } from "@/lib/types";
+import { urls } from "@/lib/urls";
+import { getLatestTeamId } from "@/scenes/PortalV3/Dashboard/server/latest-team";
+import { redirect } from "next/navigation";
+
+export const DashboardPage = async () => {
+  const session = await auth0.getSession();
+  const user = session?.user as Auth0SessionUser["user"] | undefined;
+  const userId = user?.hasura?.id;
+  const memberships = user?.hasura?.memberships;
+
+  if (!userId || !memberships) {
+    return redirect(urls.logout());
+  }
+
+  const teamIds = memberships
+    .map((membership) => membership.team?.id)
+    .filter((teamId): teamId is string => Boolean(teamId));
+
+  if (teamIds.length === 0) {
+    return redirect(urls.createTeam());
+  }
+
+  // Redis is only a cross-device navigation preference. The current session's
+  // memberships remain the source of truth for where this user may go.
+  const latestTeamId = await getLatestTeamId(userId);
+
+  // A missing or stale preference falls back deterministically, so Redis
+  // latency or failure never blocks entry to the portal.
+  const destinationTeamId =
+    latestTeamId && teamIds.includes(latestTeamId) ? latestTeamId : teamIds[0];
+
+  // Stop at the first-class team overview. App choice stays visible there
+  // instead of becoming a second persisted navigation preference.
+  return redirect(urls.teams({ team_id: destinationTeamId }));
+};

--- a/web/scenes/PortalV3/Dashboard/server/latest-team.ts
+++ b/web/scenes/PortalV3/Dashboard/server/latest-team.ts
@@ -1,0 +1,47 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+
+const latestTeamKey = (userId: string) =>
+  `developer-portal:latest-team:v1:${userId}`;
+
+/**
+ * Returns an advisory navigation preference.
+ *
+ * Team membership remains authoritative and callers must validate the returned
+ * ID against the user's current memberships before redirecting.
+ */
+export const getLatestTeamId = async (
+  userId: string,
+): Promise<string | undefined> => {
+  const redis = global.RedisClient;
+  if (!redis) return undefined;
+
+  try {
+    return (await redis.get(latestTeamKey(userId))) ?? undefined;
+  } catch (error) {
+    logger.warn("Failed to read the latest team from Redis", {
+      userId,
+      error,
+    });
+    return undefined;
+  }
+};
+
+export const rememberLatestTeam = async (
+  userId: string,
+  teamId: string,
+): Promise<void> => {
+  const redis = global.RedisClient;
+  if (!redis) return;
+
+  try {
+    await redis.set(latestTeamKey(userId), teamId);
+  } catch (error) {
+    logger.warn("Failed to remember the latest team in Redis", {
+      userId,
+      teamId,
+      error,
+    });
+  }
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/page/index.tsx
@@ -1,52 +1,15 @@
-import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
-import { Role_Enum } from "@/graphql/graphql";
-import { auth0 } from "@/lib/auth0";
-import { Auth0SessionUser } from "@/lib/types";
-import { urls } from "@/lib/urls";
-import { getSdk as getInitialAppSdk } from "@/scenes/Portal/Teams/TeamId/Apps/page/graphql/server/apps.generated";
-import { redirect } from "next/navigation";
-import { AppsPageClient } from "./AppsPageClient";
+import { TeamIdPage } from "@/scenes/PortalV3/Teams/TeamId/Team/page";
 
 type AppsPageProps = {
   params: Promise<Record<string, string>>;
 };
 
-export const AppsPage = async (props: AppsPageProps) => {
-  const session = await auth0.getSession();
-  const params = await props.params;
-  const teamId = params?.teamId;
-  const user = session?.user as Auth0SessionUser["user"] | undefined;
-
-  if (!user || !teamId) {
-    return redirect("/api/auth/logout");
-  }
-
-  const memberships = user.hasura?.memberships ?? [];
-
-  if (!memberships.find((membership) => membership.team?.id === teamId)) {
-    const redirectTeamId = memberships[0]?.team?.id;
-
-    // No teams left (e.g. last one just deleted): keep them in the portal on
-    // their profile instead of logging out.
-    return redirect(
-      redirectTeamId ? `/teams/${redirectTeamId}/apps` : urls.profile(),
-    );
-  }
-
-  const client = await getAPIServiceGraphqlClient();
-  const { app } = await getInitialAppSdk(client).InitialApp({ teamId });
-
-  if (app.length > 0) {
-    return redirect(`/teams/${teamId}/apps/${app[0].id}/world-id-4-0`);
-  }
-
-  return (
-    <AppsPageClient
-      teamId={teamId}
-      initialIsOwner={memberships.some(
-        (membership) =>
-          membership.team?.id === teamId && membership.role === Role_Enum.Owner,
-      )}
-    />
-  );
-};
+/**
+ * Compatibility wrapper for code that still imports the former V3 apps index.
+ * The route itself redirects to the canonical team overview.
+ */
+export const AppsPage = async (props: AppsPageProps) =>
+  TeamIdPage({
+    params: await props.params,
+    searchParams: {},
+  });

--- a/web/scenes/PortalV3/Teams/TeamId/Team/page/Apps/App/Skeleton.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/page/Apps/App/Skeleton.tsx
@@ -1,25 +1,16 @@
 "use client";
 
-import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import Skeleton from "react-loading-skeleton";
+import { actionCardTitleClassName } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionCard";
 import { appCardFrameClassName } from "./index";
 
-/** Mirrors `App`: same frame, logo slot, and text line metrics — only the
- *  data (logo, name, environment) shimmers. */
+/** Mirrors `App`: real card chrome with only the logo and name shimmering. */
 export const AppCardSkeleton = () => (
   <div aria-hidden className={appCardFrameClassName}>
     <Skeleton className="size-16 rounded-2xl leading-normal" inline />
 
-    <div className="grid max-w-[200px] justify-center justify-items-center gap-y-1">
-      <Typography variant={TYPOGRAPHY.M3}>
-        <Skeleton width={120} />
-      </Typography>
-      {/* Environment row: R4 line inside py-1, its tallest segment. */}
-      <div className="flex items-center py-1">
-        <Typography variant={TYPOGRAPHY.R4}>
-          <Skeleton width={96} />
-        </Typography>
-      </div>
-    </div>
+    <span className={`${actionCardTitleClassName} mt-auto block`}>
+      <Skeleton width="60%" />
+    </span>
   </div>
 );

--- a/web/scenes/PortalV3/Teams/TeamId/Team/page/Apps/App/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/page/Apps/App/index.tsx
@@ -2,27 +2,24 @@
 
 import { AppStatus, StatusVariant } from "@/components/AppStatus";
 import { Button } from "@/components/Button";
-import { Environment } from "@/components/Environment";
-import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { TYPOGRAPHY } from "@/components/Typography";
 import { urls } from "@/lib/urls";
+import { FetchAppsQuery } from "@/scenes/common/Teams/TeamId/Team/page/Apps/graphql/client/fetch-apps.generated";
+import {
+  actionCardFrameClassName,
+  actionCardTitleClassName,
+} from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionCard";
 import { useParams } from "next/navigation";
 import { useMemo } from "react";
-import { FetchAppsQuery } from "@/scenes/common/Teams/TeamId/Team/page/Apps/graphql/client/fetch-apps.generated";
 import { AppLogo } from "./AppLogo";
 
 /** Card geometry, shared with the loading skeleton. */
-export const appCardFrameClassName =
-  "relative grid justify-center justify-items-center gap-y-4 rounded-20 border border-grey-200 px-8 pt-10 pb-6";
+export const appCardFrameClassName = `${actionCardFrameClassName} relative transition-shadow hover:shadow-portal-card`;
 
 export const App = (props: { app: FetchAppsQuery["app"][number] }) => {
   const { teamId } = useParams() as { teamId: string };
   const app = useMemo(() => props.app, [props.app]);
   const metadata = useMemo(() => app.app_metadata?.[0], [app.app_metadata]);
-
-  const environment = useMemo(
-    () => (app.is_staging ? "staging" : "production"),
-    [app.is_staging],
-  );
 
   return (
     <Button
@@ -31,7 +28,7 @@ export const App = (props: { app: FetchAppsQuery["app"][number] }) => {
     >
       <AppStatus
         status={metadata.verification_status as StatusVariant}
-        className="absolute top-4 right-4 px-2 py-1"
+        className="absolute top-5 right-5 px-2 py-1"
         typography={TYPOGRAPHY.R5}
       />
 
@@ -42,14 +39,10 @@ export const App = (props: { app: FetchAppsQuery["app"][number] }) => {
         verification_status={metadata.verification_status as StatusVariant}
       />
 
-      <div className="grid max-w-[200px] justify-center gap-y-1">
-        <Typography variant={TYPOGRAPHY.M3} className="truncate text-center">
+      <div className="mt-auto min-w-0">
+        <span className={`${actionCardTitleClassName} block truncate`}>
           {metadata.name}
-        </Typography>
-
-        <div className="flex items-center justify-center gap-x-4">
-          <Environment environment={environment} engine={app.engine} />
-        </div>
+        </span>
       </div>
     </Button>
   );

--- a/web/scenes/PortalV3/Teams/TeamId/Team/page/Apps/CreateAppTile.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/page/Apps/CreateAppTile.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+export const CreateAppTile = (props: { onClick: () => void }) => (
+  <button
+    type="button"
+    onClick={props.onClick}
+    className="flex min-h-[144px] flex-col items-center justify-center gap-3 rounded-[10px] border border-dashed border-portal-border text-portal-muted transition-colors hover:border-portal-ink hover:text-portal-ink"
+    aria-label="Create an app"
+  >
+    <svg
+      viewBox="0 0 24 24"
+      className="size-6"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+    >
+      <path d="M12 5v14M5 12h14" strokeLinecap="round" />
+    </svg>
+    <span className="font-world text-13">Create an app</span>
+  </button>
+);

--- a/web/scenes/PortalV3/Teams/TeamId/Team/page/Apps/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/page/Apps/index.tsx
@@ -1,23 +1,19 @@
 "use client";
 
-import { Button } from "@/components/Button";
-import { AddCircleIcon } from "@/components/Icons/AddCircleIcon";
-import { MagnifierIcon } from "@/components/Icons/MagnifierIcon";
+import { SearchIcon } from "@/components/Icons/SearchIcon";
 import { Input } from "@/components/Input";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { useParams } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
-import { App } from "./App";
-import { AppCardSkeleton } from "./App/Skeleton";
 import { useQuery } from "@apollo/client/react";
 import {
   FetchAppsDocument,
   FetchAppsQuery,
 } from "@/scenes/common/Teams/TeamId/Team/page/Apps/graphql/client/fetch-apps.generated";
-import { Section } from "@/components/Section";
-import { PlusIcon } from "@/components/Icons/PlusIcon";
-import { DecoratedButton } from "@/components/DecoratedButton";
 import { useCreateAppDialog } from "@/scenes/common/layout/CreateAppDialog/useCreateAppDialog";
+import { useParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { App } from "./App";
+import { AppCardSkeleton } from "./App/Skeleton";
+import { CreateAppTile } from "./CreateAppTile";
 
 export const Apps = () => {
   const { teamId } = useParams() as { teamId: string };
@@ -49,44 +45,37 @@ export const Apps = () => {
   );
 
   return (
-    <Section>
-      <Section.Header>
-        <Section.Header.Title>Apps</Section.Header.Title>
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-end justify-between gap-2 border-b border-portal-border sm:min-h-[49px]">
+        <h1 className="border-b-2 border-portal-heading px-1 pb-3 font-world text-13 text-portal-heading">
+          Apps
+        </h1>
 
-        <Section.Header.Search className="md:col-span-2">
+        <div className="w-full pb-2 sm:w-64">
           <Input
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             type="search"
             label=""
-            addOnLeft={<MagnifierIcon className="text-grey-400" />}
-            placeholder="Search app by name"
-            className="w-full px-4 py-2"
+            aria-label="Search apps"
+            addOnLeft={<SearchIcon className="mx-2 text-grey-400" />}
+            placeholder="Search apps"
+            className="h-10 w-full py-0 text-sm"
           />
-        </Section.Header.Search>
+        </div>
+      </div>
 
-        <Section.Header.Button className="z-10 md:hidden">
-          <DecoratedButton
-            type="button"
-            variant="primary"
-            className="min-w-[200px] py-2.5"
-            onClick={openCreateAppDialog}
-          >
-            <PlusIcon className="size-5" />
-            New app
-          </DecoratedButton>
-        </Section.Header.Button>
-      </Section.Header>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {!searchQuery ? <CreateAppTile onClick={openCreateAppDialog} /> : null}
 
-      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-4">
         {!loading &&
           filteredApps?.map((app: FetchAppsQuery["app"][number]) => (
             <App key={app.id} app={app} />
           ))}
 
         {!loading && searchQuery && filteredApps?.length === 0 && (
-          <div className="col-span-full flex h-[200px] items-center justify-center rounded-2xl border border-grey-200">
-            <Typography variant={TYPOGRAPHY.R3} className="text-grey-400">
+          <div className="col-span-full flex min-h-[144px] items-center justify-center rounded-[10px] border border-portal-border">
+            <Typography variant={TYPOGRAPHY.R3} className="text-portal-muted">
               No apps found
             </Typography>
           </div>
@@ -97,23 +86,7 @@ export const Apps = () => {
           Array.from({ length: 4 }).map((_, index) => (
             <AppCardSkeleton key={index} />
           ))}
-
-        {!loading && app && !searchQuery && (
-          <Button
-            className="group relative flex flex-col items-center justify-center gap-y-4 rounded-20 border border-dashed border-grey-200 px-8 pt-10 pb-6 transition-colors hover:border-blue-500 max-md:hidden"
-            type="button"
-            onClick={openCreateAppDialog}
-          >
-            <AddCircleIcon className="size-8 text-grey-500 transition-colors group-hover:text-blue-500" />
-            <Typography
-              variant={TYPOGRAPHY.M3}
-              className="text-center text-grey-500 transition-colors group-hover:text-blue-500"
-            >
-              Create an app
-            </Typography>
-          </Button>
-        )}
       </div>
-    </Section>
+    </div>
   );
 };

--- a/web/scenes/PortalV3/Teams/TeamId/Team/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/page/index.tsx
@@ -1,10 +1,12 @@
+import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { Unauthorized } from "@/components/Unauthorized";
-import { Auth0SessionUser } from "@/lib/types";
+import { Role_Enum } from "@/graphql/graphql";
 import { auth0 } from "@/lib/auth0";
-import { TeamProfile } from "@/scenes/PortalV3/Teams/TeamId/Team/common/TeamProfile";
+import { Auth0SessionUser } from "@/lib/types";
+import { getSdk as getInitialAppSdk } from "@/scenes/Portal/Teams/TeamId/Apps/page/graphql/server/apps.generated";
+import { AppsPageClient } from "@/scenes/PortalV3/Teams/TeamId/Apps/page/AppsPageClient";
 import { Apps } from "./Apps";
-import { Members } from "../sections/Members";
 
 type TeamIdPageProps = {
   params: Record<string, string> | null | undefined;
@@ -17,11 +19,11 @@ export const TeamIdPage = async (props: TeamIdPageProps) => {
   const session = await auth0.getSession();
   const user = session?.user as Auth0SessionUser["user"];
 
-  const isTeamMember = user?.hasura?.memberships?.some(
+  const membership = user?.hasura?.memberships?.find(
     (membership) => membership.team?.id === teamId,
   );
 
-  if (!isTeamMember) {
+  if (!membership) {
     return (
       <SizingWrapper gridClassName="grow order-2" fullHeight>
         <Unauthorized message="You are not a member of this team" />
@@ -29,19 +31,23 @@ export const TeamIdPage = async (props: TeamIdPageProps) => {
     );
   }
 
+  const client = await getAPIServiceGraphqlClient();
+  const { app } = await getInitialAppSdk(client).InitialApp({ teamId });
+
+  // The team root owns both states: onboarding actions before the first app,
+  // then the app grid once the team has something to manage.
+  if (app.length === 0) {
+    return (
+      <AppsPageClient
+        teamId={teamId}
+        initialIsOwner={membership.role === Role_Enum.Owner}
+      />
+    );
+  }
+
   return (
-    <>
-      <SizingWrapper gridClassName="order-1">
-        <TeamProfile />
-      </SizingWrapper>
-
-      <SizingWrapper gridClassName="order-2 grow" className="flex flex-col">
-        <Members teamId={teamId} />
-
-        <div className="order-5 max-md:hidden">
-          <Apps />
-        </div>
-      </SizingWrapper>
-    </>
+    <SizingWrapper className="flex flex-col gap-8 py-8">
+      <Apps />
+    </SizingWrapper>
   );
 };

--- a/web/scenes/PortalV3/layout/Shell/AppsDropdown.tsx
+++ b/web/scenes/PortalV3/layout/Shell/AppsDropdown.tsx
@@ -14,40 +14,21 @@ import { Icon, opticalIconClassName } from "@/scenes/PortalV3/common/Icon";
 import { useCreateAppDialog } from "@/scenes/common/layout/CreateAppDialog/useCreateAppDialog";
 import { useQuery } from "@apollo/client/react";
 import { useUser } from "@auth0/nextjs-auth0/client";
-import { atom, useAtomValue, useSetAtom } from "jotai";
-import { ChevronsUpDownIcon } from "lucide-react";
+import { ChevronsUpDownIcon, LayoutGridIcon } from "lucide-react";
 import { useParams } from "next/navigation";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import {
   SearchableSwitcher,
   switcherTriggerClassName,
 } from "./SearchableSwitcher";
 
-type DropdownApp = { id: string; name: string };
-
-const lastAppAtom = atom<{ teamId: string; appId: string } | undefined>(
-  undefined,
-);
+type DropdownApp = { id: string; name: string; isOverview?: boolean };
 
 export const useCurrentAppId = (): string | undefined => {
-  const params = useParams<{ teamId?: string; appId?: string }>();
-  const teamId = params?.teamId;
-  const appId = params?.appId;
-  const setLastApp = useSetAtom(lastAppAtom);
-  const lastApp = useAtomValue(lastAppAtom);
-
-  useEffect(() => {
-    if (!teamId || !appId) return;
-    setLastApp((previous) =>
-      previous?.teamId === teamId && previous.appId === appId
-        ? previous
-        : { teamId, appId },
-    );
-  }, [teamId, appId, setLastApp]);
-
-  if (appId) return appId;
-  return lastApp && lastApp.teamId === teamId ? lastApp.appId : undefined;
+  return useParams<{ appId?: string }>()?.appId;
 };
+
+const allAppsId = "__all_apps__";
 
 const appName = (app: FetchAppsQuery["app"][number]) =>
   app.app_metadata?.[0]?.name ?? "Untitled app";
@@ -84,6 +65,13 @@ export const AppsDropdown = () => {
       );
   }, [data?.app]);
 
+  const switcherItems = useMemo<DropdownApp[]>(
+    () =>
+      apps.length > 0
+        ? [{ id: allAppsId, name: "All apps", isOverview: true }, ...apps]
+        : [],
+    [apps],
+  );
   const current = apps.find((app) => app.id === currentAppId);
   const currentLabel = current?.name ?? "All apps";
   const isUnavailable = loading || Boolean(error);
@@ -93,8 +81,8 @@ export const AppsDropdown = () => {
 
   return (
     <SearchableSwitcher
-      items={showEmptyAppRow ? [] : apps}
-      selectedId={currentAppId}
+      items={switcherItems}
+      selectedId={currentAppId ?? allAppsId}
       renderTrigger={(open) => (
         <Button
           variant="ghost"
@@ -111,12 +99,24 @@ export const AppsDropdown = () => {
           <ChevronsUpDownIcon className="size-4 text-portal-muted" />
         </Button>
       )}
-      renderLeading={(app) => <AppAvatar name={app.name} />}
+      renderLeading={(app) =>
+        app.isOverview ? (
+          <span className="flex size-6 items-center justify-center">
+            <LayoutGridIcon
+              className={`${opticalIconClassName} size-4 text-portal-muted`}
+            />
+          </span>
+        ) : (
+          <AppAvatar name={app.name} />
+        )
+      }
       getItemHref={(app) =>
-        urls.worldId40({
-          team_id: teamId,
-          app_id: app.id,
-        })
+        app.isOverview
+          ? urls.teams({ team_id: teamId })
+          : urls.worldId40({
+              team_id: teamId,
+              app_id: app.id,
+            })
       }
       searchLabel="Find an app"
       listLabel="Apps"

--- a/web/scenes/PortalV3/layout/Shell/HelpCenterMenu.tsx
+++ b/web/scenes/PortalV3/layout/Shell/HelpCenterMenu.tsx
@@ -1,19 +1,15 @@
 "use client";
 
 import {
-  DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuPortal,
   DropdownMenuSeparator,
-  DropdownMenuTrigger,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-  SidebarMenuButton,
-  SidebarMenuItem,
-  useSidebar,
-} from "@/components/ui/sidebar";
 import {
   DISCORD_URL,
   DOCS_URL,
@@ -27,6 +23,7 @@ import { urls } from "@/lib/urls";
 import { Icon, opticalIconClassName } from "@/scenes/PortalV3/common/Icon";
 import { useParams } from "next/navigation";
 import posthog from "posthog-js";
+import { useState } from "react";
 
 const itemClass = "h-10 cursor-pointer gap-3 text-portal-text focus:bg-grey-50";
 const labelClass = "px-2 py-1.5 text-portal-subtle";
@@ -50,15 +47,14 @@ const HelpLink = (props: {
   </DropdownMenuItem>
 );
 
-/** Single home for documentation, support, community, and legal links. */
+/** Documentation, support, community, and legal links inside the user menu. */
 export const HelpCenterMenu = () => {
+  const [open, setOpen] = useState(false);
   const params = useParams<{
     teamId?: string;
     appId?: string;
     actionId?: string;
   }>();
-  const { isMobile } = useSidebar();
-
   const track = (destination: string) => () => {
     posthog.capture("clicked_help", {
       helpLink: destination,
@@ -69,26 +65,20 @@ export const HelpCenterMenu = () => {
   };
 
   return (
-    <SidebarMenuItem>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <SidebarMenuButton
-            aria-label="Help center"
-            title="Help center"
-            className="h-10 cursor-pointer rounded-[10px] px-3 font-world text-13 leading-none text-portal-muted hover:bg-portal-border hover:text-portal-text"
-          >
-            <Icon
-              name="nav-help"
-              className={`${opticalIconClassName} size-4`}
-            />
-            <span>Help center</span>
-          </SidebarMenuButton>
-        </DropdownMenuTrigger>
+    <DropdownMenuSub open={open} onOpenChange={setOpen}>
+      <DropdownMenuSubTrigger
+        aria-label="Help center"
+        className={itemClass}
+        chevronClassName={`${opticalIconClassName} size-4`}
+        onPointerEnter={() => setOpen(true)}
+      >
+        <Icon name="nav-help" className={`${opticalIconClassName} size-4`} />
+        <span className="min-w-0 flex-1 truncate">Help center</span>
+      </DropdownMenuSubTrigger>
 
-        <DropdownMenuContent
-          side={isMobile ? "bottom" : "right"}
-          align="end"
-          sideOffset={12}
+      <DropdownMenuPortal>
+        <DropdownMenuSubContent
+          sideOffset={8}
           collisionPadding={16}
           className="w-72 border border-portal-border font-world"
         >
@@ -167,8 +157,8 @@ export const HelpCenterMenu = () => {
               onSelect={track("terms_of_service")}
             />
           </DropdownMenuGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </SidebarMenuItem>
+        </DropdownMenuSubContent>
+      </DropdownMenuPortal>
+    </DropdownMenuSub>
   );
 };

--- a/web/scenes/PortalV3/layout/Shell/PortalSidebar.tsx
+++ b/web/scenes/PortalV3/layout/Shell/PortalSidebar.tsx
@@ -8,8 +8,8 @@ import {
 } from "@/components/ui/sidebar";
 import { calculateColorFromString } from "@/lib/calculate-color-from-string";
 import { ChevronLeftIcon } from "lucide-react";
+import { SidebarContextHeader } from "./SidebarContextHeader";
 import { SidebarNav } from "./SidebarNav";
-import { TeamsDropdown } from "./TeamsDropdown";
 import { UserPopup } from "./UserPopup";
 
 export const PortalSidebar = (props: {
@@ -23,7 +23,7 @@ export const PortalSidebar = (props: {
   return (
     <Sidebar collapsible="offcanvas">
       <SidebarHeader className="h-(--portal-header-height) shrink-0 justify-center border-b border-portal-border px-4 py-0">
-        <TeamsDropdown teams={teams} />
+        <SidebarContextHeader teams={teams} />
       </SidebarHeader>
 
       <SidebarContent className="gap-0 pt-3">

--- a/web/scenes/PortalV3/layout/Shell/SearchableSwitcher.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SearchableSwitcher.tsx
@@ -25,7 +25,7 @@ import {
 export type SwitcherItem = { id: string; name: string };
 
 export const switcherTriggerClassName =
-  "h-9 min-w-0 px-3 font-world text-13 leading-none font-medium";
+  "h-9 min-w-0 cursor-pointer px-3 font-world text-13 leading-none font-medium";
 
 const createActionClassName =
   "h-10 w-full justify-start gap-2 rounded-8 px-3 font-world text-13 font-medium text-portal-text hover:bg-grey-50 hover:text-portal-text";

--- a/web/scenes/PortalV3/layout/Shell/SidebarContextHeader.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SidebarContextHeader.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
+import { urls } from "@/lib/urls";
+import { opticalIconClassName } from "@/scenes/PortalV3/common/Icon";
+import { ArrowLeftIcon } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { switcherTriggerClassName } from "./SearchableSwitcher";
+import { DropdownTeam, TeamsDropdown } from "./TeamsDropdown";
+
+export const SidebarContextHeader = (props: { teams: DropdownTeam[] }) => {
+  const pathname = usePathname() ?? "";
+
+  if (!pathname.startsWith(urls.profile())) {
+    return <TeamsDropdown teams={props.teams} />;
+  }
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          asChild
+          size="lg"
+          className={`${switcherTriggerClassName} text-portal-text hover:bg-portal-border focus-visible:bg-portal-border focus-visible:ring-0`}
+        >
+          <Link href={urls.dashboard()} aria-label="Back to dashboard">
+            <ArrowLeftIcon
+              className={`${opticalIconClassName} size-4 text-portal-muted`}
+            />
+            <span className="truncate">Back to dashboard</span>
+          </Link>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+};

--- a/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
@@ -20,8 +20,6 @@ import { BellIcon, LockKeyholeIcon, WalletCardsIcon } from "lucide-react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { useEffect } from "react";
-import { useCurrentAppId } from "./AppsDropdown";
-import { HelpCenterMenu } from "./HelpCenterMenu";
 import { NavItem } from "./NavItem";
 import { SandboxButton } from "./SandboxButton";
 
@@ -38,12 +36,11 @@ export const SidebarNav = (props: {
   const pathname = usePathname() ?? "";
   const params = useParams<{ teamId?: string; appId?: string }>();
   const teamId = params?.teamId;
-  const routeAppId = params?.appId;
-  const appId = useCurrentAppId();
+  const appId = params?.appId;
   const { setOpenMobile } = useSidebar();
   const { data: appsData, loading: appsLoading } = useQuery(FetchAppsDocument, {
     variables: { teamId: teamId! },
-    skip: !teamId,
+    skip: !teamId || !appId,
   });
 
   useEffect(() => setOpenMobile(false), [pathname, setOpenMobile]);
@@ -52,32 +49,31 @@ export const SidebarNav = (props: {
     appId && !appsLoading && appsData?.app?.some((app) => app.id === appId),
   );
   const teamsLandingHref = urls.teams({});
-  const appsListHref = teamId
-    ? urls.apps({ team_id: teamId })
+  const teamOverviewHref = teamId
+    ? urls.teams({ team_id: teamId })
     : teamsLandingHref;
   const appBase =
     teamId && appId ? urls.app({ team_id: teamId, app_id: appId }) : undefined;
   const ids = teamId && appId ? { team_id: teamId, app_id: appId } : undefined;
 
-  const worldIdHref = ids ? urls.worldId40(ids) : appsListHref;
-  const configurationHref = ids ? urls.configuration(ids) : appsListHref;
+  const worldIdHref = ids ? urls.worldId40(ids) : teamOverviewHref;
+  const configurationHref = ids ? urls.configuration(ids) : teamOverviewHref;
   const configurationDangerHref =
     ids && hasConfirmedApp ? urls.configurationDanger(ids) : undefined;
-  const miniAppHref = ids ? urls.miniAppPermissions(ids) : appsListHref;
+  const miniAppHref = ids ? urls.miniAppPermissions(ids) : teamOverviewHref;
   const teamSettingsHref = teamId
     ? urls.teamSettings({ team_id: teamId })
     : teamsLandingHref;
 
   const withinApp = (prefix: string) => {
-    if (!routeAppId || !teamId) return false;
-    const routeBase = urls.app({ team_id: teamId, app_id: routeAppId });
+    if (!appId || !teamId) return false;
+    const routeBase = urls.app({ team_id: teamId, app_id: appId });
     if (!pathname.startsWith(routeBase)) return false;
     const relativePath = pathname.slice(routeBase.length);
     return relativePath === prefix || relativePath.startsWith(`${prefix}/`);
   };
 
   const worldIdActive =
-    pathname === appsListHref ||
     (Boolean(appBase) && pathname === appBase) ||
     withinApp("/world-id-4-0") ||
     withinApp("/world-id-actions") ||
@@ -145,15 +141,16 @@ export const SidebarNav = (props: {
           <SidebarGroup className="px-4 py-2 group-data-[collapsible=icon]:px-3">
             <SidebarGroupContent>
               <SidebarMenu className="gap-2">
-                <NavItem
-                  label="World ID"
-                  href={worldIdHref}
-                  active={worldIdActive}
-                  icon={<NavIcon name="nav-world-id" active={worldIdActive} />}
-                />
-
                 {appId ? (
                   <>
+                    <NavItem
+                      label="World ID"
+                      href={worldIdHref}
+                      active={worldIdActive}
+                      icon={
+                        <NavIcon name="nav-world-id" active={worldIdActive} />
+                      }
+                    />
                     <NavItem
                       label="Configuration"
                       href={configurationHref}
@@ -204,7 +201,19 @@ export const SidebarNav = (props: {
                       ) : null}
                     </NavItem>
                   </>
-                ) : null}
+                ) : (
+                  <NavItem
+                    label="Overview"
+                    href={teamOverviewHref}
+                    active={pathname === teamOverviewHref}
+                    icon={
+                      <NavIcon
+                        name="nav-home"
+                        active={pathname === teamOverviewHref}
+                      />
+                    }
+                  />
+                )}
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
@@ -213,32 +222,31 @@ export const SidebarNav = (props: {
         </>
       ) : null}
 
-      <SidebarGroup className="px-4 pt-3 pb-2 group-data-[collapsible=icon]:px-3">
-        <SidebarGroupContent>
-          <SidebarMenu className="gap-2">
-            {teamId ? (
+      {teamId ? (
+        <SidebarGroup className="px-4 pt-3 pb-2 group-data-[collapsible=icon]:px-3">
+          <SidebarGroupContent>
+            <SidebarMenu className="gap-2">
               <NavItem
                 label="Team settings"
                 href={teamSettingsHref}
                 active={settingsActive}
                 icon={<NavIcon name="nav-settings" active={settingsActive} />}
               />
-            ) : null}
-            <HelpCenterMenu />
-            {configurationDangerHref ? (
-              <NavItem
-                label="Danger zone"
-                href={configurationDangerHref}
-                active={configurationDangerActive}
-                icon={<TrashIcon className="size-4" />}
-                className="hover:bg-system-error-50 hover:text-system-error-600 data-[active=true]:border-system-error-200 data-[active=true]:bg-system-error-50 data-[active=true]:text-system-error-600 data-[active=true]:shadow-none"
-              />
-            ) : null}
-          </SidebarMenu>
-        </SidebarGroupContent>
-      </SidebarGroup>
+              {configurationDangerHref ? (
+                <NavItem
+                  label="Danger zone"
+                  href={configurationDangerHref}
+                  active={configurationDangerActive}
+                  icon={<TrashIcon className="size-4" />}
+                  className="hover:bg-system-error-50 hover:text-system-error-600 data-[active=true]:border-system-error-200 data-[active=true]:bg-system-error-50 data-[active=true]:text-system-error-600 data-[active=true]:shadow-none"
+                />
+              ) : null}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      ) : null}
 
-      <div className="mt-auto px-4 pt-6 pb-3 group-data-[collapsible=icon]:hidden">
+      <div className="mt-auto px-4 pt-3 pb-3 group-data-[collapsible=icon]:hidden">
         <SandboxButton
           className="-ml-1 w-[calc(100%_+_8px)]"
           initialRequest={props.initialSandboxRequest}

--- a/web/scenes/PortalV3/layout/Shell/UserPopup.tsx
+++ b/web/scenes/PortalV3/layout/Shell/UserPopup.tsx
@@ -21,6 +21,7 @@ import { useAtomValue } from "jotai";
 import { ChevronsUpDownIcon } from "lucide-react";
 import Link from "next/link";
 import { CSSProperties } from "react";
+import { HelpCenterMenu } from "./HelpCenterMenu";
 
 export type PortalUser = { name: string; email?: string };
 
@@ -106,6 +107,7 @@ export const UserPopup = (props: { user: PortalUser; color: Color | null }) => {
                 </Link>
               </DropdownMenuItem>
             ))}
+            <HelpCenterMenu />
             <DropdownMenuSeparator className="my-2 bg-portal-border" />
             <DropdownMenuItem asChild className={itemClass}>
               <a

--- a/web/scenes/PortalV3/layout/index.tsx
+++ b/web/scenes/PortalV3/layout/index.tsx
@@ -3,6 +3,9 @@ import { auth0 } from "@/lib/auth0";
 import { isWorldUser } from "@/lib/is-world-user";
 import { logger } from "@/lib/logger";
 import { Auth0SessionUser } from "@/lib/types";
+import { rememberLatestTeam } from "@/scenes/PortalV3/Dashboard/server/latest-team";
+import { headers } from "next/headers";
+import { after } from "next/server";
 import { ReactNode } from "react";
 import { PortalShell } from "./Shell";
 
@@ -15,8 +18,17 @@ export const PortalLayout = async (props: { children: ReactNode }) => {
     .filter((t): t is NonNullable<typeof t> => !!t?.id)
     .map((t) => ({ id: t.id, name: t.name ?? "Untitled team" }));
 
-  let sandboxRequest = null;
+  const pathname = (await headers()).get("x-current-path");
+  const visitedTeamId = pathname?.match(/^\/teams\/([^/]+)(?:\/|$)/)?.[1];
   const userId = user?.hasura?.id;
+  const isTeamMember = teams.some((team) => team.id === visitedTeamId);
+
+  if (userId && visitedTeamId && isTeamMember) {
+    // Persist after rendering so remembering a preference never delays the page.
+    after(() => rememberLatestTeam(userId, visitedTeamId));
+  }
+
+  let sandboxRequest = null;
   if (userId) {
     try {
       sandboxRequest = await fetchSandboxAccessRequest(userId);

--- a/web/scenes/Root/page/index.tsx
+++ b/web/scenes/Root/page/index.tsx
@@ -1,5 +1,6 @@
 import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
 import { auth0 } from "@/lib/auth0";
+import { isPortalV3EnabledForEmail } from "@/lib/feature-flags/portal-v3/flag";
 import { logger } from "@/lib/logger";
 import { Auth0SessionUser } from "@/lib/types";
 import { urls } from "@/lib/urls";
@@ -56,6 +57,10 @@ export const RootPage = async () => {
 
   if (!membership || membership.length === 0) {
     return redirect(urls.createTeam());
+  }
+
+  if (isPortalV3EnabledForEmail(auth0User.email)) {
+    return redirect(urls.dashboard());
   }
 
   const team_id = membership[0].team_id;

--- a/web/tests/e2e/helpers/test.ts
+++ b/web/tests/e2e/helpers/test.ts
@@ -40,7 +40,8 @@ export const test = base.extend<{}, { workerStorageState: string }>({
         .fill(process.env.TEST_USER_PASSWORD);
       await page.locator("[name='submit']").click();
 
-      await expect(page).toHaveURL(/\/teams\/team_[a-f0-9]+\/apps$/);
+      // Portal V3 resolves the dashboard entry point to the latest team overview.
+      await expect(page).toHaveURL(/\/teams\/team_[a-f0-9]+$/);
 
       // Save storage state of the authenticated browser
       await page.context().storageState({ path: fileName });

--- a/web/tests/unit/apps-page-no-team-redirect.test.tsx
+++ b/web/tests/unit/apps-page-no-team-redirect.test.tsx
@@ -23,18 +23,11 @@ jest.mock(
   }),
 );
 
-jest.mock(
-  "../../scenes/PortalV3/Teams/TeamId/Apps/page/AppsPageClient",
-  () => ({
-    AppsPageClient: () => <div data-testid="v3-apps-client" />,
-  }),
-);
 jest.mock("../../scenes/Portal/Teams/TeamId/Apps/page/AppsPageClient", () => ({
   AppsPageClient: () => <div data-testid="v2-apps-client" />,
 }));
 // #endregion
 
-import { AppsPage as AppsPageV3 } from "@/scenes/PortalV3/Teams/TeamId/Apps/page";
 import { AppsPage as AppsPageV2 } from "@/scenes/Portal/Teams/TeamId/Apps/page";
 
 // #region Test Data
@@ -58,32 +51,27 @@ beforeEach(() => {
 });
 
 // #region Users with no team stay in the portal, not logged out
-describe.each([
-  ["v3", AppsPageV3],
-  ["v2", AppsPageV2],
-])("/teams/[teamId]/apps [%s, membership guard]", (_version, AppsPage) => {
+describe("/teams/[teamId]/apps [v2 membership guard]", () => {
   it("redirects a user with zero memberships to their profile", async () => {
     getSession.mockResolvedValue(sessionWithMemberships([]));
 
-    await AppsPage(props("team_1"));
+    await AppsPageV2(props("team_1"));
 
     expect(redirect).toHaveBeenCalledWith("/profile");
-    expect(InitialApp).not.toHaveBeenCalled();
   });
 
   it("redirects a member of another team to their own team's apps", async () => {
     getSession.mockResolvedValue(sessionWithMemberships(["team_mine"]));
 
-    await AppsPage(props("team_foreign"));
+    await AppsPageV2(props("team_foreign"));
 
     expect(redirect).toHaveBeenCalledWith("/teams/team_mine/apps");
-    expect(InitialApp).not.toHaveBeenCalled();
   });
 
   it("does not redirect a member of the requested team", async () => {
     getSession.mockResolvedValue(sessionWithMemberships(["team_1"]));
 
-    const result = await AppsPage(props("team_1"));
+    const result = await AppsPageV2(props("team_1"));
 
     expect(redirect).not.toHaveBeenCalled();
     expect(InitialApp).toHaveBeenCalledWith({ teamId: "team_1" });

--- a/web/tests/unit/dashboard-latest-team.test.ts
+++ b/web/tests/unit/dashboard-latest-team.test.ts
@@ -1,0 +1,104 @@
+import { DashboardPage } from "@/scenes/PortalV3/Dashboard/page";
+
+// #region Mocks
+const getSession = jest.fn();
+jest.mock("@/lib/auth0", () => ({
+  auth0: { getSession: (...args: unknown[]) => getSession(...args) },
+}));
+
+const getLatestTeamId = jest.fn();
+jest.mock("@/scenes/PortalV3/Dashboard/server/latest-team", () => ({
+  getLatestTeamId: (...args: unknown[]) => getLatestTeamId(...args),
+}));
+
+const redirect = jest.fn();
+jest.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => redirect(...args),
+}));
+
+jest.mock("@/lib/urls", () => ({
+  urls: {
+    createTeam: () => "/create-team",
+    logout: () => "/logout",
+    teams: ({ team_id }: { team_id: string }) => `/teams/${team_id}`,
+  },
+}));
+// #endregion
+
+// #region Test Data
+const sessionWithTeams = (teamIds: string[]) => ({
+  user: {
+    hasura: {
+      id: "user_1",
+      memberships: teamIds.map((id) => ({ team: { id } })),
+    },
+  },
+});
+// #endregion
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getLatestTeamId.mockResolvedValue(undefined);
+});
+
+// #region Latest team resolution
+describe("/dashboard [latest team resolution]", () => {
+  it("redirects to the remembered team when membership is still valid", async () => {
+    getSession.mockResolvedValue(sessionWithTeams(["team_1", "team_2"]));
+    getLatestTeamId.mockResolvedValue("team_2");
+
+    await DashboardPage();
+
+    expect(getLatestTeamId).toHaveBeenCalledWith("user_1");
+    expect(redirect).toHaveBeenCalledWith("/teams/team_2");
+  });
+
+  it("falls back to the first current membership for a stale Redis value", async () => {
+    getSession.mockResolvedValue(sessionWithTeams(["team_1", "team_2"]));
+    getLatestTeamId.mockResolvedValue("team_deleted");
+
+    await DashboardPage();
+
+    expect(redirect).toHaveBeenCalledWith("/teams/team_1");
+  });
+
+  it("falls back to the first membership when Redis has no value", async () => {
+    getSession.mockResolvedValue(sessionWithTeams(["team_1", "team_2"]));
+
+    await DashboardPage();
+
+    expect(redirect).toHaveBeenCalledWith("/teams/team_1");
+  });
+});
+// #endregion
+
+// #region Session guards
+describe("/dashboard [session guards]", () => {
+  it("routes users without teams into team creation", async () => {
+    getSession.mockResolvedValue(sessionWithTeams([]));
+
+    await DashboardPage();
+
+    expect(getLatestTeamId).not.toHaveBeenCalled();
+    expect(redirect).toHaveBeenCalledWith("/create-team");
+  });
+
+  it("re-authenticates sessions missing the Hasura claim", async () => {
+    getSession.mockResolvedValue({ user: {} });
+
+    await DashboardPage();
+
+    expect(getLatestTeamId).not.toHaveBeenCalled();
+    expect(redirect).toHaveBeenCalledWith("/logout");
+  });
+
+  it("re-authenticates incomplete Hasura claims without memberships", async () => {
+    getSession.mockResolvedValue({ user: { hasura: { id: "user_1" } } });
+
+    await DashboardPage();
+
+    expect(getLatestTeamId).not.toHaveBeenCalled();
+    expect(redirect).toHaveBeenCalledWith("/logout");
+  });
+});
+// #endregion

--- a/web/tests/unit/latest-team-layout.test.tsx
+++ b/web/tests/unit/latest-team-layout.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+
+// #region Mocks
+const getSession = jest.fn();
+jest.mock("@/lib/auth0", () => ({
+  auth0: { getSession: (...args: unknown[]) => getSession(...args) },
+}));
+
+const rememberLatestTeam = jest.fn();
+jest.mock("@/scenes/PortalV3/Dashboard/server/latest-team", () => ({
+  rememberLatestTeam: (...args: unknown[]) => rememberLatestTeam(...args),
+}));
+
+const getHeader = jest.fn();
+jest.mock("next/headers", () => ({
+  headers: async () => ({ get: (...args: unknown[]) => getHeader(...args) }),
+}));
+
+const after = jest.fn((callback: () => unknown) => callback());
+jest.mock("next/server", () => ({
+  after: (callback: () => unknown) => after(callback),
+}));
+
+jest.mock(
+  "@/api/v2/sandbox-access-request/server/fetch-sandbox-access-request",
+  () => ({
+    fetchSandboxAccessRequest: jest.fn().mockResolvedValue(null),
+  }),
+);
+jest.mock("@/lib/is-world-user", () => ({
+  isWorldUser: () => false,
+}));
+jest.mock("@/scenes/PortalV3/layout/Shell", () => ({
+  PortalShell: ({ children }: { children: React.ReactNode }) => children,
+}));
+// #endregion
+
+import { PortalLayout } from "@/scenes/PortalV3/layout";
+
+const sessionWithTeams = (teamIds: string[]) => ({
+  user: {
+    hasura: {
+      id: "user_1",
+      memberships: teamIds.map((id) => ({ team: { id } })),
+    },
+  },
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getHeader.mockReturnValue("/teams/team_1");
+});
+
+// #region Latest team recording
+describe("PortalV3 layout [latest team recording]", () => {
+  it("records a successful member visit after the response", async () => {
+    getSession.mockResolvedValue(sessionWithTeams(["team_1"]));
+
+    await PortalLayout({ children: <div /> });
+
+    expect(after).toHaveBeenCalledTimes(1);
+    expect(rememberLatestTeam).toHaveBeenCalledWith("user_1", "team_1");
+  });
+
+  it("does not record a team outside the user's current memberships", async () => {
+    getSession.mockResolvedValue(sessionWithTeams(["team_1"]));
+    getHeader.mockReturnValue("/teams/team_foreign");
+
+    await PortalLayout({ children: <div /> });
+
+    expect(after).not.toHaveBeenCalled();
+    expect(rememberLatestTeam).not.toHaveBeenCalled();
+  });
+
+  it("does not record non-team Portal V3 routes", async () => {
+    getSession.mockResolvedValue(sessionWithTeams(["team_1"]));
+    getHeader.mockReturnValue("/profile");
+
+    await PortalLayout({ children: <div /> });
+
+    expect(after).not.toHaveBeenCalled();
+    expect(rememberLatestTeam).not.toHaveBeenCalled();
+  });
+});
+// #endregion

--- a/web/tests/unit/latest-team-redis.test.ts
+++ b/web/tests/unit/latest-team-redis.test.ts
@@ -1,0 +1,61 @@
+// #region Mocks
+const warn = jest.fn();
+jest.mock("@/lib/logger", () => ({
+  logger: { warn: (...args: unknown[]) => warn(...args) },
+}));
+// #endregion
+
+import {
+  getLatestTeamId,
+  rememberLatestTeam,
+} from "@/scenes/PortalV3/Dashboard/server/latest-team";
+
+const redisGet = jest.fn();
+const redisSet = jest.fn();
+const originalRedis = global.RedisClient;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.RedisClient = {
+    get: (...args: unknown[]) => redisGet(...args),
+    set: (...args: unknown[]) => redisSet(...args),
+  } as typeof global.RedisClient;
+});
+
+afterAll(() => {
+  global.RedisClient = originalRedis;
+});
+
+describe("latest team Redis preference", () => {
+  it("stores and reads the team under the stable user key", async () => {
+    redisGet.mockResolvedValue("team_2");
+    redisSet.mockResolvedValue("OK");
+
+    await expect(getLatestTeamId("user_1")).resolves.toBe("team_2");
+    await rememberLatestTeam("user_1", "team_2");
+
+    const key = "developer-portal:latest-team:v1:user_1";
+    expect(redisGet).toHaveBeenCalledWith(key);
+    expect(redisSet).toHaveBeenCalledWith(key, "team_2");
+  });
+
+  it("fails open when Redis is unavailable", async () => {
+    global.RedisClient = undefined;
+
+    await expect(getLatestTeamId("user_1")).resolves.toBeUndefined();
+    await expect(
+      rememberLatestTeam("user_1", "team_2"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("fails open and logs when Redis returns an error", async () => {
+    redisGet.mockRejectedValue(new Error("Redis down"));
+    redisSet.mockRejectedValue(new Error("Redis down"));
+
+    await expect(getLatestTeamId("user_1")).resolves.toBeUndefined();
+    await expect(
+      rememberLatestTeam("user_1", "team_2"),
+    ).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/tests/unit/portal-v3-app-grid-design.test.tsx
+++ b/web/tests/unit/portal-v3-app-grid-design.test.tsx
@@ -1,0 +1,78 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+const openCreateAppDialog = jest.fn();
+jest.mock("@/scenes/common/layout/CreateAppDialog/useCreateAppDialog", () => ({
+  useCreateAppDialog: () => ({ open: openCreateAppDialog }),
+}));
+
+const refetch = jest.fn();
+jest.mock("@apollo/client/react", () => ({
+  useQuery: () => ({
+    data: {
+      app: [
+        {
+          id: "app_1",
+          is_staging: false,
+          engine: "cloud",
+          app_metadata: [
+            {
+              id: "metadata_1",
+              name: "Example app",
+              logo_img_url: "",
+              verification_status: "unverified",
+            },
+          ],
+        },
+      ],
+    },
+    loading: false,
+    refetch,
+  }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ teamId: "team_1" }),
+}));
+
+jest.mock("@/scenes/PortalV3/Teams/TeamId/Team/page/Apps/App/AppLogo", () => ({
+  AppLogo: () => <div data-testid="app-logo" />,
+}));
+jest.mock("@/components/AppStatus", () => ({
+  AppStatus: () => <span>Not verified</span>,
+}));
+// #endregion
+
+import { Apps } from "@/scenes/PortalV3/Teams/TeamId/Team/page/Apps";
+
+beforeEach(() => jest.clearAllMocks());
+
+it("uses the newer action-grid design without environment or engine tags", () => {
+  render(<Apps />);
+
+  const createTile = screen.getByRole("button", { name: "Create an app" });
+  const grid = createTile.parentElement;
+  const appLink = screen.getByRole("link");
+
+  expect(grid).toHaveClass("gap-4", "sm:grid-cols-2", "lg:grid-cols-3");
+  expect(createTile).toHaveClass(
+    "min-h-[144px]",
+    "rounded-[10px]",
+    "border-dashed",
+  );
+  expect(appLink).toHaveClass(
+    "min-h-[144px]",
+    "rounded-[10px]",
+    "border-portal-border",
+    "p-5",
+  );
+  expect(screen.getByText("Example app")).toBeInTheDocument();
+  expect(screen.queryByText("Production")).not.toBeInTheDocument();
+  expect(screen.queryByText("Cloud")).not.toBeInTheDocument();
+
+  fireEvent.click(createTile);
+  expect(openCreateAppDialog).toHaveBeenCalledTimes(1);
+});

--- a/web/tests/unit/portal-v3-apps-dropdown.test.tsx
+++ b/web/tests/unit/portal-v3-apps-dropdown.test.tsx
@@ -98,7 +98,7 @@ it("enables the trigger with the default label after loading", () => {
   expect(trigger()).toHaveClass("h-9", "px-3");
 });
 
-it("shows the route app and links app rows directly to World ID", () => {
+it("shows the route app and offers explicit app and overview destinations", () => {
   mockParams = { teamId: "team_1", appId: "app_1" };
   fetchApps.mockReturnValue({
     data: { app: [{ id: "app_1", app_metadata: [{ name: "My App" }] }] },
@@ -115,9 +115,13 @@ it("shows the route app and links app rows directly to World ID", () => {
     "/teams/team_1/apps/app_1/world-id-4-0",
   );
   expect(appLink).toHaveClass("cursor-pointer");
+  expect(screen.getByRole("link", { name: "All apps" })).toHaveAttribute(
+    "href",
+    "/teams/team_1",
+  );
 });
 
-it("remembers the route app on team-scoped routes", () => {
+it("uses only the route app as context on team-scoped routes", () => {
   mockParams = { teamId: "team_1", appId: "app_1" };
   fetchApps.mockReturnValue({
     data: { app: [{ id: "app_1", app_metadata: [{ name: "My App" }] }] },
@@ -136,7 +140,11 @@ it("remembers the route app on team-scoped routes", () => {
     </Provider>,
   );
 
-  expect(trigger()).toHaveTextContent("My App");
+  expect(trigger()).toHaveTextContent("All apps");
+  expect(screen.getByRole("link", { name: "All apps" })).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
 });
 
 it("filters all loaded apps without hiding the create action", () => {

--- a/web/tests/unit/portal-v3-portal-layout.test.tsx
+++ b/web/tests/unit/portal-v3-portal-layout.test.tsx
@@ -16,6 +16,9 @@ jest.mock(
 jest.mock("@/lib/logger", () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
+jest.mock("next/headers", () => ({
+  headers: async () => ({ get: () => "/profile" }),
+}));
 
 // Stub the shell so we test only PortalLayout's session -> shell wiring.
 jest.mock("@/scenes/PortalV3/layout/Shell", () => ({

--- a/web/tests/unit/portal-v3-shell-dropdown-focus.test.tsx
+++ b/web/tests/unit/portal-v3-shell-dropdown-focus.test.tsx
@@ -53,6 +53,32 @@ describe("Portal v3 shell dropdown focus treatment", () => {
     }
   });
 
+  it("opens Help Center options when its profile-menu item is hovered", async () => {
+    render(
+      <TooltipProvider>
+        <SidebarProvider>
+          <UserPopup
+            user={{ name: "Ada Lovelace", email: "ada@example.com" }}
+            color={null}
+          />
+        </SidebarProvider>
+      </TooltipProvider>,
+    );
+
+    fireEvent.keyDown(screen.getByRole("button", { name: "Account menu" }), {
+      key: "ArrowDown",
+    });
+    const helpCenter = await screen.findByRole("menuitem", {
+      name: "Help center",
+    });
+
+    fireEvent.pointerEnter(helpCenter);
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Documentation" }),
+    ).toBeInTheDocument();
+  });
+
   it("opens the profile menu directly above the profile row", async () => {
     render(
       <TooltipProvider>

--- a/web/tests/unit/portal-v3-sidebar-collapse.test.tsx
+++ b/web/tests/unit/portal-v3-sidebar-collapse.test.tsx
@@ -20,8 +20,8 @@ jest.mock("@/scenes/PortalV3/layout/Shell/SidebarNav", () => ({
   SidebarNav: () => <nav>sidebar-navigation</nav>,
 }));
 
-jest.mock("@/scenes/PortalV3/layout/Shell/TeamsDropdown", () => ({
-  TeamsDropdown: () => <div>teams-dropdown</div>,
+jest.mock("@/scenes/PortalV3/layout/Shell/SidebarContextHeader", () => ({
+  SidebarContextHeader: () => <div>sidebar-context-header</div>,
 }));
 
 jest.mock("@/scenes/PortalV3/layout/Shell/UserPopup", () => ({

--- a/web/tests/unit/portal-v3-sidebar-context-header.test.tsx
+++ b/web/tests/unit/portal-v3-sidebar-context-header.test.tsx
@@ -1,0 +1,59 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+const usePathname = jest.fn();
+jest.mock("next/navigation", () => ({
+  usePathname: () => usePathname(),
+}));
+
+jest.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+jest.mock("@/lib/utils", () => ({
+  cn: (...inputs: unknown[]) => inputs.filter(Boolean).join(" "),
+}));
+
+jest.mock("@/scenes/PortalV3/layout/Shell/TeamsDropdown", () => ({
+  TeamsDropdown: () => <div data-testid="teams-dropdown" />,
+}));
+// #endregion
+
+import { SidebarContextHeader } from "@/scenes/PortalV3/layout/Shell/SidebarContextHeader";
+
+const renderHeader = () =>
+  render(
+    <SidebarProvider>
+      <SidebarContextHeader teams={[]} />
+    </SidebarProvider>,
+  );
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("SidebarContextHeader [route context]", () => {
+  it("links profile routes back through the dashboard resolver", () => {
+    usePathname.mockReturnValue("/profile");
+
+    renderHeader();
+
+    const link = screen.getByRole("link", { name: "Back to dashboard" });
+    expect(link).toHaveAttribute("href", "/dashboard");
+    expect(link.querySelector("svg")).toHaveClass("-translate-y-px");
+    expect(screen.queryByTestId("teams-dropdown")).not.toBeInTheDocument();
+  });
+
+  it("keeps the team switcher on team-scoped routes", () => {
+    usePathname.mockReturnValue("/teams/team_1");
+
+    renderHeader();
+
+    expect(screen.getByTestId("teams-dropdown")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Back to dashboard" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/tests/unit/portal-v3-team-overview.test.tsx
+++ b/web/tests/unit/portal-v3-team-overview.test.tsx
@@ -1,0 +1,109 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+const getSession = jest.fn();
+jest.mock("@/lib/auth0", () => ({
+  auth0: { getSession: (...args: unknown[]) => getSession(...args) },
+}));
+
+jest.mock(
+  "@/graphql/graphql",
+  () => ({
+    Role_Enum: { Owner: "OWNER" },
+  }),
+  { virtual: true },
+);
+
+jest.mock("@/api/helpers/graphql", () => ({
+  getAPIServiceGraphqlClient: jest.fn().mockResolvedValue({}),
+}));
+
+const InitialApp = jest.fn();
+jest.mock(
+  "@/scenes/Portal/Teams/TeamId/Apps/page/graphql/server/apps.generated",
+  () => ({
+    getSdk: () => ({ InitialApp }),
+  }),
+);
+
+jest.mock("@/components/SizingWrapper", () => ({
+  SizingWrapper: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock("@/components/Unauthorized", () => ({
+  Unauthorized: () => <div data-testid="unauthorized" />,
+}));
+jest.mock("@/scenes/PortalV3/Teams/TeamId/Apps/page/AppsPageClient", () => ({
+  AppsPageClient: (props: { initialIsOwner?: boolean }) => (
+    <div
+      data-testid="empty-app-actions"
+      data-owner={String(props.initialIsOwner)}
+    />
+  ),
+}));
+jest.mock("@/scenes/PortalV3/Teams/TeamId/Team/page/Apps", () => ({
+  Apps: () => <div data-testid="apps-grid" />,
+}));
+// #endregion
+
+import { TeamIdPage } from "@/scenes/PortalV3/Teams/TeamId/Team/page";
+
+// #region Test Data
+const props = {
+  params: { teamId: "team_1" },
+  searchParams: {},
+};
+
+const sessionWithTeam = (role = "OWNER") => ({
+  user: {
+    hasura: {
+      memberships: [{ role, team: { id: "team_1" } }],
+    },
+  },
+});
+// #endregion
+
+beforeEach(() => jest.clearAllMocks());
+
+// #region Canonical overview states
+describe("Portal V3 team overview", () => {
+  it("shows the existing action cards before the team has an app", async () => {
+    getSession.mockResolvedValue(sessionWithTeam());
+    InitialApp.mockResolvedValue({ app: [] });
+
+    render(await TeamIdPage(props));
+
+    expect(screen.getByTestId("empty-app-actions")).toHaveAttribute(
+      "data-owner",
+      "true",
+    );
+    expect(screen.queryByTestId("apps-grid")).not.toBeInTheDocument();
+  });
+
+  it("shows the apps grid once the team has an app", async () => {
+    getSession.mockResolvedValue(sessionWithTeam());
+    InitialApp.mockResolvedValue({ app: [{ id: "app_1" }] });
+
+    render(await TeamIdPage(props));
+
+    expect(screen.getByTestId("apps-grid")).toBeInTheDocument();
+    expect(screen.queryByTestId("empty-app-actions")).not.toBeInTheDocument();
+  });
+
+  it("does not query apps for a team outside the current memberships", async () => {
+    getSession.mockResolvedValue(sessionWithTeam());
+
+    render(
+      await TeamIdPage({
+        params: { teamId: "team_foreign" },
+        searchParams: {},
+      }),
+    );
+
+    expect(screen.getByTestId("unauthorized")).toBeInTheDocument();
+    expect(InitialApp).not.toHaveBeenCalled();
+  });
+});
+// #endregion

--- a/web/tests/unit/pv3-r-apps-index.test.tsx
+++ b/web/tests/unit/pv3-r-apps-index.test.tsx
@@ -1,0 +1,49 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+const pickPortalVersion = jest.fn();
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: (...args: unknown[]) => pickPortalVersion(...args),
+}));
+
+const redirect = jest.fn();
+jest.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => redirect(...args),
+}));
+
+jest.mock("@/scenes/Portal/Teams/TeamId/Apps/page", () => ({
+  AppsPage: () => <div data-testid="v2-apps-page" />,
+}));
+// #endregion
+
+import RoutePage from "../../app/(portal)/teams/[teamId]/apps/page";
+
+beforeEach(() => jest.clearAllMocks());
+
+it("redirects the v3 apps index to the first-class team overview", async () => {
+  pickPortalVersion.mockImplementation(async (v3: () => unknown) => v3());
+
+  await RoutePage({
+    params: Promise.resolve({ teamId: "team_1" }),
+  });
+
+  expect(redirect).toHaveBeenCalledWith("/teams/team_1");
+});
+
+it("preserves the Portal V2 apps page", async () => {
+  pickPortalVersion.mockImplementation(
+    async (_v3: () => unknown, v2: () => unknown) => v2(),
+  );
+
+  render(
+    await RoutePage({
+      params: Promise.resolve({ teamId: "team_1" }),
+    }),
+  );
+
+  expect(screen.getByTestId("v2-apps-page")).toBeInTheDocument();
+  expect(redirect).not.toHaveBeenCalled();
+});

--- a/web/tests/unit/pv3-r-dashboard-entry.test.tsx
+++ b/web/tests/unit/pv3-r-dashboard-entry.test.tsx
@@ -1,0 +1,49 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+const pickPortalVersion = jest.fn();
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: (...args: unknown[]) => pickPortalVersion(...args),
+}));
+
+const redirect = jest.fn();
+jest.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => redirect(...args),
+}));
+
+jest.mock("@/lib/urls", () => ({
+  urls: { teams: () => "/teams" },
+}));
+
+const DashboardPage = jest.fn(() => <div data-testid="v3-dashboard-entry" />);
+jest.mock("@/scenes/PortalV3/Dashboard/page", () => ({
+  DashboardPage: () => DashboardPage(),
+}));
+// #endregion
+
+import RoutePage from "../../app/(portal)/dashboard/page";
+
+beforeEach(() => jest.clearAllMocks());
+
+it("runs the latest-team resolver for Portal V3", async () => {
+  pickPortalVersion.mockImplementation(async (v3: () => unknown) => v3());
+
+  render(await RoutePage());
+
+  expect(screen.getByTestId("v3-dashboard-entry")).toBeInTheDocument();
+  expect(DashboardPage).toHaveBeenCalledTimes(1);
+});
+
+it("keeps Portal V2 on its existing teams resolver", async () => {
+  pickPortalVersion.mockImplementation(
+    async (_v3: () => unknown, v2: () => unknown) => v2(),
+  );
+
+  await RoutePage();
+
+  expect(redirect).toHaveBeenCalledWith("/teams");
+  expect(DashboardPage).not.toHaveBeenCalled();
+});

--- a/web/tests/unit/pv3-r-team-root.test.tsx
+++ b/web/tests/unit/pv3-r-team-root.test.tsx
@@ -1,5 +1,6 @@
 /** @jest-environment jsdom */
 import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 
 const pickPortalVersion = jest.fn();
@@ -7,18 +8,11 @@ jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
   pickPortalVersion: (...args: unknown[]) => pickPortalVersion(...args),
 }));
 
-const redirect = jest.fn();
-jest.mock("next/navigation", () => ({
-  redirect: (...args: unknown[]) => redirect(...args),
-}));
-
-jest.mock("@/lib/urls", () => ({
-  urls: {
-    apps: ({ team_id }: { team_id: string }) => `/teams/${team_id}/apps`,
-  },
-}));
 jest.mock("@/scenes/Portal/Teams/TeamId/Team/page", () => ({
   TeamIdPage: () => <div data-testid="v2-team-root" />,
+}));
+jest.mock("@/scenes/PortalV3/Teams/TeamId/Team/page", () => ({
+  TeamIdPage: () => <div data-testid="v3-team-root" />,
 }));
 import RoutePage from "../../app/(portal)/teams/[teamId]/(team)/page";
 
@@ -29,8 +23,20 @@ const props = () => ({
 
 beforeEach(() => jest.clearAllMocks());
 
-it("redirects v3 team root to the apps list", async () => {
+it("renders the v3 team overview instead of redirecting", async () => {
   pickPortalVersion.mockImplementation(async (v3: () => unknown) => v3());
-  await RoutePage(props());
-  expect(redirect).toHaveBeenCalledWith("/teams/team_1/apps");
+  render(await RoutePage(props()));
+
+  expect(screen.getByTestId("v3-team-root")).toBeInTheDocument();
+  expect(screen.queryByTestId("v2-team-root")).not.toBeInTheDocument();
+});
+
+it("preserves the Portal V2 team page", async () => {
+  pickPortalVersion.mockImplementation(
+    async (_v3: () => unknown, v2: () => unknown) => v2(),
+  );
+  render(await RoutePage(props()));
+
+  expect(screen.getByTestId("v2-team-root")).toBeInTheDocument();
+  expect(screen.queryByTestId("v3-team-root")).not.toBeInTheDocument();
 });

--- a/web/tests/unit/pv3-r-teams-index.test.tsx
+++ b/web/tests/unit/pv3-r-teams-index.test.tsx
@@ -1,0 +1,46 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+const pickPortalVersion = jest.fn();
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: (...args: unknown[]) => pickPortalVersion(...args),
+}));
+
+const redirect = jest.fn();
+jest.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => redirect(...args),
+}));
+
+jest.mock("@/lib/urls", () => ({
+  urls: { dashboard: () => "/dashboard" },
+}));
+jest.mock("@/scenes/Portal/Teams/page", () => ({
+  TeamsPage: () => <div data-testid="v2-teams-page" />,
+}));
+// #endregion
+
+import RoutePage from "../../app/(portal)/teams/page";
+
+beforeEach(() => jest.clearAllMocks());
+
+it("sends Portal V3 through the latest-team dashboard resolver", async () => {
+  pickPortalVersion.mockImplementation(async (v3: () => unknown) => v3());
+
+  await RoutePage();
+
+  expect(redirect).toHaveBeenCalledWith("/dashboard");
+});
+
+it("preserves the Portal V2 teams resolver", async () => {
+  pickPortalVersion.mockImplementation(
+    async (_v3: () => unknown, v2: () => unknown) => v2(),
+  );
+
+  render(await RoutePage());
+
+  expect(screen.getByTestId("v2-teams-page")).toBeInTheDocument();
+  expect(redirect).not.toHaveBeenCalled();
+});

--- a/web/tests/unit/pv3-sidebar-section-nav.test.tsx
+++ b/web/tests/unit/pv3-sidebar-section-nav.test.tsx
@@ -21,10 +21,6 @@ jest.mock("@/lib/utils", () => ({
   cn: (...inputs: unknown[]) => inputs.filter(Boolean).join(" "),
 }));
 
-jest.mock("@/scenes/PortalV3/layout/Shell/HelpCenterMenu", () => ({
-  HelpCenterMenu: () => <button type="button">Help center</button>,
-}));
-
 jest.mock("@/scenes/PortalV3/layout/Shell/SandboxButton", () => ({
   SandboxButton: () => <button type="button">World ID Sandbox</button>,
 }));
@@ -95,8 +91,8 @@ describe("v3 SidebarNav [navigation hierarchy]", () => {
     ).not.toBeInTheDocument();
     expect(link("Team settings")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Help center" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "Help center" }),
+    ).not.toBeInTheDocument();
     expect(link("Danger zone")).toHaveAttribute(
       "href",
       `${base}/configuration/danger`,
@@ -190,13 +186,16 @@ describe("v3 SidebarNav [no app selected]", () => {
   beforeEach(() => {
     useParams.mockReturnValue({ teamId });
     useCurrentAppId.mockReturnValue(undefined);
-    usePathname.mockReturnValue(`/teams/${teamId}/apps`);
+    usePathname.mockReturnValue(`/teams/${teamId}`);
   });
 
-  it("points World ID at the apps list and hides app-only entries", () => {
+  it("shows the team overview and hides app-only entries", () => {
     renderSidebar();
-    expect(link("World ID")).toHaveAttribute("href", `/teams/${teamId}/apps`);
-    expect(isCurrent("World ID")).toBe(true);
+    expect(link("Overview")).toHaveAttribute("href", `/teams/${teamId}`);
+    expect(isCurrent("Overview")).toBe(true);
+    expect(
+      screen.queryByRole("link", { name: "World ID" }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Configuration" }),
     ).not.toBeInTheDocument();
@@ -230,22 +229,27 @@ describe("v3 SidebarNav [no app selected]", () => {
 });
 // #endregion
 
-// #region remembered app context
-describe("v3 SidebarNav [remembered app context]", () => {
+// #region route-owned app context
+describe("v3 SidebarNav [route-owned app context]", () => {
   beforeEach(() => {
     useParams.mockReturnValue({ teamId });
     useCurrentAppId.mockReturnValue(appId);
     usePathname.mockReturnValue(`/teams/${teamId}/settings`);
   });
 
-  it("keeps app links available on team-scoped routes without marking an app section current", () => {
+  it("does not carry app links into a team-scoped route", () => {
     renderSidebar();
 
-    expect(link("World ID")).toHaveAttribute("href", `${base}/world-id-4-0`);
-    expect(link("Configuration")).toBeInTheDocument();
-    expect(link("Mini App")).toBeInTheDocument();
-    expect(isCurrent("World ID")).toBe(false);
-    expect(isCurrent("Configuration")).toBe(false);
+    expect(link("Overview")).toHaveAttribute("href", `/teams/${teamId}`);
+    expect(
+      screen.queryByRole("link", { name: "World ID" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Configuration" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Mini App" }),
+    ).not.toBeInTheDocument();
     expect(link("Team settings")).toHaveAttribute("aria-current", "page");
   });
 });
@@ -275,11 +279,11 @@ describe("v3 SidebarNav [team-less pages]", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("keeps Help center and the sandbox button visible without a teamId", () => {
+  it("keeps the sandbox button visible without duplicating Help Center", () => {
     renderSidebar();
     expect(
-      screen.getByRole("button", { name: /Help center/i }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: /Help center/i }),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /World ID Sandbox/i }),
     ).toBeInTheDocument();


### PR DESCRIPTION
This PR streamlines Portal V3 navigation and makes the team overview the canonical app landing page.

- adds a Redis-backed latest-team dashboard resolver with membership validation
- replaces the profile team switcher with a back-to-dashboard action and moves Help Center into the user menu
- consolidates the Portal V3 team and apps routes around `/teams/:teamId`
- updates the team overview with the compact World ID Actions card/grid pattern
- preserves Portal V2 routing and behavior
- adds route, Redis, sidebar, and overview regression coverage

Validation:
- `npx jest --watchman=false --no-cache tests/unit` (123 suites, 569 tests)
- `npx tsc --noEmit`
- `pnpm format:check`
- `node scripts/check-optical-centering.mjs`