### PR TITLE
fix(portal-v3): fall back to the empty state when an app logo 404s

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/LivePreview/LivePreview.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/LivePreview/LivePreview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { getCDNImageUrl } from "@/lib/utils";
+import { useImageFallback } from "@/scenes/PortalV3/common/useImageFallback";
 import { useAtomValue } from "jotai";
 import { useWatch } from "react-hook-form";
 import { selectedLanguageAtom } from "../AppStore/components/FormSections/LocalisationsSection/hooks/useLanguageSelection";
@@ -95,15 +96,18 @@ export const LivePreview = ({
     ? metadataShowcaseUrls
     : images.showcase_image_urls ?? metadataShowcaseUrls;
   const hasWebsite = Boolean(basicInfo.app_website_url?.trim());
+  const logo = useImageFallback(logoImgUrl);
 
   return (
     <div className="grid w-full content-start gap-y-8">
       {/* Logo */}
-      {logoImgUrl ? (
+      {logoImgUrl && !logo.isBroken ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img
           src={logoImgUrl}
-          alt="App logo preview"
+          alt=""
+          data-testid="app-logo-preview"
+          onError={logo.onError}
           className="size-16 rounded-2xl object-cover"
         />
       ) : (

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/LogoDropZone.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/LogoDropZone.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Icon } from "@/scenes/PortalV3/common/Icon";
+import { useImageFallback } from "@/scenes/PortalV3/common/useImageFallback";
 import clsx from "clsx";
 import { DragEvent } from "react";
 
@@ -18,6 +19,7 @@ export const LogoDropZone = (props: {
   error?: string;
 }) => {
   const isInert = props.disabled || props.isUploading;
+  const logo = useImageFallback(props.imageUrl);
 
   const handleDrop = (event: DragEvent<HTMLElement>) => {
     event.preventDefault();
@@ -42,10 +44,11 @@ export const LogoDropZone = (props: {
               "border-black/8 bg-portal-canvas",
         )}
       >
-        {props.imageUrl ? (
+        {props.imageUrl && !logo.isBroken ? (
           <img
             src={props.imageUrl}
-            alt="App logo"
+            alt=""
+            onError={logo.onError}
             className={clsx(
               "absolute inset-0 size-full object-cover",
               props.isUploading && "opacity-50",

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/LogoDropZone.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/LogoDropZone.tsx
@@ -44,6 +44,9 @@ export const LogoDropZone = (props: {
               "border-black/8 bg-portal-canvas",
         )}
       >
+        {/* The file input is named by this label's text, which is empty
+            whenever a logo covers it. */}
+        <span className="sr-only">Upload app logo</span>
         {props.imageUrl && !logo.isBroken ? (
           <img
             src={props.imageUrl}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/ReviewStep.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/ReviewStep.tsx
@@ -2,6 +2,7 @@
 
 import { getCDNImageUrl } from "@/lib/utils";
 import { Icon } from "@/scenes/PortalV3/common/Icon";
+import { useImageFallback } from "@/scenes/PortalV3/common/useImageFallback";
 import { useAtomValue } from "jotai";
 import { ReactNode } from "react";
 import { useWatch } from "react-hook-form";
@@ -37,6 +38,7 @@ export const ReviewStep = (props: {
   const basicInfoDraft = useAtomValue(basicInfoDraftAtom);
   const unverifiedImages = useAtomValue(unverifiedImageAtom);
   const isVerified = appMetadata.verification_status === "verified";
+  const logo = useImageFallback(props.logoUrl);
 
   const localisations = useWatch({ control, name: "localisations" }) ?? [];
   const en = localisations.find((l) => l.language === "en");
@@ -64,10 +66,11 @@ export const ReviewStep = (props: {
   return (
     <div className="flex w-full flex-col items-start">
       <div className="size-[88px] overflow-clip rounded-[20px] border border-portal-border bg-portal-canvas">
-        {props.logoUrl && (
+        {props.logoUrl && !logo.isBroken && (
           <img
             src={props.logoUrl}
-            alt="App logo"
+            alt=""
+            onError={logo.onError}
             className="pointer-events-none size-full object-cover"
           />
         )}

--- a/web/scenes/PortalV3/common/useImageFallback/index.ts
+++ b/web/scenes/PortalV3/common/useImageFallback/index.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Guards against broken app images. A logo URL is truthy whenever the metadata
+ * row names a file, even if that object is missing from the bucket — the
+ * signed URL then 404s and the `<img>` paints its alt text over the layout.
+ * Callers render their empty state when `isBroken`, keyed on the URL so a
+ * fresh upload gets another chance.
+ */
+export const useImageFallback = (url?: string) => {
+  const [failedUrl, setFailedUrl] = useState<string>();
+
+  return {
+    isBroken: Boolean(url) && failedUrl === url,
+    onError: () => setFailedUrl(url),
+  };
+};

--- a/web/tests/unit/pv3-config-redesign.test.tsx
+++ b/web/tests/unit/pv3-config-redesign.test.tsx
@@ -591,7 +591,7 @@ describe("v3 Configuration redesign [footer and preview]", () => {
     });
     renderPage();
 
-    expect(screen.getByAltText("App logo preview")).toHaveAttribute(
+    expect(screen.getByTestId("app-logo-preview")).toHaveAttribute(
       "src",
       "https://cdn.example/unverified/logo.png",
     );
@@ -724,7 +724,7 @@ describe("v3 Configuration redesign [footer and preview]", () => {
       "src",
       "https://cdn/logo_img.png",
     );
-    expect(screen.getByAltText("App logo preview")).toHaveAttribute(
+    expect(screen.getByTestId("app-logo-preview")).toHaveAttribute(
       "src",
       "https://cdn/logo_img.png",
     );

--- a/web/tests/unit/pv3-logo-broken-image.test.tsx
+++ b/web/tests/unit/pv3-logo-broken-image.test.tsx
@@ -25,6 +25,15 @@ describe("LogoDropZone [broken image]", () => {
     expect(logoImg()).toBeNull();
   });
 
+  it("keeps the file input named while a logo covers the label", () => {
+    renderZone("https://cdn.example/unverified/uploaded.png");
+
+    expect(screen.getByLabelText(/Upload app logo/)).toHaveAttribute(
+      "type",
+      "file",
+    );
+  });
+
   it("retries when a new logo url arrives after a failure", () => {
     const rerender = renderZone("https://cdn.example/unverified/missing.png");
     fireEvent.error(logoImg()!);

--- a/web/tests/unit/pv3-logo-broken-image.test.tsx
+++ b/web/tests/unit/pv3-logo-broken-image.test.tsx
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { LogoDropZone } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/LogoDropZone";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+// #region Tests
+// A metadata row that names a logo file yields a truthy signed URL even when
+// the object is missing from the bucket, so the `imageUrl &&` guard alone let a
+// broken <img> paint its alt text across the drop zone.
+describe("LogoDropZone [broken image]", () => {
+  // The empty state's share icon is an <img> too, so match on the logo host.
+  const logoImg = () => document.querySelector('img[src^="https://cdn."]');
+
+  const renderZone = (imageUrl?: string) =>
+    render(<LogoDropZone imageUrl={imageUrl} onFileSelected={jest.fn()} />)
+      .rerender;
+
+  it("falls back to the empty state when the logo fails to load", () => {
+    renderZone("https://cdn.example/unverified/missing.png");
+    expect(screen.queryByText(/Drop an image/)).toBeNull();
+
+    fireEvent.error(logoImg()!);
+
+    expect(screen.getByText(/Drop an image/)).toBeInTheDocument();
+    expect(logoImg()).toBeNull();
+  });
+
+  it("retries when a new logo url arrives after a failure", () => {
+    const rerender = renderZone("https://cdn.example/unverified/missing.png");
+    fireEvent.error(logoImg()!);
+
+    rerender(
+      <LogoDropZone
+        imageUrl="https://cdn.example/unverified/uploaded.png"
+        onFileSelected={jest.fn()}
+      />,
+    );
+
+    expect(logoImg()).toHaveAttribute(
+      "src",
+      "https://cdn.example/unverified/uploaded.png",
+    );
+  });
+});
+// #endregion


### PR DESCRIPTION
## Problem

App logos in the v3 configuration flow rendered their `alt` text instead of an image. In the wizard the text was clipped by the circular drop zone, so it read as a positioning bug; on the review step you also got the broken-image glyph.

The cause is a truthy URL for an image that does not exist. `hasura/seeds/default/1678146259008_appSeed.sql` writes `logo_img_url = 'logo_img.png'` into `app_metadata`, `get-unverified-images` sees a non-empty column and mints a URL for it, and nothing ever checks that the object is actually in the bucket. Every call site guarded with `logoUrl && <img>`, which only asks whether the URL is a non-empty string — so the empty state was unreachable and the failed `<img>` stayed in the DOM showing its alt text.

## Change

A shared `useImageFallback` hook that swaps to the caller's existing empty state on the image's `error` event:

```ts
isBroken: Boolean(url) && failedUrl === url
```

Keyed on the URL rather than a boolean, so a fresh upload gets another attempt without needing a reset effect. Wired into the three places that render an app logo — `LogoDropZone`, `ReviewStep`, `LivePreview`. Each adds an import, one hook call, and `onError`.

`alt` is now empty on these images. They sit next to the app name, so they are decorative, and an empty alt means nothing paints in the window between a failed load and the error event. The live-preview `<img>` picked up a `data-testid`, since two existing tests queried it by alt text.

## Verification

- Reproduced end to end against a local dev server: the page requested `.../unverified/app_19c72734.../logo_img.png`, it failed, and the drop zone rendered the real "Drop an image, or Browse" state with no logo `<img>` left in the DOM.
- Confirmed the images are client-rendered only (the server HTML has zero mentions of `logo_img`), so there is no pre-hydration window where the `error` event could fire before React attaches the handler.
- `pv3-logo-broken-image.test.tsx` covers both branches: error to empty state, and a new URL retrying after a failure.
- `npx tsc --noEmit` clean, Prettier clean, 18 tests pass across the two touched suites.

## Known limit

The hook remembers one failed URL, so a byte-identical URL is suppressed without a retry. If an object appears in the bucket during the same page session it stays empty until remount. A real upload avoids this, since the new URL comes back presigned with different query params.

## Noted but not addressed

- A wrong-team URL renders a fully interactive config editor that fails only on write, because the page loads by `appId` alone while `upload-image` validates app + team + membership.
- "Error uploading image" swallows the specific GraphQL error, which is only visible in the console.
