### PR TITLE
fix(portal-v3): align Mini App notice cards across tabs

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/PermissionsForm/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/PermissionsForm/index.tsx
@@ -490,7 +490,7 @@ export const SetupForm = ({
   // serves Mini Apps.
   if (appMetadata?.app_mode === "external") {
     return (
-      <div className="grid grid-cols-auto/1fr items-start gap-x-3 rounded-[10px] bg-grey-50 p-4 sm:p-5">
+      <div className="grid max-w-[1180px] grid-cols-auto/1fr items-start gap-x-3 rounded-[10px] bg-grey-50 p-4 sm:p-5">
         <LockIcon
           className={`${noticeIconClassName} size-8 text-grey-900`}
           aria-hidden="true"

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/index.tsx
@@ -22,7 +22,7 @@ const TransactionsPageLayout = ({
   showHeading?: boolean;
 }) => {
   return (
-    <div className="my-6 min-h-dvh">
+    <div className="my-8 min-h-dvh">
       {showHeading && (
         <div className="flex items-center justify-start text-gray-900">
           <Typography variant={TYPOGRAPHY.H6}>Transactions</Typography>


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description
fixed spacing on banners, i.e. brought consistency under Mini App tabs when not registered.