### PR TITLE
fix(portal): prevent app title descender clipping

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionCard/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionCard/index.tsx
@@ -12,7 +12,8 @@ export type ActionCardItem = {
 /** Card chrome, shared with the loading skeleton. */
 export const actionCardFrameClassName =
   "flex min-h-[144px] flex-col gap-1 rounded-[10px] border border-portal-border bg-white p-5";
-export const actionCardTitleClassName = "font-ibm text-13 text-portal-heading";
+export const actionCardTitleClassName =
+  "font-ibm text-13 leading-[1.2] text-portal-heading";
 export const actionCardDescriptionClassName =
   "font-world text-13 text-portal-muted";
 

--- a/web/tests/unit/portal-v3-app-grid-design.test.tsx
+++ b/web/tests/unit/portal-v3-app-grid-design.test.tsx
@@ -69,7 +69,7 @@ it("uses the newer action-grid design without environment or engine tags", () =>
     "border-portal-border",
     "p-5",
   );
-  expect(screen.getByText("Example app")).toBeInTheDocument();
+  expect(screen.getByText("Example app")).toHaveClass("leading-[1.2]");
   expect(screen.queryByText("Production")).not.toBeInTheDocument();
   expect(screen.queryByText("Cloud")).not.toBeInTheDocument();
 


### PR DESCRIPTION
This PR fixes clipped descenders in Portal V3 app-card titles.

- adds an explicit 1.2 line-height to the shared IBM Plex Mono title style so truncation no longer clips letters such as `g`
- adds a regression assertion for the app-grid title style
- validates the focused Jest test, TypeScript, and Prettier