### PR TITLE
fix(portal-v3): correct app logo loading placeholder

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Team/page/Apps/App/AppLogo/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/page/Apps/App/AppLogo/index.tsx
@@ -19,30 +19,28 @@ export const AppLogo = (props: {
   );
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
-  const handleLoad = (e: any) => {
-    setIsLoading(false);
-  };
-
   return (
     <div>
       {src && props.verification_status === "verified" && (
-        <div className={clsx("relative size-16")}>
+        <div className="relative size-16">
           <Image
             className={clsx("size-16 rounded-2xl shadow-image", {
-              "absolute opacity-0": isLoading,
+              "opacity-0": isLoading,
             })}
             src={src}
-            width={500}
-            height={500}
-            alt="team logo"
-            onLoad={handleLoad}
+            width={64}
+            height={64}
+            alt="app logo"
+            onLoad={() => setIsLoading(false)}
             onError={() => setSrc(null)}
           />
-          <Skeleton
-            className={clsx("absolute size-16 rounded-2xl shadow-image", {
-              hidden: !isLoading,
-            })}
-          />
+          {isLoading && (
+            <Skeleton
+              containerClassName="absolute inset-0 leading-none"
+              className="size-full rounded-2xl shadow-image"
+              inline
+            />
+          )}
         </div>
       )}
 

--- a/web/tests/unit/portal-v3-app-logo.test.tsx
+++ b/web/tests/unit/portal-v3-app-logo.test.tsx
@@ -1,0 +1,49 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img {...props} />
+  ),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  getCDNImageUrl: (appId: string, src: string) =>
+    `https://cdn.example.com/${appId}/${src}`,
+}));
+// #endregion
+
+import { AppLogo } from "@/scenes/PortalV3/Teams/TeamId/Team/page/Apps/App/AppLogo";
+
+// #region Verified logo loading
+describe("AppLogo [verified logo loading]", () => {
+  it("overlays the skeleton only until the logo loads", () => {
+    const { container } = render(
+      <AppLogo
+        appId="app_1234567890abcdef1234567890abcdef"
+        name="Example app"
+        src="logo.png"
+        verification_status="verified"
+      />,
+    );
+
+    const image = screen.getByRole("img", { name: "app logo" });
+    const skeleton = container.querySelector(".react-loading-skeleton");
+
+    expect(image).toHaveClass("opacity-0");
+    expect(skeleton?.parentElement).toHaveClass("absolute", "inset-0");
+
+    fireEvent.load(image);
+
+    expect(image).not.toHaveClass("opacity-0");
+    expect(
+      container.querySelector(".react-loading-skeleton"),
+    ).not.toBeInTheDocument();
+  });
+});
+// #endregion


### PR DESCRIPTION
This PR fixes the broken app logo loading placeholder in Portal V3.

- Positions the loading skeleton through its container so `react-loading-skeleton` styles cannot override the overlay positioning.
- Removes the skeleton after the app logo loads while preserving the existing fallback for missing or failed logos.
- Uses the rendered 64×64 dimensions and corrects the image alternative text.
- Adds regression coverage for the loading lifecycle.
- Validates the change with focused Jest tests, TypeScript, Prettier, diff integrity, and a secret scan.

<img width="3270" height="1728" alt="image" src="https://github.com/user-attachments/assets/a74cf950-0f62-4e0e-af0d-ea4d71083813" />
