### PR TITLE
fix(world-id): unblock the actions grid while registration is pending

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
@@ -273,6 +273,41 @@ export const WorldIdLayout = (props: {
     };
   }, [props.appId, refetchOverview]);
 
+  const rpId = rp?.rp_id;
+  const rpServerStatus = rp?.status;
+  // The rp-status endpoint is what reconciles a pending registration (it reads
+  // on-chain state and syncs the DB row), but its usual host — RpSummary —
+  // only mounts on the Configuration section. Keep pending converging while
+  // the user sits on Actions so the grid unlocks without a manual refresh.
+  useEffect(() => {
+    if (!rpId || activeTab === WORLD_ID_TABS.Configuration) return;
+    if (effectiveRpStatus !== RpRegistrationStatus.Pending) return;
+
+    let cancelled = false;
+    const reconcile = async () => {
+      try {
+        const response = await fetch(`/api/v4/rp-status/${rpId}`, {
+          signal: AbortSignal.timeout(4000),
+        });
+        if (cancelled || !response.ok) return;
+        const result = (await response.json()) as { production_status: string };
+        if (result.production_status !== rpServerStatus) refetchOverview();
+      } catch {
+        // Retain the last known status when reconciliation is unavailable.
+      }
+    };
+
+    void reconcile();
+    const interval = setInterval(() => {
+      if (!document.hidden) void reconcile();
+    }, 5000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [activeTab, effectiveRpStatus, refetchOverview, rpId, rpServerStatus]);
+
   const consumeCreateAction = useCallback(() => {
     setCreateAfterSetup(false);
     consumeSearchParams("createAction");

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionsGrid/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionsGrid/index.tsx
@@ -19,6 +19,8 @@ export const ActionsGrid = (props: {
   appId: string;
   search: string;
   canCreate: boolean;
+  /** Why creation is unavailable, shown when the grid has nothing to render. */
+  emptyReason: string;
   initialDialogOpen?: boolean;
   onCreateActionConsumed: () => void;
   onActionsChanged: () => void;
@@ -50,6 +52,16 @@ export const ActionsGrid = (props: {
     (page - 1) * ACTIONS_PER_PAGE,
     page * ACTIONS_PER_PAGE,
   );
+  // The create tile is its own empty state, so only explain a grid that would
+  // otherwise render nothing at all.
+  const emptyMessage =
+    filtered.length > 0
+      ? null
+      : props.search
+        ? "No actions match your search."
+        : props.canCreate
+          ? null
+          : props.emptyReason;
 
   const handleDialogClose = (success?: boolean) => {
     setDialogOpen(false);
@@ -79,6 +91,12 @@ export const ActionsGrid = (props: {
             action={action}
           />
         ))}
+
+        {emptyMessage ? (
+          <div className="col-span-full rounded-[10px] border border-dashed border-portal-border px-5 py-12 text-center font-world text-13 text-portal-muted">
+            {emptyMessage}
+          </div>
+        ) : null}
       </div>
 
       {totalPages > 1 ? (

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/index.tsx
@@ -25,6 +25,11 @@ export const WorldIdActionsPage = () => {
       appId={appId}
       search={actionsSearch}
       canCreate={canManageWorldId && hasActiveRp}
+      emptyReason={
+        canManageWorldId
+          ? "Finish registering your relying party to create actions."
+          : "Ask a team owner or admin to create actions."
+      }
       initialDialogOpen={shouldOpenCreateAction}
       onCreateActionConsumed={consumeCreateAction}
       onActionsChanged={refreshOverview}

--- a/web/tests/unit/pv3-world-id-action-card.test.tsx
+++ b/web/tests/unit/pv3-world-id-action-card.test.tsx
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { ActionsSearchToolbar } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/ActionsSearchToolbar";
 import { ActionCard } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionCard";
 import { ActionsGrid } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page/ActionsGrid";
@@ -56,6 +57,7 @@ it("renders the create action card before existing actions", () => {
       appId="app_1"
       search=""
       canCreate
+      emptyReason="Ask a team owner or admin to create actions."
       onCreateActionConsumed={jest.fn()}
       onActionsChanged={jest.fn()}
     />,
@@ -80,6 +82,7 @@ it("paginates action cards", () => {
       appId="app_1"
       search=""
       canCreate={false}
+      emptyReason="Ask a team owner or admin to create actions."
       onCreateActionConsumed={jest.fn()}
       onActionsChanged={jest.fn()}
     />,
@@ -91,6 +94,54 @@ it("paginates action cards", () => {
   expect(screen.getByRole("link", { name: "action-13" })).toBeInTheDocument();
 });
 
+const emptyGrid = (over: Partial<ComponentProps<typeof ActionsGrid>> = {}) => (
+  <ActionsGrid
+    actions={[]}
+    teamId="team_1"
+    appId="app_1"
+    search=""
+    canCreate={false}
+    emptyReason="Ask a team owner or admin to create actions."
+    onCreateActionConsumed={jest.fn()}
+    onActionsChanged={jest.fn()}
+    {...over}
+  />
+);
+
+it("explains an empty grid that offers no way to create", () => {
+  render(emptyGrid());
+
+  expect(
+    screen.getByText("Ask a team owner or admin to create actions."),
+  ).toBeInTheDocument();
+});
+
+it("explains a search that filters every action out", () => {
+  render(
+    emptyGrid({
+      actions: [{ id: "action_1", action: "verify", description: "" }],
+      search: "nothing-matches",
+      canCreate: true,
+    }),
+  );
+
+  expect(screen.getByText("No actions match your search.")).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Create action" }),
+  ).toBeInTheDocument();
+});
+
+it("leaves the create tile as the only empty state when creation is allowed", () => {
+  render(emptyGrid({ canCreate: true }));
+
+  expect(
+    screen.getByRole("button", { name: "Create action" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText("Ask a team owner or admin to create actions."),
+  ).not.toBeInTheDocument();
+});
+
 it("opens a deferred create intent when it becomes actionable", async () => {
   const props = {
     actions: [],
@@ -98,6 +149,7 @@ it("opens a deferred create intent when it becomes actionable", async () => {
     appId: "app_1",
     search: "",
     canCreate: true,
+    emptyReason: "Ask a team owner or admin to create actions.",
     onCreateActionConsumed: jest.fn(),
     onActionsChanged: jest.fn(),
   };

--- a/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
+++ b/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
@@ -1,6 +1,12 @@
 /** @jest-environment jsdom */
 import "@testing-library/jest-dom";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import React from "react";
 import { WorldIdLayout } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout";
 import { WorldIdPage } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page";
@@ -10,6 +16,7 @@ import { WorldIdPage } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/p
 // BanMessageDialog is a static import. Revisit if that import graph grows.
 const useQueryMock = jest.fn();
 const refetch = jest.fn();
+const fetchMock = jest.fn();
 jest.mock("@apollo/client/react", () => ({
   useQuery: (...args: unknown[]) => useQueryMock(...args),
 }));
@@ -192,6 +199,14 @@ beforeEach(() => {
   useQueryMock.mockReset();
   // refetchOverview calls .catch() on the result.
   refetch.mockResolvedValue({});
+  // The layout reconciles a pending RP through /api/v4/rp-status.
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({ ok: false });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  Object.defineProperty(AbortSignal, "timeout", {
+    configurable: true,
+    value: () => new AbortController().signal,
+  });
   Object.defineProperty(document, "visibilityState", {
     value: "visible",
     configurable: true,
@@ -298,6 +313,42 @@ describe("WorldIdLayout [optimistic status]", () => {
       "data-can-create",
       "false",
     );
+  });
+
+  it("reconciles a pending registration while the user is on Actions", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ production_status: "registered" }),
+    });
+    setQuery({ data: makeData({ status: "pending" }), loading: false });
+    render(el());
+
+    await waitFor(() => expect(refetch).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v4/rp-status/rp_0123456789abcdef",
+      expect.anything(),
+    );
+  });
+
+  it("does not refetch when reconciliation still reports pending", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ production_status: "pending" }),
+    });
+    setQuery({ data: makeData({ status: "pending" }), loading: false });
+    render(el());
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("leaves pending reconciliation to RpSummary on Configuration", () => {
+    searchParams = new URLSearchParams("tab=configuration");
+    setQuery({ data: makeData({ status: "pending" }), loading: false });
+    render(el());
+
+    expect(screen.getByTestId("rp-summary")).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("lets a background refetch override an optimistic status for the same RP", () => {


### PR DESCRIPTION
## Problem

After registering a relying party, the Actions section renders a grid with no create tile (`canCreate` requires `status='registered'`, the row is `pending`), no actions, and no explanation — a blank page. Nothing on that page ever re-checks the status: the rp-status reconciler is mounted only by `RpSummary` on the Configuration section, so the grid stays blank until a window refocus. #2214 keeps the registration flow itself on Configuration, but any arrival at Actions during the pending window (sidebar item, bare `/world-id` re-entry) still hits the dead end.

Two adjacent cases render the same blank grid and never recover: a member (non-admin) viewing a registered app with zero actions, and a search query matching nothing.

## Change

- **Poll the reconciler from the layout** while an RP is pending and the user is off Configuration. Same endpoint, cadence (5s, skipped while hidden), timeout (4s), and hidden-tab behavior as `useRpRegistrationController`. When production status changes, refetch the overview — the grid flips to the normal Actions page with the create tile, no user action needed. The effect unmounts once the status leaves `pending`, so there is no steady-state polling.
- **Give the grid an empty state** instead of rendering nothing: "Finish registering your relying party to create actions." (owner, pending), "Ask a team owner or admin to create actions." (member — mirrors the copy Configuration already uses at `RegisterRpEmptyState`), "No actions match your search." (search miss). When the create tile is shown it remains the only empty state.

Registration flow, tab defaults, and sidebar behavior are unchanged from main.

## Failure handling

- Reconciliation fetch failures are swallowed and retried on the next tick; the page keeps the last known status (same posture as the existing controller).
- The poll is bounded: single in-flight guard via effect lifecycle, 4s abort, stops on status change, tab change, or unmount.

## Testing

- `tests/unit/pv3-world-id-layout-freshness.test.tsx`: pending on Actions triggers reconciliation and refetches on status change; no refetch while still pending; no layout poll on Configuration (RpSummary owns it there).
- `tests/unit/pv3-world-id-action-card.test.tsx`: empty-reason message, search-miss message, and create-tile-only when creation is allowed.
- 674/674 unit tests, `tsc`, Prettier clean.

Fixes this:
<img width="1711" height="917" alt="image" src="https://github.com/user-attachments/assets/d76d440e-03f7-4438-a8f7-c5fb2cf47fc0" />
