### PR TITLE
fix(world-id): keep registration on configuration

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/EnableWorldId40/Dialog/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/EnableWorldId40/Dialog/index.tsx
@@ -4,7 +4,7 @@ import { FormDialog } from "@/components/FormDialog";
 import { RegisterRpDocument } from "@/scenes/common/layout/CreateAppDialog/client/register-rp.generated";
 import { useMutation } from "@apollo/client/react";
 import dynamic from "next/dynamic";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import { useCallback, useState } from "react";
 import { toast } from "react-toastify";
 import {
@@ -39,7 +39,7 @@ type RegisterRpDialogProps = {
   open: boolean;
   onClose: (value: boolean) => void;
   appId: string;
-  onComplete?: () => void;
+  onComplete?: () => Promise<void> | void;
 };
 
 export const RegisterRpDialog = ({
@@ -49,7 +49,6 @@ export const RegisterRpDialog = ({
   onClose: onCloseDialog,
 }: RegisterRpDialogProps) => {
   const { teamId } = useParams() as { teamId: string | undefined };
-  const router = useRouter();
 
   const [registerRp, { loading: registeringRp }] =
     useMutation(RegisterRpDocument);
@@ -57,8 +56,10 @@ export const RegisterRpDialog = ({
   const [step, setStep] = useState<RegisterRpDialogStep>(
     "configure-signer-key",
   );
+  const [finishingSetup, setFinishingSetup] = useState(false);
   const [signerKeySetup, setSignerKeySetup] =
     useState<SignerKeySetup>("generate");
+  const loading = registeringRp || finishingSetup;
 
   const onClose = useCallback(() => {
     onCloseDialog(false);
@@ -72,11 +73,21 @@ export const RegisterRpDialog = ({
     setSignerKeySetup("generate");
   }, []);
 
-  const completeRpSetup = useCallback(() => {
-    onComplete?.();
-    router.refresh();
-    onClose();
-  }, [onClose, onComplete, router]);
+  const completeRpSetup = useCallback(async () => {
+    setFinishingSetup(true);
+
+    try {
+      await onComplete?.();
+      toast.success("App configured successfully");
+    } catch {
+      toast.error(
+        "Relying Party registered, but the configuration could not be refreshed. Reload the page to see the latest status.",
+      );
+    } finally {
+      setFinishingSetup(false);
+      onClose();
+    }
+  }, [onClose, onComplete]);
 
   const onConfigureBack = useCallback(() => {
     onClose();
@@ -118,8 +129,7 @@ export const RegisterRpDialog = ({
           return;
         }
 
-        toast.success("App configured successfully");
-        completeRpSetup();
+        await completeRpSetup();
       } catch {
         toast.error("Failed to register Relying Party");
       }
@@ -132,7 +142,7 @@ export const RegisterRpDialog = ({
       open={open}
       onClose={onClose}
       afterLeave={afterLeave}
-      dismissable={!registeringRp}
+      dismissable={!loading}
       // This dialog lazy-mounts already open behind a loading overlay that
       // mimics the backdrop; animating the first mount would un-dim the page
       // between the overlay unmounting and the fade-in.
@@ -151,7 +161,8 @@ export const RegisterRpDialog = ({
         <UseExistingKeyContent
           onBack={onSignerKeyBack}
           onContinue={onSignerKeyContinue}
-          loading={registeringRp}
+          loading={loading}
+          loadingLabel={finishingSetup ? "Finishing setup…" : undefined}
           hideTitle
         />
       )}
@@ -159,7 +170,8 @@ export const RegisterRpDialog = ({
         <GenerateNewKeyContent
           onBack={onSignerKeyBack}
           onContinue={onSignerKeyContinue}
-          loading={registeringRp}
+          loading={loading}
+          loadingLabel={finishingSetup ? "Finishing setup…" : undefined}
           hideTitle
         />
       )}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/GenerateNewKey/GenerateNewKeyContent/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/GenerateNewKey/GenerateNewKeyContent/index.tsx
@@ -25,6 +25,7 @@ export type GenerateNewKeyContentProps = {
   onContinue: (publicKey: string) => void;
   className?: string;
   loading?: boolean;
+  loadingLabel?: string;
   /** Skip the internal heading when a dialog header already carries it. */
   hideTitle?: boolean;
 };
@@ -34,6 +35,7 @@ export const GenerateNewKeyContent = ({
   onContinue,
   className,
   loading,
+  loadingLabel,
   hideTitle,
 }: GenerateNewKeyContentProps) => {
   const [privateKey, setPrivateKey] = useState<string>("");
@@ -190,10 +192,13 @@ export const GenerateNewKeyContent = ({
           type="submit"
           disabled={!isValid || loading}
           data-testid="button-generate-new-key-create"
-          className={`${formDialogPrimaryActionClassName} order-1 md:order-none`}
+          className={`${formDialogPrimaryActionClassName} order-1 gap-x-2 md:order-none`}
         >
           {loading ? (
-            <SpinnerIcon className="size-5 animate-spin" />
+            <>
+              <SpinnerIcon className="size-5 animate-spin" />
+              {loadingLabel}
+            </>
           ) : (
             "Continue"
           )}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/UseExistingKey/UseExistingKeyContent/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/UseExistingKey/UseExistingKeyContent/index.tsx
@@ -40,6 +40,7 @@ export type UseExistingKeyContentProps = {
   onContinue: (publicKey: string) => void;
   className?: string;
   loading?: boolean;
+  loadingLabel?: string;
   /** Skip the internal heading when a dialog header already carries it. */
   hideTitle?: boolean;
 };
@@ -49,6 +50,7 @@ export const UseExistingKeyContent = ({
   onContinue,
   className,
   loading = false,
+  loadingLabel,
   hideTitle,
 }: UseExistingKeyContentProps) => {
   const defaultValues: FormValues = useMemo(() => ({ public_key: "" }), []);
@@ -124,9 +126,16 @@ export const UseExistingKeyContent = ({
           type="submit"
           disabled={!isValid || loading}
           data-testid="button-use-existing-key-create"
-          className={`${formDialogPrimaryActionClassName} order-1 md:order-none`}
+          className={`${formDialogPrimaryActionClassName} order-1 gap-x-2 md:order-none`}
         >
-          {loading ? <SpinnerIcon className="size-5 animate-spin" /> : "Create"}
+          {loading ? (
+            <>
+              <SpinnerIcon className="size-5 animate-spin" />
+              {loadingLabel}
+            </>
+          ) : (
+            "Create"
+          )}
         </button>
       </div>
     </form>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RegisterRpEmptyState.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RegisterRpEmptyState.tsx
@@ -29,7 +29,7 @@ export const RegisterRpEmptyState = (props: {
   initialOpen?: boolean;
   isStaging: boolean;
   canManageWorldId: boolean;
-  onRegistered: () => void;
+  onRegistered: () => Promise<void>;
   onSetupClosed: (completed: boolean) => void;
 }) => {
   const canRegister = !props.isStaging && props.canManageWorldId;
@@ -50,7 +50,6 @@ export const RegisterRpEmptyState = (props: {
     const completed = completedRef.current;
     completedRef.current = false;
     setOpen(false);
-    props.onRegistered();
     props.onSetupClosed(completed);
   };
 
@@ -116,8 +115,9 @@ export const RegisterRpEmptyState = (props: {
         <RegisterRpDialog
           open={open}
           appId={props.appId}
-          onComplete={() => {
+          onComplete={async () => {
             completedRef.current = true;
+            await props.onRegistered();
           }}
           onClose={closeDialog}
         />

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
@@ -172,11 +172,12 @@ export const WorldIdLayout = (props: {
   });
   const normalizedRequestedTab = normalizeWorldIdTab(requestedTab);
   const shouldNormalizeTab =
-    requestedTab !== null &&
-    (requestedTab !== normalizedRequestedTab ||
-      (!createActionRequested &&
-        !enableWorldId4Requested &&
-        requestedTab !== availableTab));
+    (requestedTab === null && !hasRpRegistration && !createActionRequested) ||
+    (requestedTab !== null &&
+      (requestedTab !== normalizedRequestedTab ||
+        (!createActionRequested &&
+          !enableWorldId4Requested &&
+          requestedTab !== availableTab)));
   const { openSetup, openAction, consumeEnable, consumeCreate } =
     getSetupIntent({
       enableRequested: enableWorldId4Requested,
@@ -236,6 +237,9 @@ export const WorldIdLayout = (props: {
     () => void refetch().catch(() => {}),
     [refetch],
   );
+  const waitForOverviewRefresh = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
 
   const handleRpChanged = useCallback(
     (status?: RpRegistrationStatus) => {
@@ -384,7 +388,7 @@ export const WorldIdLayout = (props: {
                     initialOpen={openSetup || setupRequested}
                     isStaging={app.is_staging}
                     canManageWorldId={props.canManageWorldId}
-                    onRegistered={refetchOverview}
+                    onRegistered={waitForOverviewRefresh}
                     onSetupClosed={(completed) => {
                       setSetupRequested(false);
                       if (completed) {

--- a/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
+++ b/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
@@ -345,6 +345,29 @@ describe("WorldIdLayout [setup to create handoff]", () => {
     expect(screen.queryByTestId("danger-zone-section")).not.toBeInTheDocument();
   });
 
+  it("keeps a direct registration on Configuration after Apollo refetches", () => {
+    setQuery({ data: makeData({ rp: false }), loading: false });
+    const view = render(el());
+
+    fireEvent.click(screen.getByText("complete-setup"));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(replace).toHaveBeenLastCalledWith(
+      "/teams/team_1/apps/app_1/world-id?tab=configuration",
+      { scroll: false },
+    );
+
+    setQuery({ data: makeData({ status: "pending" }), loading: false });
+    view.rerender(el());
+
+    expect(screen.getByTestId("rp-summary")).toHaveAttribute(
+      "data-status",
+      "pending",
+    );
+    expect(screen.queryByTestId("actions-grid")).not.toBeInTheDocument();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
   it("still defaults to Configuration when legacy actions exist without an RP", () => {
     setQuery({
       data: makeData({ rp: false, legacy: true }),

--- a/web/tests/unit/pv3-world-id-unregistered-summary.test.tsx
+++ b/web/tests/unit/pv3-world-id-unregistered-summary.test.tsx
@@ -1,14 +1,36 @@
 /** @jest-environment jsdom */
 
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { generateRpIdString } from "@/lib/rp";
 import { RegisterRpEmptyState } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RegisterRpEmptyState";
 
 jest.mock("next/dynamic", () => ({
   __esModule: true,
-  default: () => (props: { open: boolean }) =>
-    props.open ? <div role="dialog">Configure signer key</div> : null,
+  default:
+    () =>
+    (props: {
+      open: boolean;
+      onClose?: (value: boolean) => void;
+      onComplete?: () => Promise<void> | void;
+    }) =>
+      props.open ? (
+        <div role="dialog">
+          Configure signer key
+          <button
+            type="button"
+            onClick={async () => {
+              await props.onComplete?.();
+              props.onClose?.(false);
+            }}
+          >
+            Complete registration
+          </button>
+          <button type="button" onClick={() => props.onClose?.(false)}>
+            Cancel registration
+          </button>
+        </div>
+      ) : null,
 }));
 
 const defaultProps = {
@@ -55,6 +77,34 @@ it("opens managed signer setup directly from the signer-address slot", () => {
   );
 
   expect(screen.getByRole("dialog")).toHaveTextContent("Configure signer key");
+});
+
+it("refreshes the overview before closing a completed registration", async () => {
+  render(<RegisterRpEmptyState {...defaultProps} />);
+
+  fireEvent.click(
+    screen.getByRole("button", { name: "Register relying party" }),
+  );
+  fireEvent.click(
+    screen.getByRole("button", { name: "Complete registration" }),
+  );
+
+  expect(defaultProps.onRegistered).toHaveBeenCalledTimes(1);
+  await waitFor(() =>
+    expect(defaultProps.onSetupClosed).toHaveBeenCalledWith(true),
+  );
+});
+
+it("does not report a registration when the dialog is cancelled", () => {
+  render(<RegisterRpEmptyState {...defaultProps} />);
+
+  fireEvent.click(
+    screen.getByRole("button", { name: "Register relying party" }),
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Cancel registration" }));
+
+  expect(defaultProps.onSetupClosed).toHaveBeenCalledWith(false);
+  expect(defaultProps.onRegistered).not.toHaveBeenCalled();
 });
 
 it.each([

--- a/web/tests/unit/world-id-key-step-loading.test.tsx
+++ b/web/tests/unit/world-id-key-step-loading.test.tsx
@@ -19,6 +19,8 @@ const refresh = jest.fn();
 
 function mockGenerateKeyStep(props: {
   onContinue: (publicKey: string) => void;
+  loading?: boolean;
+  loadingLabel?: string;
 }) {
   if (!mockKeyStepReady) {
     throw mockPendingKeyStep;
@@ -28,11 +30,12 @@ function mockGenerateKeyStep(props: {
     <button
       type="button"
       data-testid="generate-key-step"
+      disabled={props.loading}
       onClick={() =>
         props.onContinue("0x1234567890abcdef1234567890abcdef12345678")
       }
     >
-      Generate key step loaded
+      {props.loading ? props.loadingLabel : "Generate key step loaded"}
     </button>
   );
 }
@@ -193,7 +196,13 @@ it("PortalV3 registers the relying party in managed mode", async () => {
   registerRp.mockResolvedValue({
     data: { register_rp: { rp_id: "rp_1234567890abcdef" } },
   });
-  const onComplete = jest.fn();
+  let resolveOverviewRefresh: () => void = () => {};
+  const onComplete = jest.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveOverviewRefresh = resolve;
+      }),
+  );
   const onClose = jest.fn();
 
   render(
@@ -220,6 +229,11 @@ it("PortalV3 registers the relying party in managed mode", async () => {
     }),
   );
   expect(onComplete).toHaveBeenCalledTimes(1);
-  expect(refresh).toHaveBeenCalledTimes(1);
-  expect(onClose).toHaveBeenCalledWith(false);
+  expect(await screen.findByText("Finishing setup…")).toBeInTheDocument();
+  expect(refresh).not.toHaveBeenCalled();
+  expect(onClose).not.toHaveBeenCalled();
+
+  await act(async () => resolveOverviewRefresh());
+
+  await waitFor(() => expect(onClose).toHaveBeenCalledWith(false));
 });


### PR DESCRIPTION
This PR keeps RP registration on World ID Configuration until the refreshed RP state is ready.

- removes the full App Router refresh after registration
- shows `Finishing setup…` while the Apollo overview refetch completes
- keeps direct registration on Configuration while preserving the create-action handoff
- avoids refetching when the modal is cancelled
- validates the flow with 86 focused World ID tests, TypeScript, ESLint, and Prettier