### PR TITLE
fix(portal): match app dropdown avatar colors

### DIFF
--- a/web/scenes/PortalV3/layout/Shell/AppsDropdown.tsx
+++ b/web/scenes/PortalV3/layout/Shell/AppsDropdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Placeholder } from "@/components/PlaceholderImage";
 import { Button } from "@/components/ui/button";
 import { Role_Enum } from "@/graphql/graphql";
 import { Auth0SessionUser } from "@/lib/types";
@@ -52,12 +52,12 @@ export const useCurrentAppId = (): string | undefined => {
 const appName = (app: FetchAppsQuery["app"][number]) =>
   app.app_metadata?.[0]?.name ?? "Untitled app";
 
-const AppAvatar = (props: { name: string }) => (
-  <Avatar className="size-6">
-    <AvatarFallback className="bg-[#d6f0d5] font-world text-[11px] leading-none font-normal text-[#00c230]">
-      {props.name[0]?.toUpperCase() ?? "A"}
-    </AvatarFallback>
-  </Avatar>
+const AppAvatar = (props: DropdownApp) => (
+  <Placeholder
+    name={props.name}
+    seed={props.id}
+    className="size-6 shrink-0 rounded-full font-world text-[11px] leading-none font-normal"
+  />
 );
 
 export const AppsDropdown = () => {
@@ -106,12 +106,12 @@ export const AppsDropdown = () => {
             "text-portal-text hover:bg-portal-border hover:text-portal-text disabled:cursor-default",
           )}
         >
-          {current ? <AppAvatar name={current.name} /> : null}
+          {current ? <AppAvatar {...current} /> : null}
           <span className="max-w-[260px] truncate">{currentLabel}</span>
           <ChevronsUpDownIcon className="size-4 text-portal-muted" />
         </Button>
       )}
-      renderLeading={(app) => <AppAvatar name={app.name} />}
+      renderLeading={(app) => <AppAvatar {...app} />}
       getItemHref={(app) =>
         urls.worldId40({
           team_id: teamId,

--- a/web/tests/unit/portal-v3-apps-dropdown.test.tsx
+++ b/web/tests/unit/portal-v3-apps-dropdown.test.tsx
@@ -117,6 +117,26 @@ it("shows the route app and links app rows directly to World ID", () => {
   expect(appLink).toHaveClass("cursor-pointer");
 });
 
+it("uses the same deterministic app color in the trigger and app row", () => {
+  mockParams = { teamId: "team_1", appId: "app_1" };
+  fetchApps.mockReturnValue({
+    data: { app: [{ id: "app_1", app_metadata: [{ name: "My App" }] }] },
+    loading: false,
+    error: undefined,
+  });
+
+  renderDropdown();
+
+  const initials = screen.getAllByText("M");
+  const backgroundClass = (initial: HTMLElement) =>
+    initial.parentElement?.className
+      .split(" ")
+      .find((className) => className.startsWith("bg-"));
+
+  expect(initials).toHaveLength(2);
+  expect(backgroundClass(initials[0])).toBe(backgroundClass(initials[1]));
+});
+
 it("remembers the route app on team-scoped routes", () => {
   mockParams = { teamId: "team_1", appId: "app_1" };
   fetchApps.mockReturnValue({


### PR DESCRIPTION
This PR aligns fallback app avatar colors between the team apps page and the Portal V3 header dropdown.

- Reuses the shared app placeholder in the dropdown, seeded by the stable app ID.
- Keeps colors consistent in the dropdown trigger, dropdown rows, and team app cards, including after app renames.
- Adds focused unit coverage for deterministic color parity.
- Validated with the focused Jest suite, TypeScript, Prettier, and `git diff --check`.