### PR TITLE
fix(portal): persist latest team on switch

### DIFF
--- a/web/app/(portal)/teams/[teamId]/layout.tsx
+++ b/web/app/(portal)/teams/[teamId]/layout.tsx
@@ -1,3 +1,18 @@
-import { TeamIdLayout } from "@/scenes/Portal/Teams/TeamId/layout";
+import { pickPortalVersion } from "@/lib/feature-flags/portal-v3/activation";
+import { TeamIdLayout as TeamIdLayoutV2 } from "@/scenes/Portal/Teams/TeamId/layout";
+import { TeamIdLayout as TeamIdLayoutV3 } from "@/scenes/PortalV3/Teams/TeamId/layout";
+import { ReactNode } from "react";
 
-export default TeamIdLayout;
+export default async function Layout(props: {
+  params: Promise<{ teamId?: string }>;
+  children: ReactNode;
+}) {
+  return pickPortalVersion(
+    () => (
+      <TeamIdLayoutV3 params={props.params}>{props.children}</TeamIdLayoutV3>
+    ),
+    () => (
+      <TeamIdLayoutV2 params={props.params}>{props.children}</TeamIdLayoutV2>
+    ),
+  );
+}

--- a/web/scenes/PortalV3/Teams/TeamId/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/layout/index.tsx
@@ -1,0 +1,38 @@
+import { auth0 } from "@/lib/auth0";
+import { Auth0SessionUser } from "@/lib/types";
+import { rememberLatestTeam } from "@/scenes/PortalV3/Dashboard/server/latest-team";
+import { AppCreatedToast } from "@/scenes/common/Apps/AppCreatedToast";
+import { TeamCreatedToast } from "@/scenes/common/Teams/TeamCreatedToast";
+import { after } from "next/server";
+import { ReactNode } from "react";
+
+type TeamIdLayoutProps = {
+  params: Promise<{ teamId?: string }>;
+  children: ReactNode;
+};
+
+export const TeamIdLayout = async (props: TeamIdLayoutProps) => {
+  const [{ teamId }, session] = await Promise.all([
+    props.params,
+    auth0.getSession(),
+  ]);
+  const user = session?.user as Auth0SessionUser["user"] | undefined;
+  const userId = user?.hasura?.id;
+  const isTeamMember = user?.hasura?.memberships?.some(
+    (membership) => membership.team?.id === teamId,
+  );
+
+  if (userId && teamId && isTeamMember) {
+    // This dynamic layout reruns when a client-side team switch changes teamId.
+    // Persist after rendering so remembering a preference never delays the page.
+    after(() => rememberLatestTeam(userId, teamId));
+  }
+
+  return (
+    <>
+      <AppCreatedToast />
+      <TeamCreatedToast />
+      {props.children}
+    </>
+  );
+};

--- a/web/scenes/PortalV3/layout/index.tsx
+++ b/web/scenes/PortalV3/layout/index.tsx
@@ -3,9 +3,6 @@ import { auth0 } from "@/lib/auth0";
 import { isWorldUser } from "@/lib/is-world-user";
 import { logger } from "@/lib/logger";
 import { Auth0SessionUser } from "@/lib/types";
-import { rememberLatestTeam } from "@/scenes/PortalV3/Dashboard/server/latest-team";
-import { headers } from "next/headers";
-import { after } from "next/server";
 import { ReactNode } from "react";
 import { PortalShell } from "./Shell";
 
