### PR TITLE
Replace dash separators in portal copy

### DIFF
--- a/web/scenes/Onboarding/Home/components/DeveloperStories/index.tsx
+++ b/web/scenes/Onboarding/Home/components/DeveloperStories/index.tsx
@@ -187,7 +187,7 @@ export const DeveloperStories = () => {
                 allowFullScreen
                 className="size-full"
                 src={`https://www.youtube.com/embed/${story.youtubeId}?autoplay=1&rel=0`}
-                title={`${story.name} — developer story`}
+                title={`${story.name}: developer story`}
               />
             ) : (
               <>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/GenerateNewKey/GenerateNewKeyContent/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/GenerateNewKey/GenerateNewKeyContent/index.tsx
@@ -90,8 +90,7 @@ export const GenerateNewKeyContent = ({
         <Typography variant={TYPOGRAPHY.H6}>Generate new key</Typography>
         <Typography as="p" variant={TYPOGRAPHY.R3} className="text-grey-500">
           We&apos;ve generated a secure signing key for your application. Save
-          this key securely - you&apos;ll need it to sign operations in your
-          app.
+          this key securely. You&apos;ll need it to sign operations in your app.
         </Typography>
       </div>
 
@@ -146,7 +145,7 @@ export const GenerateNewKeyContent = ({
           </Typography>
           <Typography as="ul" variant={TYPOGRAPHY.S4} className="grid">
             <li className="pl-4 -indent-4">
-              • Save this private key securely - it cannot be recovered if lost
+              • Save this private key securely. It cannot be recovered if lost
             </li>
             <li className="pl-4 -indent-4">
               • Never share your private key or commit it to version control

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Notifications/page.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/MiniApp/Notifications/page.tsx
@@ -348,7 +348,7 @@ export const NotificationsPage = () => {
               />
 
               <p className="px-2 font-world text-xs leading-[130%] text-grey-500">
-                {walletAddressCount}/1000 addresses - Enter one or more wallet
+                {walletAddressCount}/1000 addresses. Enter one or more wallet
                 addresses, separated by commas
               </p>
               {errors.walletAddresses?.message && (

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/index.tsx
@@ -336,7 +336,7 @@ export const ConfigurationWizard = (props: {
             <div className="hidden min-w-0 items-center sm:flex">
               {isAwaiting ? (
                 <p className="min-w-0 truncate text-13 leading-[1.3] font-[350] text-portal-subtle">
-                  In review — editing is locked until review completes.
+                  In review. Editing is locked until review completes.
                 </p>
               ) : isEditable ? (
                 <SaveStatusIndicator />

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/page.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/page.tsx
@@ -235,7 +235,7 @@ const ActionsFooter = ({
               variant={TYPOGRAPHY.R5}
               className="min-w-0 truncate text-grey-500"
             >
-              In review — editing is locked until review completes.
+              In review. Editing is locked until review completes.
             </Typography>
           ) : isEditable ? (
             <SaveStatusIndicator />

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/GenerateNewKey/GenerateNewKeyContent/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/GenerateNewKey/GenerateNewKeyContent/index.tsx
@@ -98,7 +98,7 @@ export const GenerateNewKeyContent = ({
       )}
       <p className="font-world text-14 leading-[1.5] text-portal-muted">
         We&apos;ve generated a secure signing key for your application. Save
-        this key securely — you&apos;ll need it to sign operations in your app.
+        this key securely. You&apos;ll need it to sign operations in your app.
       </p>
 
       <div>
@@ -158,7 +158,7 @@ export const GenerateNewKeyContent = ({
         </p>
         <ul className="mt-1 grid gap-y-1 font-world text-13 leading-[1.4] font-[350] text-system-warning-650">
           <li className="pl-4 -indent-4">
-            • Save this private key securely — it cannot be recovered if lost
+            • Save this private key securely. It cannot be recovered if lost
           </li>
           <li className="pl-4 -indent-4">
             • Never share your private key or commit it to version control

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Notifications/page.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Notifications/page.tsx
@@ -346,7 +346,7 @@ export const NotificationsPage = () => {
               />
 
               <p className="px-2 font-world text-xs leading-[130%] text-grey-500">
-                {walletAddressCount}/1000 addresses - Enter one or more wallet
+                {walletAddressCount}/1000 addresses. Enter one or more wallet
                 addresses, separated by commas
               </p>
               {errors.walletAddresses?.message && (

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/PermissionsForm/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/PermissionsForm/index.tsx
@@ -539,7 +539,7 @@ export const SetupForm = ({
             <section className="grid gap-y-3 pb-4">
               <SectionHeader
                 title="Additional Domains"
-                tooltip="Additional Domains are the external websites your Mini App is allowed to open or make requests to from inside World App. Anything you don't list here is blocked, so add every domain your app needs to reach — you don't need to include subdomains, as they're covered automatically."
+                tooltip="Additional Domains are the external websites your Mini App is allowed to open or make requests to from inside World App. Anything you don't list here is blocked, so add every domain your app needs to reach. You don't need to include subdomains, as they're covered automatically."
               />
 
               <EntryList
@@ -599,7 +599,7 @@ export const SetupForm = ({
               <SectionHeader
                 title="Permit2 Tokens"
                 description="List all the tokens that you intend to use in your Mini App. Any other tokens will be blocked."
-                tooltip="Permit2 is Uniswap's shared approval contract that lets users authorize token spending with a single signature instead of a separate on-chain approval per token. List the ERC-20 tokens your Mini App will move through Permit2 — only these tokens can be used for payments or transfers, and any token not listed here is rejected."
+                tooltip="Permit2 is Uniswap's shared approval contract that lets users authorize token spending with a single signature instead of a separate on-chain approval per token. List the ERC-20 tokens your Mini App will move through Permit2. Only these tokens can be used for payments or transfers, and any token not listed here is rejected."
               />
 
               <EntryList
@@ -626,7 +626,7 @@ export const SetupForm = ({
               <SectionHeader
                 title="Contract Entrypoints"
                 description="List here contracts that you intend to call functions directly on."
-                tooltip="Contract Entrypoints are the smart contracts your Mini App is allowed to call functions on directly. List every contract address your app interacts with — calls to any contract not listed here are blocked, which keeps your app scoped to only the on-chain interactions you expect."
+                tooltip="Contract Entrypoints are the smart contracts your Mini App is allowed to call functions on directly. List every contract address your app interacts with. Calls to any contract not listed here are blocked, which keeps your app scoped to only the on-chain interactions you expect."
               />
 
               <EntryList

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/WorldId40Pane/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/WorldId40Pane/index.tsx
@@ -33,7 +33,7 @@ export const WorldId40Pane = (props: {
     initialStagingStatus: props.initialStagingStatus,
     onStatusReconciled: props.onRpChanged,
     onRetryError: () =>
-      toast.error("Failed to retry registration — please try again"),
+      toast.error("Failed to retry registration. Please try again"),
   });
 
   const formattedDate = new Date(props.createdAt).toLocaleDateString("en-US", {

--- a/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/McpSetup/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/McpSetup/index.tsx
@@ -52,7 +52,7 @@ export const McpSetup = () => {
         copiedTimeoutRef.current = setTimeout(() => setCopied(false), 2_000);
       })
       .catch(() =>
-        toast.error("Couldn't copy — select the command and copy it manually"),
+        toast.error("Couldn't copy. Select the command and copy it manually"),
       );
   };
 

--- a/web/scenes/PortalV3/layout/Shell/SandboxButton.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SandboxButton.tsx
@@ -128,7 +128,7 @@ export const SandboxButton = (props: {
       });
 
       if (!response.ok) {
-        toast.error("Couldn't send your request — please try again.");
+        toast.error("Couldn't send your request. Please try again.");
         return;
       }
 
@@ -141,7 +141,7 @@ export const SandboxButton = (props: {
       setExistingRequest(data.request);
       setRequestEmail(data.request.email);
     } catch {
-      toast.error("Couldn't send your request — please try again.");
+      toast.error("Couldn't send your request. Please try again.");
     } finally {
       setRequestSending(false);
     }

--- a/web/tests/unit/pv3-config-redesign.test.tsx
+++ b/web/tests/unit/pv3-config-redesign.test.tsx
@@ -641,7 +641,7 @@ describe("v3 Configuration redesign [footer and preview]", () => {
     renderPage();
 
     expect(
-      screen.getByText(/In review — editing is locked/),
+      screen.getByText(/In review\. Editing is locked/),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Un-submit" }),


### PR DESCRIPTION
## Summary

- Replace dash separators in the listed portal messages with periods or a colon
- Preserve the original wording and word order
- Update the matching locked-state test assertion

## Why

Several portal messages use dash separators that make the copy feel machine-generated. This keeps the wording intact while using standard sentence punctuation.

## Impact

User-facing messages retain the same meaning and wording. Only separator punctuation and the necessary capitalization after new periods change.

## Validation

- `pnpm format:check`
- `npx tsc --noEmit`
- Six focused Jest suites: 36 tests passed
- `git diff --check`