### PR TITLE
Standardize destructive action trigger styling

### DIFF
--- a/web/components/ActionDangerZone/index.tsx
+++ b/web/components/ActionDangerZone/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { DecoratedButton } from "@/components/DecoratedButton";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { Dialog } from "@/components/Dialog";
 import { DialogOverlay } from "@/components/DialogOverlay";
 import { DialogPanel } from "@/components/DialogPanel";
@@ -144,17 +145,13 @@ export const ActionDangerZone = (props: ActionDangerZoneProps) => {
           </Typography>
         </div>
 
-        <DecoratedButton
-          type="button"
-          variant="danger"
+        <DestructiveTriggerButton
           onClick={() => setOpenDeleteModal(true)}
           disabled={isDeleting || !canDelete}
-          className="h-14 w-fit rounded-full bg-danger px-6 hover:bg-system-error-700"
+          className="w-fit"
         >
-          <Typography variant={TYPOGRAPHY.R3} className="text-white">
-            Delete action
-          </Typography>
-        </DecoratedButton>
+          Delete action
+        </DestructiveTriggerButton>
       </div>
     </div>
   );

--- a/web/components/DestructiveTriggerButton/index.tsx
+++ b/web/components/DestructiveTriggerButton/index.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@/components/Button";
+import type { ComponentProps } from "react";
+import { twMerge } from "tailwind-merge";
+
+const destructiveTriggerDisplayClassName = "inline-flex";
+const destructiveTriggerVisualClassName =
+  "h-8 items-center justify-center rounded-full border border-system-error-300 bg-white px-4 font-world leading-none font-medium whitespace-nowrap text-system-error-600 outline-hidden transition-colors hover:border-system-error-400 hover:bg-system-error-50 focus-visible:ring-2 focus-visible:ring-system-error-300 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:border-system-error-100 disabled:bg-white disabled:text-system-error-300 disabled:hover:bg-white";
+
+type DestructiveTriggerButtonProps = ComponentProps<"button">;
+
+export const DestructiveTriggerButton = (
+  props: DestructiveTriggerButtonProps,
+) => {
+  const { className, type = "button", ...buttonProps } = props;
+
+  return (
+    <Button
+      {...buttonProps}
+      type={type}
+      className={`${twMerge(
+        destructiveTriggerDisplayClassName,
+        className,
+        destructiveTriggerVisualClassName,
+      )} text-13`}
+    />
+  );
+};