@@ -18,15 +15,7 @@ export const PortalLayout = async (props: { children: ReactNode }) => {
     .filter((t): t is NonNullable<typeof t> => !!t?.id)
     .map((t) => ({ id: t.id, name: t.name ?? "Untitled team" }));
 
-  const pathname = (await headers()).get("x-current-path");
-  const visitedTeamId = pathname?.match(/^\/teams\/([^/]+)(?:\/|$)/)?.[1];
   const userId = user?.hasura?.id;
-  const isTeamMember = teams.some((team) => team.id === visitedTeamId);
-
-  if (userId && visitedTeamId && isTeamMember) {
-    // Persist after rendering so remembering a preference never delays the page.
-    after(() => rememberLatestTeam(userId, visitedTeamId));
-  }
 
   let sandboxRequest = null;
   if (userId) {

--- a/web/tests/unit/latest-team-layout.test.tsx
+++ b/web/tests/unit/latest-team-layout.test.tsx
@@ -11,31 +11,20 @@ jest.mock("@/scenes/PortalV3/Dashboard/server/latest-team", () => ({
   rememberLatestTeam: (...args: unknown[]) => rememberLatestTeam(...args),
 }));
 
-const getHeader = jest.fn();
-jest.mock("next/headers", () => ({
-  headers: async () => ({ get: (...args: unknown[]) => getHeader(...args) }),
-}));
-
 const after = jest.fn((callback: () => unknown) => callback());
 jest.mock("next/server", () => ({
   after: (callback: () => unknown) => after(callback),
 }));
 
-jest.mock(
-  "@/api/v2/sandbox-access-request/server/fetch-sandbox-access-request",
-  () => ({
-    fetchSandboxAccessRequest: jest.fn().mockResolvedValue(null),
-  }),
-);
-jest.mock("@/lib/is-world-user", () => ({
-  isWorldUser: () => false,
+jest.mock("@/scenes/common/Apps/AppCreatedToast", () => ({
+  AppCreatedToast: () => null,
 }));
-jest.mock("@/scenes/PortalV3/layout/Shell", () => ({
-  PortalShell: ({ children }: { children: React.ReactNode }) => children,
+jest.mock("@/scenes/common/Teams/TeamCreatedToast", () => ({
+  TeamCreatedToast: () => null,
 }));
 // #endregion
 
-import { PortalLayout } from "@/scenes/PortalV3/layout";
+import { TeamIdLayout } from "@/scenes/PortalV3/Teams/TeamId/layout";
 
 const sessionWithTeams = (teamIds: string[]) => ({
   user: {
@@ -48,15 +37,17 @@ const sessionWithTeams = (teamIds: string[]) => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
-  getHeader.mockReturnValue("/teams/team_1");
 });
 
 // #region Latest team recording
-describe("PortalV3 layout [latest team recording]", () => {
+describe("PortalV3 team layout [latest team recording]", () => {
   it("records a successful member visit after the response", async () => {
     getSession.mockResolvedValue(sessionWithTeams(["team_1"]));
 
-    await PortalLayout({ children: <div /> });
+    await TeamIdLayout({
+      params: Promise.resolve({ teamId: "team_1" }),
+      children: <div />,
+    });
 
     expect(after).toHaveBeenCalledTimes(1);
     expect(rememberLatestTeam).toHaveBeenCalledWith("user_1", "team_1");
@@ -64,19 +55,23 @@ describe("PortalV3 layout [latest team recording]", () => {
 
   it("does not record a team outside the user's current memberships", async () => {
     getSession.mockResolvedValue(sessionWithTeams(["team_1"]));
-    getHeader.mockReturnValue("/teams/team_foreign");
 
-    await PortalLayout({ children: <div /> });
+    await TeamIdLayout({
+      params: Promise.resolve({ teamId: "team_foreign" }),
+      children: <div />,
+    });
 
     expect(after).not.toHaveBeenCalled();
     expect(rememberLatestTeam).not.toHaveBeenCalled();
   });
 
-  it("does not record non-team Portal V3 routes", async () => {
-    getSession.mockResolvedValue(sessionWithTeams(["team_1"]));
-    getHeader.mockReturnValue("/profile");
+  it("does not record a team without an authenticated user", async () => {
+    getSession.mockResolvedValue(null);
 
-    await PortalLayout({ children: <div /> });
+    await TeamIdLayout({
+      params: Promise.resolve({ teamId: "team_1" }),
+      children: <div />,
+    });
 
     expect(after).not.toHaveBeenCalled();
     expect(rememberLatestTeam).not.toHaveBeenCalled();

--- a/web/tests/unit/pv3-r-teamid-layout.test.tsx
+++ b/web/tests/unit/pv3-r-teamid-layout.test.tsx
@@ -1,0 +1,56 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+let usePortalV3 = true;
+jest.mock("@/lib/feature-flags/portal-v3/activation", () => ({
+  pickPortalVersion: async (v3: () => unknown, v2: () => unknown) =>
+    usePortalV3 ? v3() : v2(),
+}));
+jest.mock("@/scenes/Portal/Teams/TeamId/layout", () => ({
+  TeamIdLayout: ({ children }: React.PropsWithChildren) => (
+    <div data-testid="v2-team-id-layout">{children}</div>
+  ),
+}));
+jest.mock("@/scenes/PortalV3/Teams/TeamId/layout", () => ({
+  TeamIdLayout: ({ children }: React.PropsWithChildren) => (
+    <div data-testid="v3-team-id-layout">{children}</div>
+  ),
+}));
+// #endregion
+
+import Layout from "../../app/(portal)/teams/[teamId]/layout";
+
+const renderLayout = async () =>
+  render(
+    await Layout({
+      params: Promise.resolve({ teamId: "team_1" }),
+      children: <div data-testid="team-page" />,
+    }),
+  );
+
+beforeEach(() => {
+  usePortalV3 = true;
+});
+
+it("records Portal V3 visits through the dynamic team layout", async () => {
+  await renderLayout();
+
+  expect(screen.getByTestId("v3-team-id-layout")).toContainElement(
+    screen.getByTestId("team-page"),
+  );
+  expect(screen.queryByTestId("v2-team-id-layout")).not.toBeInTheDocument();
+});
+
+it("preserves the existing Portal V2 team layout", async () => {
+  usePortalV3 = false;
+
+  await renderLayout();
+
+  expect(screen.getByTestId("v2-team-id-layout")).toContainElement(
+    screen.getByTestId("team-page"),
+  );
+  expect(screen.queryByTestId("v3-team-id-layout")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
This PR fixes latest-team persistence when switching teams from the Portal V3 dropdown.

- Moves latest-team recording from the cached portal shell into the dynamic `[teamId]` layout, so client-side team navigation records the selection.
- Preserves server-side membership validation and non-blocking Redis writes while leaving Portal V2 behavior unchanged.
- Adds route and membership-guard regression coverage.

Checks:
- `pnpm exec jest tests/unit --watchman=false --runInBand` (130 suites, 584 tests)
- `pnpm exec tsc --noEmit`
- `pnpm format:check`
- `git diff --check`