### PR TITLE
feat(portal-v3): move the app danger zone into a configuration dropdown

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/DangerZoneDisclosure.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/DangerZoneDisclosure.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Icon } from "@/scenes/PortalV3/common/Icon";
+import { DangerZoneSection } from "./DangerZoneSection";
+
+/**
+ * Danger zone as a collapsed row inside the wizard's Advanced settings, so
+ * deleting an app takes a deliberate expand instead of a sidebar destination.
+ */
+export const DangerZoneDisclosure = (props: {
+  appId: string;
+  teamId: string;
+  appName?: string;
+}) => (
+  <details className="group">
+    <summary className="flex w-fit cursor-pointer items-center gap-2 select-none">
+      <Icon
+        name="chevron-down"
+        className="size-3 -rotate-90 transition-transform group-open:rotate-0"
+      />
+      <span className="font-world text-sm font-medium text-portal-text">
+        Danger zone
+      </span>
+    </summary>
+
+    <div className="pt-4">
+      <DangerZoneSection
+        appId={props.appId}
+        teamId={props.teamId}
+        appName={props.appName}
+      />
+    </div>
+  </details>
+);

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/DangerZoneSection.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/DangerZoneSection.tsx
@@ -10,7 +10,7 @@ import { useMemo, useState } from "react";
 import { DeleteModal } from "./DeleteModal";
 
 type DangerZoneSectionProps = {
-  appId: `app_${string}`;
+  appId: string;
   teamId: string;
   appName?: string;
 };
