### PR TITLE
style(portal-v3): give the Mini App tab one design language

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Develop/page.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Develop/page.tsx
@@ -3,7 +3,14 @@
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { ErrorPage } from "@/components/ErrorPage";
 import { InformationCircleIcon } from "@/components/Icons/InformationCircleIcon";
-import { Typography } from "@/components/Typography";
+import {
+  MiniAppPage,
+  MiniAppPageColumn,
+  MiniAppPageHeader,
+  MiniAppSectionHeading,
+} from "../common/MiniAppPage";
+import { NoticeCallout } from "../common/NoticeCallout";
+import { miniAppButtonClassName } from "../common/styles";
 import {
   Tooltip,
   TooltipContent,
@@ -131,33 +138,18 @@ export const DevelopContent = ({
     appMetadata.verification_status === "changes_requested";
 
   return (
-    <div className="grid gap-y-10 pt-8 pb-12">
-      <div className="grid gap-y-2">
-        <Typography
-          as="h1"
-          className="font-world text-[26px] leading-[120%] font-semibold tracking-[-0.01em] text-[#191C20]"
-        >
-          Develop
-        </Typography>
-        <Typography
-          as="p"
-          className="font-world text-[15px] leading-[130%] font-medium text-grey-500"
-        >
-          Set the URL World App opens and preview your Mini App.
-        </Typography>
-      </div>
+    <MiniAppPage>
+      <MiniAppPageHeader
+        title="Develop"
+        description="Set the URL World App opens and preview your Mini App."
+      />
 
       <div className="flex flex-col gap-10 lg:flex-row lg:items-start lg:justify-between lg:gap-x-12 xl:gap-x-20">
-        <div className="grid w-full gap-y-8 lg:max-w-[620px]">
+        <MiniAppPageColumn>
           <section className="grid gap-y-4">
             <div className="flex items-center justify-between gap-4">
               <div className="flex items-center gap-1.5">
-                <Typography
-                  as="h2"
-                  className="font-world text-[17px] leading-[120%] font-medium text-grey-900"
-                >
-                  App URL
-                </Typography>
+                <MiniAppSectionHeading>App URL</MiniAppSectionHeading>
 
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -214,36 +206,37 @@ export const DevelopContent = ({
             />
 
             {isVerifiedOnly && (
-              <div className="flex flex-wrap items-center justify-between gap-4 rounded-[10px] bg-grey-50 p-4">
-                <Typography className="font-world text-[13px] leading-[130%] font-medium text-grey-700">
-                  This is the verified App URL. Create a draft before making
-                  changes.
-                </Typography>
-                {canManageDraft && (
-                  <DecoratedButton
-                    type="button"
-                    variant="secondary"
-                    loading={isCreating}
-                    onClick={() => void createNewDraft()}
-                    className="h-10 shrink-0 px-4 py-0"
-                  >
-                    Create draft
-                  </DecoratedButton>
-                )}
-              </div>
+              <NoticeCallout
+                action={
+                  canManageDraft && (
+                    <DecoratedButton
+                      type="button"
+                      variant="secondary"
+                      loading={isCreating}
+                      onClick={() => void createNewDraft()}
+                      className={miniAppButtonClassName}
+                    >
+                      Create draft
+                    </DecoratedButton>
+                  )
+                }
+              >
+                This is the verified App URL. Create a draft before making
+                changes.
+              </NoticeCallout>
             )}
 
             {isInReview && (
-              <Typography className="rounded-[10px] bg-grey-50 p-4 font-world text-[13px] leading-[130%] font-medium text-grey-700">
+              <NoticeCallout>
                 This draft is in review, so its App URL is temporarily locked.
-              </Typography>
+              </NoticeCallout>
             )}
 
             {needsResolution && (
-              <Typography className="rounded-[10px] bg-system-warning-100 p-4 font-world text-[13px] leading-[130%] font-medium text-system-warning-600">
+              <NoticeCallout variant="warning">
                 Resolve the requested changes in Get Verified before editing
                 this App URL.
-              </Typography>
+              </NoticeCallout>
             )}
           </section>
 
@@ -254,9 +247,9 @@ export const DevelopContent = ({
               appMetadata={appMetadata}
             />
           </section>
-        </div>
+        </MiniAppPageColumn>
       </div>
-    </div>
+    </MiniAppPage>
   );
 };
 
@@ -276,9 +269,9 @@ export const DevelopPage = (props: DevelopPageProps) => {
 
   if (loading || !app) {
     return (
-      <div className="pt-8 pb-12">
+      <MiniAppPage>
         <FormSkeleton count={4} />
-      </div>
+      </MiniAppPage>
     );
   }
 

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Notifications/page.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Notifications/page.tsx
@@ -3,18 +3,31 @@
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { NotificationBellIcon } from "@/components/Icons/NotificationBellIcon";
 import { Link } from "@/components/Link";
-import { Typography } from "@/components/Typography";
 import { urls } from "@/lib/urls";
 import { useParams } from "next/navigation";
 import posthog from "posthog-js";
 import { useRef, useState } from "react";
 import type { ChangeEvent, ReactNode } from "react";
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import { FormSkeleton } from "../../Configuration/PageComponents/FormSkeleton";
+import { TextField } from "../../Configuration/Wizard/TextField";
 import { useQuery } from "@apollo/client/react";
 import { FetchNotificationAppMetadataDocument } from "@/scenes/common/Teams/TeamId/Apps/AppId/MiniApp/Notifications/graphql/client/fetch-notification-app-metadata.generated";
 import { noticeIconClassName } from "@/scenes/PortalV3/common/Icon";
+import {
+  MiniAppPage,
+  MiniAppPageColumn,
+  MiniAppPageHeader,
+  MiniAppSectionHeading,
+} from "../common/MiniAppPage";
+import { NoticeCallout } from "../common/NoticeCallout";
+import { TextArea } from "../common/TextArea";
+import {
+  miniAppButtonClassName,
+  miniAppButtonLargeClassName,
+  miniAppFieldHintClassName,
+} from "../common/styles";
 
 type NotificationFormData = {
   walletAddresses: string;
@@ -31,23 +44,26 @@ const NotificationsNotice = ({
   title: string;
   body: ReactNode;
 }) => (
-  <div className="my-8 grid gap-y-10">
-    <div className="grid grid-cols-auto/1fr items-start gap-x-3 rounded-[10px] bg-grey-50 p-4 sm:p-5">
-      <NotificationBellIcon
-        className={`${noticeIconClassName} size-8`}
-        aria-hidden="true"
-      />
+  <MiniAppPage>
+    <MiniAppPageHeader
+      title="Notifications"
+      description="Send notifications to specific wallet addresses."
+    />
 
-      <div className="min-w-0 font-world text-[13px] leading-[120%] text-grey-900">
-        <Typography as="p" className="font-world text-[13px] font-semibold">
-          {title}
-        </Typography>
-        <Typography as="p" className="font-world text-[13px] font-medium">
-          {body}
-        </Typography>
-      </div>
-    </div>
-  </div>
+    <MiniAppPageColumn>
+      <NoticeCallout
+        title={title}
+        icon={
+          <NotificationBellIcon
+            className={`${noticeIconClassName} size-8 shrink-0`}
+            aria-hidden="true"
+          />
+        }
+      >
+        {body}
+      </NoticeCallout>
+    </MiniAppPageColumn>
+  </MiniAppPage>
 );
 
 export const NotificationsPage = () => {
@@ -79,6 +95,7 @@ export const NotificationsPage = () => {
   const {
     register,
     handleSubmit,
+    control,
     formState: { errors },
     watch,
     setValue,
@@ -237,9 +254,9 @@ export const NotificationsPage = () => {
 
   if (loading) {
     return (
-      <div className="my-8">
+      <MiniAppPage>
         <FormSkeleton count={5} />
-      </div>
+      </MiniAppPage>
     );
   }
 
@@ -284,83 +301,79 @@ export const NotificationsPage = () => {
   }
 
   return (
-    <section
-      aria-labelledby="notifications-heading"
-      className="my-8 grid w-full max-w-[580px] gap-y-10"
-    >
-      <Typography
+    <MiniAppPage>
+      <MiniAppPageHeader
         id="notifications-heading"
-        as="h1"
-        className="font-world text-[26px] leading-[120%] font-semibold tracking-[-0.01em] text-[#191C20]"
-      >
-        Notifications
-      </Typography>
+        title="Notifications"
+        description="Send notifications to specific wallet addresses."
+      />
 
-      <div className="grid grid-cols-auto/1fr items-start gap-x-3 rounded-[10px] bg-[#E6F0FF] p-4 sm:p-5">
-        <NotificationBellIcon className="size-8" aria-hidden="true" />
+      <MiniAppPageColumn labelledBy="notifications-heading">
+        <NoticeCallout
+          variant="info"
+          title="Notifications"
+          icon={
+            <NotificationBellIcon
+              className="size-8 shrink-0"
+              aria-hidden="true"
+            />
+          }
+        >
+          Unverified apps are limited to 40 notifications per 4 hours.{" "}
+          <a
+            href="https://docs.world.org/api-reference/developer-portal/send-notification"
+            target="_blank"
+            className="inline-block whitespace-nowrap underline"
+            rel="noopener noreferrer"
+          >
+            Docs reference
+          </a>
+        </NoticeCallout>
 
-        <div className="min-w-0 font-world text-[13px] leading-[120%] text-grey-900">
-          <Typography as="p" className="font-world text-[13px] font-semibold">
-            Notifications
-          </Typography>
-          <Typography as="p" className="font-world text-[13px] font-medium">
-            Send notifications to specific wallet addresses. Unverified apps are
-            limited to 40 notifications per 4 hours.{" "}
-            <a
-              href="https://docs.world.org/api-reference/developer-portal/send-notification"
-              target="_blank"
-              className="inline-block whitespace-nowrap underline"
-              rel="noopener noreferrer"
-            >
-              Docs reference
-            </a>
-          </Typography>
-        </div>
-      </div>
+        <form onSubmit={handleSubmit(onSubmit)} className="grid w-full gap-y-5">
+          <div className="grid gap-y-4">
+            <div className="flex items-center justify-between gap-x-5">
+              <MiniAppSectionHeading>Wallet addresses</MiniAppSectionHeading>
 
-      <form onSubmit={handleSubmit(onSubmit)} className="grid w-full gap-y-5">
-        <div className="grid gap-y-5">
-          <div className="flex items-center justify-between gap-x-5">
-            <Typography
-              as="h2"
-              className="font-world text-[17px] leading-[120%] font-medium text-grey-900"
-            >
-              Wallet addresses
-            </Typography>
+              <div className="flex gap-x-2">
+                <input
+                  type="file"
+                  accept=".csv"
+                  className="hidden"
+                  onChange={handleFileUpload}
+                  ref={fileInputRef}
+                />
 
-            <div className="flex gap-x-2">
-              <input
-                type="file"
-                accept=".csv"
-                className="hidden"
-                onChange={handleFileUpload}
-                ref={fileInputRef}
-              />
-
-              <DecoratedButton
-                type="button"
-                variant="secondary"
-                onClick={handleImportClick}
-                className="h-10 min-w-[109px] px-3.5 py-0 text-[15px] font-semibold"
-              >
-                Import CSV
-              </DecoratedButton>
-
-              {walletAddressesValue && (
                 <DecoratedButton
                   type="button"
                   variant="secondary"
-                  onClick={handleClearAddresses}
-                  className="h-10 min-w-[109px] px-3.5 py-0 text-[15px] font-semibold"
+                  onClick={handleImportClick}
+                  className={miniAppButtonClassName}
                 >
-                  Clear all
+                  Import CSV
                 </DecoratedButton>
-              )}
-            </div>
-          </div>
 
-          <div className="grid gap-y-1">
-            <textarea
+                {walletAddressesValue && (
+                  <DecoratedButton
+                    type="button"
+                    variant="secondary"
+                    onClick={handleClearAddresses}
+                    className={miniAppButtonClassName}
+                  >
+                    Clear all
+                  </DecoratedButton>
+                )}
+              </div>
+            </div>
+
+            <TextArea
+              label="Wallet addresses"
+              id="notification-wallet-addresses"
+              rows={4}
+              className="h-[88px]"
+              placeholder="0x… , 0x…"
+              hint={`${walletAddressCount}/1000 addresses, separated by commas`}
+              error={errors.walletAddresses?.message}
               {...register("walletAddresses", {
                 required: "Wallet addresses are required",
                 validate: (value) => {
@@ -375,49 +388,44 @@ export const NotificationsPage = () => {
                   return true;
                 },
               })}
-              rows={4}
-              placeholder="Enter wallet addresses separated by commas"
-              className="h-[120px] resize-none rounded-[10px] border-0 bg-grey-50 p-4 font-world text-[15px] leading-[130%] text-grey-900 placeholder:text-grey-500 focus:ring-0 focus:outline-hidden"
-              aria-invalid={errors.walletAddresses ? "true" : "false"}
             />
-
-            <p className="px-2 font-world text-xs leading-[130%] text-grey-500">
-              {walletAddressCount}/1000 addresses. Enter one or more wallet
-              addresses, separated by commas
-            </p>
-            {errors.walletAddresses?.message && (
-              <p className="px-2 text-xs text-system-error-500">
-                {errors.walletAddresses.message}
-              </p>
-            )}
           </div>
-        </div>
 
-        <div className="grid gap-y-1">
-          <input
-            {...register("title", {
-              maxLength: {
-                value: 30,
-                message: "Title cannot exceed 30 characters",
-              },
-            })}
-            maxLength={30}
-            placeholder="Notification title"
-            className="h-14 rounded-[10px] border-0 bg-grey-50 px-4 py-3 font-world text-[15px] leading-[130%] text-grey-900 placeholder:text-grey-500 focus:ring-0 focus:outline-hidden"
-            aria-invalid={errors.title ? "true" : "false"}
-          />
-          <p className="px-2 font-world text-xs leading-[130%] text-grey-500">
-            {titleValue?.length || 0}/30 characters
-          </p>
-          {errors.title?.message && (
-            <p className="px-2 text-xs text-system-error-500">
-              {errors.title.message}
+          <div className="grid gap-y-1.5">
+            <Controller
+              control={control}
+              name="title"
+              rules={{
+                maxLength: {
+                  value: 30,
+                  message: "Title cannot exceed 30 characters",
+                },
+              }}
+              render={({ field }) => (
+                <TextField
+                  label="Notification title"
+                  name="title"
+                  maxLength={30}
+                  value={field.value ?? ""}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                  error={errors.title?.message}
+                />
+              )}
+            />
+            <p className={miniAppFieldHintClassName}>
+              {titleValue?.length || 0}/30 characters
             </p>
-          )}
-        </div>
+          </div>
 
-        <div className="grid gap-y-1">
-          <textarea
+          <TextArea
+            label="Notification message"
+            id="notification-message"
+            rows={2}
+            className="h-[44px]"
+            maxLength={200}
+            hint={`${messageValue?.length || 0}/200 characters`}
+            error={errors.message?.message}
             {...register("message", {
               required: "Message is required",
               maxLength: {
@@ -425,71 +433,64 @@ export const NotificationsPage = () => {
                 message: "Message cannot exceed 200 characters",
               },
             })}
-            maxLength={200}
-            rows={1}
-            placeholder="Notification message"
-            className="h-14 resize-none rounded-[10px] border-0 bg-grey-50 px-4 py-3 font-world text-[15px] leading-[130%] text-grey-900 placeholder:text-grey-500 focus:ring-0 focus:outline-hidden"
-            aria-invalid={errors.message ? "true" : "false"}
           />
-          <p className="px-2 font-world text-xs leading-[130%] text-grey-500">
-            {messageValue?.length || 0}/200 characters
-          </p>
-          {errors.message?.message && (
-            <p className="px-2 text-xs text-system-error-500">
-              {errors.message.message}
-            </p>
-          )}
-        </div>
 
-        <div className="grid gap-y-1">
-          <input
-            {...register("miniAppPath", {
-              required: "Mini App Path is required",
-            })}
-            placeholder="Mini App Path"
-            className="h-14 rounded-[10px] border-0 bg-grey-50 px-4 py-3 font-world text-[15px] leading-[130%] text-grey-900 placeholder:text-grey-500 focus:ring-0 focus:outline-hidden"
-            aria-invalid={errors.miniAppPath ? "true" : "false"}
-          />
-          <p className="px-2 font-world text-xs leading-[130%] text-grey-500">
-            The path inside your mini app that will open when the notification
-            is tapped
-          </p>
-          {errors.miniAppPath?.message && (
-            <p className="px-2 text-xs text-system-error-500">
-              {errors.miniAppPath.message}
+          <div className="grid gap-y-1.5">
+            <Controller
+              control={control}
+              name="miniAppPath"
+              rules={{ required: "Mini App Path is required" }}
+              render={({ field }) => (
+                <TextField
+                  label="Mini App path"
+                  name="miniAppPath"
+                  required
+                  value={field.value ?? ""}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                  error={errors.miniAppPath?.message}
+                />
+              )}
+            />
+            <p className={miniAppFieldHintClassName}>
+              The path inside your mini app that will open when the notification
+              is tapped
             </p>
-          )}
-        </div>
+          </div>
 
-        <div className="grid gap-y-1">
-          <input
-            {...register("apiKey", {
-              required: "API Key is required",
-            })}
-            placeholder="API Key"
-            className="h-14 rounded-[10px] border-0 bg-grey-50 px-4 py-3 font-world text-[15px] leading-[130%] text-grey-900 placeholder:text-grey-500 focus:ring-0 focus:outline-hidden"
-            aria-invalid={errors.apiKey ? "true" : "false"}
-          />
-          <p className="px-2 font-world text-xs leading-[130%] text-grey-500">
-            Your Developer Portal API key (format: api_...). Obtain it from the
-            API Keys tab.
-          </p>
-          {errors.apiKey?.message && (
-            <p className="px-2 text-xs text-system-error-500">
-              {errors.apiKey.message}
+          <div className="grid gap-y-1.5">
+            <Controller
+              control={control}
+              name="apiKey"
+              rules={{ required: "API Key is required" }}
+              render={({ field }) => (
+                <TextField
+                  label="API key"
+                  name="apiKey"
+                  required
+                  value={field.value ?? ""}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                  error={errors.apiKey?.message}
+                />
+              )}
+            />
+            <p className={miniAppFieldHintClassName}>
+              Your Developer Portal API key (format: api_...). Obtain it from
+              the API Keys tab.
             </p>
-          )}
-        </div>
+          </div>
 
-        <DecoratedButton
-          type="submit"
-          disabled={isSubmitting}
-          loading={isSubmitting}
-          className="mt-5 h-14 w-fit px-6 py-0 text-[17px] font-semibold"
-        >
-          Send notification
-        </DecoratedButton>
-      </form>
-    </section>
+          <DecoratedButton
+            type="submit"
+            disabled={isSubmitting}
+            loading={isSubmitting}
+            className={`mt-5 w-fit ${miniAppButtonLargeClassName}`}
+          >
+            Send notification
+          </DecoratedButton>
+        </form>
+      </MiniAppPageColumn>
+    </MiniAppPage>
   );
 };

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/ErrorState/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/ErrorState/index.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { CircleIconContainer } from "@/components/CircleIconContainer";
 import { DecoratedButton } from "@/components/DecoratedButton";
-import { CloseIcon } from "@/components/Icons/CloseIcon";
+import { AlertIcon } from "@/components/Icons/AlertIcon";
+import { ModalIcon } from "@/components/ModalIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
 
 export const ErrorState = () => {
@@ -11,30 +11,40 @@ export const ErrorState = () => {
   };
 
   return (
-    <div className="flex min-h-[400px] flex-col items-center justify-center gap-y-6 text-center">
-      <div className="grid max-w-[300px] justify-items-center gap-y-4">
-        <div className="grid gap-y-2 font-rubik leading-[1.2]">
-          <CircleIconContainer variant="error">
-            <CloseIcon className="size-4 text-system-error-500" />
-          </CircleIconContainer>
+    <div className="flex min-h-[400px] flex-col items-center justify-center">
+      {/* Same icon, copy and spacing recipe as DeleteConfirmationDialog. */}
+      <div className="grid max-w-md justify-items-center gap-y-6">
+        <ModalIcon variant="error">
+          <AlertIcon className="size-7 text-white" />
+        </ModalIcon>
+
+        <div className="grid w-full place-items-center gap-y-5">
+          <Typography
+            as="h3"
+            variant={TYPOGRAPHY.H6}
+            className="text-center text-grey-900"
+          >
+            Failed to load transactions
+          </Typography>
+
+          <Typography
+            variant={TYPOGRAPHY.R3}
+            className="text-center text-grey-500"
+          >
+            Something went wrong while loading transactions. Please try
+            refreshing the page.
+          </Typography>
         </div>
-        <Typography variant={TYPOGRAPHY.H6}>
-          Failed to load transactions
-        </Typography>
-        <Typography variant={TYPOGRAPHY.R3} className="text-grey-700">
-          Something went wrong while loading transactions. Please try refreshing
-          the page.
-        </Typography>
+
+        <DecoratedButton
+          type="button"
+          variant="secondary"
+          className="px-8 py-3"
+          onClick={handleRetry}
+        >
+          <Typography variant={TYPOGRAPHY.R3}>Try Again</Typography>
+        </DecoratedButton>
       </div>
-      <DecoratedButton
-        type="button"
-        variant="secondary"
-        className="h-fit max-w-full px-8"
-        color="primary"
-        onClick={handleRetry}
-      >
-        <Typography variant={TYPOGRAPHY.M3}>Try Again</Typography>
-      </DecoratedButton>
     </div>
   );
 };

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/ErrorState/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/ErrorState/index.tsx
@@ -12,7 +12,7 @@ export const ErrorState = () => {
 
   return (
     <div className="flex min-h-[400px] flex-col items-center justify-center">
-      {/* Same icon, copy and spacing recipe as DeleteConfirmationDialog. */}
+      {/* Same icon, copy and spacing recipe as the delete confirmation modals. */}
       <div className="grid max-w-md justify-items-center gap-y-6">
         <ModalIcon variant="error">
           <AlertIcon className="size-7 text-white" />

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/ErrorState/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/ErrorState/index.tsx
@@ -2,8 +2,8 @@
 
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { AlertIcon } from "@/components/Icons/AlertIcon";
-import { ModalIcon } from "@/components/ModalIcon";
-import { TYPOGRAPHY, Typography } from "@/components/Typography";
+import { MiniAppMessageState } from "../../../common/MiniAppMessageState";
+import { miniAppButtonClassName } from "../../../common/styles";
 
 export const ErrorState = () => {
   const handleRetry = () => {
@@ -11,40 +11,21 @@ export const ErrorState = () => {
   };
 
   return (
-    <div className="flex min-h-[400px] flex-col items-center justify-center">
-      {/* Same icon, copy and spacing recipe as the delete confirmation modals. */}
-      <div className="grid max-w-md justify-items-center gap-y-6">
-        <ModalIcon variant="error">
-          <AlertIcon className="size-7 text-white" />
-        </ModalIcon>
-
-        <div className="grid w-full place-items-center gap-y-5">
-          <Typography
-            as="h3"
-            variant={TYPOGRAPHY.H6}
-            className="text-center text-grey-900"
-          >
-            Failed to load transactions
-          </Typography>
-
-          <Typography
-            variant={TYPOGRAPHY.R3}
-            className="text-center text-grey-500"
-          >
-            Something went wrong while loading transactions. Please try
-            refreshing the page.
-          </Typography>
-        </div>
-
+    <MiniAppMessageState
+      variant="error"
+      icon={<AlertIcon className="size-7 text-white" />}
+      title="Failed to load transactions"
+      description="Something went wrong while loading transactions. Please try refreshing the page."
+      action={
         <DecoratedButton
           type="button"
           variant="secondary"
-          className="px-8 py-3"
+          className={miniAppButtonClassName}
           onClick={handleRetry}
         >
-          <Typography variant={TYPOGRAPHY.R3}>Try Again</Typography>
+          Try Again
         </DecoratedButton>
-      </div>
-    </div>
+      }
+    />
   );
 };

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/TransactionsTable/TransactionRow/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/TransactionsTable/TransactionRow/index.tsx
@@ -44,7 +44,7 @@ export const TransactionRow = (props: {
           <Typography variant={TYPOGRAPHY.R4}>
             {formatAmount(transaction.inputTokenAmount, transaction.inputToken)}
           </Typography>
-          <Typography variant={TYPOGRAPHY.R4} className="text-gray-500">
+          <Typography variant={TYPOGRAPHY.R4} className="text-grey-500">
             {transaction.inputToken}
           </Typography>
         </div>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/index.tsx
@@ -1,5 +1,4 @@
 import { DecoratedButton } from "@/components/DecoratedButton";
-import { TYPOGRAPHY, Typography } from "@/components/Typography";
 import { PaymentMetadata } from "@/lib/types";
 import { getTransactionData } from "@/scenes/common/Teams/TeamId/Apps/AppId/MiniApp/Transactions/page/server/getTransactionData";
 import { ComponentProps } from "react";
@@ -7,29 +6,30 @@ import { Suspense } from "react";
 import { SkeletonTable } from "@/components/Skeletons";
 import { ErrorState } from "./ErrorState";
 import { TransactionsTable } from "./TransactionsTable";
+import { MiniAppMessageState } from "../../common/MiniAppMessageState";
+import { MiniAppPage, MiniAppPageHeader } from "../../common/MiniAppPage";
+import { miniAppButtonClassName } from "../../common/styles";
 
 type TransactionsPageProps = {
   params: Record<string, string> | null | undefined;
 };
 
+// The heading is unconditional: it used to be hidden on the empty state, so the
+// page lost its title exactly for developers who have taken no payments yet.
 const TransactionsPageLayout = ({
   children,
-  showHeading = true,
 }: {
   children: React.ReactNode;
-  showHeading?: boolean;
-}) => {
-  return (
-    <div className="my-8 min-h-dvh">
-      {showHeading && (
-        <div className="flex items-center justify-start text-gray-900">
-          <Typography variant={TYPOGRAPHY.H6}>Transactions</Typography>
-        </div>
-      )}
-      <div className={showHeading ? "pt-12" : ""}>{children}</div>
-    </div>
-  );
-};
+}) => (
+  <MiniAppPage>
+    <MiniAppPageHeader
+      title="Transactions"
+      description="Payments your Mini App has received."
+    />
+
+    {children}
+  </MiniAppPage>
+);
 
 const SparkleIcon = (props: ComponentProps<"svg">) => {
   return (
@@ -47,64 +47,22 @@ const SparkleIcon = (props: ComponentProps<"svg">) => {
   );
 };
 
-const EmptyState = () => {
-  return (
-    <div className="grid justify-items-center pt-8">
-      <div className="grid justify-items-center gap-y-6">
-        <div className="relative size-16 shrink-0 rounded-full bg-grey-400 text-grey-0">
-          <span
-            className="pointer-events-none absolute inset-0 rounded-full opacity-20"
-            style={{
-              background:
-                "radial-gradient(99.88% 100% at 22.73% 0%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%)",
-            }}
-          />
-          <span className="pointer-events-none absolute inset-0 rounded-full border border-white/10" />
-          <span
-            className="absolute"
-            style={{
-              left: "23.44%",
-              right: "23.44%",
-              top: "23.44%",
-              bottom: "23.44%",
-            }}
-          >
-            <span
-              className="absolute"
-              style={{
-                left: "6%",
-                right: "6%",
-                top: "6%",
-                bottom: "6%",
-              }}
-            >
-              <SparkleIcon className="size-full" />
-            </span>
-          </span>
-        </div>
-
-        <div className="grid justify-items-center gap-y-2">
-          <Typography variant={TYPOGRAPHY.H6}>No transactions yet</Typography>
-        </div>
-        <Typography
-          variant={TYPOGRAPHY.R3}
-          className="text-center text-grey-500"
-        >
-          Once you receive your first payment, you
-          <br />
-          will see the transaction here.
-        </Typography>
-
-        <DecoratedButton
-          href="https://docs.world.org/mini-apps/commands/pay"
-          className="min-w-[112px] py-4"
-        >
-          See docs
-        </DecoratedButton>
-      </div>
-    </div>
-  );
-};
+const EmptyState = () => (
+  <MiniAppMessageState
+    variant="neutral"
+    icon={<SparkleIcon className="size-7 text-white" />}
+    title="No transactions yet"
+    description="Once you receive your first payment, you will see the transaction here."
+    action={
+      <DecoratedButton
+        href="https://docs.world.org/mini-apps/commands/pay"
+        className={miniAppButtonClassName}
+      >
+        See docs
+      </DecoratedButton>
+    }
+  />
+);
 
 const TransactionsContent = ({
   transactionData,
@@ -154,7 +112,7 @@ export const TransactionsPage = async (props: TransactionsPageProps) => {
   // Early return for empty state
   if (transactionData.length === 0) {
     return (
-      <TransactionsPageLayout showHeading={false}>
+      <TransactionsPageLayout>
         <EmptyState />
       </TransactionsPageLayout>
     );

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/common/MiniAppMessageState/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/common/MiniAppMessageState/index.tsx
@@ -1,0 +1,34 @@
+import { ModalIcon } from "@/components/ModalIcon";
+import { ReactNode } from "react";
+
+/**
+ * Full-height empty/error state for a Mini App subtab: the 88px ModalIcon the
+ * delete confirmations use, then the tab's own page type ramp. Transactions had
+ * an empty state on a bespoke 64px circle and an error state on a soft ring,
+ * with two different heading fonts between them.
+ */
+export const MiniAppMessageState = (props: {
+  variant: "error" | "neutral";
+  icon: ReactNode;
+  title: string;
+  description: ReactNode;
+  action?: ReactNode;
+}) => (
+  <div className="flex min-h-[400px] flex-col items-center justify-center">
+    <div className="grid max-w-md justify-items-center gap-y-6">
+      <ModalIcon variant={props.variant}>{props.icon}</ModalIcon>
+
+      <div className="grid w-full place-items-center gap-y-5">
+        <h2 className="text-center font-world text-[26px] leading-[120%] font-semibold tracking-[-0.01em] text-grey-900">
+          {props.title}
+        </h2>
+
+        <p className="text-center font-world text-[15px] leading-[130%] font-medium text-grey-500">
+          {props.description}
+        </p>
+      </div>
+
+      {props.action}
+    </div>
+  </div>
+);

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/common/MiniAppPage/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/common/MiniAppPage/index.tsx
@@ -1,0 +1,82 @@
+import { ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * One page shell and one title ramp for every Mini App subtab. Develop set the
+ * pattern; Transactions and Notifications each had their own vertical rhythm,
+ * content width and title typeface before this.
+ */
+export const MiniAppPage = (props: {
+  children: ReactNode;
+  className?: string;
+}) => (
+  <div className={twMerge("grid gap-y-10 pt-8 pb-12", props.className)}>
+    {props.children}
+  </div>
+);
+
+/**
+ * Form-width column. Wider content (the transactions table) skips it. Pass
+ * `labelledBy` to make it a named landmark pointing at the page heading.
+ */
+export const MiniAppPageColumn = (props: {
+  children: ReactNode;
+  className?: string;
+  labelledBy?: string;
+}) => {
+  const Component = props.labelledBy ? "section" : "div";
+
+  return (
+    <Component
+      aria-labelledby={props.labelledBy}
+      className={twMerge(
+        "grid w-full gap-y-8 lg:max-w-[620px]",
+        props.className,
+      )}
+    >
+      {props.children}
+    </Component>
+  );
+};
+
+export const MiniAppPageHeader = (props: {
+  title: string;
+  description?: ReactNode;
+  /** Right-aligned slot for a save indicator or action. */
+  trailing?: ReactNode;
+  id?: string;
+}) => (
+  <div className="flex items-start justify-between gap-4">
+    <div className="grid gap-y-2">
+      <h1
+        id={props.id}
+        className="font-world text-[26px] leading-[120%] font-semibold tracking-[-0.01em] text-grey-900"
+      >
+        {props.title}
+      </h1>
+
+      {props.description && (
+        <p className="font-world text-[15px] leading-[130%] font-medium text-grey-500">
+          {props.description}
+        </p>
+      )}
+    </div>
+
+    {props.trailing}
+  </div>
+);
+
+/** Section heading inside a subtab, one step below the page title. */
+export const MiniAppSectionHeading = (props: {
+  children: ReactNode;
+  className?: string;
+}) => (
+  <h2
+    className={twMerge(
+      "font-world text-[17px] leading-[120%] font-medium text-grey-900",
+      props.className,
+    )}
+  >
+    {props.children}
+  </h2>
+);

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/common/NoticeCallout/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/common/NoticeCallout/index.tsx
@@ -1,0 +1,50 @@
+import { ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
+
+type NoticeVariant = "neutral" | "info" | "warning";
+
+const variantClassName: Record<NoticeVariant, string> = {
+  neutral: "bg-grey-50 text-grey-700",
+  // additional-blue-100, not the #E6F0FF that Notifications hardcoded.
+  info: "bg-additional-blue-100 text-grey-900",
+  warning: "bg-system-warning-100 text-system-warning-600",
+};
+
+/**
+ * The inline notice box shared by the Mini App subtabs — locked drafts, review
+ * status, "notifications unavailable", the notifications rate-limit note. Each
+ * of those rolled its own padding and background before.
+ */
+export const NoticeCallout = (props: {
+  children: ReactNode;
+  variant?: NoticeVariant;
+  /** Leading glyph, rendered in its own column so long copy stays aligned. */
+  icon?: ReactNode;
+  /** Trailing action, e.g. "Create draft". */
+  action?: ReactNode;
+  title?: string;
+  className?: string;
+}) => {
+  const { variant = "neutral", icon, action, title, children } = props;
+
+  return (
+    <div
+      className={twMerge(
+        "flex flex-wrap items-start justify-between gap-3 rounded-[10px] p-4",
+        variantClassName[variant],
+        props.className,
+      )}
+    >
+      <div className="flex min-w-0 flex-1 items-start gap-x-3">
+        {icon}
+
+        <div className="min-w-0 font-world text-[13px] leading-[130%] font-medium">
+          {title && <p className="font-semibold">{title}</p>}
+          <p>{children}</p>
+        </div>
+      </div>
+
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  );
+};

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/common/TextArea/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/common/TextArea/index.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import clsx from "clsx";
+import { TextareaHTMLAttributes, forwardRef } from "react";
+
+/**
+ * Multi-line sibling of the Wizard's TextField, with the same box chrome
+ * (bordered white box, 10px radius, floating 13px label) so the Notifications
+ * form stops mixing borderless grey boxes into a bordered-white tab.
+ */
+export const TextArea = forwardRef<
+  HTMLTextAreaElement,
+  TextareaHTMLAttributes<HTMLTextAreaElement> & {
+    label: string;
+    error?: string;
+    hint?: string;
+  }
+>(function TextArea({ label, error, hint, className, id, ...rest }, ref) {
+  const hintId = hint || error ? `${id ?? label}-hint` : undefined;
+
+  return (
+    <div className="flex w-full flex-col gap-1.5">
+      <label
+        className={clsx(
+          "flex w-full flex-col gap-1 rounded-[10px] border p-4",
+          error
+            ? "border-[#ea392a] bg-system-error-50"
+            : "border-portal-border bg-white",
+        )}
+      >
+        <span
+          className={clsx(
+            "text-13 leading-[1.3] font-[350]",
+            error ? "text-[#ea392a]" : "text-portal-subtle",
+          )}
+        >
+          {label}
+        </span>
+
+        <textarea
+          ref={ref}
+          id={id}
+          aria-invalid={Boolean(error)}
+          aria-describedby={hintId}
+          className={clsx(
+            "w-full min-w-0 resize-none bg-transparent p-0 text-15 leading-[1.3] font-[350] text-portal-ink outline-none placeholder:text-portal-subtle",
+            className,
+          )}
+          {...rest}
+        />
+      </label>
+
+      {(hint || error) && (
+        <p
+          id={hintId}
+          className={clsx(
+            "text-13 leading-[1.3] font-[350]",
+            error ? "text-[#ea392a]" : "text-portal-subtle",
+          )}
+        >
+          {error ?? hint}
+        </p>
+      )}
+    </div>
+  );
+});

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/common/styles.ts
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MiniApp/common/styles.ts
@@ -1,0 +1,12 @@
+/**
+ * Button sizes for the Mini App tab. DecoratedButton is shared with v2, so the
+ * sizes live here as className overrides instead. Two sizes only — the tab had
+ * four before (h-10 px-4, h-10 min-w-[109px] px-3.5, h-14 px-6, py-4).
+ */
+export const miniAppButtonClassName = "h-10 shrink-0 px-4 py-0";
+export const miniAppButtonLargeClassName =
+  "h-14 shrink-0 px-6 py-0 text-[17px] font-semibold";
+
+/** Helper text under a field, matching TextField's own hint ramp. */
+export const miniAppFieldHintClassName =
+  "text-13 leading-[1.3] font-[350] text-portal-subtle";

--- a/web/tests/unit/pv3-mini-app-notifications.test.tsx
+++ b/web/tests/unit/pv3-mini-app-notifications.test.tsx
@@ -83,21 +83,26 @@ const setMetadata = ({
   });
 };
 
+// The fields carry floating labels rather than placeholder-only labelling, so
+// they are addressed by accessible name. TextField renders its label twice
+// while empty (one copy class-hidden, which jsdom does not apply), so the
+// single-line fields match on a substring.
 const submitNotification = async () => {
+  fireEvent.change(screen.getByRole("textbox", { name: "Wallet addresses" }), {
+    target: { value: "0x0000000000000000000000000000000000000001" },
+  });
   fireEvent.change(
-    screen.getByPlaceholderText("Enter wallet addresses separated by commas"),
-    { target: { value: "0x0000000000000000000000000000000000000001" } },
+    screen.getByRole("textbox", { name: /Notification title/ }),
+    { target: { value: "Test notification" } },
   );
-  fireEvent.change(screen.getByPlaceholderText("Notification title"), {
-    target: { value: "Test notification" },
-  });
-  fireEvent.change(screen.getByPlaceholderText("Notification message"), {
-    target: { value: "Testing the Mini App" },
-  });
-  fireEvent.change(screen.getByPlaceholderText("Mini App Path"), {
+  fireEvent.change(
+    screen.getByRole("textbox", { name: "Notification message" }),
+    { target: { value: "Testing the Mini App" } },
+  );
+  fireEvent.change(screen.getByRole("textbox", { name: /Mini App path/ }), {
     target: { value: `worldapp://mini-app?app_id=${appId}` },
   });
-  fireEvent.change(screen.getByPlaceholderText("API Key"), {
+  fireEvent.change(screen.getByRole("textbox", { name: /API key/ }), {
     target: { value: "api_test" },
   });
   fireEvent.click(screen.getByRole("button", { name: "Send notification" }));
@@ -173,11 +178,10 @@ describe("NotificationsPage metadata states", () => {
 
     const content = screen.getByRole("region", { name: "Notifications" });
     const heading = screen.getByRole("heading", { name: "Notifications" });
-    const note = screen.getByText(
-      /Send notifications to specific wallet addresses/,
-    );
+    const note = screen.getByText(/Unverified apps are limited to/);
 
-    expect(content).toHaveClass("max-w-[580px]");
+    // Shared Mini App form column, so the tab's subtabs stay the same width.
+    expect(content).toHaveClass("lg:max-w-[620px]");
     expect(
       heading.compareDocumentPosition(note) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Each Mini App subtab had grown its own design language. Normalizes all three (Develop, Transactions, Notifications) onto Develop's, since two of the three already followed it.

| | Develop | Notifications | Transactions |
|---|---|---|---|
| Page title | `font-world` 26px | `font-world` 26px | **`font-twk` 24px** |
| Rhythm | `pt-8 pb-12` | `my-8` | `my-8` + `pt-12` |
| Width | 620px | 580px | full |
| Inputs | shared `TextField` | 4× raw, copied classes | — |
| Callouts | `bg-grey-50` | **`bg-[#E6F0FF]`** | — |
| Button sizes | 1 | 2 | 1 |

New `MiniApp/common/`: `MiniAppPage`, `MiniAppPageColumn`, `MiniAppPageHeader`, `MiniAppSectionHeading`, `NoticeCallout` (neutral/info/warning), `MiniAppMessageState`, a `TextArea` matching `TextField`'s chrome, and two button sizes.

Transactions' empty and error states now share `MiniAppMessageState` — they were a bespoke 64px circle and an 88px one with different heading fonts.

### Two fixes that aren't cosmetic

- **Transactions dropped its page heading on the empty state** (`showHeading={false}`), so the title vanished for exactly the developers who have taken no payments yet.
- **Off-palette greys**: Transactions used `text-gray-900/500` — Tailwind's stock `gray`, not the design system's `grey` (`styles/globals.css` defines `--color-grey-*` and no custom `gray`), so those were the wrong colour. The two hardcoded `#191C20` titles are now `text-grey-900`, the same value.

## Reviewer notes

- v3 only — `scenes/Portal` untouched.
- Notifications' fields move from placeholder-as-label to the shared floating label, so its tests address them by accessible name. `TextField` renders its label twice while empty (one copy class-hidden, which jsdom doesn't apply), hence the substring matches.
- Notifications keeps its named landmark via `MiniAppPageColumn labelledBy`.
- Verified in the browser: header, all three callout variants, and both message states.

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