--- a/web/scenes/Portal/Profile/DangerZone/page/index.tsx
+++ b/web/scenes/Portal/Profile/DangerZone/page/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { DecoratedButton } from "@/components/DecoratedButton";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { UserInfo } from "@/scenes/Portal/Profile/common/UserInfo";
@@ -30,14 +30,12 @@ export const DangerZone = () => {
               undone.
             </Typography>
 
-            <DecoratedButton
+            <DestructiveTriggerButton
               type="button"
               onClick={() => setOpen(true)}
-              variant="danger"
-              className="max-w-44 py-3"
             >
               Delete account
-            </DecoratedButton>
+            </DestructiveTriggerButton>
           </div>
         </Section>
       </SizingWrapper>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { DecoratedButton } from "@/components/DecoratedButton";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { LegacyVerificationLevel } from "@/lib/idkit";
@@ -115,13 +116,12 @@ export const ActionIdKioskPage = (props: ActionIdKioskPageProps) => {
                 )}
 
                 {kioskAction?.kiosk_enabled && (
-                  <DecoratedButton
+                  <DestructiveTriggerButton
                     type="button"
-                    variant="danger"
                     onClick={() => handleToggleKiosk(false)}
                   >
                     Deactivate Kiosk
-                  </DecoratedButton>
+                  </DestructiveTriggerButton>
                 )}
               </div>
             )}

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Danger/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/Configuration/Danger/page/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { DecoratedButton } from "@/components/DecoratedButton";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { Role_Enum } from "@/graphql/graphql";
@@ -84,14 +84,13 @@ export const AppProfileDangerPage = ({ params }: AppProfileDangerPageProps) => {
               </Typography>
             </div>
 
-            <DecoratedButton
+            <DestructiveTriggerButton
               type="button"
-              variant="destructive"
               onClick={() => setOpenDeleteModal(true)}
               className={clsx("w-fit", { hidden: !isEnoughPermissions })}
             >
-              <Typography variant={TYPOGRAPHY.R3}>Delete app</Typography>
-            </DecoratedButton>
+              Delete app
+            </DestructiveTriggerButton>
           </div>
         </SizingWrapper>
         <DeleteModal

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/ClientInformation/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/ClientInformation/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { CopyButton } from "@/components/CopyButton";
-import { DecoratedButton } from "@/components/DecoratedButton";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { LockIcon } from "@/components/Icons/LockIcon";
 import { Input } from "@/components/Input";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
@@ -151,14 +151,9 @@ export const ClientInformationPage = (props: {
                   { hidden: !isEnoughPermissions },
                 )}
               >
-                <DecoratedButton
-                  type="button"
-                  variant="secondary"
-                  className="h-9"
-                  onClick={handleReset}
-                >
+                <DestructiveTriggerButton type="button" onClick={handleReset}>
                   Reset
-                </DecoratedButton>
+                </DestructiveTriggerButton>
 
                 {clientSecret !== "" && (
                   <CopyButton

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/WorldId40Content.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/WorldId40Content.tsx
@@ -2,11 +2,11 @@
 
 import { CopyButton } from "@/components/CopyButton";
 import { DecoratedButton } from "@/components/DecoratedButton";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { Notification } from "@/components/Notification";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { useMutation } from "@apollo/client/react";
-import clsx from "clsx";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { RetryRpDocument } from "@/scenes/common/Teams/TeamId/Apps/AppId/WorldId40/page/graphql/client/retry-rp.generated";
@@ -285,15 +285,13 @@ export const WorldId40Content = ({
                   This will create a new signer key and disable the existing key
                 </Typography>
               </div>
-              <DecoratedButton
+              <DestructiveTriggerButton
                 type="button"
-                variant="secondary"
                 disabled={!isActive || mode === "self_managed"}
-                className="h-8 rounded-full px-4 py-0 text-xs"
                 onClick={() => setIsRotateDialogOpen(true)}
               >
                 Reset
-              </DecoratedButton>
+              </DestructiveTriggerButton>
             </div>
           </div>
         </div>
@@ -314,16 +312,10 @@ export const WorldId40Content = ({
                   Move this RP to a self-managed configuration
                 </Typography>
               </div>
-              <DecoratedButton
+              <DestructiveTriggerButton
                 type="button"
-                variant="danger"
                 disabled={!isActive || mode === "self_managed"}
-                className={clsx(
-                  "h-8 shrink-0 rounded-full px-4 text-[13px] font-semibold",
-                  !isActive || mode === "self_managed"
-                    ? "" // Let DecoratedButton handle disabled styles
-                    : "bg-danger text-white hover:bg-system-error-700",
-                )}
+                className="shrink-0"
                 title={
                   mode === "self_managed"
                     ? "Already in self-managed mode"
@@ -334,7 +326,7 @@ export const WorldId40Content = ({
                 onClick={() => setIsSwitchDialogOpen(true)}
               >
                 Switch
-              </DecoratedButton>
+              </DestructiveTriggerButton>
             </div>
           </div>
         </div>

--- a/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/WorldId40Content.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Apps/AppId/WorldId40/page/WorldId40Content.tsx
@@ -285,13 +285,15 @@ export const WorldId40Content = ({
                   This will create a new signer key and disable the existing key
                 </Typography>
               </div>
-              <DestructiveTriggerButton
+              <DecoratedButton
                 type="button"
+                variant="secondary"
                 disabled={!isActive || mode === "self_managed"}
+                className="h-8 rounded-full px-4 py-0 text-xs"
                 onClick={() => setIsRotateDialogOpen(true)}
               >
                 Reset
-              </DestructiveTriggerButton>
+              </DecoratedButton>
             </div>
           </div>
         </div>

--- a/web/scenes/Portal/Teams/TeamId/Team/Danger/page/index.tsx
+++ b/web/scenes/Portal/Teams/TeamId/Team/Danger/page/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { DecoratedButton } from "@/components/DecoratedButton";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { DeleteTeamDialog } from "@/scenes/Portal/common/DeleteTeamDialog";
 import { useParams } from "next/navigation";
 import { useState } from "react";
@@ -46,13 +46,12 @@ export const TeamDangerPage = () => {
               cannot be undone.
             </p>
 
-            <DecoratedButton
+            <DestructiveTriggerButton
               type="submit"
-              variant="danger"
               onClick={() => setIsOpenDeleteDialog(true)}
             >
               Delete team
-            </DecoratedButton>
+            </DestructiveTriggerButton>
           </div>
         </Section>
       </SizingWrapper>

--- a/web/scenes/PortalV3/Profile/page/index.tsx
+++ b/web/scenes/PortalV3/Profile/page/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Button } from "@/components/Button";
 import { Checkbox } from "@/components/Checkbox";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { Input } from "@/components/Input";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { Auth0SessionUser } from "@/lib/types";
@@ -194,13 +194,11 @@ export const ProfilePage = () => {
             />
 
             <div className="flex justify-end">
-              <Button
-                type="button"
+              <DestructiveTriggerButton
                 onClick={() => setIsDeleteAccountOpen(true)}
-                className="inline-flex h-8 items-center justify-center rounded-8 border border-system-error-300 bg-white px-4 font-world text-13 leading-none font-medium text-system-error-600 outline-hidden transition-colors hover:border-system-error-400 hover:bg-system-error-50 focus-visible:ring-2 focus-visible:ring-system-error-300 focus-visible:ring-offset-2"
               >
                 Delete account
-              </Button>
+              </DestructiveTriggerButton>
             </div>
           </div>
         </div>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Actions/ActionId/Kiosk/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { DecoratedButton } from "@/components/DecoratedButton";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { LegacyVerificationLevel } from "@/lib/idkit";
@@ -115,13 +116,11 @@ export const ActionIdKioskPage = (props: ActionIdKioskPageProps) => {
                 )}
 
                 {kioskAction?.kiosk_enabled && (
-                  <DecoratedButton
-                    type="button"
-                    variant="danger"
+                  <DestructiveTriggerButton
                     onClick={() => handleToggleKiosk(false)}
                   >
                     Deactivate Kiosk
-                  </DecoratedButton>
+                  </DestructiveTriggerButton>
                 )}
               </div>
             )}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/DangerZoneSection.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Danger/DangerZoneSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { DecoratedButton } from "@/components/DecoratedButton";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { Role_Enum } from "@/graphql/graphql";
 import { Auth0SessionUser } from "@/lib/types";
@@ -108,22 +108,12 @@ export const DangerZoneSection = ({
         }
         footerAction={
           isEnoughPermissions && (
-            <DecoratedButton
-              type="button"
-              variant="destructive"
+            <DestructiveTriggerButton
               onClick={() => setOpenDeleteModal(true)}
-              className={
-                variant === "compact"
-                  ? "h-9 shrink-0 rounded-full px-4 py-0"
-                  : "shrink-0"
-              }
+              className="shrink-0"
             >
-              <Typography
-                variant={variant === "compact" ? TYPOGRAPHY.B3 : TYPOGRAPHY.R3}
-              >
-                Delete app
-              </Typography>
-            </DecoratedButton>
+              Delete app
+            </DestructiveTriggerButton>
           )
         }
       />

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/ClientInformation/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/SignInWithWorldId/page/ClientInformation/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { CopyButton } from "@/components/CopyButton";
-import { DecoratedButton } from "@/components/DecoratedButton";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { LockIcon } from "@/components/Icons/LockIcon";
 import { Input } from "@/components/Input";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
@@ -162,14 +162,9 @@ export const ClientInformationPage = (props: {
                   { hidden: !isEnoughPermissions },
                 )}
               >
-                <DecoratedButton
-                  type="button"
-                  variant="secondary"
-                  className="h-9"
-                  onClick={handleReset}
-                >
+                <DestructiveTriggerButton onClick={handleReset}>
                   Reset
-                </DecoratedButton>
+                </DestructiveTriggerButton>
 
                 {clientSecret !== "" && (
                   <CopyButton

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RpSummary.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RpSummary.tsx
@@ -145,7 +145,7 @@ export const RpSummary = (props: {
             />
           </div>
 
-          <div className="flex flex-col items-start gap-3">
+          <div className="flex flex-col gap-6">
             {controlsDisabledReason ? (
               <Typography
                 id="world-id-configuration-disabled-reason"
@@ -156,31 +156,72 @@ export const RpSummary = (props: {
                 {controlsDisabledReason}
               </Typography>
             ) : null}
-            <div className="flex flex-wrap items-center gap-3">
-              <DestructiveTriggerButton
-                disabled={!props.canManageWorldId || !isActive || isSelfManaged}
-                className="shrink-0"
-                aria-describedby={
-                  controlsDisabledReason
-                    ? "world-id-configuration-disabled-reason"
-                    : undefined
-                }
-                onClick={() => setIsRotateOpen(true)}
-              >
-                Rotate signer key
-              </DestructiveTriggerButton>
-              <DestructiveTriggerButton
-                disabled={!props.canManageWorldId || !isActive || isSelfManaged}
-                className="shrink-0"
-                aria-describedby={
-                  controlsDisabledReason
-                    ? "world-id-configuration-disabled-reason"
-                    : undefined
-                }
-                onClick={() => setIsSwitchOpen(true)}
-              >
-                Switch to self-managed
-              </DestructiveTriggerButton>
+
+            <div className="flex flex-col gap-4">
+              <Typography as="h3" variant={TYPOGRAPHY.S2}>
+                Key
+              </Typography>
+
+              <div className="flex items-center justify-between gap-4 rounded-xl border border-grey-100 p-6">
+                <div className="flex flex-col gap-1">
+                  <Typography variant={TYPOGRAPHY.S2}>
+                    Rotate signer key
+                  </Typography>
+                  <Typography variant={TYPOGRAPHY.B3} className="text-grey-500">
+                    This will create a new signer key and disable the existing
+                    key
+                  </Typography>
+                </div>
+
+                <DecoratedButton
+                  type="button"
+                  variant="secondary"
+                  disabled={
+                    !props.canManageWorldId || !isActive || isSelfManaged
+                  }
+                  className="h-8 shrink-0 rounded-full px-4 py-0 text-xs"
+                  aria-describedby={
+                    controlsDisabledReason
+                      ? "world-id-configuration-disabled-reason"
+                      : undefined
+                  }
+                  onClick={() => setIsRotateOpen(true)}
+                >
+                  Rotate signer key
+                </DecoratedButton>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-4">
+              <Typography as="h3" variant={TYPOGRAPHY.S2}>
+                Danger zone
+              </Typography>
+
+              <div className="flex items-center justify-between gap-4 rounded-[10px] border border-grey-100 px-6 py-4">
+                <div className="flex flex-col gap-1">
+                  <Typography variant={TYPOGRAPHY.S2}>
+                    Switch to self-managed
+                  </Typography>
+                  <Typography variant={TYPOGRAPHY.B3} className="text-grey-500">
+                    Move this RP to a self-managed configuration
+                  </Typography>
+                </div>
+
+                <DestructiveTriggerButton
+                  disabled={
+                    !props.canManageWorldId || !isActive || isSelfManaged
+                  }
+                  className="shrink-0"
+                  aria-describedby={
+                    controlsDisabledReason
+                      ? "world-id-configuration-disabled-reason"
+                      : undefined
+                  }
+                  onClick={() => setIsSwitchOpen(true)}
+                >
+                  Switch to self-managed
+                </DestructiveTriggerButton>
+              </div>
             </div>
           </div>
         </div>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RpSummary.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RpSummary.tsx
@@ -2,6 +2,7 @@
 
 import { CopyButton } from "@/components/CopyButton";
 import { DecoratedButton } from "@/components/DecoratedButton";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { Notification } from "@/components/Notification";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { RpRegistrationStatus } from "@/lib/rp-registration-status";
@@ -156,11 +157,9 @@ export const RpSummary = (props: {
               </Typography>
             ) : null}
             <div className="flex flex-wrap items-center gap-3">
-              <DecoratedButton
-                type="button"
-                variant="secondary"
+              <DestructiveTriggerButton
                 disabled={!props.canManageWorldId || !isActive || isSelfManaged}
-                className="h-9 shrink-0 rounded-full px-4 py-0 text-xs"
+                className="shrink-0"
                 aria-describedby={
                   controlsDisabledReason
                     ? "world-id-configuration-disabled-reason"
@@ -169,12 +168,10 @@ export const RpSummary = (props: {
                 onClick={() => setIsRotateOpen(true)}
               >
                 Rotate signer key
-              </DecoratedButton>
-              <DecoratedButton
-                type="button"
-                variant="danger"
+              </DestructiveTriggerButton>
+              <DestructiveTriggerButton
                 disabled={!props.canManageWorldId || !isActive || isSelfManaged}
-                className="h-9 shrink-0 rounded-full px-4 py-0 text-xs"
+                className="shrink-0"
                 aria-describedby={
                   controlsDisabledReason
                     ? "world-id-configuration-disabled-reason"
@@ -183,7 +180,7 @@ export const RpSummary = (props: {
                 onClick={() => setIsSwitchOpen(true)}
               >
                 Switch to self-managed
-              </DecoratedButton>
+              </DestructiveTriggerButton>
             </div>
           </div>
         </div>

--- a/web/scenes/PortalV3/Teams/TeamId/Team/sections/DangerZone/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/sections/DangerZone/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { DecoratedButton } from "@/components/DecoratedButton";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { DeleteTeamDialog } from "@/scenes/PortalV3/common/DeleteTeamDialog";
 import { useState } from "react";
 
@@ -18,14 +18,12 @@ export const TeamDangerZone = (props: {
 
   return (
     <>
-      <DecoratedButton
-        type="button"
-        variant="destructive"
-        className="h-8 shrink-0 rounded-8 px-4 py-0 font-world text-13 focus-visible:ring-2 focus-visible:ring-system-error-300 focus-visible:ring-offset-2 focus-visible:outline-hidden"
+      <DestructiveTriggerButton
+        className="shrink-0"
         onClick={() => setIsOpenDeleteDialog(true)}
       >
         Delete team
-      </DecoratedButton>
+      </DestructiveTriggerButton>
 
       <DeleteTeamDialog
         open={isOpenDeleteDialog}

--- a/web/tests/unit/destructive-trigger-button.test.tsx
+++ b/web/tests/unit/destructive-trigger-button.test.tsx
@@ -1,0 +1,81 @@
+/** @jest-environment jsdom */
+
+import "@testing-library/jest-dom";
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+describe("DestructiveTriggerButton", () => {
+  it("renders the shared red-outline pill treatment", () => {
+    const onClick = jest.fn();
+
+    render(
+      <DestructiveTriggerButton className="h-7 shrink-0" onClick={onClick}>
+        Trigger action
+      </DestructiveTriggerButton>,
+    );
+
+    const button = screen.getByRole("button", { name: "Trigger action" });
+
+    expect(button).toHaveAttribute("type", "button");
+    expect(button).toHaveClass(
+      "h-8",
+      "shrink-0",
+      "rounded-full",
+      "border-system-error-300",
+      "bg-white",
+      "text-13",
+      "text-system-error-600",
+    );
+    expect(button).not.toHaveClass("h-7");
+
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("owns disabled styling and blocks activation", () => {
+    const onClick = jest.fn();
+
+    render(
+      <DestructiveTriggerButton disabled onClick={onClick}>
+        Delete team
+      </DestructiveTriggerButton>,
+    );
+
+    const button = screen.getByRole("button", { name: "Delete team" });
+
+    expect(button).toBeDisabled();
+    expect(button).toHaveClass(
+      "disabled:cursor-not-allowed",
+      "disabled:border-system-error-100",
+      "disabled:text-system-error-300",
+    );
+
+    fireEvent.click(button);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("forwards an explicit native button type", () => {
+    render(
+      <DestructiveTriggerButton type="submit">
+        Submit action
+      </DestructiveTriggerButton>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Submit action" }),
+    ).toHaveAttribute("type", "submit");
+  });
+
+  it("allows callers to hide the trigger without overriding its visual size", () => {
+    render(
+      <DestructiveTriggerButton className="hidden h-7">
+        Hidden action
+      </DestructiveTriggerButton>,
+    );
+
+    const button = screen.getByRole("button", { name: "Hidden action" });
+
+    expect(button).toHaveClass("hidden", "h-8");
+    expect(button).not.toHaveClass("inline-flex", "h-7");
+  });
+});

--- a/web/tests/unit/pv3-world-id-rp-summary.test.tsx
+++ b/web/tests/unit/pv3-world-id-rp-summary.test.tsx
@@ -72,7 +72,7 @@ beforeEach(() => {
   mockStagingStatus = null;
 });
 
-it("shows the vertical RP identity fields and management controls", () => {
+it("shows the vertical RP identity fields and separated management controls", () => {
   renderSummary();
 
   const summary = screen.getByRole("region", {
@@ -108,8 +108,22 @@ it("shows the vertical RP identity fields and management controls", () => {
   });
   expect(rotateButton).toBeEnabled();
   expect(switchButton).toBeEnabled();
-  expect(rotateButton.parentElement).toBe(switchButton.parentElement);
-  expect(rotateButton.parentElement).toHaveClass("flex", "flex-wrap");
+  expect(screen.getByRole("heading", { name: "Key" })).toBeInTheDocument();
+  expect(
+    screen.getByRole("heading", { name: "Danger zone" }),
+  ).toBeInTheDocument();
+  expect(rotateButton.parentElement).not.toBe(switchButton.parentElement);
+  expect(rotateButton).toHaveClass(
+    "border-grey-200",
+    "bg-grey-0",
+    "text-grey-700",
+  );
+  expect(rotateButton).not.toHaveClass("text-system-error-600");
+  expect(switchButton).toHaveClass(
+    "border-system-error-300",
+    "bg-white",
+    "text-system-error-600",
+  );
 });
 
 it.each([


### PR DESCRIPTION
## Summary

- add a shared red-outline pill treatment for page-level destructive triggers
- apply it across the legacy and PortalV3 account, app, team, action, kiosk, client-secret, and self-managed controls
- keep signer-key rotation neutral and restore the Key / Danger zone control hierarchy
- preserve every existing dialog, handler, mutation, disabled condition, and confirmation flow

## Why

Destructive page actions used a mix of neutral, outlined, and solid treatments. A shared trigger component keeps genuinely destructive actions visually consistent without making credential maintenance look destructive.

## User impact

Destructive triggers now share the same height, pill shape, red outline, typography, hover, focus, and disabled states. Signer-key rotation remains a neutral secondary action in its original Key section; switching to self-managed remains in the Danger zone.

## Validation

- `npx tsc --noEmit`
- `pnpm format:check`
- targeted Jest suites for the shared trigger, World ID summary, profile, configuration, and team settings
- visual verification on localhost for Rotate signer key, Switch to self-managed, Delete app, and Delete account