### PR TITLE
feat(portal): redesign team settings navigation

### DIFF
--- a/web/app/(portal)/teams/[teamId]/(team)/settings/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/(team)/settings/page.tsx
@@ -8,9 +8,17 @@ export const metadata: Metadata = {
   title: generateMetaTitle({ left: "Team settings" }),
 };
 
-export default async function Page() {
+type TeamSettingsSearchParams = {
+  tab?: string | string[];
+};
+
+export default async function Page(
+  props: { searchParams?: Promise<TeamSettingsSearchParams> } = {},
+) {
+  const searchParams = (await props.searchParams) ?? {};
+
   return pickPortalVersion(
-    () => <TeamSettingsPageV3 />,
+    () => <TeamSettingsPageV3 requestedTab={searchParams.tab} />,
     () => <TeamSettingsPage />,
   );
 }

--- a/web/components/LoggedUserNav/index.tsx
+++ b/web/components/LoggedUserNav/index.tsx
@@ -164,7 +164,14 @@ export const LoggedUserNav = () => {
 
               {hasOwnerPermission && (
                 <Dropdown.ListItem asChild>
-                  <Link href={`/teams/${teamId}/settings`}>
+                  <Link
+                    href={urls.teamSettings({
+                      team_id: teamRes.data.team.id,
+                      return_to: urls.teams({
+                        team_id: teamRes.data.team.id,
+                      }),
+                    })}
+                  >
                     <Dropdown.ListItemIcon asChild>
                       <SettingsIcon />
                     </Dropdown.ListItemIcon>

--- a/web/lib/team-settings.ts
+++ b/web/lib/team-settings.ts
@@ -1,0 +1,58 @@
+import { urls } from "./urls";
+
+export const TEAM_SETTINGS_TABS = {
+  General: "general",
+  Members: "members",
+  ApiKeys: "api-keys",
+} as const;
+
+export type TeamSettingsTab =
+  (typeof TEAM_SETTINGS_TABS)[keyof typeof TEAM_SETTINGS_TABS];
+
+type QueryValue = string | string[] | undefined;
+
+const portalOrigin = "https://developer.worldcoin.org";
+
+export const getPortalReturnTo = (value: QueryValue): string | null => {
+  if (
+    typeof value !== "string" ||
+    !value.startsWith("/") ||
+    value.startsWith("//") ||
+    value.includes("\\")
+  ) {
+    return null;
+  }
+
+  try {
+    const returnTo = new URL(value, portalOrigin);
+
+    if (returnTo.origin !== portalOrigin) {
+      return null;
+    }
+
+    return `${returnTo.pathname}${returnTo.search}${returnTo.hash}`;
+  } catch {
+    return null;
+  }
+};
+
+export const resolvePortalReturnTo = (value: QueryValue): string =>
+  getPortalReturnTo(value) ?? urls.dashboard();
+
+export const resolveTeamSettingsTab = (
+  value: QueryValue,
+  canViewApiKeys: boolean,
+): TeamSettingsTab => {
+  if (value === TEAM_SETTINGS_TABS.Members) {
+    return TEAM_SETTINGS_TABS.Members;
+  }
+
+  if (value === TEAM_SETTINGS_TABS.ApiKeys && canViewApiKeys) {
+    return TEAM_SETTINGS_TABS.ApiKeys;
+  }
+
+  return TEAM_SETTINGS_TABS.General;
+};
+
+export const isTeamSettingsPath = (pathname: string): boolean =>
+  /^\/teams\/[^/]+\/settings\/?$/.test(pathname);

--- a/web/lib/urls.ts
+++ b/web/lib/urls.ts
@@ -130,8 +130,24 @@ export const urls = {
   teamApiKeys: (params: { team_id: string }): string =>
     `/teams/${params.team_id}/api-keys`,
 
-  teamSettings: (params: { team_id: string }): string =>
-    `/teams/${params.team_id}/settings`,
+  teamSettings: (params: {
+    team_id: string;
+    return_to?: string;
+    tab?: string;
+  }): string => {
+    const searchParams = new URLSearchParams();
+
+    if (params.return_to) {
+      searchParams.set("return_to", params.return_to);
+    }
+
+    if (params.tab) {
+      searchParams.set("tab", params.tab);
+    }
+
+    const query = searchParams.toString();
+    return `/teams/${params.team_id}/settings${query ? `?${query}` : ""}`;
+  },
 
   profile: (): "/profile" => "/profile",
   profileTeams: (): "/profile/teams" => "/profile/teams",

--- a/web/scenes/Portal/Profile/Teams/page/List/Item/index.tsx
+++ b/web/scenes/Portal/Profile/Teams/page/List/Item/index.tsx
@@ -144,6 +144,7 @@ export const Item = (props: ItemsProps) => {
                     <Link
                       href={urls.teamSettings({
                         team_id: item.team.id,
+                        return_to: urls.profile(),
                       })}
                     >
                       <Dropdown.ListItemIcon asChild>

--- a/web/scenes/PortalV3/Profile/Teams/page/LeaveTeamDialog/index.tsx
+++ b/web/scenes/PortalV3/Profile/Teams/page/LeaveTeamDialog/index.tsx
@@ -12,13 +12,10 @@ import { toast } from "react-toastify";
 import { useMutation } from "@apollo/client/react";
 import { LeaveTeamDocument } from "@/scenes/common/Profile/Teams/page/LeaveTeamDialog/graphql/client/leave-team.generated";
 
-import {
-  FetchMeDocument,
-  FetchMeQuery,
-} from "@/scenes/common/me-query/client/graphql/client/me-query.generated";
+import { FetchMeDocument } from "@/scenes/common/me-query/client/graphql/client/me-query.generated";
 
 type LeaveTeamDialogProps = DialogProps & {
-  team?: NonNullable<FetchMeQuery["user_by_pk"]>["memberships"][0]["team"];
+  team?: { id: string; name?: string | null };
 };
 
 export const LeaveTeamDialog = (props: LeaveTeamDialogProps) => {
@@ -41,7 +38,7 @@ export const LeaveTeamDialog = (props: LeaveTeamDialogProps) => {
         refetchQueries: [FetchMeDocument],
       });
 
-      toast.success("Team leaved!");
+      toast.success("You left the team");
       props.onClose(true);
     } catch (e) {
       console.error("Leave Team Dialog: ", e);

--- a/web/scenes/PortalV3/Profile/Teams/page/List/Item/index.tsx
+++ b/web/scenes/PortalV3/Profile/Teams/page/List/Item/index.tsx
@@ -94,6 +94,7 @@ export const Item = (props: ItemsProps) => {
                 <Link
                   href={urls.teamSettings({
                     team_id: item.team.id,
+                    return_to: urls.profile(),
                   })}
                 >
                   <Dropdown.ListItemIcon asChild>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/TextField.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/TextField.tsx
@@ -29,9 +29,12 @@ export const TextField = (props: {
   maxLength?: number;
   trailing?: ReactNode;
   className?: string;
+  /** Keep the field accessible while omitting a label already shown nearby. */
+  hideLabel?: boolean;
 }) => {
   const [isFocused, setIsFocused] = useState(false);
-  const isFloating = props.readOnly || isFocused || props.value.length > 0;
+  const isFloating =
+    !props.hideLabel && (props.readOnly || isFocused || props.value.length > 0);
   const isInert = props.readOnly || props.disabled;
 
   const requiredMark = props.required && (
@@ -58,20 +61,23 @@ export const TextField = (props: {
         )}
       >
         <span className="flex min-w-0 flex-1 flex-col overflow-clip">
-          <span
-            className={clsx(
-              "w-full text-13 leading-[1.3] font-[350]",
-              props.error ? "text-[#ea392a]" : "text-portal-subtle",
-              !isFloating && "hidden",
-            )}
-          >
-            {props.label}
-            {requiredMark}
-          </span>
+          {!props.hideLabel && (
+            <span
+              className={clsx(
+                "w-full text-13 leading-[1.3] font-[350]",
+                props.error ? "text-[#ea392a]" : "text-portal-subtle",
+                !isFloating && "hidden",
+              )}
+            >
+              {props.label}
+              {requiredMark}
+            </span>
+          )}
           <input
             name={props.name}
             type={props.type ?? "text"}
             value={props.value}
+            aria-label={props.hideLabel ? props.label : undefined}
             readOnly={props.readOnly}
             disabled={props.disabled}
             maxLength={props.maxLength}
@@ -83,10 +89,10 @@ export const TextField = (props: {
             }}
             className={clsx(
               "w-full min-w-0 bg-transparent p-0 text-15 leading-[1.3] font-[350] text-portal-ink outline-none",
-              !isFloating && "sr-only",
+              !props.hideLabel && !isFloating && "sr-only",
             )}
           />
-          {!isFloating && (
+          {!props.hideLabel && !isFloating && (
             <span className="w-full text-15 leading-[1.3] font-[350] text-portal-subtle">
               {props.label}
               {requiredMark}

--- a/web/scenes/PortalV3/Teams/TeamId/Team/Settings/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/Settings/page/index.tsx
@@ -1,19 +1,27 @@
 "use client";
 import { SizingWrapper } from "@/components/SizingWrapper";
 import { Role_Enum } from "@/graphql/graphql";
+import {
+  resolveTeamSettingsTab,
+  TEAM_SETTINGS_TABS,
+} from "@/lib/team-settings";
 import { Auth0SessionUser } from "@/lib/types";
 import { checkUserPermissions } from "@/lib/utils";
 import { FetchTeamDocument } from "@/scenes/common/Teams/TeamId/Team/common/TeamProfile/graphql/client/fetch-team.generated";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { useQuery } from "@apollo/client/react";
 import { useParams } from "next/navigation";
+import { SettingsPanel } from "../../common/SettingsPanel";
 import { ApiKeys } from "../../sections/ApiKeys";
 import { McpSetup } from "../../sections/ApiKeys/McpSetup";
 import { TeamDangerZone } from "../../sections/DangerZone";
+import { LeaveTeam } from "../../sections/LeaveTeam";
 import { Members } from "../../sections/Members";
 import { TeamSettingsForm } from "../../sections/SettingsForm";
 
-export const TeamSettingsPage = () => {
+type QueryValue = string | string[] | undefined;
+
+export const TeamSettingsPage = (props: { requestedTab?: QueryValue }) => {
   const { teamId } = useParams() as { teamId: string };
   const { user } = useUser() as Auth0SessionUser;
 
@@ -27,11 +35,13 @@ export const TeamSettingsPage = () => {
     Role_Enum.Owner,
     Role_Enum.Admin,
   ]);
+  const activeTab = resolveTeamSettingsTab(props.requestedTab, canViewApiKeys);
 
-  // Single team fetch for the whole settings page. The name form and the danger
-  // zone read from this instead of each firing their own useFetchTeamQuery.
+  // Only General needs the team record. Members and credentials own their
+  // separate queries, so switching tabs does not fetch hidden page sections.
   const { data, refetch: refetchTeam } = useQuery(FetchTeamDocument, {
     variables: { teamId },
+    skip: activeTab !== TEAM_SETTINGS_TABS.General,
   });
   const team = data?.team_by_pk;
 
@@ -40,29 +50,80 @@ export const TeamSettingsPage = () => {
       gridClassName="order-1 grow"
       className="mx-auto w-full max-w-[1120px]"
     >
-      <div className="flex flex-col gap-5 py-8 pb-28 md:py-10 md:pb-28">
-        <TeamSettingsForm
-          teamId={teamId}
-          teamName={team?.name ?? ""}
-          memberCount={team?.memberships.length ?? 0}
-          canWrite={canWriteTeamSettings}
-          onSaved={refetchTeam}
-        />
+      <div className="flex flex-col py-8 pb-28 md:py-10 md:pb-28">
+        <header className="mb-6">
+          <h1 className="font-twk text-24 leading-[1.2] font-[550] text-portal-heading">
+            Team settings
+          </h1>
+        </header>
 
-        <Members teamId={teamId} />
+        <div className="grid gap-5">
+          {activeTab === TEAM_SETTINGS_TABS.General ? (
+            <>
+              <SettingsPanel>
+                <SettingsPanel.Header>
+                  <SettingsPanel.Title>Team name</SettingsPanel.Title>
+                </SettingsPanel.Header>
+                <SettingsPanel.Body className="border-t border-grey-100 px-5 py-5">
+                  <TeamSettingsForm
+                    teamId={teamId}
+                    teamName={team?.name ?? ""}
+                    canWrite={canWriteTeamSettings}
+                    onSaved={refetchTeam}
+                  />
+                </SettingsPanel.Body>
+              </SettingsPanel>
 
-        {canViewApiKeys ? (
-          <>
+              <McpSetup />
+
+              {team ? (
+                <SettingsPanel tone="danger">
+                  <SettingsPanel.Header>
+                    <SettingsPanel.Title>Danger zone</SettingsPanel.Title>
+                  </SettingsPanel.Header>
+                  <SettingsPanel.Body className="border-t border-system-error-100">
+                    {canWriteTeamSettings ? (
+                      <div className="flex flex-col gap-4 px-5 py-5 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                          <h3 className="font-world text-13 font-medium text-grey-900">
+                            Delete team
+                          </h3>
+                          <p className="mt-1 font-gta text-13 leading-5 text-grey-400">
+                            Permanently delete this team and all of its apps.
+                          </p>
+                        </div>
+                        <TeamDangerZone
+                          team={{ id: team.id, name: team.name }}
+                        />
+                      </div>
+                    ) : (
+                      <div className="flex flex-col gap-4 px-5 py-5 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                          <h3 className="font-world text-13 font-medium text-grey-900">
+                            Leave team
+                          </h3>
+                          <p className="mt-1 font-gta text-13 leading-5 text-grey-400">
+                            You will need another invitation to rejoin this
+                            team.
+                          </p>
+                        </div>
+                        <LeaveTeam team={{ id: team.id, name: team.name }} />
+                      </div>
+                    )}
+                  </SettingsPanel.Body>
+                </SettingsPanel>
+              ) : null}
+            </>
+          ) : null}
+
+          {activeTab === TEAM_SETTINGS_TABS.Members ? (
+            <Members teamId={teamId} />
+          ) : null}
+
+          {activeTab === TEAM_SETTINGS_TABS.ApiKeys && canViewApiKeys ? (
             <ApiKeys teamId={teamId} canWrite={canWriteTeamSettings} />
-            <McpSetup />
-          </>
-        ) : null}
-
-        {canWriteTeamSettings && team ? (
-          <div className="flex justify-end">
-            <TeamDangerZone team={{ id: team.id, name: team.name }} />
-          </div>
-        ) : null}
+          ) : null}
+        </div>
       </div>
     </SizingWrapper>
   );

--- a/web/scenes/PortalV3/Teams/TeamId/Team/sections/LeaveTeam/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/sections/LeaveTeam/index.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { DestructiveTriggerButton } from "@/components/DestructiveTriggerButton";
+import { urls } from "@/lib/urls";
+import { LeaveTeamDialog } from "@/scenes/PortalV3/Profile/Teams/page/LeaveTeamDialog";
+import { useUser } from "@auth0/nextjs-auth0/client";
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+
+export const LeaveTeam = (props: {
+  team: { id: string; name?: string | null };
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { invalidate } = useUser();
+  const router = useRouter();
+
+  const close = useCallback(
+    async (didLeave: boolean) => {
+      setIsOpen(false);
+
+      if (!didLeave) {
+        return;
+      }
+
+      const response = await fetch("/api/update-session", {
+        method: "POST",
+      }).catch(() => null);
+
+      if (response?.ok) {
+        await invalidate();
+      }
+
+      router.refresh();
+      router.push(urls.dashboard());
+    },
+    [invalidate, router],
+  );
+
+  return (
+    <>
+      <DestructiveTriggerButton onClick={() => setIsOpen(true)}>
+        Leave team
+      </DestructiveTriggerButton>
+
+      <LeaveTeamDialog team={props.team} open={isOpen} onClose={close} />
+    </>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Team/sections/SettingsForm/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/sections/SettingsForm/index.tsx
@@ -1,12 +1,17 @@
 "use client";
 import { teamNameSchema } from "@/lib/schema";
 import { useRefetchQueries } from "@/lib/use-refetch-queries";
-import { Image as TeamImage } from "@/scenes/PortalV3/Teams/TeamId/Team/common/TeamProfile/Image";
+import { TextField } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/TextField";
+import {
+  AutosaveStatus,
+  useAutosave,
+} from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/hook/use-autosave";
 import { FetchMeDocument } from "@/scenes/common/me-query/client/graphql/client/me-query.generated";
+import { useUser } from "@auth0/nextjs-auth0/client";
 import { yupResolver } from "@hookform/resolvers/yup";
-import clsx from "clsx";
-import { useCallback, useEffect } from "react";
-import { useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef } from "react";
+import { Controller, useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import * as yup from "yup";
 import { validateAndUpdateTeamServerSide } from "../../Settings/server/submit";
@@ -21,119 +26,103 @@ type FormValues = yup.InferType<typeof schema>;
 
 // Team name comes from the parent settings page (single fetch); `onSaved` lets
 // the parent refetch after a successful update so its copy stays in sync.
-// `canWrite` makes the display-name field read-only for non-owners.
+// `canWrite` makes the display-name field unavailable to non-owners.
 export const TeamSettingsForm = (props: {
   teamId: string;
   teamName: string;
-  memberCount: number;
   canWrite: boolean;
   onSaved?: () => void;
 }) => {
-  const { teamId, teamName, memberCount, canWrite, onSaved } = props;
+  const { teamId, teamName, canWrite, onSaved } = props;
   const { refetch: refetchMe } = useRefetchQueries(FetchMeDocument);
+  const { invalidate } = useUser();
+  const router = useRouter();
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    formState: { isDirty, isValid, errors, isSubmitting },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     defaultValues: {
       name: teamName,
     },
     resolver: yupResolver(schema),
     mode: "onChange",
   });
+  const {
+    control,
+    reset,
+    formState: { errors },
+  } = form;
+  const previousTeamNameRef = useRef(teamName);
 
   useEffect(() => {
-    reset({ name: teamName });
-  }, [reset, teamName]);
+    if (previousTeamNameRef.current === teamName) {
+      return;
+    }
 
-  const submit = useCallback(
-    async (values: FormValues) => {
-      if (!canWrite) {
-        return;
-      }
+    previousTeamNameRef.current = teamName;
+    if (!form.getFieldState("name").isDirty) {
+      reset({ name: teamName });
+    }
+  }, [form, reset, teamName]);
 
+  const save = useCallback(
+    async (values: FormValues, signal: AbortSignal) => {
       const result = await validateAndUpdateTeamServerSide(values.name, teamId);
-      if (!result.success) {
-        toast.error(result.message);
-      } else {
-        toast.success("Your team was successfully updated");
-        await Promise.all([onSaved?.(), refetchMe()]);
-        reset(values);
+      if (signal.aborted) {
+        throw new DOMException("Aborted", "AbortError");
       }
+      if (!result.success) {
+        throw new Error(result.message);
+      }
+
+      const [sessionResponse] = await Promise.all([
+        fetch("/api/update-session", { method: "POST" }).catch(() => null),
+        Promise.allSettled([onSaved?.(), refetchMe()]),
+      ]);
+
+      if (sessionResponse?.ok) {
+        await invalidate();
+      }
+
+      router.refresh();
     },
-    [canWrite, teamId, onSaved, refetchMe, reset],
+    [invalidate, onSaved, refetchMe, router, teamId],
   );
 
+  const onAutosaveStatus = useCallback((status: AutosaveStatus) => {
+    if (status.state === "saved") {
+      toast.success("Team name updated");
+    } else if (status.state === "error") {
+      toast.error(status.error.message);
+    }
+  }, []);
+
+  useAutosave<FormValues>({
+    form,
+    save,
+    enabled: canWrite,
+    debounceMs: 1500,
+    onStatus: onAutosaveStatus,
+  });
+
   return (
-    <form
-      className="flex min-w-0 items-center gap-4"
-      onSubmit={handleSubmit(submit)}
-    >
-      <div className="size-12 shrink-0 overflow-hidden rounded-full">
-        <TeamImage
-          src={null}
-          teamName={teamName}
-          alt="Team logo"
-          className="rounded-full"
-        />
-      </div>
-
-      <div className="min-w-0 flex-1">
-        <input
-          {...register("name")}
-          aria-label="Team name"
-          aria-invalid={errors.name ? "true" : "false"}
-          readOnly={!canWrite}
-          className={clsx(
-            "-ml-2 block h-9 w-full max-w-xl rounded-8 border bg-transparent px-2 font-twk text-[22px] leading-7 font-[550] text-grey-900 outline-hidden transition-colors",
-            {
-              "cursor-text border-transparent hover:border-grey-200 focus:border-blue-150 focus:ring-2 focus:ring-blue-150":
-                canWrite && !errors.name,
-              "border-system-error-500 focus:ring-2 focus:ring-system-error-200":
-                canWrite && errors.name,
-              "cursor-default border-transparent": !canWrite,
-            },
-          )}
-        />
-
-        <p className="mt-0.5 truncate font-gta text-13 leading-5 text-grey-400">
-          Team settings · {memberCount}{" "}
-          {memberCount === 1 ? "member" : "members"}
-        </p>
-
-        {errors.name?.message ? (
-          <p className="mt-1 font-gta text-12 text-system-error-500">
-            {errors.name.message}
-          </p>
-        ) : null}
-      </div>
-
-      {canWrite && isDirty ? (
-        <div className="fixed bottom-6 left-1/2 z-40 flex max-w-[calc(100vw-48px)] -translate-x-1/2 items-center gap-2 rounded-12 bg-portal-ink p-2 pl-4 shadow-lg md:left-[calc(50%+140px)]">
-          <span className="mr-2 font-world text-13 whitespace-nowrap text-white/75">
-            Unsaved changes
-          </span>
-
-          <button
-            type="button"
-            onClick={() => reset({ name: teamName })}
-            className="h-8 rounded-8 px-3 font-world text-13 font-medium text-white/75 transition-colors hover:bg-white/10 hover:text-white focus-visible:ring-2 focus-visible:ring-grey-300 focus-visible:outline-hidden"
-          >
-            Cancel
-          </button>
-
-          <button
-            type="submit"
-            disabled={!isValid || isSubmitting}
-            className="h-8 rounded-8 bg-white px-4 font-world text-13 font-medium text-portal-ink transition-colors hover:bg-grey-100 focus-visible:ring-2 focus-visible:ring-grey-300 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:bg-grey-300 disabled:text-grey-500"
-          >
-            Save
-          </button>
-        </div>
-      ) : null}
-    </form>
+    <div className="w-full max-w-xl">
+      <Controller
+        control={control}
+        name="name"
+        render={({ field }) => (
+          <TextField
+            label="Team name"
+            name={field.name}
+            value={field.value}
+            onChange={field.onChange}
+            onBlur={field.onBlur}
+            disabled={!canWrite}
+            error={errors.name?.message}
+            maxLength={128}
+            required
+            hideLabel
+          />
+        )}
+      />
+    </div>
   );
 };

--- a/web/scenes/PortalV3/layout/Shell/AppsDropdown.tsx
+++ b/web/scenes/PortalV3/layout/Shell/AppsDropdown.tsx
@@ -3,6 +3,7 @@
 import { Placeholder } from "@/components/PlaceholderImage";
 import { Button } from "@/components/ui/button";
 import { Role_Enum } from "@/graphql/graphql";
+import { isTeamSettingsPath } from "@/lib/team-settings";
 import { Auth0SessionUser } from "@/lib/types";
 import { urls } from "@/lib/urls";
 import { checkUserPermissions, cn } from "@/lib/utils";
@@ -15,7 +16,7 @@ import { useCreateAppDialog } from "@/scenes/common/layout/CreateAppDialog/useCr
 import { useQuery } from "@apollo/client/react";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { ChevronsUpDownIcon, LayoutGridIcon } from "lucide-react";
-import { useParams } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 import { useMemo } from "react";
 import {
   SearchableSwitcher,
@@ -43,6 +44,8 @@ const AppAvatar = (props: DropdownApp) => (
 
 export const AppsDropdown = () => {
   const { teamId } = useParams<{ teamId?: string; appId?: string }>();
+  const pathname = usePathname() ?? "";
+  const isTeamSettings = isTeamSettingsPath(pathname);
   const { user } = useUser() as Auth0SessionUser;
   const canCreateApp = checkUserPermissions(user, teamId ?? "", [
     Role_Enum.Owner,
@@ -53,7 +56,7 @@ export const AppsDropdown = () => {
 
   const { data, loading, error } = useQuery(FetchAppsDocument, {
     variables: { teamId: teamId! },
-    skip: !teamId,
+    skip: !teamId || isTeamSettings,
   });
 
   const apps = useMemo<DropdownApp[]>(() => {
@@ -77,7 +80,7 @@ export const AppsDropdown = () => {
   const isUnavailable = loading || Boolean(error);
   const showEmptyAppRow = !loading && Boolean(data) && apps.length === 0;
 
-  if (!teamId) return null;
+  if (!teamId || isTeamSettings) return null;
 
   return (
     <SearchableSwitcher

--- a/web/scenes/PortalV3/layout/Shell/PortalSidebar.tsx
+++ b/web/scenes/PortalV3/layout/Shell/PortalSidebar.tsx
@@ -15,9 +15,10 @@ import { UserPopup } from "./UserPopup";
 export const PortalSidebar = (props: {
   user: { name?: string | null; email?: string | null };
   teams: { id: string; name: string }[];
+  apiKeyTeamIds?: string[];
   sandboxRequest?: SandboxAccessRequestState | null;
 }) => {
-  const { user, teams, sandboxRequest } = props;
+  const { user, teams, apiKeyTeamIds = [], sandboxRequest } = props;
   const name = user.name ?? user.email ?? "Account";
 
   return (
@@ -27,7 +28,10 @@ export const PortalSidebar = (props: {
       </SidebarHeader>
 
       <SidebarContent className="gap-0 pt-3">
-        <SidebarNav initialSandboxRequest={sandboxRequest} />
+        <SidebarNav
+          initialSandboxRequest={sandboxRequest}
+          apiKeyTeamIds={apiKeyTeamIds}
+        />
       </SidebarContent>
 
       <SidebarFooter className="px-4 pb-4">

--- a/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
@@ -8,16 +8,33 @@ import {
   SidebarSeparator,
   useSidebar,
 } from "@/components/ui/sidebar";
+import {
+  getPortalReturnTo,
+  isTeamSettingsPath,
+  resolvePortalReturnTo,
+  resolveTeamSettingsTab,
+  TEAM_SETTINGS_TABS,
+} from "@/lib/team-settings";
 import { urls } from "@/lib/urls";
 import { cn } from "@/lib/utils";
 import { Icon } from "@/scenes/PortalV3/common/Icon";
 import {
+  ArrowLeftIcon,
   BadgeCheckIcon,
   BellIcon,
+  ChevronRightIcon,
+  KeyRoundIcon,
   LockKeyholeIcon,
+  Settings2Icon,
+  UsersIcon,
   WalletCardsIcon,
 } from "lucide-react";
-import { useParams, usePathname, useRouter } from "next/navigation";
+import {
+  useParams,
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
 import {
   createContext,
   type MouseEventHandler,
@@ -109,9 +126,11 @@ const NavIcon = (props: { name: string; active?: boolean }) => (
 
 export const SidebarNav = (props: {
   initialSandboxRequest?: SandboxAccessRequestState | null;
+  apiKeyTeamIds?: string[];
 }) => {
   const pathname = usePathname() ?? "";
   const params = useParams<{ teamId?: string; appId?: string }>();
+  const committedSearchParams = useSearchParams();
   const teamId = params?.teamId;
   const appId = params?.appId;
   const { setOpenMobile } = useSidebar();
@@ -128,6 +147,9 @@ export const SidebarNav = (props: {
   // Sidebar destinations may use query-backed sections. Route ownership and
   // active parent checks must compare only the pathname portion.
   const currentPathname = currentHref.split(/[?#]/, 1)[0];
+  const currentSearchParams = optimisticHref
+    ? new URLSearchParams(optimisticHref.split("?", 2)[1] ?? "")
+    : committedSearchParams;
 
   const beginNavigation =
     (href: string): MouseEventHandler<HTMLAnchorElement> =>
@@ -167,8 +189,13 @@ export const SidebarNav = (props: {
 
   const configurationHref = ids ? urls.configuration(ids) : teamOverviewHref;
   const miniAppHref = ids ? urls.miniAppPermissions(ids) : teamOverviewHref;
-  const teamSettingsHref = teamId
+  const teamSettingsBase = teamId
     ? urls.teamSettings({ team_id: teamId })
+    : teamsLandingHref;
+  const committedQuery = committedSearchParams.toString();
+  const returnTo = `${pathname}${committedQuery ? `?${committedQuery}` : ""}`;
+  const teamSettingsHref = teamId
+    ? urls.teamSettings({ team_id: teamId, return_to: returnTo })
     : teamsLandingHref;
 
   const withinApp = (prefix: string) => {
@@ -190,9 +217,58 @@ export const SidebarNav = (props: {
     withinApp("/mini-app") ||
     withinApp("/transactions") ||
     withinApp("/notifications");
-  const settingsActive = teamId
-    ? currentPathname.startsWith(teamSettingsHref)
-    : false;
+  const settingsActive = teamId ? currentPathname === teamSettingsBase : false;
+  const teamSettingsContext = isTeamSettingsPath(currentPathname);
+  const canViewApiKeys = Boolean(
+    teamId && props.apiKeyTeamIds?.includes(teamId),
+  );
+  const activeTeamSettingsTab = resolveTeamSettingsTab(
+    currentSearchParams.get("tab") ?? undefined,
+    canViewApiKeys,
+  );
+  const settingsReturnTo =
+    getPortalReturnTo(currentSearchParams.get("return_to") ?? undefined) ??
+    undefined;
+  const goBackHref = resolvePortalReturnTo(
+    currentSearchParams.get("return_to") ?? undefined,
+  );
+  const teamSettingsItems = teamId
+    ? [
+        {
+          label: "General",
+          value: TEAM_SETTINGS_TABS.General,
+          href: urls.teamSettings({
+            team_id: teamId,
+            return_to: settingsReturnTo,
+          }),
+          icon: <Settings2Icon strokeWidth={1.5} className="size-4" />,
+        },
+        {
+          label: "Members",
+          value: TEAM_SETTINGS_TABS.Members,
+          href: urls.teamSettings({
+            team_id: teamId,
+            return_to: settingsReturnTo,
+            tab: TEAM_SETTINGS_TABS.Members,
+          }),
+          icon: <UsersIcon strokeWidth={1.5} className="size-4" />,
+        },
+        ...(canViewApiKeys
+          ? [
+              {
+                label: "API Keys",
+                value: TEAM_SETTINGS_TABS.ApiKeys,
+                href: urls.teamSettings({
+                  team_id: teamId,
+                  return_to: settingsReturnTo,
+                  tab: TEAM_SETTINGS_TABS.ApiKeys,
+                }),
+                icon: <KeyRoundIcon strokeWidth={1.5} className="size-4" />,
+              },
+            ]
+          : []),
+      ]
+    : [];
   const miniAppPermissionsActive =
     currentPathname === (appBase ? `${appBase}/mini-app` : "") ||
     withinApp("/mini-app/permissions");
@@ -234,6 +310,53 @@ export const SidebarNav = (props: {
   const pathContext = /\/apps\/[^/]+/.test(currentPathname) ? "app" : "team";
   const paramsContext = appId ? "app" : "team";
   const pillContextKey = `${teamId ?? "none"}:${paramsContext}:${pathContext}`;
+
+  if (teamSettingsContext) {
+    return (
+      <nav
+        aria-label="Team settings navigation"
+        className="relative flex min-h-0 flex-1 flex-col"
+      >
+        <NavActivePill key={`${pillContextKey}:settings`} />
+        <SidebarGroup className="px-4 py-2 group-data-[collapsible=icon]:px-3">
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <NavItem
+                label="Settings"
+                href={goBackHref}
+                onNavigate={beginNavigation(goBackHref)}
+                icon={<ArrowLeftIcon strokeWidth={1.5} className="size-4" />}
+                className="relative justify-center font-medium text-portal-text [&>span:first-child]:absolute [&>span:first-child]:left-3"
+              />
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup className="px-4 pt-2 pb-2 group-data-[collapsible=icon]:px-3">
+          <SidebarGroupContent>
+            <SidebarMenu className="gap-2">
+              {teamSettingsItems.map((item) => (
+                <NavItem
+                  key={item.value}
+                  label={item.label}
+                  href={item.href}
+                  active={activeTeamSettingsTab === item.value}
+                  onNavigate={beginNavigation(item.href)}
+                  icon={item.icon}
+                />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <div className="mt-auto px-4 pt-3 pb-3 group-data-[collapsible=icon]:hidden">
+          <SandboxButton
+            className="-ml-1 w-[calc(100%_+_8px)]"
+            initialRequest={props.initialSandboxRequest}
+          />
+        </div>
+      </nav>
+    );
+  }
 
   return (
     <nav
@@ -319,6 +442,12 @@ export const SidebarNav = (props: {
                 active={settingsActive}
                 onNavigate={beginNavigation(teamSettingsHref)}
                 icon={<NavIcon name="nav-settings" active={settingsActive} />}
+                trailing={
+                  <ChevronRightIcon
+                    aria-hidden="true"
+                    className="size-4 text-portal-muted"
+                  />
+                }
               />
             </SidebarMenu>
           </SidebarGroupContent>

--- a/web/scenes/PortalV3/layout/Shell/index.tsx
+++ b/web/scenes/PortalV3/layout/Shell/index.tsx
@@ -14,10 +14,17 @@ import { SidebarAnimationShell } from "./SidebarNav";
 export const PortalShell = (props: {
   user: { name?: string | null; email?: string | null };
   teams?: { id: string; name: string }[];
+  apiKeyTeamIds?: string[];
   sandboxRequest?: SandboxAccessRequestState | null;
   children?: ReactNode;
 }) => {
-  const { user, teams = [], sandboxRequest = null, children } = props;
+  const {
+    user,
+    teams = [],
+    apiKeyTeamIds = [],
+    sandboxRequest = null,
+    children,
+  } = props;
 
   return (
     <TooltipProvider>
@@ -40,6 +47,7 @@ export const PortalShell = (props: {
           <PortalSidebar
             user={user}
             teams={teams}
+            apiKeyTeamIds={apiKeyTeamIds}
             sandboxRequest={sandboxRequest}
           />
 

--- a/web/scenes/PortalV3/layout/index.tsx
+++ b/web/scenes/PortalV3/layout/index.tsx
@@ -1,4 +1,5 @@
 import { fetchSandboxAccessRequest } from "@/api/v2/sandbox-access-request/server/fetch-sandbox-access-request";
+import { Role_Enum } from "@/graphql/graphql";
 import { auth0 } from "@/lib/auth0";
 import { isWorldUser } from "@/lib/is-world-user";
 import { logger } from "@/lib/logger";
@@ -10,10 +11,19 @@ import { PortalShell } from "./Shell";
 export const PortalLayout = async (props: { children: ReactNode }) => {
   const session = await auth0.getSession();
   const user = session?.user as Auth0SessionUser["user"];
-  const teams = (user?.hasura?.memberships ?? [])
+  const memberships = user?.hasura?.memberships ?? [];
+  const teams = memberships
     .map((m) => m.team)
     .filter((t): t is NonNullable<typeof t> => !!t?.id)
     .map((t) => ({ id: t.id, name: t.name ?? "Untitled team" }));
+  const apiKeyTeamIds = memberships
+    .filter(
+      (membership) =>
+        membership.role === Role_Enum.Owner ||
+        membership.role === Role_Enum.Admin,
+    )
+    .map((membership) => membership.team?.id)
+    .filter((teamId): teamId is string => Boolean(teamId));
 
   const userId = user?.hasura?.id;
 
@@ -37,6 +47,7 @@ export const PortalLayout = async (props: { children: ReactNode }) => {
         email: user?.email,
       }}
       teams={teams}
+      apiKeyTeamIds={apiKeyTeamIds}
       sandboxRequest={sandboxRequest}
     >
       {props.children}

--- a/web/tests/unit/leave-team-settings.test.tsx
+++ b/web/tests/unit/leave-team-settings.test.tsx
@@ -1,0 +1,54 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+const invalidate = jest.fn();
+jest.mock("@auth0/nextjs-auth0/client", () => ({
+  useUser: () => ({ invalidate }),
+}));
+
+const routerPush = jest.fn();
+const routerRefresh = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush, refresh: routerRefresh }),
+}));
+
+jest.mock("@/scenes/PortalV3/Profile/Teams/page/LeaveTeamDialog", () => ({
+  LeaveTeamDialog: (props: {
+    open: boolean;
+    onClose: (didLeave: boolean) => void;
+  }) =>
+    props.open ? (
+      <button type="button" onClick={() => props.onClose(true)}>
+        Confirm leave
+      </button>
+    ) : null,
+}));
+// #endregion
+
+import { LeaveTeam } from "@/scenes/PortalV3/Teams/TeamId/Team/sections/LeaveTeam";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+});
+
+describe("Team settings LeaveTeam [successful leave]", () => {
+  it("refreshes the session before returning to the dashboard", async () => {
+    render(<LeaveTeam team={{ id: "team_1", name: "Test team" }} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Leave team" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm leave" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/update-session", {
+        method: "POST",
+      });
+      expect(invalidate).toHaveBeenCalledTimes(1);
+      expect(routerRefresh).toHaveBeenCalledTimes(1);
+      expect(routerPush).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+});

--- a/web/tests/unit/portal-v3-apps-dropdown.test.tsx
+++ b/web/tests/unit/portal-v3-apps-dropdown.test.tsx
@@ -7,7 +7,7 @@ import React from "react";
 // #region Mocks
 const fetchApps = jest.fn();
 jest.mock("@apollo/client/react", () => ({
-  useQuery: () => fetchApps(),
+  useQuery: (...args: unknown[]) => fetchApps(...args),
 }));
 jest.mock(
   "@/scenes/common/layout/AppSelector/graphql/client/fetch-apps.generated",
@@ -39,8 +39,10 @@ jest.mock("@/lib/utils", () => ({
 }));
 
 let mockParams: Record<string, string | undefined> = { teamId: "team_1" };
+let mockPathname = "/teams/team_1";
 jest.mock("next/navigation", () => ({
   useParams: () => mockParams,
+  usePathname: () => mockPathname,
 }));
 // #endregion
 
@@ -57,6 +59,26 @@ const renderDropdown = (store = createStore()) =>
 beforeEach(() => {
   jest.clearAllMocks();
   mockParams = { teamId: "team_1" };
+  mockPathname = "/teams/team_1";
+});
+
+it("hides the app switcher and skips its query on team settings", () => {
+  mockPathname = "/teams/team_1/settings";
+  fetchApps.mockReturnValue({
+    data: undefined,
+    loading: false,
+    error: undefined,
+  });
+
+  renderDropdown();
+
+  expect(
+    screen.queryByRole("button", { name: "Switch app" }),
+  ).not.toBeInTheDocument();
+  expect(fetchApps).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ skip: true }),
+  );
 });
 
 it("disables the trigger while the apps query is loading", () => {

--- a/web/tests/unit/portal-v3-portal-layout.test.tsx
+++ b/web/tests/unit/portal-v3-portal-layout.test.tsx
@@ -25,12 +25,14 @@ jest.mock("@/scenes/PortalV3/layout/Shell", () => ({
   PortalShell: (props: {
     user: { name?: string | null };
     teams: { id: string }[];
+    apiKeyTeamIds: string[];
     sandboxRequest: { email: string } | null;
     children: React.ReactNode;
   }) => (
     <div
       data-testid="shell"
       data-team-count={props.teams.length}
+      data-api-key-team-ids={props.apiKeyTeamIds.join(",")}
       data-sandbox-email={props.sandboxRequest?.email}
       data-user-name={props.user.name}
     >
@@ -52,11 +54,20 @@ it("mounts the shell with teams from the session", async () => {
       sub: "auth0|ada",
       name: "Ada",
       email: "ada@example.com",
-      hasura: { memberships: [{ team: { id: "team_1", name: "Acme" } }] },
+      hasura: {
+        memberships: [
+          { role: "OWNER", team: { id: "team_1", name: "Acme" } },
+          { role: "MEMBER", team: { id: "team_2", name: "Other" } },
+        ],
+      },
     },
   });
   render(await PortalLayout({ children: <div data-testid="body" /> }));
-  expect(screen.getByTestId("shell")).toHaveAttribute("data-team-count", "1");
+  expect(screen.getByTestId("shell")).toHaveAttribute("data-team-count", "2");
+  expect(screen.getByTestId("shell")).toHaveAttribute(
+    "data-api-key-team-ids",
+    "team_1",
+  );
   expect(screen.getByTestId("body")).toBeInTheDocument();
 });
 

--- a/web/tests/unit/portal-v3-sidebar-context-header.test.tsx
+++ b/web/tests/unit/portal-v3-sidebar-context-header.test.tsx
@@ -47,7 +47,7 @@ describe("SidebarContextHeader [route context]", () => {
   });
 
   it("keeps the team switcher on team-scoped routes", () => {
-    usePathname.mockReturnValue("/teams/team_1");
+    usePathname.mockReturnValue("/teams/team_1/settings");
 
     renderHeader();
 

--- a/web/tests/unit/pv3-r-team-settings.test.tsx
+++ b/web/tests/unit/pv3-r-team-settings.test.tsx
@@ -9,11 +9,22 @@ jest.mock("@/scenes/Portal/Teams/TeamId/Team/Settings/page", () => ({
   TeamSettingsPage: () => <div data-testid="v2-team-settings" />,
 }));
 jest.mock("@/scenes/PortalV3/Teams/TeamId/Team/Settings/page", () => ({
-  TeamSettingsPage: () => <div data-testid="v3-team-settings" />,
+  TeamSettingsPage: (props: { requestedTab?: string | string[] }) => (
+    <div data-testid="v3-team-settings" data-tab={props.requestedTab} />
+  ),
 }));
 import RoutePage from "../../app/(portal)/teams/[teamId]/(team)/settings/page";
 it("renders v3 team-settings", async () => {
-  render(await RoutePage());
-  expect(screen.getByTestId("v3-team-settings")).toBeInTheDocument();
+  render(
+    await RoutePage({
+      searchParams: Promise.resolve({
+        tab: "members",
+      }),
+    }),
+  );
+  expect(screen.getByTestId("v3-team-settings")).toHaveAttribute(
+    "data-tab",
+    "members",
+  );
   expect(screen.queryByTestId("v2-team-settings")).not.toBeInTheDocument();
 });

--- a/web/tests/unit/pv3-sidebar-section-nav.test.tsx
+++ b/web/tests/unit/pv3-sidebar-section-nav.test.tsx
@@ -81,12 +81,12 @@ const makeWorldIdNavigationData = (options?: {
   action: options?.legacy ? [{ id: "legacy_1" }] : [],
 });
 
-const renderSidebar = () =>
+const renderSidebar = (apiKeyTeamIds = [teamId]) =>
   render(
     <TooltipProvider>
       <SidebarProvider>
         <SidebarAnimationShell>
-          <SidebarNav />
+          <SidebarNav apiKeyTeamIds={apiKeyTeamIds} />
         </SidebarAnimationShell>
       </SidebarProvider>
     </TooltipProvider>,
@@ -135,7 +135,15 @@ describe("v3 SidebarNav [navigation hierarchy]", () => {
     );
     expect(link("Mini App")).toBeInTheDocument();
     noLink("Permissions");
-    expect(link("Team settings")).toBeInTheDocument();
+    expect(link("Team settings")).toHaveAttribute(
+      "href",
+      `/teams/${teamId}/settings?return_to=${encodeURIComponent(base)}`,
+    );
+    const settingsChevron = link("Team settings").querySelector(
+      "svg.lucide-chevron-right",
+    );
+    expect(settingsChevron).toHaveClass("size-4");
+    expect(settingsChevron?.parentElement).toHaveClass("ml-auto");
   });
 });
 // #endregion
@@ -307,16 +315,66 @@ describe("v3 SidebarNav [World ID subnavigation]", () => {
 
 // #region route-owned app context
 describe("v3 SidebarNav [route-owned app context]", () => {
-  it("shows Overview instead of app-only entries on team routes", () => {
+  it("shows the Settings back header and section navigation", () => {
     useParams.mockReturnValue({ teamId });
     usePathname.mockReturnValue(`/teams/${teamId}/settings`);
+    useSearchParams.mockReturnValue(
+      new URLSearchParams({
+        return_to: `${base}/configuration?view=review`,
+        tab: "members",
+      }),
+    );
     renderSidebar();
 
-    expect(link("Overview")).toHaveAttribute("href", `/teams/${teamId}`);
-    expect(isCurrent("Team settings")).toBe(true);
+    expect(link("Settings")).toHaveAttribute(
+      "href",
+      `${base}/configuration?view=review`,
+    );
+    expect(link("Settings")).toHaveClass(
+      "justify-center",
+      "data-[active=false]:hover:bg-portal-border",
+    );
+    expect(link("General")).toHaveAttribute(
+      "href",
+      `/teams/${teamId}/settings?return_to=${encodeURIComponent(
+        `${base}/configuration?view=review`,
+      )}`,
+    );
+    expect(isCurrent("Members")).toBe(true);
+    expect(link("API Keys")).toHaveAttribute(
+      "href",
+      expect.stringContaining("tab=api-keys"),
+    );
+    noLink("Overview");
+    noLink("Team settings");
     noLink("World ID");
     noLink("Get verified");
     noLink("Mini App");
+  });
+
+  it("shows API Keys only to owners and admins", () => {
+    useParams.mockReturnValue({ teamId });
+    usePathname.mockReturnValue(`/teams/${teamId}/settings`);
+    useSearchParams.mockReturnValue(new URLSearchParams({ tab: "api-keys" }));
+
+    const permitted = renderSidebar([teamId]);
+    expect(isCurrent("API Keys")).toBe(true);
+    permitted.unmount();
+
+    renderSidebar([]);
+    noLink("API Keys");
+    expect(isCurrent("General")).toBe(true);
+  });
+
+  it("defaults the Settings back header to the dashboard for an unsafe return target", () => {
+    useParams.mockReturnValue({ teamId });
+    usePathname.mockReturnValue(`/teams/${teamId}/settings`);
+    useSearchParams.mockReturnValue(
+      new URLSearchParams({ return_to: "https://evil.example" }),
+    );
+    renderSidebar();
+
+    expect(link("Settings")).toHaveAttribute("href", "/dashboard");
   });
 
   it("hides team-scoped links entirely without a teamId", () => {

--- a/web/tests/unit/team-settings-form.test.tsx
+++ b/web/tests/unit/team-settings-form.test.tsx
@@ -1,0 +1,141 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+// #region Mocks
+const validateAndUpdateTeamServerSide = jest.fn();
+jest.mock("@/scenes/PortalV3/Teams/TeamId/Team/Settings/server/submit", () => ({
+  validateAndUpdateTeamServerSide: (...args: unknown[]) =>
+    validateAndUpdateTeamServerSide(...args),
+}));
+
+const refetchMe = jest.fn();
+jest.mock("@/lib/use-refetch-queries", () => ({
+  useRefetchQueries: () => ({ refetch: refetchMe }),
+}));
+
+const invalidate = jest.fn();
+jest.mock("@auth0/nextjs-auth0/client", () => ({
+  useUser: () => ({ invalidate }),
+}));
+
+const refresh = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+const toastSuccess = jest.fn();
+const toastError = jest.fn();
+jest.mock("react-toastify", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+// #endregion
+
+import { TeamSettingsForm } from "@/scenes/PortalV3/Teams/TeamId/Team/sections/SettingsForm";
+
+// #region Test Data
+const teamId = "team_cd7aa5f3c2a797a06e66eb6eefbf2f48";
+
+const advanceAutosave = async (milliseconds: number) => {
+  await act(async () => {
+    await jest.advanceTimersByTimeAsync(milliseconds);
+  });
+};
+// #endregion
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+  validateAndUpdateTeamServerSide.mockResolvedValue({
+    success: true,
+    message: "Team updated successfully",
+  });
+  refetchMe.mockResolvedValue(undefined);
+  invalidate.mockResolvedValue(undefined);
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+// #region Autosave
+describe("TeamSettingsForm autosave", () => {
+  it("renders one simple field and saves it after 1.5 seconds", async () => {
+    const onSaved = jest.fn().mockResolvedValue(undefined);
+    render(
+      <TeamSettingsForm
+        teamId={teamId}
+        teamName="Test team"
+        canWrite={true}
+        onSaved={onSaved}
+      />,
+    );
+
+    const input = screen.getByLabelText(/Team name/);
+    expect(input).toHaveValue("Test team");
+    expect(screen.queryByAltText("Team logo")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Team settings ·/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Team name")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Save" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "Platform team" } });
+    await advanceAutosave(1499);
+    expect(validateAndUpdateTeamServerSide).not.toHaveBeenCalled();
+
+    await advanceAutosave(1);
+    expect(validateAndUpdateTeamServerSide).toHaveBeenCalledWith(
+      "Platform team",
+      teamId,
+    );
+    expect(onSaved).toHaveBeenCalledTimes(1);
+    expect(refetchMe).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith("/api/update-session", {
+      method: "POST",
+    });
+    expect(invalidate).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).toHaveBeenCalledWith("Team name updated");
+  });
+
+  it("shows the server error and keeps the edited value", async () => {
+    validateAndUpdateTeamServerSide.mockResolvedValue({
+      success: false,
+      message: "Unable to update team",
+    });
+    render(
+      <TeamSettingsForm teamId={teamId} teamName="Test team" canWrite={true} />,
+    );
+
+    const input = screen.getByLabelText(/Team name/);
+    fireEvent.change(input, { target: { value: "Platform team" } });
+    await advanceAutosave(1500);
+
+    expect(input).toHaveValue("Platform team");
+    expect(toastError).toHaveBeenCalledWith("Unable to update team");
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("disables editing and autosave without owner permission", async () => {
+    render(
+      <TeamSettingsForm
+        teamId={teamId}
+        teamName="Test team"
+        canWrite={false}
+      />,
+    );
+
+    expect(screen.getByLabelText(/Team name/)).toBeDisabled();
+    await advanceAutosave(1500);
+    expect(validateAndUpdateTeamServerSide).not.toHaveBeenCalled();
+  });
+});
+// #endregion

--- a/web/tests/unit/team-settings-navigation.test.ts
+++ b/web/tests/unit/team-settings-navigation.test.ts
@@ -1,0 +1,67 @@
+import {
+  getPortalReturnTo,
+  isTeamSettingsPath,
+  resolvePortalReturnTo,
+  resolveTeamSettingsTab,
+  TEAM_SETTINGS_TABS,
+} from "@/lib/team-settings";
+import { urls } from "@/lib/urls";
+
+// #region return_to validation
+describe("Team settings return_to validation", () => {
+  it("accepts and normalizes a Developer Portal path", () => {
+    expect(
+      getPortalReturnTo("/teams/team_1/apps/app_1/../app_2?tab=actions#top"),
+    ).toBe("/teams/team_1/apps/app_2?tab=actions#top");
+  });
+
+  it.each([
+    undefined,
+    ["/teams/team_1"],
+    "https://evil.example/teams/team_1",
+    "//evil.example/teams/team_1",
+    "/\\evil.example/teams/team_1",
+    "javascript:alert(1)",
+  ])("rejects a non-portal return target: %p", (returnTo) => {
+    expect(getPortalReturnTo(returnTo)).toBeNull();
+    expect(resolvePortalReturnTo(returnTo)).toBe("/dashboard");
+  });
+});
+// #endregion
+
+// #region route and tab helpers
+describe("Team settings route helpers", () => {
+  it("builds one settings route with encoded return and tab parameters", () => {
+    expect(
+      urls.teamSettings({
+        team_id: "team_1",
+        return_to: "/teams/team_1/apps/app_1?tab=actions",
+        tab: TEAM_SETTINGS_TABS.Members,
+      }),
+    ).toBe(
+      "/teams/team_1/settings?return_to=%2Fteams%2Fteam_1%2Fapps%2Fapp_1%3Ftab%3Dactions&tab=members",
+    );
+  });
+
+  it.each([
+    ["/teams/team_1/settings", true],
+    ["/teams/team_1/settings/", true],
+    ["/teams/team_1", false],
+    ["/profile/settings", false],
+  ])("classifies %s as team settings: %s", (pathname, expected) => {
+    expect(isTeamSettingsPath(pathname)).toBe(expected);
+  });
+
+  it("keeps credentials owner/admin-only and defaults unknown tabs to General", () => {
+    expect(resolveTeamSettingsTab(TEAM_SETTINGS_TABS.ApiKeys, true)).toBe(
+      TEAM_SETTINGS_TABS.ApiKeys,
+    );
+    expect(resolveTeamSettingsTab(TEAM_SETTINGS_TABS.ApiKeys, false)).toBe(
+      TEAM_SETTINGS_TABS.General,
+    );
+    expect(resolveTeamSettingsTab("unknown", true)).toBe(
+      TEAM_SETTINGS_TABS.General,
+    );
+  });
+});
+// #endregion

--- a/web/tests/unit/team-settings-permissions.test.tsx
+++ b/web/tests/unit/team-settings-permissions.test.tsx
@@ -2,6 +2,7 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { Role_Enum } from "@/graphql/graphql";
+import { TEAM_SETTINGS_TABS } from "@/lib/team-settings";
 import { TeamSettingsPage } from "@/scenes/PortalV3/Teams/TeamId/Team/Settings/page";
 
 // #region Mocks
@@ -34,18 +35,21 @@ jest.mock("next/navigation", () => ({
   useParams: () => ({ teamId }),
 }));
 
+const useQuery = jest.fn();
 jest.mock("@apollo/client/react", () => ({
-  useQuery: () => ({
-    data: {
-      team_by_pk: {
-        id: teamId,
-        name: "Test team",
-        memberships: [],
-      },
-    },
-    refetch: jest.fn(),
-  }),
+  useQuery: (...args: unknown[]) => useQuery(...args),
 }));
+
+const queryResult = {
+  data: {
+    team_by_pk: {
+      id: teamId,
+      name: "Test team",
+      memberships: [{ user_id: "user_1" }],
+    },
+  },
+  refetch: jest.fn(),
+};
 
 jest.mock("@/components/SizingWrapper", () => ({
   SizingWrapper: ({ children }: React.PropsWithChildren) => (
@@ -70,6 +74,9 @@ jest.mock(
 jest.mock("@/scenes/PortalV3/Teams/TeamId/Team/sections/DangerZone", () => ({
   TeamDangerZone: () => <button type="button">Delete team</button>,
 }));
+jest.mock("@/scenes/PortalV3/Teams/TeamId/Team/sections/LeaveTeam", () => ({
+  LeaveTeam: () => <button type="button">Leave team</button>,
+}));
 // #endregion
 
 const sessionWithRole = (role: Role_Enum) => ({
@@ -77,37 +84,36 @@ const sessionWithRole = (role: Role_Enum) => ({
 });
 
 describe("Team settings permissions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useQuery.mockReturnValue(queryResult);
+  });
+
   it.each([
     {
       role: Role_Enum.Owner,
-      canViewCredentials: true,
       canDeleteTeam: true,
+      canLeaveTeam: false,
     },
     {
       role: Role_Enum.Admin,
-      canViewCredentials: true,
       canDeleteTeam: false,
+      canLeaveTeam: true,
     },
     {
       role: Role_Enum.Member,
-      canViewCredentials: false,
       canDeleteTeam: false,
+      canLeaveTeam: true,
     },
   ])(
-    "renders the allowed controls for $role",
-    ({ role, canViewCredentials, canDeleteTeam }) => {
+    "renders the allowed General controls for $role",
+    ({ role, canDeleteTeam, canLeaveTeam }) => {
       mockSession = sessionWithRole(role);
       render(<TeamSettingsPage />);
 
-      expect(screen.getByLabelText("Members")).toBeInTheDocument();
-
-      if (canViewCredentials) {
-        expect(screen.getByLabelText("API keys")).toBeInTheDocument();
-        expect(screen.getByLabelText("MCP setup")).toBeInTheDocument();
-      } else {
-        expect(screen.queryByLabelText("API keys")).not.toBeInTheDocument();
-        expect(screen.queryByLabelText("MCP setup")).not.toBeInTheDocument();
-      }
+      expect(screen.getByLabelText("Team profile")).toBeInTheDocument();
+      expect(screen.getByLabelText("MCP setup")).toBeInTheDocument();
+      expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
 
       if (canDeleteTeam) {
         expect(
@@ -118,6 +124,51 @@ describe("Team settings permissions", () => {
           screen.queryByRole("button", { name: "Delete team" }),
         ).not.toBeInTheDocument();
       }
+
+      if (canLeaveTeam) {
+        expect(
+          screen.getByRole("button", { name: "Leave team" }),
+        ).toBeInTheDocument();
+      } else {
+        expect(
+          screen.queryByRole("button", { name: "Leave team" }),
+        ).not.toBeInTheDocument();
+      }
     },
   );
+
+  it("renders the Members tab without mounting General or credentials", () => {
+    mockSession = sessionWithRole(Role_Enum.Member);
+    render(<TeamSettingsPage requestedTab={TEAM_SETTINGS_TABS.Members} />);
+
+    expect(screen.getByLabelText("Members")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Team profile")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("API keys")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("MCP setup")).not.toBeInTheDocument();
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ skip: true }),
+    );
+  });
+
+  it.each([Role_Enum.Owner, Role_Enum.Admin])(
+    "renders API Keys for %s",
+    (role) => {
+      mockSession = sessionWithRole(role);
+      render(<TeamSettingsPage requestedTab={TEAM_SETTINGS_TABS.ApiKeys} />);
+
+      expect(screen.getByLabelText("API keys")).toBeInTheDocument();
+      expect(screen.queryByLabelText("MCP setup")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Team profile")).not.toBeInTheDocument();
+    },
+  );
+
+  it("falls back to General when a member requests credentials directly", () => {
+    mockSession = sessionWithRole(Role_Enum.Member);
+    render(<TeamSettingsPage requestedTab={TEAM_SETTINGS_TABS.ApiKeys} />);
+
+    expect(screen.getByLabelText("Team profile")).toBeInTheDocument();
+    expect(screen.getByLabelText("MCP setup")).toBeInTheDocument();
+    expect(screen.queryByLabelText("API keys")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
This PR redesigns Team Settings around a dedicated sidebar context.

- Adds General, Members, and permission-aware API Keys sidebar sections with validated return navigation.
- Simplifies team-name editing with 1.5-second autosave, live session/sidebar refresh, and toast feedback.
- Keeps owner-only deletion, adds leave-team handling for non-owners, hides the app selector in team settings, and surfaces MCP setup under General.
- Adds focused navigation, permissions, autosave, and leave-team coverage.
- Validates with 116 focused tests, TypeScript, Prettier, ESLint, `git diff --check`, and a staged-diff secret scan.