### PR TITLE
feat(portal-v3): mirror loaded layouts in World ID skeletons

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/LegacyActions/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/LegacyActions/page/index.tsx
@@ -17,6 +17,18 @@ import { LegacyActionsGrid } from "./LegacyActionsGrid";
 
 const EMPTY_ACTIONS: GetActionsQuery["actions"] = [];
 
+/** Shared with the World ID layout skeleton so both assert the same banner. */
+export const LegacyActionsDeprecationBanner = () => (
+  <Notification variant="warning">
+    <div className="text-system-warning-800">
+      <Typography as="p" variant={TYPOGRAPHY.S3}>
+        This functionality is deprecated in 4.0. It&apos;s still viewable for
+        your convenience. Please make all new actions in the 4.0 view.
+      </Typography>
+    </div>
+  </Notification>
+);
+
 export const LegacyActionsPage = () => {
   const { teamId, appId, appEngine, actionsSearch, refreshOverview } =
     useWorldIdLayout();
@@ -60,14 +72,7 @@ export const LegacyActionsPage = () => {
 
   return (
     <div className="flex flex-col gap-6">
-      <Notification variant="warning">
-        <div className="text-system-warning-800">
-          <Typography as="p" variant={TYPOGRAPHY.S3}>
-            This functionality is deprecated in 4.0. It's still viewable for
-            your convenience. Please make all new actions in the 4.0 view.
-          </Typography>
-        </div>
-      </Notification>
+      <LegacyActionsDeprecationBanner />
 
       {loading ? (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/Skeleton.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/Skeleton.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { WORLD_ID_TABS, type WorldIdTab } from "@/lib/world-id-tabs";
+import { LegacyActionsDeprecationBanner } from "../LegacyActions/page";
+import { ActionCardSkeleton } from "../page/ActionCard/Skeleton";
+import { CreateActionTile } from "../page/ActionsGrid/CreateActionTile";
+import { ActionsSearchToolbar } from "./ActionsSearchToolbar";
+import { SummaryFieldSkeleton } from "./SummaryField";
+
+const ActionCardsGridSkeleton = (props: { withCreateTile?: boolean }) => (
+  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    {/* No onClick — the tile renders disabled until the real grid mounts. */}
+    {props.withCreateTile ? <CreateActionTile /> : null}
+    <ActionCardSkeleton />
+    <ActionCardSkeleton />
+    <ActionCardSkeleton />
+  </div>
+);
+
+/**
+ * Loading mirror of the World ID section, shaped by the tab the URL already
+ * names — the loaded tab then fills in place. A bare /world-id entry has no
+ * tab yet, so it gets the Actions shape, the default for registered apps.
+ * Data-dependent chrome is not asserted — no summary-field labels (an
+ * unregistered app shows the register empty state instead), no Key/Danger
+ * zone sections — with one deliberate exception: managers get the create
+ * tile, because an active RP is by far the common case on the Actions tab;
+ * an inactive one drops the tile when data lands.
+ */
+export const WorldIdLayoutSkeleton = (props: {
+  tab: WorldIdTab | null;
+  canManageWorldId: boolean;
+}) => {
+  const tab = props.tab ?? WORLD_ID_TABS.Actions;
+
+  if (tab === WORLD_ID_TABS.Configuration) {
+    return (
+      <div aria-hidden className="flex flex-col gap-4">
+        <Typography as="h2" variant={TYPOGRAPHY.H7} className="text-portal-ink">
+          World ID Configuration
+        </Typography>
+
+        {/* RpSummary's section wrappers, so the field stack lands where the
+            loaded fields (or the register empty state) will. */}
+        <section className="flex w-full max-w-[580px] flex-col gap-4">
+          <div className="flex flex-col gap-8">
+            <div className="flex flex-col gap-5">
+              <SummaryFieldSkeleton />
+              <SummaryFieldSkeleton />
+              <SummaryFieldSkeleton />
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    // inert: the toolbar is the real search box; it must not accept input
+    // before the grid exists to filter.
+    <div aria-hidden inert className="flex flex-col gap-6">
+      <ActionsSearchToolbar search="" onSearchChange={() => {}} />
+
+      {tab === WORLD_ID_TABS.LegacyActions ? (
+        // LegacyActionsPage's own wrapper: banner + grid share a gap-6 column.
+        <div className="flex flex-col gap-6">
+          <LegacyActionsDeprecationBanner />
+          <ActionCardsGridSkeleton />
+        </div>
+      ) : (
+        <ActionCardsGridSkeleton withCreateTile={props.canManageWorldId} />
+      )}
+    </div>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/Skeleton.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/Skeleton.tsx
@@ -12,7 +12,7 @@ import { SummaryField, SummaryFieldSkeleton } from "./SummaryField";
 const ActionCardsGridSkeleton = (props: { withCreateTile?: boolean }) => (
   <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
     {/* No onClick — the tile renders disabled until the real grid mounts. */}
-    {props.withCreateTile ? <CreateActionTile /> : null}
+    {props.withCreateTile && <CreateActionTile />}
     <ActionCardSkeleton />
     <ActionCardSkeleton />
     <ActionCardSkeleton />
@@ -64,19 +64,22 @@ export const WorldIdLayoutSkeleton = (props: {
     );
   }
 
+  const isLegacyActions = tab === WORLD_ID_TABS.LegacyActions;
+
   return (
     // inert: the toolbar is the real search box; it must not accept input
     // before the grid exists to filter.
     <div aria-hidden inert className="flex flex-col gap-6">
       <ActionsSearchToolbar search="" onSearchChange={() => {}} />
 
-      {tab === WORLD_ID_TABS.LegacyActions ? (
+      {isLegacyActions && (
         // LegacyActionsPage's own wrapper: banner + grid share a gap-6 column.
         <div className="flex flex-col gap-6">
           <LegacyActionsDeprecationBanner />
           <ActionCardsGridSkeleton />
         </div>
-      ) : (
+      )}
+      {!isLegacyActions && (
         <ActionCardsGridSkeleton withCreateTile={props.canManageWorldId} />
       )}
     </div>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/Skeleton.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/Skeleton.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { generateRpIdString } from "@/lib/rp";
 import { WORLD_ID_TABS, type WorldIdTab } from "@/lib/world-id-tabs";
 import { LegacyActionsDeprecationBanner } from "../LegacyActions/page";
 import { ActionCardSkeleton } from "../page/ActionCard/Skeleton";
 import { CreateActionTile } from "../page/ActionsGrid/CreateActionTile";
 import { ActionsSearchToolbar } from "./ActionsSearchToolbar";
-import { SummaryFieldSkeleton } from "./SummaryField";
+import { SummaryField, SummaryFieldSkeleton } from "./SummaryField";
 
 const ActionCardsGridSkeleton = (props: { withCreateTile?: boolean }) => (
   <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -22,33 +23,40 @@ const ActionCardsGridSkeleton = (props: { withCreateTile?: boolean }) => (
  * Loading mirror of the World ID section, shaped by the tab the URL already
  * names — the loaded tab then fills in place. A bare /world-id entry has no
  * tab yet, so it gets the Actions shape, the default for registered apps.
- * Data-dependent chrome is not asserted — no summary-field labels (an
- * unregistered app shows the register empty state instead), no Key/Danger
- * zone sections — with one deliberate exception: managers get the create
+ * Data-dependent chrome is not asserted — no Key/Danger zone sections, and
+ * the signer value shimmers (registered shows an address, unregistered the
+ * register button) — with one deliberate exception: managers get the create
  * tile, because an active RP is by far the common case on the Actions tab;
  * an inactive one drops the tile when data lands.
  */
 export const WorldIdLayoutSkeleton = (props: {
   tab: WorldIdTab | null;
+  appId: string;
   canManageWorldId: boolean;
 }) => {
   const tab = props.tab ?? WORLD_ID_TABS.Actions;
 
   if (tab === WORLD_ID_TABS.Configuration) {
     return (
-      <div aria-hidden className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4">
         <Typography as="h2" variant={TYPOGRAPHY.H7} className="text-portal-ink">
           World ID Configuration
         </Typography>
 
         {/* RpSummary's section wrappers, so the field stack lands where the
-            loaded fields (or the register empty state) will. */}
+            loaded fields (or the register empty state) will. App ID and RP ID
+            render for real in BOTH variants — the RP ID is derived from the
+            app id (uint64(keccak256)), not stored data. */}
         <section className="flex w-full max-w-[580px] flex-col gap-4">
           <div className="flex flex-col gap-8">
             <div className="flex flex-col gap-5">
-              <SummaryFieldSkeleton />
-              <SummaryFieldSkeleton />
-              <SummaryFieldSkeleton />
+              <SummaryField label="App ID" value={props.appId} copy />
+              <SummaryField
+                label="RP ID"
+                value={generateRpIdString(props.appId)}
+                copy
+              />
+              <SummaryFieldSkeleton label="Signer address" />
             </div>
           </div>
         </section>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/SummaryField.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/SummaryField.tsx
@@ -5,18 +5,19 @@ import clsx from "clsx";
 import Skeleton from "react-loading-skeleton";
 
 /**
- * Skeleton twin of SummaryField: same wrappers and type ramp, shimmer in both
- * slots. The label shimmers too — while the overview loads we don't know
- * whether summary fields render at all (an unregistered app shows the
- * register empty state instead), so no label text is asserted.
+ * Skeleton twin of SummaryField: same wrappers and type ramp, real label,
+ * shimmer in the value slot. Used for fields whose label is identical across
+ * the registered and unregistered configuration variants but whose value
+ * needs data.
  */
-export const SummaryFieldSkeleton = () => (
-  <div aria-hidden className="w-full min-w-0">
+export const SummaryFieldSkeleton = (props: { label: string }) => (
+  <div className="w-full min-w-0">
     <Typography variant={TYPOGRAPHY.B4} className="text-grey-500">
-      <Skeleton width={80} />
+      {props.label}
     </Typography>
     <div className="mt-1 flex min-w-0 items-center justify-between gap-2">
       <Typography
+        aria-hidden
         variant={TYPOGRAPHY.B3}
         className="min-w-0 grow text-grey-900"
       >

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/SummaryField.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/SummaryField.tsx
@@ -2,6 +2,29 @@ import { CopyButton } from "@/components/CopyButton";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { opticalIconClassName } from "@/scenes/PortalV3/common/Icon";
 import clsx from "clsx";
+import Skeleton from "react-loading-skeleton";
+
+/**
+ * Skeleton twin of SummaryField: same wrappers and type ramp, shimmer in both
+ * slots. The label shimmers too — while the overview loads we don't know
+ * whether summary fields render at all (an unregistered app shows the
+ * register empty state instead), so no label text is asserted.
+ */
+export const SummaryFieldSkeleton = () => (
+  <div aria-hidden className="w-full min-w-0">
+    <Typography variant={TYPOGRAPHY.B4} className="text-grey-500">
+      <Skeleton width={80} />
+    </Typography>
+    <div className="mt-1 flex min-w-0 items-center justify-between gap-2">
+      <Typography
+        variant={TYPOGRAPHY.B3}
+        className="min-w-0 grow text-grey-900"
+      >
+        <Skeleton width="60%" />
+      </Typography>
+    </div>
+  </div>
+);
 
 export const SummaryField = (props: {
   label: string;

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
@@ -376,7 +376,7 @@ export const WorldIdLayout = (props: {
       <SizingWrapper className="flex flex-col gap-8 py-8">
         {app?.is_banned ? <BanBanner /> : null}
 
-        {initialLoading ? (
+        {initialLoading && (
           <WorldIdLayoutSkeleton
             // Deep-link intents pin the destination before data arrives,
             // mirroring resolveActiveWorldIdTab's intent-first branches:
@@ -390,7 +390,8 @@ export const WorldIdLayout = (props: {
             appId={props.appId}
             canManageWorldId={props.canManageWorldId}
           />
-        ) : (
+        )}
+        {!initialLoading && (
           <div className="flex flex-col gap-6">
             {activeTab !== WORLD_ID_TABS.Configuration ? (
               <ActionsSearchToolbar

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
@@ -378,7 +378,15 @@ export const WorldIdLayout = (props: {
 
         {initialLoading ? (
           <WorldIdLayoutSkeleton
-            tab={normalizedRequestedTab}
+            // Deep-link intents pin the destination before data arrives,
+            // mirroring resolveActiveWorldIdTab's intent-first branches:
+            // enable always lands on Configuration; create does too until an
+            // active RP is known (the dialog then opens over Actions).
+            tab={
+              createActionRequested || enableWorldId4Requested
+                ? WORLD_ID_TABS.Configuration
+                : normalizedRequestedTab
+            }
             appId={props.appId}
             canManageWorldId={props.canManageWorldId}
           />

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/Button";
 import { ErrorPage } from "@/components/ErrorPage";
 import { AlertIcon } from "@/components/Icons/AlertIcon";
 import { SizingWrapper } from "@/components/SizingWrapper";
-import { SkeletonForm } from "@/components/Skeletons";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { RpRegistrationStatus } from "@/lib/rp-registration-status";
 import type { EngineType } from "@/lib/types";
@@ -36,6 +35,7 @@ import {
 import { RegisterRpEmptyState } from "./RegisterRpEmptyState";
 import { RpSummary } from "./RpSummary";
 import { ActionsSearchToolbar } from "./ActionsSearchToolbar";
+import { WorldIdLayoutSkeleton } from "./Skeleton";
 import { getSetupIntent } from "./setup-intent";
 import {
   WorldIdLayoutContext,
@@ -377,9 +377,10 @@ export const WorldIdLayout = (props: {
         {app?.is_banned ? <BanBanner /> : null}
 
         {initialLoading ? (
-          <div className="rounded-xl border border-grey-100 bg-white p-5">
-            <SkeletonForm count={3} className="max-w-[760px] py-2" />
-          </div>
+          <WorldIdLayoutSkeleton
+            tab={normalizedRequestedTab}
+            canManageWorldId={props.canManageWorldId}
+          />
         ) : (
           <div className="flex flex-col gap-6">
             {activeTab !== WORLD_ID_TABS.Configuration ? (

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/index.tsx
@@ -379,6 +379,7 @@ export const WorldIdLayout = (props: {
         {initialLoading ? (
           <WorldIdLayoutSkeleton
             tab={normalizedRequestedTab}
+            appId={props.appId}
             canManageWorldId={props.canManageWorldId}
           />
         ) : (

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/page/VerificationHistory/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/page/VerificationHistory/index.tsx
@@ -12,6 +12,7 @@ import {
 import { useQuery } from "@apollo/client/react";
 import { formatDistanceToNowStrict } from "date-fns";
 import { useEffect, useState } from "react";
+import Skeleton from "react-loading-skeleton";
 import { GetActionVerificationHistoryDocument } from "./graphql/client/get-action-verification-history.generated";
 
 const rowsPerPageOptions = [5, 10, 20];
@@ -62,8 +63,36 @@ export const VerificationHistory = (props: {
     }
   }, [currentPage, pageCount]);
 
-  if (error || (!action && loading)) {
+  if (error) {
     return null;
+  }
+
+  if (!action && loading) {
+    return (
+      // The loaded card's chrome with its real heading; the content area
+      // reserves the empty state's height, the shortest real variant.
+      <section
+        aria-hidden
+        aria-busy
+        className="rounded-16 border border-portal-border bg-white p-6 shadow-portal-card"
+      >
+        <div className="flex items-center gap-1.5">
+          <Typography
+            as="h2"
+            variant={TYPOGRAPHY.H7}
+            className="text-portal-heading"
+          >
+            Verification history
+          </Typography>
+          <InformationCircleIcon className="size-4 text-grey-300" />
+        </div>
+
+        <div className="flex min-h-44 flex-col items-center justify-center gap-2">
+          <Skeleton width={176} />
+          <Skeleton width={320} />
+        </div>
+      </section>
+    );
   }
 
   const nullifiers = action?.nullifiers ?? [];

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/page/index.tsx
@@ -70,20 +70,21 @@ export const WorldIdActionDetailPage = (props: {
             Actions
           </Link>
           <span className="font-world text-13 text-portal-subtle">/</span>
-          {!action ? (
+          {!action && (
             // Same type ramp as the loaded name — a bare Skeleton inherits
             // the 16px base and makes this row 3px taller than loaded.
             <span className="font-ibm text-13 font-medium">
               <Skeleton width={120} />
             </span>
-          ) : (
+          )}
+          {action && (
             <span className="font-ibm text-13 font-medium text-portal-heading">
               {action.action}
             </span>
           )}
         </div>
 
-        {action ? (
+        {action && (
           <UpdateActionV4Form
             key={action.id}
             action={action}
@@ -91,7 +92,8 @@ export const WorldIdActionDetailPage = (props: {
             canModify={canModify}
             onUpdated={() => void refetch().catch(() => {})}
           />
-        ) : (
+        )}
+        {!action && (
           // UpdateActionV4Form's chrome with shimmer values, so the loaded
           // form fills in place.
           <div aria-hidden className="flex w-full flex-col gap-4">

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldIdActions/ActionId/page/index.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { ErrorPage } from "@/components/ErrorPage";
+import { CopyIcon } from "@/components/Icons/CopyIcon";
 import { SizingWrapper } from "@/components/SizingWrapper";
+import { TextField } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/Configuration/Wizard/TextField";
 import { urls } from "@/lib/urls";
 import { WORLD_ID_TABS } from "@/lib/world-id-tabs";
 import { useQuery } from "@apollo/client/react";
@@ -69,7 +71,11 @@ export const WorldIdActionDetailPage = (props: {
           </Link>
           <span className="font-world text-13 text-portal-subtle">/</span>
           {!action ? (
-            <Skeleton width={120} />
+            // Same type ramp as the loaded name — a bare Skeleton inherits
+            // the 16px base and makes this row 3px taller than loaded.
+            <span className="font-ibm text-13 font-medium">
+              <Skeleton width={120} />
+            </span>
           ) : (
             <span className="font-ibm text-13 font-medium text-portal-heading">
               {action.action}
@@ -86,9 +92,23 @@ export const WorldIdActionDetailPage = (props: {
             onUpdated={() => void refetch().catch(() => {})}
           />
         ) : (
-          <div className="grid gap-4 rounded-16 border border-portal-border bg-white p-5 shadow-portal-card md:grid-cols-2">
-            <Skeleton height={48} />
-            <Skeleton height={48} />
+          // UpdateActionV4Form's chrome with shimmer values, so the loaded
+          // form fills in place.
+          <div aria-hidden className="flex w-full flex-col gap-4">
+            <TextField
+              label="Action identifier"
+              value=""
+              readOnly
+              muted
+              loading
+              trailing={
+                <CopyIcon
+                  aria-hidden
+                  className="size-5 shrink-0 text-portal-ink"
+                />
+              }
+            />
+            <TextField label="Short description" value="" loading />
           </div>
         )}
 

--- a/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
+++ b/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
@@ -257,6 +257,17 @@ describe("WorldIdLayout [loading boundary]", () => {
     expect(screen.queryByTestId("rp-summary")).not.toBeInTheDocument();
   });
 
+  it("shows the configuration shape for setup/create deep links", () => {
+    searchParams = new URLSearchParams("createAction=true");
+    setQuery({ data: undefined, loading: true });
+    render(el());
+
+    expect(
+      screen.getByRole("heading", { name: "World ID Configuration" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
+  });
+
   it("shows the legacy-shaped skeleton with the deprecation banner", () => {
     searchParams = new URLSearchParams("tab=legacy-actions");
     setQuery({ data: undefined, loading: true });

--- a/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
+++ b/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
@@ -30,6 +30,7 @@ jest.mock(
   "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/LegacyActions/page",
   () => ({
     LegacyActionsPage: () => <div data-testid="legacy-actions-child" />,
+    LegacyActionsDeprecationBanner: () => <div data-testid="legacy-banner" />,
   }),
 );
 
@@ -81,10 +82,6 @@ jest.mock(
     },
   }),
 );
-
-jest.mock("@/components/Skeletons", () => ({
-  SkeletonForm: () => <div data-testid="skeleton-form" />,
-}));
 
 jest.mock(
   "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RpSummary",
@@ -218,13 +215,54 @@ afterEach(() => jest.restoreAllMocks());
 
 // #region Loading boundary
 describe("WorldIdLayout [loading boundary]", () => {
-  it("renders only the configuration skeleton until RP data resolves", () => {
+  it("shows the actions-shaped skeleton until RP data resolves", () => {
     setQuery({ data: undefined, loading: true });
     render(el());
 
-    expect(screen.getByTestId("skeleton-form")).toBeInTheDocument();
     expect(screen.queryByTestId("actions-grid")).not.toBeInTheDocument();
+    // The toolbar is real chrome, but inert — there is no grid to filter yet.
+    const search = screen.getByPlaceholderText(/search/i);
+    expect(search.closest("[inert]")).not.toBeNull();
+    // Managers get the create tile asserted (an active RP is the common
+    // case); it renders disabled until the real grid mounts.
+    expect(
+      screen.getByRole("button", { name: "Create action", hidden: true }),
+    ).toBeDisabled();
+  });
+
+  it("omits the create tile for members while loading", () => {
+    setQuery({ data: undefined, loading: true });
+    render(el({ canManageWorldId: false }));
+
+    expect(
+      screen.queryByRole("button", { name: "Create action", hidden: true }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the configuration-shaped skeleton when the URL names that tab", () => {
+    searchParams = new URLSearchParams("tab=configuration");
+    setQuery({ data: undefined, loading: true });
+    render(el());
+
+    expect(
+      screen.getByRole("heading", {
+        name: "World ID Configuration",
+        hidden: true,
+      }),
+    ).toBeInTheDocument();
     expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("rp-summary")).not.toBeInTheDocument();
+  });
+
+  it("shows the legacy-shaped skeleton with the deprecation banner", () => {
+    searchParams = new URLSearchParams("tab=legacy-actions");
+    setQuery({ data: undefined, loading: true });
+    render(el());
+
+    expect(screen.getByTestId("legacy-banner")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("legacy-actions-child"),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps real content during a background refetch and never remounts the grid", () => {
@@ -259,7 +297,7 @@ describe("WorldIdLayout [loading boundary]", () => {
     setQuery({ data: makeData(), loading: true });
     render(el());
 
-    expect(screen.queryByTestId("skeleton-form")).not.toBeInTheDocument();
+    expect(document.querySelector(".react-loading-skeleton")).toBeNull();
     expect(screen.getByTestId("rp-summary")).toBeInTheDocument();
     expect(replace).toHaveBeenCalledWith(
       "/teams/team_1/apps/app_1/world-id?tab=configuration",

--- a/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
+++ b/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
@@ -8,6 +8,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import React from "react";
+import { generateRpIdString } from "@/lib/rp";
 import { WorldIdLayout } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout";
 import { WorldIdPage } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/page";
 
@@ -245,11 +246,13 @@ describe("WorldIdLayout [loading boundary]", () => {
     render(el());
 
     expect(
-      screen.getByRole("heading", {
-        name: "World ID Configuration",
-        hidden: true,
-      }),
+      screen.getByRole("heading", { name: "World ID Configuration" }),
     ).toBeInTheDocument();
+    // App ID and RP ID are route-derived and identical in both loaded
+    // variants, so they render for real; only the signer value shimmers.
+    expect(screen.getByText("app_1")).toBeInTheDocument();
+    expect(screen.getByText(generateRpIdString("app_1"))).toBeInTheDocument();
+    expect(screen.getByText("Signer address")).toBeInTheDocument();
     expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
     expect(screen.queryByTestId("rp-summary")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
This PR makes every loading state under the World ID tab look like the page it resolves into, so data fills in place instead of replacing a generic placeholder. Same approach as #2218, applied to the World ID section.

Before, the section rendered one bordered box of gray bars for all destinations. Now the skeleton is shaped by the tab the URL already names:

- **Actions / Legacy actions**: the real search toolbar (inert until there is a grid to filter), the legacy deprecation banner (shared component, so both surfaces assert the same text), and action-card skeletons sitting in the loaded grid's exact slots. Managers also get the real create tile, disabled — an active RP is the common case on the Actions tab; an inactive one drops it when data lands.
- **Configuration**: the real "World ID Configuration" heading plus summary-field-shaped shimmers in RpSummary's column. Field labels are not asserted because an unregistered app resolves to the register empty state instead.
- **Bare /world-id** (no tab yet): the Actions shape, the default for registered apps.
- **Action details**: replaces the wrong-shaped two-column bordered placeholder with the real update-form chrome via TextField's new loading mode (byte-identical to the same change in #2218 so the branches merge cleanly), aligns the breadcrumb shimmer to the loaded name's type ramp (it sat 3px tall and shifted everything below), and renders Verification history's card chrome with its real heading while loading instead of popping the section in afterwards.

Data-dependent chrome stays shimmer or absent rather than guessed; card count and history height reserve the smallest real variant.

Verified by comparing `getBoundingClientRect` between forced-loading and loaded states: configuration heading/section rects and legacy toolbar/banner/card rects are identical, and the layout skeleton hands off seamlessly to the legacy page's own in-page skeleton. Validated with 716 unit tests (including new coverage for each skeleton branch), TypeScript, and Prettier.