### PR TITLE
fix(world-id): hide app deletion before setup

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
@@ -397,7 +397,7 @@ export const WorldIdLayout = (props: {
                   />
                 ) : null}
 
-                {app ? (
+                {rp ? (
                   <div className="w-full max-w-[580px]">
                     <DangerZoneSection
                       appId={props.appId}

--- a/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
+++ b/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
@@ -332,7 +332,7 @@ describe("WorldIdLayout [setup to create handoff]", () => {
     );
   });
 
-  it("hides the Actions section until the app has an RP registration", () => {
+  it("hides Actions and app deletion until the app has an RP registration", () => {
     setQuery({ data: makeData({ rp: false }), loading: false });
     render(el());
 
@@ -342,6 +342,7 @@ describe("WorldIdLayout [setup to create handoff]", () => {
     );
     expect(screen.queryByTestId("actions-grid")).not.toBeInTheDocument();
     expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("danger-zone-section")).not.toBeInTheDocument();
   });
 
   it("still defaults to Configuration when legacy actions exist without an RP", () => {


### PR DESCRIPTION
## Summary

- Hide the app deletion panel until the app has an RP registration.
- Add regression coverage for apps without World ID configured.

## Why

The deletion panel was gated on the app record, which exists before World ID setup. Gating it on the RP registration keeps it hidden during setup while preserving it for configured apps.

## Validation

- Targeted Jest suite: 21 tests passed
- TypeScript check passed
- Formatting check passed