### PR TITLE
feat(world-id): simplify relying party registration

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/EnableWorldId40/Dialog/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/EnableWorldId40/Dialog/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { FormDialog } from "@/components/FormDialog";
-import { getGraphQLErrorCode } from "@/lib/errors";
 import { RegisterRpDocument } from "@/scenes/common/layout/CreateAppDialog/client/register-rp.generated";
 import { useMutation } from "@apollo/client/react";
 import dynamic from "next/dynamic";
@@ -12,8 +11,6 @@ import {
   ConfigureSignerKeyContent,
   SignerKeySetup,
 } from "../../ConfigureSignerKey/ConfigureSignerKeyContent";
-import { EnableWorldId40Content } from "../EnableWorldId40Content";
-import { SelfManagedTransactionInfoContent } from "../SelfManagedTransactionInfo/SelfManagedTransactionInfoContent";
 
 const GenerateNewKeyContent = dynamic(() =>
   import("../../GenerateNewKey/GenerateNewKeyContent").then(
@@ -27,64 +24,51 @@ const UseExistingKeyContent = dynamic(() =>
   ),
 );
 
-type EnableWorldIdDialogStep =
-  | "enable-world-id-4-0"
+type RegisterRpDialogStep =
   | "configure-signer-key"
   | "use-existing-key"
-  | "generate-new-key"
-  | "self-managed-transaction";
+  | "generate-new-key";
 
-const STEP_TITLES: Record<EnableWorldIdDialogStep, string> = {
-  "enable-world-id-4-0": "Enable World ID",
+const STEP_TITLES: Record<RegisterRpDialogStep, string> = {
   "configure-signer-key": "Configure signer key",
   "use-existing-key": "Use existing key",
   "generate-new-key": "Generate new key",
-  "self-managed-transaction": "Self-managed registration",
 };
 
-type EnableWorldIdDialogProps = {
+type RegisterRpDialogProps = {
   open: boolean;
   onClose: (value: boolean) => void;
   appId: string;
   onComplete?: () => void;
 };
 
-export const EnableWorldIdDialog = ({
+export const RegisterRpDialog = ({
   appId,
   onComplete,
-  ...props
-}: EnableWorldIdDialogProps) => {
+  open,
+  onClose: onCloseDialog,
+}: RegisterRpDialogProps) => {
   const { teamId } = useParams() as { teamId: string | undefined };
   const router = useRouter();
-  // Self-Managed availability previously read the World ID 4.0 rollout flag,
-  // but that gate was already true wherever this dialog could actually render
-  // (the dialog itself was flag-gated). With the flag removed (v4 is the
-  // default), hardcoding true preserves the existing behavior — it is not a new
-  // self-managed product change.
-  const isSelfManagedEnabled = true;
 
   const [registerRp, { loading: registeringRp }] =
     useMutation(RegisterRpDocument);
 
-  const [step, setStep] = useState<EnableWorldIdDialogStep>(
-    "enable-world-id-4-0",
-  );
-  const [worldIdMode, setWorldIdMode] = useState<"managed" | "self-managed">(
-    "managed",
+  const [step, setStep] = useState<RegisterRpDialogStep>(
+    "configure-signer-key",
   );
   const [signerKeySetup, setSignerKeySetup] =
     useState<SignerKeySetup>("generate");
 
   const onClose = useCallback(() => {
-    props.onClose(false);
-  }, [props]);
+    onCloseDialog(false);
+  }, [onCloseDialog]);
 
   // Reset only after the leave transition: the dialog keeps rendering while it
   // fades out, so resetting in onClose would snap the content back to step one
   // mid-fade.
   const afterLeave = useCallback(() => {
-    setStep("enable-world-id-4-0");
-    setWorldIdMode("managed");
+    setStep("configure-signer-key");
     setSignerKeySetup("generate");
   }, []);
 
@@ -94,64 +78,9 @@ export const EnableWorldIdDialog = ({
     onClose();
   }, [onClose, onComplete, router]);
 
-  const onEnableContinue = useCallback(
-    (mode: "managed" | "self-managed") => {
-      setWorldIdMode(mode);
-
-      if (mode === "self-managed") {
-        setStep("self-managed-transaction");
-        return;
-      }
-
-      setStep("configure-signer-key");
-    },
-    [setWorldIdMode, setStep],
-  );
-
-  const onSelfManagedComplete = useCallback(async () => {
-    if (!teamId) {
-      toast.error("Unable to complete setup. Please close and try again.");
-      return;
-    }
-
-    try {
-      const { data } = await registerRp({
-        variables: {
-          app_id: appId,
-          mode: "self_managed",
-          signer_address: null,
-        },
-        context: {
-          fetchOptions: {
-            timeout: 30000,
-          },
-        },
-      });
-
-      if (!data?.register_rp?.rp_id) {
-        toast.error("Failed to create registration record");
-        return;
-      }
-
-      toast.success("App configured successfully");
-      completeRpSetup();
-    } catch (error) {
-      const code = getGraphQLErrorCode(error);
-
-      if (code === "already_registered") {
-        // Idempotent — treat as success
-        toast.success("App configured successfully");
-        completeRpSetup();
-        return;
-      }
-
-      toast.error("Failed to create registration record");
-    }
-  }, [teamId, registerRp, appId, completeRpSetup]);
-
   const onConfigureBack = useCallback(() => {
-    setStep("enable-world-id-4-0");
-  }, [setStep]);
+    onClose();
+  }, [onClose]);
 
   const onConfigureContinue = useCallback((setup: SignerKeySetup) => {
     setSignerKeySetup(setup);
@@ -176,12 +105,10 @@ export const EnableWorldIdDialog = ({
       }
 
       try {
-        const hasuraMode =
-          worldIdMode === "self-managed" ? "self_managed" : "managed";
         const { data } = await registerRp({
           variables: {
             app_id: appId,
-            mode: hasuraMode,
+            mode: "managed",
             signer_address: publicKey,
           },
         });
@@ -193,16 +120,16 @@ export const EnableWorldIdDialog = ({
 
         toast.success("App configured successfully");
         completeRpSetup();
-      } catch (error) {
+      } catch {
         toast.error("Failed to register Relying Party");
       }
     },
-    [teamId, worldIdMode, registerRp, appId, completeRpSetup],
+    [teamId, registerRp, appId, completeRpSetup],
   );
 
   return (
     <FormDialog
-      open={props.open}
+      open={open}
       onClose={onClose}
       afterLeave={afterLeave}
       dismissable={!registeringRp}
@@ -211,37 +138,8 @@ export const EnableWorldIdDialog = ({
       // between the overlay unmounting and the fade-in.
       appear={false}
       title={STEP_TITLES[step]}
-      closeLabel="Close World ID setup dialog"
-      // The self-managed step lists full contract addresses and a function
-      // signature — widen the panel so they fit, and let the body scroll on
-      // short viewports instead of clipping.
-      panelClassName={
-        step === "self-managed-transaction"
-          ? "max-h-[calc(100dvh-2rem)] md:w-[544px] md:max-w-[calc(100vw-2rem)]"
-          : undefined
-      }
-      bodyClassName={
-        step === "self-managed-transaction"
-          ? "min-h-0 overflow-y-auto"
-          : undefined
-      }
+      closeLabel="Close RP registration dialog"
     >
-      {step === "enable-world-id-4-0" && (
-        <EnableWorldId40Content
-          onContinue={onEnableContinue}
-          onCancel={onClose}
-          isSelfManagedEnabled={isSelfManagedEnabled}
-          initialMode={worldIdMode}
-        />
-      )}
-      {step === "self-managed-transaction" && (
-        <SelfManagedTransactionInfoContent
-          appId={appId}
-          onBack={() => setStep("enable-world-id-4-0")}
-          onComplete={onSelfManagedComplete}
-          completionLoading={registeringRp}
-        />
-      )}
       {step === "configure-signer-key" && (
         <ConfigureSignerKeyContent
           onBack={onConfigureBack}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RegisterRpEmptyState.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RegisterRpEmptyState.tsx
@@ -3,16 +3,18 @@
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { SpinnerIcon } from "@/components/Icons/SpinnerIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { generateRpIdString } from "@/lib/rp";
 import dynamic from "next/dynamic";
 import { useEffect, useRef, useState } from "react";
+import { SummaryField } from "./SummaryField";
 
 // Show a fallback while an initially open dialog loads. Mimics the dialog
 // overlay so the modal doesn't pop in from an undimmed page.
-const EnableWorldIdDialog = dynamic(
+const RegisterRpDialog = dynamic(
   () =>
     import(
       "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/EnableWorldId40/Dialog"
-    ).then((module) => module.EnableWorldIdDialog),
+    ).then((module) => module.RegisterRpDialog),
   {
     loading: () => (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-[15px]">
@@ -30,19 +32,19 @@ export const RegisterRpEmptyState = (props: {
   onRegistered: () => void;
   onSetupClosed: (completed: boolean) => void;
 }) => {
-  const canEnable = !props.isStaging && props.canManageWorldId;
-  const [open, setOpen] = useState(Boolean(props.initialOpen) && canEnable);
+  const canRegister = !props.isStaging && props.canManageWorldId;
+  const [open, setOpen] = useState(Boolean(props.initialOpen) && canRegister);
   // Keep the dialog mounted after its first open so FormDialog can play its
   // leave transition and reset its wizard state in afterLeave.
   const [hasOpened, setHasOpened] = useState(open);
   const completedRef = useRef(false);
 
   useEffect(() => {
-    if (props.initialOpen && canEnable) {
+    if (props.initialOpen && canRegister) {
       setOpen(true);
       setHasOpened(true);
     }
-  }, [props.initialOpen, canEnable]);
+  }, [props.initialOpen, canRegister]);
 
   const closeDialog = () => {
     const completed = completedRef.current;
@@ -52,41 +54,66 @@ export const RegisterRpEmptyState = (props: {
     props.onSetupClosed(completed);
   };
 
-  return (
-    <section className="flex flex-col items-start justify-between gap-5 rounded-xl border border-grey-100 bg-white p-5 sm:flex-row sm:items-center">
-      <div>
-        <Typography as="h2" variant={TYPOGRAPHY.S2}>
-          Set up World ID
-        </Typography>
-        <Typography
-          as="p"
-          variant={TYPOGRAPHY.R4}
-          className="mt-1 max-w-2xl text-grey-500"
-        >
-          {props.isStaging
-            ? "World ID isn't available for staging apps."
-            : !props.canManageWorldId
-              ? "Ask a team owner or admin to enable World ID."
-              : "Register a Relying Party to start requesting World ID verifications for this app."}
-        </Typography>
-      </div>
+  const unavailableReason = props.isStaging
+    ? "RP registration is not available for staging apps."
+    : !props.canManageWorldId
+      ? "Ask a team owner or admin to register this relying party."
+      : null;
 
-      {canEnable ? (
-        <DecoratedButton
-          type="button"
-          variant="primary"
-          className="shrink-0"
-          onClick={() => {
-            setOpen(true);
-            setHasOpened(true);
-          }}
-        >
-          Enable World ID
-        </DecoratedButton>
-      ) : null}
+  return (
+    <>
+      <section
+        aria-label="World ID configuration"
+        className="flex w-full max-w-[580px] flex-col gap-4"
+      >
+        <div className="flex flex-col gap-8">
+          <div className="flex flex-col gap-5">
+            <SummaryField label="App ID" value={props.appId} copy />
+            <SummaryField
+              label="RP ID"
+              value={generateRpIdString(props.appId)}
+              copy
+            />
+            <div className="w-full min-w-0">
+              <Typography variant={TYPOGRAPHY.B4} className="text-grey-500">
+                Signer address
+              </Typography>
+              <div className="mt-1 flex flex-col items-start gap-2">
+                <DecoratedButton
+                  type="button"
+                  variant="primary"
+                  disabled={!canRegister}
+                  className="h-9 shrink-0 rounded-full px-4 py-0 text-xs"
+                  aria-describedby={
+                    unavailableReason
+                      ? "world-id-registration-unavailable-reason"
+                      : undefined
+                  }
+                  onClick={() => {
+                    setOpen(true);
+                    setHasOpened(true);
+                  }}
+                >
+                  Register relying party
+                </DecoratedButton>
+                {unavailableReason ? (
+                  <Typography
+                    id="world-id-registration-unavailable-reason"
+                    as="p"
+                    variant={TYPOGRAPHY.B4}
+                    className="text-grey-500"
+                  >
+                    {unavailableReason}
+                  </Typography>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
 
       {hasOpened ? (
-        <EnableWorldIdDialog
+        <RegisterRpDialog
           open={open}
           appId={props.appId}
           onComplete={() => {
@@ -95,6 +122,6 @@ export const RegisterRpEmptyState = (props: {
           onClose={closeDialog}
         />
       ) : null}
-    </section>
+    </>
   );
 };

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RpSummary.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RpSummary.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { CopyButton } from "@/components/CopyButton";
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
 import { Notification } from "@/components/Notification";
@@ -8,43 +7,13 @@ import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { RpRegistrationStatus } from "@/lib/rp-registration-status";
 import { RotateSignerKeyDialog } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId40/page/RotateSignerKeyDialog";
 import { SwitchToSelfManagedDialog } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId40/page/SwitchToSelfManagedDialog";
-import { opticalIconClassName } from "@/scenes/PortalV3/common/Icon";
 import {
   type RpEnvironment,
   useRpRegistrationController,
 } from "@/scenes/common/Teams/TeamId/Apps/AppId/WorldId40/page/use-rp-registration-controller";
-import clsx from "clsx";
 import { useState } from "react";
 import { toast } from "react-toastify";
-
-const SummaryField = (props: {
-  label: string;
-  value: string;
-  copy?: boolean;
-}) => (
-  <div className="w-full min-w-0">
-    <Typography variant={TYPOGRAPHY.B4} className="text-grey-500">
-      {props.label}
-    </Typography>
-    <div className="mt-1 flex min-w-0 items-center justify-between gap-2">
-      <Typography
-        variant={TYPOGRAPHY.B3}
-        className="min-w-0 truncate text-grey-900"
-        title={props.value}
-      >
-        {props.value}
-      </Typography>
-      {props.copy ? (
-        <CopyButton
-          fieldName={props.label}
-          fieldValue={props.value}
-          className="ml-auto shrink-0 !pr-0 text-grey-500"
-          iconClassName={clsx("!size-4", opticalIconClassName)}
-        />
-      ) : null}
-    </div>
-  </div>
-);
+import { SummaryField } from "./SummaryField";
 
 export const RpSummary = (props: {
   appId: string;
@@ -78,13 +47,13 @@ export const RpSummary = (props: {
   const signerAddress = isSelfManaged
     ? "Unavailable in Portal"
     : props.signerAddress ?? "Not available";
-  const controlsDisabledReason = !props.canManageWorldId
-    ? "Ask a team owner or admin to change RP settings."
-    : isSelfManaged
-      ? "Signer keys are managed outside the Portal."
-      : !isActive
-        ? "The RP must be active before its configuration can be changed."
-        : null;
+  const controlsDisabledReason = isActive
+    ? !props.canManageWorldId
+      ? "Ask a team owner or admin to change RP settings."
+      : isSelfManaged
+        ? "Signer keys are managed outside the Portal."
+        : null
+    : null;
   const handleConfigurationChanged = () => {
     markProductionPending();
     props.onRpChanged?.(RpRegistrationStatus.Pending);
@@ -145,100 +114,104 @@ export const RpSummary = (props: {
             />
           </div>
 
-          <div className="flex flex-col gap-6">
-            {controlsDisabledReason ? (
-              <Typography
-                id="world-id-configuration-disabled-reason"
-                as="p"
-                variant={TYPOGRAPHY.B4}
-                className="text-grey-500"
-              >
-                {controlsDisabledReason}
-              </Typography>
-            ) : null}
+          {isActive ? (
+            <div className="flex flex-col gap-6">
+              {controlsDisabledReason ? (
+                <Typography
+                  id="world-id-configuration-disabled-reason"
+                  as="p"
+                  variant={TYPOGRAPHY.B4}
+                  className="text-grey-500"
+                >
+                  {controlsDisabledReason}
+                </Typography>
+              ) : null}
 
-            <div className="flex flex-col gap-4">
-              <Typography as="h3" variant={TYPOGRAPHY.S2}>
-                Key
-              </Typography>
+              <div className="flex flex-col gap-4">
+                <Typography as="h3" variant={TYPOGRAPHY.S2}>
+                  Key
+                </Typography>
 
-              <div className="flex items-center justify-between gap-4 rounded-xl border border-grey-100 p-6">
-                <div className="flex flex-col gap-1">
-                  <Typography variant={TYPOGRAPHY.S2}>
+                <div className="flex items-center justify-between gap-4 rounded-xl border border-grey-100 p-6">
+                  <div className="flex flex-col gap-1">
+                    <Typography variant={TYPOGRAPHY.S2}>
+                      Rotate signer key
+                    </Typography>
+                    <Typography
+                      variant={TYPOGRAPHY.B3}
+                      className="text-grey-500"
+                    >
+                      This will create a new signer key and disable the existing
+                      key
+                    </Typography>
+                  </div>
+
+                  <DecoratedButton
+                    type="button"
+                    variant="secondary"
+                    disabled={!props.canManageWorldId || isSelfManaged}
+                    className="h-8 shrink-0 rounded-full px-4 py-0 text-xs"
+                    aria-describedby={
+                      controlsDisabledReason
+                        ? "world-id-configuration-disabled-reason"
+                        : undefined
+                    }
+                    onClick={() => setIsRotateOpen(true)}
+                  >
                     Rotate signer key
-                  </Typography>
-                  <Typography variant={TYPOGRAPHY.B3} className="text-grey-500">
-                    This will create a new signer key and disable the existing
-                    key
-                  </Typography>
+                  </DecoratedButton>
                 </div>
-
-                <DecoratedButton
-                  type="button"
-                  variant="secondary"
-                  disabled={
-                    !props.canManageWorldId || !isActive || isSelfManaged
-                  }
-                  className="h-8 shrink-0 rounded-full px-4 py-0 text-xs"
-                  aria-describedby={
-                    controlsDisabledReason
-                      ? "world-id-configuration-disabled-reason"
-                      : undefined
-                  }
-                  onClick={() => setIsRotateOpen(true)}
-                >
-                  Rotate signer key
-                </DecoratedButton>
               </div>
-            </div>
 
-            <div className="flex flex-col gap-4">
-              <Typography as="h3" variant={TYPOGRAPHY.S2}>
-                Danger zone
-              </Typography>
+              <div className="flex flex-col gap-4">
+                <Typography as="h3" variant={TYPOGRAPHY.S2}>
+                  Danger zone
+                </Typography>
 
-              <div className="flex items-center justify-between gap-4 rounded-[10px] border border-grey-100 px-6 py-4">
-                <div className="flex flex-col gap-1">
-                  <Typography variant={TYPOGRAPHY.S2}>
+                <div className="flex items-center justify-between gap-4 rounded-[10px] border border-grey-100 px-6 py-4">
+                  <div className="flex flex-col gap-1">
+                    <Typography variant={TYPOGRAPHY.S2}>
+                      Switch to self-managed
+                    </Typography>
+                    <Typography
+                      variant={TYPOGRAPHY.B3}
+                      className="text-grey-500"
+                    >
+                      Move this RP to a self-managed configuration
+                    </Typography>
+                  </div>
+
+                  <DestructiveTriggerButton
+                    disabled={!props.canManageWorldId || isSelfManaged}
+                    className="shrink-0"
+                    aria-describedby={
+                      controlsDisabledReason
+                        ? "world-id-configuration-disabled-reason"
+                        : undefined
+                    }
+                    onClick={() => setIsSwitchOpen(true)}
+                  >
                     Switch to self-managed
-                  </Typography>
-                  <Typography variant={TYPOGRAPHY.B3} className="text-grey-500">
-                    Move this RP to a self-managed configuration
-                  </Typography>
+                  </DestructiveTriggerButton>
                 </div>
-
-                <DestructiveTriggerButton
-                  disabled={
-                    !props.canManageWorldId || !isActive || isSelfManaged
-                  }
-                  className="shrink-0"
-                  aria-describedby={
-                    controlsDisabledReason
-                      ? "world-id-configuration-disabled-reason"
-                      : undefined
-                  }
-                  onClick={() => setIsSwitchOpen(true)}
-                >
-                  Switch to self-managed
-                </DestructiveTriggerButton>
               </div>
             </div>
-          </div>
+          ) : null}
         </div>
 
         {productionStatus === RpRegistrationStatus.Pending ? (
           <Notification variant="info">
             <div>
               <Typography as="p" variant={TYPOGRAPHY.S3}>
-                Configuration update pending
+                Registration in progress
               </Typography>
               <Typography
                 as="p"
                 variant={TYPOGRAPHY.S4}
                 className="mt-1 text-grey-500"
               >
-                World ID configuration changes will be available after the
-                update completes.
+                Your relying party is being registered on-chain. This usually
+                takes a few minutes.
               </Typography>
             </div>
           </Notification>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RpSummary.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RpSummary.tsx
@@ -210,8 +210,8 @@ export const RpSummary = (props: {
                 variant={TYPOGRAPHY.S4}
                 className="mt-1 text-grey-500"
               >
-                Your relying party configuration is being processed on-chain.
-                This usually takes a few minutes.
+                Your changes are being processed on-chain. This could take up to
+                a minute.
               </Typography>
             </div>
           </Notification>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RpSummary.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RpSummary.tsx
@@ -203,15 +203,15 @@ export const RpSummary = (props: {
           <Notification variant="info">
             <div>
               <Typography as="p" variant={TYPOGRAPHY.S3}>
-                Registration in progress
+                Configuration in progress
               </Typography>
               <Typography
                 as="p"
                 variant={TYPOGRAPHY.S4}
                 className="mt-1 text-grey-500"
               >
-                Your relying party is being registered on-chain. This usually
-                takes a few minutes.
+                Your relying party configuration is being processed on-chain.
+                This usually takes a few minutes.
               </Typography>
             </div>
           </Notification>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/SummaryField.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/SummaryField.tsx
@@ -1,0 +1,33 @@
+import { CopyButton } from "@/components/CopyButton";
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { opticalIconClassName } from "@/scenes/PortalV3/common/Icon";
+import clsx from "clsx";
+
+export const SummaryField = (props: {
+  label: string;
+  value: string;
+  copy?: boolean;
+}) => (
+  <div className="w-full min-w-0">
+    <Typography variant={TYPOGRAPHY.B4} className="text-grey-500">
+      {props.label}
+    </Typography>
+    <div className="mt-1 flex min-w-0 items-center justify-between gap-2">
+      <Typography
+        variant={TYPOGRAPHY.B3}
+        className="min-w-0 truncate text-grey-900"
+        title={props.value}
+      >
+        {props.value}
+      </Typography>
+      {props.copy ? (
+        <CopyButton
+          fieldName={props.label}
+          fieldValue={props.value}
+          className="ml-auto shrink-0 !pr-0 text-grey-500"
+          iconClassName={clsx("!size-4", opticalIconClassName)}
+        />
+      ) : null}
+    </div>
+  </div>
+);

--- a/web/tests/e2e/specs/app.spec.ts
+++ b/web/tests/e2e/specs/app.spec.ts
@@ -32,10 +32,10 @@ test.describe("App", () => {
       new RegExp(`/teams/${constants.teamId}/apps/app_[a-f0-9]+/world-id$`),
     );
     await expect(
-      page.getByRole("heading", { name: "Set up World ID" }),
+      page.getByRole("heading", { name: "World ID Configuration" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Enable World ID" }),
+      page.getByRole("button", { name: "Register relying party" }),
     ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Create action" }),

--- a/web/tests/unit/pv3-world-id-rp-summary.test.tsx
+++ b/web/tests/unit/pv3-world-id-rp-summary.test.tsx
@@ -127,7 +127,7 @@ it("shows the vertical RP identity fields and separated management controls", ()
 });
 
 it.each([
-  [RpRegistrationStatus.Pending, "Configuration update pending"],
+  [RpRegistrationStatus.Pending, "Registration in progress"],
   [RpRegistrationStatus.Failed, "Production registration failed"],
   [RpRegistrationStatus.Deactivated, "Registration deactivated"],
 ])("keeps the RP identity visible in the %s state", (status, message) => {
@@ -137,11 +137,11 @@ it.each([
   expect(screen.getByText(message)).toBeInTheDocument();
   expect(screen.getByText("rp_1234567890abcdef")).toBeInTheDocument();
   expect(
-    screen.getByRole("button", { name: "Rotate signer key" }),
-  ).toBeDisabled();
+    screen.queryByRole("button", { name: "Rotate signer key" }),
+  ).not.toBeInTheDocument();
   expect(
-    screen.getByRole("button", { name: "Switch to self-managed" }),
-  ).toBeDisabled();
+    screen.queryByRole("button", { name: "Switch to self-managed" }),
+  ).not.toBeInTheDocument();
 });
 
 it("explains self-managed signer ownership and disables Portal controls", () => {

--- a/web/tests/unit/pv3-world-id-rp-summary.test.tsx
+++ b/web/tests/unit/pv3-world-id-rp-summary.test.tsx
@@ -127,7 +127,7 @@ it("shows the vertical RP identity fields and separated management controls", ()
 });
 
 it.each([
-  [RpRegistrationStatus.Pending, "Registration in progress"],
+  [RpRegistrationStatus.Pending, "Configuration in progress"],
   [RpRegistrationStatus.Failed, "Production registration failed"],
   [RpRegistrationStatus.Deactivated, "Registration deactivated"],
 ])("keeps the RP identity visible in the %s state", (status, message) => {

--- a/web/tests/unit/pv3-world-id-unregistered-summary.test.tsx
+++ b/web/tests/unit/pv3-world-id-unregistered-summary.test.tsx
@@ -1,0 +1,77 @@
+/** @jest-environment jsdom */
+
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { generateRpIdString } from "@/lib/rp";
+import { RegisterRpEmptyState } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RegisterRpEmptyState";
+
+jest.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => (props: { open: boolean }) =>
+    props.open ? <div role="dialog">Configure signer key</div> : null,
+}));
+
+const defaultProps = {
+  appId: "app_9cdd0a714aec9ed17dca660bc9ffe72a",
+  isStaging: false,
+  canManageWorldId: true,
+  onRegistered: jest.fn(),
+  onSetupClosed: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it("shows the finalized configuration shape before registration", () => {
+  render(<RegisterRpEmptyState {...defaultProps} />);
+
+  expect(
+    screen.getByRole("region", { name: "World ID configuration" }),
+  ).toBeInTheDocument();
+  expect(screen.getByText(defaultProps.appId)).toBeInTheDocument();
+  expect(
+    screen.getByText(generateRpIdString(defaultProps.appId)),
+  ).toBeInTheDocument();
+  expect(screen.getByText("Signer address")).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Register relying party" }),
+  ).toBeEnabled();
+  expect(
+    screen.queryByRole("button", { name: "Rotate signer key" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Switch to self-managed" }),
+  ).not.toBeInTheDocument();
+  expect(screen.queryByText(/Enable World ID/i)).not.toBeInTheDocument();
+  expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+});
+
+it("opens managed signer setup directly from the signer-address slot", () => {
+  render(<RegisterRpEmptyState {...defaultProps} />);
+
+  fireEvent.click(
+    screen.getByRole("button", { name: "Register relying party" }),
+  );
+
+  expect(screen.getByRole("dialog")).toHaveTextContent("Configure signer key");
+});
+
+it.each([
+  [{ isStaging: true }, "RP registration is not available for staging apps."],
+  [
+    { canManageWorldId: false },
+    "Ask a team owner or admin to register this relying party.",
+  ],
+])(
+  "keeps the summary visible when registration is unavailable",
+  (overrides, reason) => {
+    render(<RegisterRpEmptyState {...defaultProps} {...overrides} />);
+
+    expect(screen.getByText(defaultProps.appId)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Register relying party" }),
+    ).toBeDisabled();
+    expect(screen.getByText(reason)).toBeInTheDocument();
+  },
+);

--- a/web/tests/unit/world-id-key-step-loading.test.tsx
+++ b/web/tests/unit/world-id-key-step-loading.test.tsx
@@ -1,19 +1,40 @@
 /** @jest-environment jsdom */
 
 import "@testing-library/jest-dom";
-import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import React, { Suspense } from "react";
 
 let mockKeyStepReady = false;
 let mockPendingKeyStep: Promise<void>;
 let mockResolvePendingKeyStep: () => void;
+const registerRp = jest.fn();
+const refresh = jest.fn();
 
-function mockGenerateKeyStep() {
+function mockGenerateKeyStep(props: {
+  onContinue: (publicKey: string) => void;
+}) {
   if (!mockKeyStepReady) {
     throw mockPendingKeyStep;
   }
 
-  return <div data-testid="generate-key-step">Generate key step loaded</div>;
+  return (
+    <button
+      type="button"
+      data-testid="generate-key-step"
+      onClick={() =>
+        props.onContinue("0x1234567890abcdef1234567890abcdef12345678")
+      }
+    >
+      Generate key step loaded
+    </button>
+  );
 }
 
 function mockExistingKeyStep() {
@@ -32,11 +53,11 @@ jest.mock("next/dynamic", () => ({
 }));
 
 jest.mock("@apollo/client/react", () => ({
-  useMutation: () => [jest.fn(), { loading: false }],
+  useMutation: () => [registerRp, { loading: false }],
 }));
 jest.mock("next/navigation", () => ({
   useParams: () => ({ teamId: "team_1" }),
-  useRouter: () => ({ refresh: jest.fn(), replace: jest.fn() }),
+  useRouter: () => ({ refresh, replace: jest.fn() }),
 }));
 jest.mock("react-toastify", () => ({
   toast: { error: jest.fn(), success: jest.fn() },
@@ -78,10 +99,6 @@ jest.mock(
   () => ({ SelfManagedTransactionInfoContent: () => null }),
 );
 jest.mock(
-  "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/EnableWorldId40/SelfManagedTransactionInfo/SelfManagedTransactionInfoContent",
-  () => ({ SelfManagedTransactionInfoContent: () => null }),
-);
-jest.mock(
   "@/scenes/Portal/Teams/TeamId/Apps/AppId/GenerateNewKey/GenerateNewKeyContent",
   () => ({ GenerateNewKeyContent: mockGenerateKeyStep }),
 );
@@ -99,16 +116,17 @@ jest.mock(
 );
 
 import { EnableWorldIdDialog as PortalDialog } from "@/scenes/Portal/Teams/TeamId/Apps/AppId/EnableWorldId40/Dialog";
-import { EnableWorldIdDialog as PortalV3Dialog } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/EnableWorldId40/Dialog";
+import { RegisterRpDialog as PortalV3Dialog } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/EnableWorldId40/Dialog";
 
 const cases = [
-  ["Portal", "generate", PortalDialog],
-  ["Portal", "existing", PortalDialog],
-  ["PortalV3", "generate", PortalV3Dialog],
-  ["PortalV3", "existing", PortalV3Dialog],
+  ["Portal", "generate", PortalDialog, true],
+  ["Portal", "existing", PortalDialog, true],
+  ["PortalV3", "generate", PortalV3Dialog, false],
+  ["PortalV3", "existing", PortalV3Dialog, false],
 ] as const;
 
 beforeEach(() => {
+  jest.clearAllMocks();
   mockKeyStepReady = false;
   mockPendingKeyStep = new Promise((resolve) => {
     mockResolvePendingKeyStep = () => {
@@ -120,7 +138,7 @@ beforeEach(() => {
 
 it.each(cases)(
   "%s keeps Configure visible while the %s key step suspends",
-  async (_portal, setup, DialogComponent) => {
+  async (_portal, setup, DialogComponent, hasEnableStep) => {
     render(
       <Suspense fallback={<div data-testid="outer-loading" />}>
         <DialogComponent
@@ -131,7 +149,9 @@ it.each(cases)(
       </Suspense>,
     );
 
-    fireEvent.click(screen.getByTestId("button-enable-world-id-40-continue"));
+    if (hasEnableStep) {
+      fireEvent.click(screen.getByTestId("button-enable-world-id-40-continue"));
+    }
     // Title case in Portal, sentence case in the PortalV3 modal header.
     await screen.findByText(/configure signer key/i);
 
@@ -167,3 +187,39 @@ it.each(cases)(
     ).not.toBeInTheDocument();
   },
 );
+
+it("PortalV3 registers the relying party in managed mode", async () => {
+  mockKeyStepReady = true;
+  registerRp.mockResolvedValue({
+    data: { register_rp: { rp_id: "rp_1234567890abcdef" } },
+  });
+  const onComplete = jest.fn();
+  const onClose = jest.fn();
+
+  render(
+    <PortalV3Dialog
+      appId="app_00000000000000000000000000000000"
+      onComplete={onComplete}
+      onClose={onClose}
+      open
+    />,
+  );
+
+  expect(screen.getByText("Configure signer key")).toBeInTheDocument();
+  expect(screen.queryByText("Enable World ID")).not.toBeInTheDocument();
+  fireEvent.click(screen.getByTestId("button-configure-signer-key-continue"));
+  fireEvent.click(await screen.findByTestId("generate-key-step"));
+
+  await waitFor(() =>
+    expect(registerRp).toHaveBeenCalledWith({
+      variables: {
+        app_id: "app_00000000000000000000000000000000",
+        mode: "managed",
+        signer_address: "0x1234567890abcdef1234567890abcdef12345678",
+      },
+    }),
+  );
+  expect(onComplete).toHaveBeenCalledTimes(1);
+  expect(refresh).toHaveBeenCalledTimes(1);
+  expect(onClose).toHaveBeenCalledWith(false);
+});


### PR DESCRIPTION
This PR simplifies World ID relying party setup while preserving the existing registered configuration controls.

- shows the finalized Configuration view before RP registration, with deterministic App and RP IDs and a registration action in the signer-address slot
- opens managed signer-key setup directly and removes the separate enablement and initial mode-selection flow
- keeps RP identity and registration progress visible while hiding rotate and switch controls until registration completes
- preserves the existing Key and Danger zone cards for registered RPs
- adds focused unit coverage and updates the create-app E2E expectation
- validates with 44 focused tests, TypeScript, ESLint, Prettier, and a clean staged secret scan