### PR TITLE
feat(portal-v3): mirror loaded layout in Get Verified skeleton

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/AppModeCards.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/AppModeCards.tsx
@@ -2,6 +2,7 @@
 
 import { Icon, opticalIconClassName } from "@/scenes/PortalV3/common/Icon";
 import clsx from "clsx";
+import Skeleton from "react-loading-skeleton";
 
 export type AppMode = "mini-app" | "external";
 
@@ -18,52 +19,74 @@ const APP_MODES: { value: AppMode; title: string; description: string }[] = [
   },
 ];
 
-/** "Advanced settings" radio cards choosing between Mini App and External. */
-export const AppModeCards = (props: {
-  value: AppMode;
-  onChange: (value: AppMode) => void;
-  disabled?: boolean;
-}) => (
+/**
+ * "Advanced settings" radio cards choosing between Mini App and External.
+ * `loading` keeps the static card chrome but shimmers the selection marker —
+ * which mode is chosen is data we don't have yet.
+ */
+export const AppModeCards = (
+  props: { disabled?: boolean } & (
+    | { loading: true; value?: never; onChange?: never }
+    | { loading?: false; value: AppMode; onChange: (value: AppMode) => void }
+  ),
+) => (
   <div className="flex w-full items-start gap-4">
     {APP_MODES.map((mode) => {
-      const isSelected = props.value === mode.value;
+      const isSelected = !props.loading && props.value === mode.value;
       return (
         <label
           key={mode.value}
           className={clsx(
             "flex min-w-0 flex-1 flex-col gap-3 rounded-[10px] border border-portal-border px-6 py-5",
-            props.disabled ? "cursor-default opacity-60" : "cursor-pointer",
+            props.disabled && "opacity-60",
+            props.disabled || props.loading
+              ? "cursor-default"
+              : "cursor-pointer",
           )}
         >
           <span className="flex w-full items-center justify-between">
             <span className="text-15 leading-[1.2] font-medium whitespace-nowrap text-portal-ink">
               {mode.title}
             </span>
-            <input
-              type="radio"
-              name="app-mode"
-              value={mode.value}
-              checked={isSelected}
-              disabled={props.disabled}
-              onChange={() => props.onChange(mode.value)}
-              className="sr-only"
-            />
-            <span
-              aria-hidden="true"
-              className={clsx(
-                "flex size-5 shrink-0 items-center justify-center rounded-full",
-                // Optical lift against the cap-height card title, applied to
-                // both selected and unselected markers so they stay aligned.
-                opticalIconClassName,
-                isSelected
-                  ? "bg-portal-ink"
-                  : "border-[1.25px] border-portal-border",
-              )}
-            >
-              {isSelected && (
-                <Icon name="radio-check" className="size-[13.333px]" />
-              )}
-            </span>
+            {props.loading ? (
+              <Skeleton
+                circle
+                width={20}
+                height={20}
+                containerClassName={clsx(
+                  "flex size-5 shrink-0",
+                  opticalIconClassName,
+                )}
+              />
+            ) : (
+              <>
+                <input
+                  type="radio"
+                  name="app-mode"
+                  value={mode.value}
+                  checked={isSelected}
+                  disabled={props.disabled}
+                  onChange={() => props.onChange(mode.value)}
+                  className="sr-only"
+                />
+                <span
+                  aria-hidden="true"
+                  className={clsx(
+                    "flex size-5 shrink-0 items-center justify-center rounded-full",
+                    // Optical lift against the cap-height card title, applied to
+                    // both selected and unselected markers so they stay aligned.
+                    opticalIconClassName,
+                    isSelected
+                      ? "bg-portal-ink"
+                      : "border-[1.25px] border-portal-border",
+                  )}
+                >
+                  {isSelected && (
+                    <Icon name="radio-check" className="size-[13.333px]" />
+                  )}
+                </span>
+              </>
+            )}
           </span>
           {/* Description wraps at 218px in Figma (hug-content text box). Color
               is nucleus/foreground-secondary (#7d7d7d) — no portal token. */}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/BasicInformationStep.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/BasicInformationStep.tsx
@@ -117,6 +117,39 @@ export const WizardLogoUpload = (props: {
 };
 
 /**
+ * Skeleton twin of BasicInformationStep below — same containers and labels,
+ * shimmer in every value slot (via the fields' `loading` mode). Keep the two
+ * in sync when fields change.
+ */
+export const BasicInformationStepSkeleton = () => (
+  <div className="flex w-full flex-col gap-14">
+    <div className="flex w-full flex-col gap-4">
+      <div className="flex w-full items-start gap-4">
+        <TextField label="App name" required value="" loading />
+        <TextField label="Publisher" readOnly value="" loading />
+      </div>
+      <TextField label="App URL" required value="" loading />
+      <TextField label="App Official Website" required value="" loading />
+      <TextField
+        label="App ID"
+        readOnly
+        muted
+        value=""
+        loading
+        trailing={<CopyIcon aria-hidden className="size-5 shrink-0" />}
+      />
+    </div>
+
+    <div className="flex w-full flex-col gap-5">
+      <h2 className="text-15 leading-[1.2] font-medium text-portal-ink">
+        Advanced settings
+      </h2>
+      <AppModeCards loading />
+    </div>
+  </div>
+);
+
+/**
  * Step 1 of the configuration wizard: identity fields plus the Mini App /
  * External mode choice. Persists through the same paths as the previous
  * page: the basic-information autosave form (name/URLs) and the app-mode

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/Skeleton.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/Skeleton.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import Skeleton from "react-loading-skeleton";
+import { BasicInformationStepSkeleton } from "./BasicInformationStep";
+import {
+  primaryButtonClassName,
+  secondaryButtonClassName,
+  wizardActionBarClassName,
+  wizardActionBarInnerClassName,
+  wizardBasicBodyClassName,
+  wizardFrameClassName,
+  wizardLogoRowClassName,
+  wizardScrollRegionClassName,
+  wizardStepperRowClassName,
+} from "./index";
+
+/**
+ * Loading mirror of the wizard on its first step: the real frame, field
+ * boxes, mode cards and action bar render for real; every data slot
+ * shimmers. Data-dependent chrome is never asserted — the stepper is a plain
+ * bar because mini apps have one more step, and the logo circle carries no
+ * empty-state copy because a logo may exist.
+ */
+export const ConfigurationWizardSkeleton = () => (
+  <div aria-hidden className={wizardFrameClassName}>
+    <div className={wizardStepperRowClassName}>
+      <Skeleton
+        height={20}
+        borderRadius={9999}
+        containerClassName="flex h-5 w-full max-w-[560px]"
+      />
+    </div>
+
+    <div className={wizardScrollRegionClassName}>
+      <div className={wizardLogoRowClassName}>
+        {/* LogoDropZone's size-36 circle. */}
+        <Skeleton circle width={144} height={144} containerClassName="flex" />
+      </div>
+      <div className={wizardBasicBodyClassName}>
+        <BasicInformationStepSkeleton />
+      </div>
+    </div>
+
+    <div className={wizardActionBarClassName}>
+      <div className={wizardActionBarInnerClassName}>
+        <div className="flex flex-1 justify-start">
+          {/* Back is genuinely disabled on the first step, so this matches
+              the loaded state; Continue enables once data lands. */}
+          <button type="button" disabled className={secondaryButtonClassName}>
+            Back
+          </button>
+        </div>
+        <div className="flex flex-1 justify-end">
+          {/* Same inner typography as AppStoreActionsButton so the button
+              keeps its exact width when the real action replaces it. */}
+          <button type="button" disabled className={primaryButtonClassName}>
+            <Typography
+              variant={TYPOGRAPHY.M4}
+              className="leading-none whitespace-nowrap"
+            >
+              Continue
+            </Typography>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+);

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/Skeleton.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/Skeleton.tsx
@@ -3,6 +3,7 @@
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import Skeleton from "react-loading-skeleton";
 import { BasicInformationStepSkeleton } from "./BasicInformationStep";
+import { StepperSkeleton } from "./Stepper";
 import {
   primaryButtonClassName,
   secondaryButtonClassName,
@@ -16,22 +17,16 @@ import {
 } from "./index";
 
 /**
- * Loading mirror of the wizard on its first step: the real frame, field
- * boxes, mode cards and action bar render for real; every data slot
- * shimmers. Data-dependent chrome is never asserted — the stepper is a plain
- * bar because mini apps have one more step, and the logo circle carries no
- * empty-state copy because a logo may exist.
+ * Loading mirror of the wizard on its first step: the real frame, stepper
+ * geometry, field boxes, mode cards and action bar render for real; every data
+ * slot shimmers. Data-dependent chrome is never asserted — the stepper shows
+ * no numbers or active step (mini apps have one more step), and the logo
+ * circle carries no empty-state copy because a logo may exist.
  */
 export const ConfigurationWizardSkeleton = () => (
   <div aria-hidden className={wizardFrameClassName}>
     <div className={wizardStepperRowClassName}>
-      {/* 695px = the rendered width of the 4-step stepper, the narrowest
-          real variant (mini apps get a 5th step). */}
-      <Skeleton
-        height={20}
-        borderRadius={9999}
-        containerClassName="flex h-5 w-full max-w-[695px]"
-      />
+      <StepperSkeleton />
     </div>
 
     <div className={wizardScrollRegionClassName}>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/Skeleton.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/Skeleton.tsx
@@ -25,10 +25,12 @@ import {
 export const ConfigurationWizardSkeleton = () => (
   <div aria-hidden className={wizardFrameClassName}>
     <div className={wizardStepperRowClassName}>
+      {/* 695px = the rendered width of the 4-step stepper, the narrowest
+          real variant (mini apps get a 5th step). */}
       <Skeleton
         height={20}
         borderRadius={9999}
-        containerClassName="flex h-5 w-full max-w-[560px]"
+        containerClassName="flex h-5 w-full max-w-[695px]"
       />
     </div>
 

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/Stepper.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/Stepper.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/scenes/PortalV3/common/Icon";
 import clsx from "clsx";
 import { Fragment } from "react";
+import Skeleton from "react-loading-skeleton";
 
 export enum WizardStep {
   BASIC = "basic-information",
@@ -66,6 +67,19 @@ export const getWizardStepForField = (
   return isMiniApp ? WizardStep.STORE_LISTING : WizardStep.BASIC;
 };
 
+// Row/connector/step geometry, shared with StepperSkeleton so the loading
+// state wraps at exactly the same widths as the real stepper.
+// flex-wrap: on narrow windows the row breaks into lines instead of ever
+// producing a horizontal scrollbar.
+const stepperRowClassName = "flex flex-wrap items-center justify-center gap-4";
+const stepperConnectorClassName = clsx(
+  "h-px w-8 bg-portal-border",
+  opticalIconClassName,
+);
+const stepperStepClassName = "flex items-center gap-2";
+const stepperLabelClassName =
+  "text-13 leading-[1.2] font-medium whitespace-nowrap";
+
 /**
  * Numbered-dot step indicator across the top of the configuration wizard.
  * True to the Figma frames: steps behind the active one show the green
@@ -77,28 +91,23 @@ export const Stepper = (props: {
   activeIndex: number;
   onStepSelect?: (step: WizardStep) => void;
 }) => (
-  // flex-wrap: on narrow windows the row breaks into lines instead of ever
-  // producing a horizontal scrollbar.
-  <ol className="flex flex-wrap items-center justify-center gap-4">
+  <ol className={stepperRowClassName}>
     {props.steps.map((step, index) => {
       const isActive = index === props.activeIndex;
       const isCompleted = index < props.activeIndex;
       return (
         <Fragment key={step.id}>
           {index > 0 && (
-            <li
-              aria-hidden="true"
-              className={clsx(
-                "h-px w-8 bg-portal-border",
-                opticalIconClassName,
-              )}
-            />
+            <li aria-hidden="true" className={stepperConnectorClassName} />
           )}
           <li aria-current={isActive ? "step" : undefined}>
             <button
               type="button"
               onClick={() => props.onStepSelect?.(step.id)}
-              className="flex cursor-pointer items-center gap-2 transition-opacity hover:opacity-70"
+              className={clsx(
+                stepperStepClassName,
+                "cursor-pointer transition-opacity hover:opacity-70",
+              )}
             >
               {/* Both bubble variants and the connector carry the same 1px
                   optical lift against the cap-height label — correcting only
@@ -129,7 +138,7 @@ export const Stepper = (props: {
               )}
               <span
                 className={clsx(
-                  "text-13 leading-[1.2] font-medium whitespace-nowrap",
+                  stepperLabelClassName,
                   isActive || isCompleted
                     ? "text-portal-ink"
                     : "text-portal-subtle",
@@ -142,5 +151,43 @@ export const Stepper = (props: {
         </Fragment>
       );
     })}
+  </ol>
+);
+
+/**
+ * Loading twin of Stepper: same row, connector, bubble and label geometry, so
+ * it reserves the height the real stepper will occupy and breaks onto the same
+ * number of lines at every width — a fixed-height bar would jump by 36px per
+ * wrapped line once data arrived.
+ *
+ * Sized to the external-app step list, the narrowest real variant; each label
+ * reserves its true text width by rendering the real string invisibly, with
+ * shimmer painted over it. Which step is active, and whether a fifth
+ * store-listing step exists, are data we don't have yet — neither is asserted.
+ */
+export const StepperSkeleton = () => (
+  <ol aria-hidden className={stepperRowClassName}>
+    {getWizardSteps(false).map((step, index) => (
+      <Fragment key={step.id}>
+        {index > 0 && <li className={stepperConnectorClassName} />}
+        <li>
+          <span className={stepperStepClassName}>
+            <Skeleton
+              circle
+              width={20}
+              height={20}
+              containerClassName={clsx("flex size-5", opticalIconClassName)}
+            />
+            <span className={clsx(stepperLabelClassName, "relative")}>
+              <span className="invisible">{step.label}</span>
+              <Skeleton
+                height="100%"
+                containerClassName="absolute inset-0 block"
+              />
+            </span>
+          </span>
+        </li>
+      </Fragment>
+    ))}
   </ol>
 );

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/TextField.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/TextField.tsx
@@ -2,6 +2,7 @@
 
 import clsx from "clsx";
 import { KeyboardEventHandler, ReactNode, useState } from "react";
+import Skeleton from "react-loading-skeleton";
 
 /**
  * Wizard text field with the label floating inside the box. The box chrome is
@@ -32,11 +33,17 @@ export const TextField = (props: {
   className?: string;
   /** Keep the field accessible while omitting a label already shown nearby. */
   hideLabel?: boolean;
+  /**
+   * Skeleton mode: same box chrome, floating label, shimmer in the value
+   * slot, no input. `value` is ignored.
+   */
+  loading?: boolean;
 }) => {
   const [isFocused, setIsFocused] = useState(false);
   const isFloating =
-    !props.hideLabel && (props.readOnly || isFocused || props.value.length > 0);
-  const isInert = props.readOnly || props.disabled;
+    !props.hideLabel &&
+    (props.loading || props.readOnly || isFocused || props.value.length > 0);
+  const isInert = props.loading || props.readOnly || props.disabled;
 
   const requiredMark = props.required && (
     // Figma nucleus/status-negative (#ea392a) — no portal token for it yet.
@@ -74,26 +81,32 @@ export const TextField = (props: {
               {requiredMark}
             </span>
           )}
-          <input
-            name={props.name}
-            type={props.type ?? "text"}
-            value={props.value}
-            aria-label={props.hideLabel ? props.label : undefined}
-            readOnly={props.readOnly}
-            disabled={props.disabled}
-            maxLength={props.maxLength}
-            onChange={(event) => props.onChange?.(event.target.value)}
-            onKeyDown={props.onKeyDown}
-            onFocus={() => setIsFocused(true)}
-            onBlur={() => {
-              setIsFocused(false);
-              props.onBlur?.();
-            }}
-            className={clsx(
-              "w-full min-w-0 bg-transparent p-0 text-15 leading-[1.3] font-[350] text-portal-ink outline-none",
-              !props.hideLabel && !isFloating && "sr-only",
-            )}
-          />
+          {props.loading ? (
+            <span className="w-full text-15 leading-[1.3] font-[350]">
+              <Skeleton width="40%" />
+            </span>
+          ) : (
+            <input
+              name={props.name}
+              type={props.type ?? "text"}
+              value={props.value}
+              aria-label={props.hideLabel ? props.label : undefined}
+              readOnly={props.readOnly}
+              disabled={props.disabled}
+              maxLength={props.maxLength}
+              onChange={(event) => props.onChange?.(event.target.value)}
+              onKeyDown={props.onKeyDown}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => {
+                setIsFocused(false);
+                props.onBlur?.();
+              }}
+              className={clsx(
+                "w-full min-w-0 bg-transparent p-0 text-15 leading-[1.3] font-[350] text-portal-ink outline-none",
+                !props.hideLabel && !isFloating && "sr-only",
+              )}
+            />
+          )}
           {!props.hideLabel && !isFloating && (
             <span className="w-full text-15 leading-[1.3] font-[350] text-portal-subtle">
               {props.label}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/index.tsx
@@ -35,10 +35,25 @@ import {
   WizardStep,
 } from "./Stepper";
 
-const secondaryButtonClassName =
+export const secondaryButtonClassName =
   "flex h-10 items-center justify-center rounded-[10px] bg-portal-canvas px-6 text-15 leading-[1.2] font-semibold text-portal-ink transition-colors hover:bg-portal-border disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-portal-canvas";
-const primaryButtonClassName =
+export const primaryButtonClassName =
   "flex h-10 items-center justify-center rounded-[10px] bg-portal-ink px-6 text-15 leading-[1.2] font-semibold text-white transition-colors hover:bg-portal-ink-hover disabled:cursor-not-allowed disabled:opacity-60";
+
+// Frame chrome shared with Skeleton.tsx so the loading state can never drift
+// from the loaded layout.
+export const wizardFrameClassName =
+  "flex h-[calc(100dvh-var(--portal-header-height))] w-full flex-col overflow-x-clip px-6 pt-[43px] font-world";
+export const wizardStepperRowClassName =
+  "relative flex w-full shrink-0 justify-center";
+export const wizardScrollRegionClassName =
+  "-mx-6 min-h-0 w-auto flex-1 overflow-x-hidden overflow-y-auto px-6 pb-8";
+export const wizardLogoRowClassName = "mt-[76px] flex justify-center";
+export const wizardBasicBodyClassName = "mx-auto mt-10 w-full max-w-[626px]";
+export const wizardActionBarClassName =
+  "-mx-6 shrink-0 border-t border-portal-border bg-white px-6 py-3";
+export const wizardActionBarInnerClassName =
+  "mx-auto flex w-full max-w-[626px] items-center gap-3";
 
 /**
  * Q3 2026 configuration wizard (Figma: Dev Portal Q3 2026). The designed
@@ -162,13 +177,13 @@ export const ConfigurationWizard = (props: {
     // previous page's docked layout. overflow-x-clip keeps stray wide content
     // from ever handing the shell a horizontal scrollbar (which focus would
     // then jump along).
-    <div className="flex h-[calc(100dvh-var(--portal-header-height))] w-full flex-col overflow-x-clip px-6 pt-[43px] font-world">
+    <div className={wizardFrameClassName}>
       {props.banner && (
         <div className="mx-auto mb-6 w-full max-w-[626px] shrink-0">
           {props.banner}
         </div>
       )}
-      <div className="relative flex w-full shrink-0 justify-center">
+      <div className={wizardStepperRowClassName}>
         <Stepper
           steps={steps}
           activeIndex={activeIndex}
@@ -200,10 +215,7 @@ export const ConfigurationWizard = (props: {
           overflow-x-hidden means wide content clips rather than ever growing
           a horizontal scrollbar. Full-bleed (-mx-6) so the scrollbar hugs the
           frame edge instead of floating beside the content column. */}
-      <div
-        ref={scrollContainerRef}
-        className="-mx-6 min-h-0 w-auto flex-1 overflow-x-hidden overflow-y-auto px-6 pb-8"
-      >
+      <div ref={scrollContainerRef} className={wizardScrollRegionClassName}>
         <AppStoreForm
           appId={appId}
           teamId={teamId}
@@ -213,7 +225,7 @@ export const ConfigurationWizard = (props: {
             className={stepWrapperClassName(WizardStep.BASIC, "")}
             aria-hidden={activeStep !== WizardStep.BASIC}
           >
-            <div className="mt-[76px] flex justify-center">
+            <div className={wizardLogoRowClassName}>
               <WizardLogoUpload
                 appId={appId}
                 teamId={teamId}
@@ -221,7 +233,7 @@ export const ConfigurationWizard = (props: {
                 canEdit={isEditable && canManageDraft}
               />
             </div>
-            <div className="mx-auto mt-10 w-full max-w-[626px]">
+            <div className={wizardBasicBodyClassName}>
               <BasicInformationStep
                 ref={basicInfoRef}
                 appId={appId}
@@ -283,8 +295,8 @@ export const ConfigurationWizard = (props: {
 
       {/* Docked action bar: pinned below the scroll region, matching the
           previous page's fixed footer. */}
-      <div className="-mx-6 shrink-0 border-t border-portal-border bg-white px-6 py-3">
-        <div className="mx-auto flex w-full max-w-[626px] items-center gap-3">
+      <div className={wizardActionBarClassName}>
+        <div className={wizardActionBarInnerClassName}>
           <div className="flex flex-1 justify-start">
             {/* Always rendered: a disabled Back on the first step reads as
                 "you're at the start", where a missing button reads as broken. */}

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/page.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/page.tsx
@@ -8,7 +8,6 @@ import { useQuery } from "@apollo/client/react";
 import { useAtom } from "jotai";
 import { useParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
-import Skeleton from "react-loading-skeleton";
 import { AppStoreFormProvider } from "../AppStore/app-store-form-provider";
 import {
   AppMetadata,
@@ -19,6 +18,7 @@ import { RejectionBanner } from "../RejectionBanner";
 import { ResolveModal } from "../ResolveModal";
 import { SaveStatusProvider } from "../SaveStatus";
 import { ConfigurationWizard } from "./index";
+import { ConfigurationWizardSkeleton } from "./Skeleton";
 import { WizardStep } from "./Stepper";
 
 type ConfigurationWizardPageProps = {
@@ -98,17 +98,7 @@ export const ConfigurationWizardPage = ({
   }
 
   if (loading || isLocalisationsLoading || !app || !appMetadata) {
-    return (
-      <div className="mx-auto grid w-full max-w-[626px] gap-y-6 pt-24">
-        <Skeleton
-          height={144}
-          width={144}
-          circle
-          className="justify-self-center"
-        />
-        <Skeleton count={4} height={56} />
-      </div>
-    );
+    return <ConfigurationWizardSkeleton />;
   }
 
   return (


### PR DESCRIPTION
This PR makes the get verified wizard's loading state look like the loaded page, so data fills in place instead of replacing a generic placeholder.

Before, the loading state was a bare circle and four gray bars. Now the skeleton composes the wizard's real chrome — stepper row, logo circle, the labelled App name / Publisher / App URL / App Official Website / App ID boxes, the Advanced settings mode cards, and the docked Back/Continue bar — with shimmer only in the value slots.

- extracts the wizard frame/action-bar classNames into shared constants so the skeleton cannot drift from the loaded layout
- adds `loading` variants to `TextField` (floating label + shimmer value) and `AppModeCards` (real cards, shimmer selection marker)
- keeps data-dependent chrome unasserted: the stepper stays a shimmer bar (mini apps have 5 steps, external 4) and the mode selection marker shimmers
- colocates `BasicInformationStepSkeleton` with the real step so field changes stay in sync
- verified zero layout shift by comparing `getBoundingClientRect` of the circle, all five field boxes, heading, mode cards, and action buttons between skeleton and loaded states; validated with 707 unit tests, TypeScript, and Prettier