@@ -22,7 +22,7 @@ export const DangerZoneCard = ({
   footerAction,
 }: {
   name: React.ReactNode;
-  footerText: React.ReactNode;
+  footerText?: React.ReactNode;
   footerAction?: React.ReactNode;
 }) => (
   <div className="overflow-hidden rounded-2xl border border-system-error-200 bg-grey-0">
@@ -40,19 +40,21 @@ export const DangerZoneCard = ({
       </Typography>
     </div>
 
-    <div className="flex items-center justify-between gap-4 border-t border-system-error-100 bg-system-error-50 px-6 py-4">
-      <Typography variant={TYPOGRAPHY.R4} className="text-system-error-700">
-        {footerText}
-      </Typography>
-
+    <div className="flex items-center gap-4 px-6 pb-6">
       {footerAction}
+
+      {footerText && (
+        <Typography variant={TYPOGRAPHY.R4} className="text-system-error-700">
+          {footerText}
+        </Typography>
+      )}
     </div>
   </div>
 );
 
 /**
- * Destructive app action. Kept on its own route so it cannot be mistaken for
- * another step in the configuration form.
+ * Destructive app action, revealed from the collapsed Danger zone disclosure
+ * in the wizard's Advanced settings.
  */
 export const DangerZoneSection = ({
   appId,
@@ -73,7 +75,7 @@ export const DangerZoneSection = ({
         name={truncateString(appName, 30)}
         footerText={
           isEnoughPermissions
-            ? "You’ll be asked to confirm before anything is deleted."
+            ? undefined
             : "Only a team owner can delete this app."
         }
         footerAction={

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/DeleteModal/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/DeleteModal/index.tsx
@@ -24,16 +24,19 @@ type DeleteModalProps = {
   teamId: string;
 };
 
-const createSchema = (appName: string) =>
-  yup
-    .object()
-    .shape({
-      app_name: yup
-        .string()
-        .oneOf([appName], "Please check if the input is correct")
-        .required("This field is required"),
-    })
-    .noUnknown();
+// Typing the word beats typing the app name: same deliberate pause, no
+// copy-pasting a long name. Case-insensitive so DELETE works too.
+const schema = yup
+  .object()
+  .shape({
+    app_name: yup
+      .string()
+      .matches(/^delete$/i, "Please check if the input is correct")
+      .required("This field is required"),
+  })
+  .noUnknown();
+
+type DeleteFormValues = yup.Asserts<typeof schema>;
 
 export const DeleteModal = (props: DeleteModalProps) => {
   const { openDeleteModal, setOpenDeleteModal, appName, appId, teamId } = props;
@@ -42,7 +45,6 @@ export const DeleteModal = (props: DeleteModalProps) => {
   const { refetch: refetchApps } = useRefetchQueries(FetchAppsDocument, {
     teamId,
   });
-  const schema = createSchema(appName);
 
   const handleDeleteApp = async () => {
     if (deletingApp) {
@@ -88,8 +90,6 @@ export const DeleteModal = (props: DeleteModalProps) => {
       setDeletingApp(false);
     }
   };
-
-  type DeleteFormValues = yup.Asserts<typeof schema>;
 
   const {
     register,
@@ -139,8 +139,7 @@ export const DeleteModal = (props: DeleteModalProps) => {
             label={
               <>
                 To verify, type{" "}
-                <span className="font-medium text-grey-900">{appName}</span>{" "}
-                below
+                <span className="font-medium text-grey-900">Delete</span> below
               </>
             }
             errors={errors.app_name}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/BasicInformationStep.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/BasicInformationStep.tsx
@@ -16,6 +16,7 @@ import {
   BasicInformationHandle,
   useBasicInformationForm,
 } from "../BasicInformation";
+import { DangerZoneDisclosure } from "../Danger/DangerZoneDisclosure";
 import { unverifiedImageAtom } from "../layout/ImagesProvider";
 import { useAppModeToggle } from "../MiniAppConfiguration";
 import { AppModeCards } from "./AppModeCards";
@@ -247,6 +248,12 @@ export const BasicInformationStep = forwardRef<
               void handleAppModeToggle(wantsMiniApp);
             }
           }}
+        />
+
+        <DangerZoneDisclosure
+          appId={appId}
+          teamId={teamId}
+          appName={appMetadata.name}
         />
       </div>
     </div>

--- a/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { SandboxAccessRequestState } from "@/api/v2/sandbox-access-request/server/fetch-sandbox-access-request";
-import { TrashIcon } from "@/components/Icons/TrashIcon";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -13,9 +12,7 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import { urls } from "@/lib/urls";
-import { FetchAppsDocument } from "@/scenes/common/layout/AppSelector/graphql/client/fetch-apps.generated";
 import { Icon, opticalIconClassName } from "@/scenes/PortalV3/common/Icon";
-import { useQuery } from "@apollo/client/react";
 import { BellIcon, LockKeyholeIcon, WalletCardsIcon } from "lucide-react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
@@ -38,16 +35,9 @@ export const SidebarNav = (props: {
   const teamId = params?.teamId;
   const appId = params?.appId;
   const { setOpenMobile } = useSidebar();
-  const { data: appsData, loading: appsLoading } = useQuery(FetchAppsDocument, {
-    variables: { teamId: teamId! },
-    skip: !teamId || !appId,
-  });
 
   useEffect(() => setOpenMobile(false), [pathname, setOpenMobile]);
 
-  const hasConfirmedApp = Boolean(
-    appId && !appsLoading && appsData?.app?.some((app) => app.id === appId),
-  );
   const teamsLandingHref = urls.teams({});
   const teamOverviewHref = teamId
     ? urls.teams({ team_id: teamId })
@@ -58,8 +48,6 @@ export const SidebarNav = (props: {
 
   const worldIdHref = ids ? urls.worldId40(ids) : teamOverviewHref;
   const configurationHref = ids ? urls.configuration(ids) : teamOverviewHref;
-  const configurationDangerHref =
-    ids && hasConfirmedApp ? urls.configurationDanger(ids) : undefined;
   const miniAppHref = ids ? urls.miniAppPermissions(ids) : teamOverviewHref;
   const teamSettingsHref = teamId
     ? urls.teamSettings({ team_id: teamId })
@@ -78,9 +66,7 @@ export const SidebarNav = (props: {
     withinApp("/world-id-4-0") ||
     withinApp("/world-id-actions") ||
     withinApp("/actions");
-  const configurationActive =
-    withinApp("/configuration") && !withinApp("/configuration/danger");
-  const configurationDangerActive = withinApp("/configuration/danger");
+  const configurationActive = withinApp("/configuration");
   const miniAppActive =
     withinApp("/mini-app") ||
     withinApp("/transactions") ||
@@ -232,15 +218,6 @@ export const SidebarNav = (props: {
                 active={settingsActive}
                 icon={<NavIcon name="nav-settings" active={settingsActive} />}
               />
-              {configurationDangerHref ? (
-                <NavItem
-                  label="Danger zone"
-                  href={configurationDangerHref}
-                  active={configurationDangerActive}
-                  icon={<TrashIcon className="size-4" />}
-                  className="hover:bg-system-error-50 hover:text-system-error-600 data-[active=true]:border-system-error-200 data-[active=true]:bg-system-error-50 data-[active=true]:text-system-error-600 data-[active=true]:shadow-none"
-                />
-              ) : null}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/web/tests/unit/pv3-danger-zone-disclosure.test.tsx
+++ b/web/tests/unit/pv3-danger-zone-disclosure.test.tsx
@@ -1,0 +1,67 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen, within } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+const checkUserPermissions = jest.fn(() => true);
+jest.mock("@/lib/utils", () => ({
+  checkUserPermissions: (...args: unknown[]) => checkUserPermissions(),
+  truncateString: (value?: string) => value ?? "",
+}));
+
+jest.mock("@auth0/nextjs-auth0/client", () => ({
+  useUser: () => ({ user: { sub: "user_1" } }),
+}));
+
+jest.mock(
+  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/DeleteModal",
+  () => ({
+    DeleteModal: (props: { openDeleteModal: boolean }) =>
+      props.openDeleteModal ? <div data-testid="delete-modal" /> : null,
+  }),
+);
+
+import { DangerZoneDisclosure } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/DangerZoneDisclosure";
+// #endregion
+
+const renderDisclosure = () =>
+  render(
+    <DangerZoneDisclosure
+      appId="app_1"
+      teamId="team_1"
+      appName="Sign In App"
+    />,
+  );
+
+beforeEach(() => jest.clearAllMocks());
+
+// #region collapsed dropdown
+describe("v3 DangerZoneDisclosure", () => {
+  it("keeps the delete card inside a collapsed dropdown", () => {
+    const { container } = renderDisclosure();
+    const details = container.querySelector("details") as HTMLDetailsElement;
+
+    expect(details.open).toBe(false);
+    expect(within(details).getByText("Danger zone")).toBeInTheDocument();
+    expect(within(details).getByText(/Permanently delete/)).toHaveTextContent(
+      "Sign In App",
+    );
+    expect(
+      within(details).getByRole("button", { name: "Delete app" }),
+    ).toBeInTheDocument();
+  });
+
+  it("replaces the delete action with a note for non-owners", () => {
+    checkUserPermissions.mockReturnValue(false);
+    renderDisclosure();
+
+    expect(
+      screen.getByText("Only a team owner can delete this app."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Delete app" }),
+    ).not.toBeInTheDocument();
+  });
+});
+// #endregion

--- a/web/tests/unit/pv3-sidebar-section-nav.test.tsx
+++ b/web/tests/unit/pv3-sidebar-section-nav.test.tsx
@@ -25,17 +25,6 @@ jest.mock("@/scenes/PortalV3/layout/Shell/SandboxButton", () => ({
   SandboxButton: () => <button type="button">World ID Sandbox</button>,
 }));
 
-const fetchApps = jest.fn();
-jest.mock("@apollo/client/react", () => ({
-  useQuery: () => fetchApps(),
-}));
-jest.mock(
-  "@/scenes/common/layout/AppSelector/graphql/client/fetch-apps.generated",
-  () => ({
-    FetchAppsDocument: {},
-  }),
-);
-
 const useCurrentAppId = jest.fn();
 jest.mock("@/scenes/PortalV3/layout/Shell/AppsDropdown", () => ({
   useCurrentAppId: () => useCurrentAppId(),
@@ -67,10 +56,6 @@ beforeEach(() => {
   jest.clearAllMocks();
   useParams.mockReturnValue({ teamId, appId });
   useCurrentAppId.mockReturnValue(appId);
-  fetchApps.mockReturnValue({
-    data: { app: [{ id: appId }] },
-    loading: false,
-  });
   usePathname.mockReturnValue(base);
 });
 
@@ -93,10 +78,10 @@ describe("v3 SidebarNav [navigation hierarchy]", () => {
     expect(
       screen.queryByRole("button", { name: "Help center" }),
     ).not.toBeInTheDocument();
-    expect(link("Danger zone")).toHaveAttribute(
-      "href",
-      `${base}/configuration/danger`,
-    );
+    // Destructive settings live inside Configuration, not the sidebar.
+    expect(
+      screen.queryByRole("link", { name: "Danger zone" }),
+    ).not.toBeInTheDocument();
   });
 
   it("marks World ID current on the app root", () => {
@@ -112,13 +97,6 @@ describe("v3 SidebarNav [active section]", () => {
     usePathname.mockReturnValue(`${base}/configuration`);
     renderSidebar();
     expect(isCurrent("Configuration")).toBe(true);
-  });
-
-  it("marks only Danger zone current on the danger route", () => {
-    usePathname.mockReturnValue(`${base}/configuration/danger`);
-    renderSidebar();
-    expect(isCurrent("Danger zone")).toBe(true);
-    expect(isCurrent("Configuration")).toBe(false);
   });
 
   it("expands Mini App children and marks the current child route", () => {
@@ -201,29 +179,6 @@ describe("v3 SidebarNav [no app selected]", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Mini App" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: "Danger zone" }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("hides Danger zone until FetchApps confirms the route app", () => {
-    useParams.mockReturnValue({ teamId, appId });
-    fetchApps.mockReturnValue({ data: undefined, loading: true });
-    usePathname.mockReturnValue(base);
-    renderSidebar();
-    expect(
-      screen.queryByRole("link", { name: "Danger zone" }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("hides Danger zone when the route app is absent from FetchApps", () => {
-    useParams.mockReturnValue({ teamId, appId });
-    fetchApps.mockReturnValue({ data: { app: [] }, loading: false });
-    usePathname.mockReturnValue(base);
-    renderSidebar();
-    expect(
-      screen.queryByRole("link", { name: "Danger zone" }),
     ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What

Deleting an app was a top-level sidebar destination, which gave a destructive action the same weight as everyday navigation. It now lives as a collapsed **Danger zone** disclosure under **Advanced settings** in the configuration wizard's Basic information step, beside the other app-level settings.

## Changes

- **New `DangerZoneDisclosure`** — collapsed `<details>` row that expands to the existing delete card, matching the `<details>`/`<summary>` pattern already used by the action `SettingsCard`.
- **`SidebarNav`** — Danger zone item removed, along with the `FetchApps` query that existed only to gate it (one less client query per shell render). Configuration stays highlighted on the danger path.
- **`DangerZoneSection`** — dropped the "You'll be asked to confirm before anything is deleted." line and the red footer band; Delete app moved to the left at the card's 24px inset. `appId` relaxed to `string` since the wizard passes a plain string.
- **`DeleteModal`** — confirm by typing `Delete` rather than the full app name, matching [`DeleteTeamDialog`](https://github.com/worldcoin/developer-portal/blob/main/web/scenes/PortalV3/common/DeleteTeamDialog/index.tsx). Accepted case-insensitively so `DELETE` works too; the schema no longer depends on props, so it moved to module scope.

The standalone `/configuration/danger` route still renders — it is just no longer linked from V3 nav, since the old portal shares that route.

## Testing

- New `pv3-danger-zone-disclosure.test.tsx`: collapsed by default, and the owner-permission gate.
- `pv3-sidebar-section-nav.test.tsx` updated to assert the sidebar no longer carries a Danger zone link.
- Full unit suite: 568 passed / 124 suites. `tsc --noEmit` and `prettier --check` clean.
- Verified in a local dev server: collapsed row under Advanced settings, expands to the delete card, and the confirm dialog asks for `Delete`.
