### PR TITLE
fix(world-id): make a new rp_id unguessable before it is registered

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -101,11 +101,11 @@ ENABLE_UNPREDICTABLE_RP_ID=
 # SSM; treat it like a signing key. Rotating it only changes the ids that
 # unregistered apps will get, so rotation is safe.
 RP_ID_SALT=
-# The outgoing salt, for ONE drain window after a rotation. A self-managed
-# developer who was shown an id derived from the old salt has already registered
-# it on-chain; without this their registration is orphaned. Clear it once no
-# in-flight setup can still be using it.
-RP_ID_SALT_PREVIOUS=
+# NOTE on rotation: the outgoing salt is deliberately NOT kept as a fallback. An
+# attacker who learned a leaked salt could pre-register the old-salt id and have it
+# adopted, which is the squat this exists to prevent. So rotate during a quiet
+# window: a self-managed developer caught between the instructions screen and
+# completion will have their registration orphaned and need manual cleanup.
 
 # Verifier Contract
 VERIFIER_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000

--- a/web/.env.example
+++ b/web/.env.example
@@ -90,6 +90,17 @@ RP_REGISTRY_SAFE_4337_MODULE_ADDRESS=0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226
 RP_REGISTRY_KMS_REGION=eu-west-1
 RP_REGISTRY_UPDATE_RP_TYPEHASH=0xe52c0a4424a7d2015a13748c3738793d6b1dd1774e4ee82516251372da305465
 RP_REGISTRY_DOMAIN_SEPARATOR=0x150a3a11bbb5ea6c4cfbd7cedc050d67bb55333eb8700bec241368de512607f1
+# When true, a NEW registration's rp_id is HMAC(RP_ID_SALT, app_id) instead of
+# the public uint64(keccak256(app_id)), so nobody can compute an unregistered
+# app's rp_id and claim it on-chain first. Already-registered rows keep their
+# stored id either way, so this is safe to flip and to roll back.
+# Enabling it without a usable RP_ID_SALT fails registration rather than falling
+# back to the guessable derivation.
+ENABLE_UNPREDICTABLE_RP_ID=
+# Secret (>=32 chars) keying the derivation above. Inject from Secrets Manager /
+# SSM; treat it like a signing key. Rotating it only changes the ids that
+# unregistered apps will get, so rotation is safe.
+RP_ID_SALT=
 
 # Verifier Contract
 VERIFIER_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000

--- a/web/.env.example
+++ b/web/.env.example
@@ -101,6 +101,11 @@ ENABLE_UNPREDICTABLE_RP_ID=
 # SSM; treat it like a signing key. Rotating it only changes the ids that
 # unregistered apps will get, so rotation is safe.
 RP_ID_SALT=
+# The outgoing salt, for ONE drain window after a rotation. A self-managed
+# developer who was shown an id derived from the old salt has already registered
+# it on-chain; without this their registration is orphaned. Clear it once no
+# in-flight setup can still be using it.
+RP_ID_SALT_PREVIOUS=
 
 # Verifier Contract
 VERIFIER_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000

--- a/web/api/hasura/register-rp/index.ts
+++ b/web/api/hasura/register-rp/index.ts
@@ -5,8 +5,17 @@ import {
   submitManagedRpRegistration,
   type ManagedRegistrationResult,
 } from "@/api/helpers/rp-registration-flows";
-import { resolveRpIdForNewRegistration } from "@/api/helpers/rp-id";
-import { normalizeAddress, RpRegistrationStatus } from "@/api/helpers/rp-utils";
+import {
+  candidateRpIdsForApp,
+  resolveRpIdForNewRegistration,
+} from "@/api/helpers/rp-id";
+import {
+  getRpRegistryConfig,
+  normalizeAddress,
+  parseRpId,
+  RpRegistrationStatus,
+} from "@/api/helpers/rp-utils";
+import { getRpFromContract } from "@/api/helpers/temporal-rpc";
 import { protectInternalEndpoint } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { logger } from "@/lib/logger";
@@ -159,6 +168,47 @@ export const POST = async (req: NextRequest) => {
         code: "config_error",
         app_id,
       });
+    }
+
+    // ...unless the derivation changed between the two reads. The developer saw
+    // a number on the instructions screen and registered THAT one on-chain from
+    // their own wallet; if the flag flipped in between — a rolling deploy serving
+    // the two requests from tasks with different env, or a rollback — deriving
+    // again here yields a different id, and we would store a row for an id nobody
+    // registered while their real registration is orphaned. Self-managed rows
+    // never time out, so that app would be stuck until manual cleanup.
+    //
+    // Prefer whichever candidate the chain says is actually registered. Both are
+    // derived from the app_id server-side, so this cannot be steered into
+    // claiming an arbitrary id. Best-effort: if the reads fail, keep the
+    // currently-derived id, which is the pre-existing behaviour.
+    const selfManagedConfig = getRpRegistryConfig();
+    const candidates = candidateRpIdsForApp(app_id);
+    if (selfManagedConfig && candidates.length > 1) {
+      for (const candidate of candidates) {
+        try {
+          const onChain = await getRpFromContract(
+            parseRpId(candidate),
+            selfManagedConfig.contractAddress,
+          );
+          if (onChain.initialized) {
+            if (candidate !== rpIdString) {
+              logger.warn(
+                "Self-managed rp_id scheme changed mid-flow; using the id the developer registered",
+                { app_id, derived: rpIdString, registered: candidate },
+              );
+              rpIdString = candidate;
+            }
+            break;
+          }
+        } catch (error) {
+          logger.warn("Could not read on-chain state for an rp_id candidate", {
+            error,
+            app_id,
+            candidate,
+          });
+        }
+      }
     }
     const { insert_rp_registration_one: claimedSlot } = await getClaimRpSdk(
       client,

--- a/web/api/hasura/register-rp/index.ts
+++ b/web/api/hasura/register-rp/index.ts
@@ -5,11 +5,8 @@ import {
   submitManagedRpRegistration,
   type ManagedRegistrationResult,
 } from "@/api/helpers/rp-registration-flows";
-import {
-  generateRpIdString,
-  normalizeAddress,
-  RpRegistrationStatus,
-} from "@/api/helpers/rp-utils";
+import { resolveRpIdForNewRegistration } from "@/api/helpers/rp-id";
+import { normalizeAddress, RpRegistrationStatus } from "@/api/helpers/rp-utils";
 import { protectInternalEndpoint } from "@/api/helpers/utils";
 import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { logger } from "@/lib/logger";
@@ -145,7 +142,24 @@ export const POST = async (req: NextRequest) => {
 
   // Self-managed: just create the DB record. No KMS / on-chain work.
   if (mode === "self_managed") {
-    const rpIdString = generateRpIdString(app_id);
+    let rpIdString: string;
+    try {
+      // Must match what getSelfManagedRegistrationInfo showed the developer —
+      // they have already submitted register(uint64 rpId, ...) on-chain with
+      // that number. Both call the same resolver so they cannot drift.
+      rpIdString = resolveRpIdForNewRegistration(app_id);
+    } catch (error) {
+      logger.error("Cannot derive an rp_id for self-managed registration", {
+        error,
+        app_id,
+      });
+      return errorHasuraQuery({
+        req,
+        detail: "RP Registry is not configured correctly.",
+        code: "config_error",
+        app_id,
+      });
+    }
     const { insert_rp_registration_one: claimedSlot } = await getClaimRpSdk(
       client,
     ).ClaimRpRegistration({

--- a/web/api/helpers/rp-id.ts
+++ b/web/api/helpers/rp-id.ts
@@ -98,29 +98,34 @@ export function resolveRpIdForNewRegistration(appId: string): `rp_${string}` {
  * on-chain registration is orphaned. Self-managed rows never time out, so that
  * app is stuck until someone cleans it up by hand.
  *
- * The order is the security-critical part, and it does NOT follow the flag.
- * "Initialized on-chain" is not evidence that the *developer* registered it: the
- * legacy id is guessable by anyone, so a squatter's registration looks identical.
- * Probing legacy first during a rollback — where the developer was shown, and
- * registered, the salted id — would find the squatter's row and bind the app to
- * an attacker-controlled rp_id. Probing salted first cannot be gamed the same
- * way, because an attacker cannot compute the salted id to register it. Legacy is
- * only ever selected when the salted id is unregistered, which is the honest
- * roll-forward case; a squatted legacy id there is the pre-existing exposure this
- * PR is narrowing, not a new one.
+ * Which ids are eligible is the security-critical part. "Initialized on-chain" is
+ * not evidence that the *developer* registered it: the legacy id is guessable by
+ * anyone, so a squatter's registration looks identical to the real thing.
  *
- * Both values are derived here from the app_id, so nothing caller-supplied widens
- * what can be claimed. The caller keeps whatever the current scheme yields when
- * neither candidate is on-chain.
+ * So while the feature is ON, the legacy id is not a candidate at all. Merely
+ * ordering it last was not enough — a developer who clicks Continue before their
+ * salted `register()` is visible on-chain (mined late, or a lagging RPC read)
+ * leaves the salted candidate looking uninitialized, and a squatted legacy id
+ * would then be the first initialized one found and get stored as this app's
+ * rp_id. Under the new scheme an initialized legacy id is by definition not
+ * something we handed out, so there is nothing there to adopt.
  *
- * `RP_ID_SALT_PREVIOUS` covers rotation. Without it, rotating while a developer
- * is between the instructions screen and completion orphans the registration they
+ * The cost is the roll-forward window: instructions screen served with the flag
+ * off, developer registers the legacy id, completion lands on a task with the flag
+ * on. No candidate matches, and the row is created under the salted id — a wedged
+ * registration needing manual cleanup. That is recoverable; binding an app to an
+ * attacker's rp_id is not, and the window is one deploy transition.
+ *
+ * All values are derived here from the app_id, so nothing caller-supplied widens
+ * what can be claimed. The caller keeps whatever the current scheme yields when no
+ * candidate is on-chain.
+ *
+ * `RP_ID_SALT_PREVIOUS` covers rotation. Without it, rotating while a developer is
+ * between the instructions screen and completion orphans the registration they
  * just paid for: the id they were shown is derived from a salt that no longer
  * exists anywhere. Since rotation is the advertised remedy for a leaked salt, it
- * has to be safe to perform — set the outgoing value here for one drain window,
- * then drop it. It is probed after the current salt and before legacy, so it
- * never takes precedence over the live scheme and never demotes the ordering
- * below a guessable id.
+ * has to be safe to perform — set the outgoing value for one drain window, then
+ * drop it.
  */
 export function candidateRpIdsForApp(appId: string): `rp_${string}`[] {
   const usableSalt = (salt: string | undefined) =>
@@ -129,12 +134,18 @@ export function candidateRpIdsForApp(appId: string): `rp_${string}`[] {
   const current = usableSalt(process.env.RP_ID_SALT);
   const previous = usableSalt(process.env.RP_ID_SALT_PREVIOUS);
 
-  const ordered = [
+  const salted = [
     current ? deriveSaltedRpIdString(appId, current) : null,
     previous ? deriveSaltedRpIdString(appId, previous) : null,
-    // Always last: the only candidate an attacker can compute.
-    generateRpIdString(appId),
   ];
+
+  // Flag on: salted only — an initialized legacy id is not ours to adopt.
+  // Flag off: legacy IS the current scheme, so adopting it is correct by
+  // definition. The salted ids stay reachable, and first, for the rollback window
+  // where the screen may have shown one; an attacker cannot have planted those.
+  const ordered = isUnpredictableRpIdEnabled()
+    ? salted
+    : [...salted, generateRpIdString(appId)];
 
   return Array.from(
     new Set(ordered.filter((id): id is `rp_${string}` => Boolean(id))),

--- a/web/api/helpers/rp-id.ts
+++ b/web/api/helpers/rp-id.ts
@@ -85,8 +85,8 @@ export function resolveRpIdForNewRegistration(appId: string): `rp_${string}` {
 }
 
 /**
- * Every rp_id this deployment could have handed out for `appId`, current scheme
- * first.
+ * Every rp_id this deployment could have handed out for `appId`, in the order a
+ * caller should probe the chain: **salted first, always.**
  *
  * The self-managed flow derives the id twice across a gap it does not control:
  * the instructions screen shows the developer a number, the developer submits
@@ -98,9 +98,20 @@ export function resolveRpIdForNewRegistration(appId: string): `rp_${string}` {
  * on-chain registration is orphaned. Self-managed rows never time out, so that
  * app is stuck until someone cleans it up by hand.
  *
- * Enumerating the candidates lets the caller pick the one the developer actually
- * registered. Both values are derived here from the app_id, so nothing
- * caller-supplied widens what can be claimed.
+ * The order is the security-critical part, and it does NOT follow the flag.
+ * "Initialized on-chain" is not evidence that the *developer* registered it: the
+ * legacy id is guessable by anyone, so a squatter's registration looks identical.
+ * Probing legacy first during a rollback — where the developer was shown, and
+ * registered, the salted id — would find the squatter's row and bind the app to
+ * an attacker-controlled rp_id. Probing salted first cannot be gamed the same
+ * way, because an attacker cannot compute the salted id to register it. Legacy is
+ * only ever selected when the salted id is unregistered, which is the honest
+ * roll-forward case; a squatted legacy id there is the pre-existing exposure this
+ * PR is narrowing, not a new one.
+ *
+ * Both values are derived here from the app_id, so nothing caller-supplied widens
+ * what can be claimed. The caller keeps whatever the current scheme yields when
+ * neither candidate is on-chain.
  *
  * Salt *rotation* mid-flow is still not covered — the previous salt is gone by
  * definition. Rotation should be treated as a deliberate operation, not a
@@ -114,12 +125,7 @@ export function candidateRpIdsForApp(appId: string): `rp_${string}`[] {
       ? deriveSaltedRpIdString(appId, salt)
       : null;
 
-  // Current scheme first so it wins when the chain says nothing.
-  const ordered = isUnpredictableRpIdEnabled()
-    ? [salted, legacy]
-    : [legacy, salted];
-
   return Array.from(
-    new Set(ordered.filter((id): id is `rp_${string}` => Boolean(id))),
+    new Set([salted, legacy].filter((id): id is `rp_${string}` => Boolean(id))),
   );
 }

--- a/web/api/helpers/rp-id.ts
+++ b/web/api/helpers/rp-id.ts
@@ -113,19 +113,30 @@ export function resolveRpIdForNewRegistration(appId: string): `rp_${string}` {
  * what can be claimed. The caller keeps whatever the current scheme yields when
  * neither candidate is on-chain.
  *
- * Salt *rotation* mid-flow is still not covered — the previous salt is gone by
- * definition. Rotation should be treated as a deliberate operation, not a
- * routine one.
+ * `RP_ID_SALT_PREVIOUS` covers rotation. Without it, rotating while a developer
+ * is between the instructions screen and completion orphans the registration they
+ * just paid for: the id they were shown is derived from a salt that no longer
+ * exists anywhere. Since rotation is the advertised remedy for a leaked salt, it
+ * has to be safe to perform — set the outgoing value here for one drain window,
+ * then drop it. It is probed after the current salt and before legacy, so it
+ * never takes precedence over the live scheme and never demotes the ordering
+ * below a guessable id.
  */
 export function candidateRpIdsForApp(appId: string): `rp_${string}`[] {
-  const legacy = generateRpIdString(appId);
-  const salt = process.env.RP_ID_SALT;
-  const salted =
-    salt && salt.length >= MIN_SALT_LENGTH
-      ? deriveSaltedRpIdString(appId, salt)
-      : null;
+  const usableSalt = (salt: string | undefined) =>
+    salt && salt.length >= MIN_SALT_LENGTH ? salt : null;
+
+  const current = usableSalt(process.env.RP_ID_SALT);
+  const previous = usableSalt(process.env.RP_ID_SALT_PREVIOUS);
+
+  const ordered = [
+    current ? deriveSaltedRpIdString(appId, current) : null,
+    previous ? deriveSaltedRpIdString(appId, previous) : null,
+    // Always last: the only candidate an attacker can compute.
+    generateRpIdString(appId),
+  ];
 
   return Array.from(
-    new Set([salted, legacy].filter((id): id is `rp_${string}` => Boolean(id))),
+    new Set(ordered.filter((id): id is `rp_${string}` => Boolean(id))),
   );
 }

--- a/web/api/helpers/rp-id.ts
+++ b/web/api/helpers/rp-id.ts
@@ -83,3 +83,43 @@ export function resolveRpIdForNewRegistration(appId: string): `rp_${string}` {
 
   return deriveSaltedRpIdString(appId, salt);
 }
+
+/**
+ * Every rp_id this deployment could have handed out for `appId`, current scheme
+ * first.
+ *
+ * The self-managed flow derives the id twice across a gap it does not control:
+ * the instructions screen shows the developer a number, the developer submits
+ * `register(uint64 rpId, ...)` from their own wallet, and `register_rp` derives
+ * it again to insert the row. If the flag flips between those two reads — a
+ * rolling deploy serves them from tasks with different env, or the feature is
+ * rolled back — the second derivation returns a different id, and the Portal
+ * would store a row for an id nobody registered while the developer's actual
+ * on-chain registration is orphaned. Self-managed rows never time out, so that
+ * app is stuck until someone cleans it up by hand.
+ *
+ * Enumerating the candidates lets the caller pick the one the developer actually
+ * registered. Both values are derived here from the app_id, so nothing
+ * caller-supplied widens what can be claimed.
+ *
+ * Salt *rotation* mid-flow is still not covered — the previous salt is gone by
+ * definition. Rotation should be treated as a deliberate operation, not a
+ * routine one.
+ */
+export function candidateRpIdsForApp(appId: string): `rp_${string}`[] {
+  const legacy = generateRpIdString(appId);
+  const salt = process.env.RP_ID_SALT;
+  const salted =
+    salt && salt.length >= MIN_SALT_LENGTH
+      ? deriveSaltedRpIdString(appId, salt)
+      : null;
+
+  // Current scheme first so it wins when the chain says nothing.
+  const ordered = isUnpredictableRpIdEnabled()
+    ? [salted, legacy]
+    : [legacy, salted];
+
+  return Array.from(
+    new Set(ordered.filter((id): id is `rp_${string}` => Boolean(id))),
+  );
+}

--- a/web/api/helpers/rp-id.ts
+++ b/web/api/helpers/rp-id.ts
@@ -120,32 +120,32 @@ export function resolveRpIdForNewRegistration(appId: string): `rp_${string}` {
  * what can be claimed. The caller keeps whatever the current scheme yields when no
  * candidate is on-chain.
  *
- * `RP_ID_SALT_PREVIOUS` covers rotation. Without it, rotating while a developer is
- * between the instructions screen and completion orphans the registration they
- * just paid for: the id they were shown is derived from a salt that no longer
- * exists anywhere. Since rotation is the advertised remedy for a leaked salt, it
- * has to be safe to perform — set the outgoing value for one drain window, then
- * drop it.
+ * A PREVIOUS salt is deliberately NOT a candidate. Probing one would rescue an
+ * in-flight self-managed setup across a rotation, but the reason to rotate is a
+ * leaked salt — and an attacker who learned it can pre-register the old-salt id and
+ * have it adopted any time the developer's current-salt transaction is not visible
+ * yet. That is the same squat this change closes, reopened by the mitigation for
+ * it.
+ *
+ * The cost of leaving it out: rotating while a developer sits between the
+ * instructions screen and completion orphans that registration, and the row needs
+ * manual cleanup. Rotate during a quiet window. Recoverable beats adoptable — the
+ * same trade already made for the legacy id above.
  */
 export function candidateRpIdsForApp(appId: string): `rp_${string}`[] {
-  const usableSalt = (salt: string | undefined) =>
-    salt && salt.length >= MIN_SALT_LENGTH ? salt : null;
+  const salt = process.env.RP_ID_SALT;
+  const salted =
+    salt && salt.length >= MIN_SALT_LENGTH
+      ? deriveSaltedRpIdString(appId, salt)
+      : null;
 
-  const current = usableSalt(process.env.RP_ID_SALT);
-  const previous = usableSalt(process.env.RP_ID_SALT_PREVIOUS);
-
-  const salted = [
-    current ? deriveSaltedRpIdString(appId, current) : null,
-    previous ? deriveSaltedRpIdString(appId, previous) : null,
-  ];
-
-  // Flag on: salted only — an initialized legacy id is not ours to adopt.
+  // Flag on: the salted id only — an initialized legacy id is not ours to adopt.
   // Flag off: legacy IS the current scheme, so adopting it is correct by
-  // definition. The salted ids stay reachable, and first, for the rollback window
-  // where the screen may have shown one; an attacker cannot have planted those.
+  // definition. The salted id stays reachable, and first, for the rollback window
+  // where the screen may have shown it; an attacker cannot have planted that one.
   const ordered = isUnpredictableRpIdEnabled()
-    ? salted
-    : [...salted, generateRpIdString(appId)];
+    ? [salted]
+    : [salted, generateRpIdString(appId)];
 
   return Array.from(
     new Set(ordered.filter((id): id is `rp_${string}` => Boolean(id))),

--- a/web/api/helpers/rp-id.ts
+++ b/web/api/helpers/rp-id.ts
@@ -1,0 +1,85 @@
+import "server-only";
+
+import { createHmac } from "crypto";
+import { generateRpIdString } from "@/lib/rp";
+
+/**
+ * An rp_id must stay `rp_` + exactly 16 lowercase hex chars: `parseRpId` reads
+ * it back as the uint64 the registry indexes RPs by, `isValidRpId` enforces the
+ * shape on every inbound route, and the admin screens match it with a literal
+ * /^rp_[0-9a-f]{16}$/ regex. Both derivations below must produce that shape.
+ */
+const RP_ID_HEX_CHARS = 16;
+
+/**
+ * A short salt would let an attacker who can guess it reconstruct the whole
+ * namespace, which is the property we are buying here. 32 chars is the floor
+ * for the generated-secret sizes we use elsewhere; the deployed value is a
+ * 32-byte random string.
+ */
+const MIN_SALT_LENGTH = 32;
+
+/**
+ * The legacy scheme is `uint64(keccak256(app_id))` — a pure function of a
+ * *public* app_id. Since on-chain `register()` is permissionless, zero-fee and
+ * first-come, anyone can harvest app_ids from `/api/v2/public/apps`, compute
+ * the rp_id of every app that has not migrated yet, and claim it (H1 #3910854).
+ *
+ * The salted scheme keys the same derivation with a server-side secret, so the
+ * rp_id of an unregistered app is not computable by anyone who does not hold
+ * the salt. Nothing else about the id changes: it stays a deterministic pure
+ * function of the app_id *given the salt*, which is what lets the three call
+ * sites that derive it independently — the managed pipeline, the self-managed
+ * Hasura action, and the self-managed instructions screen the developer copies
+ * the number from — keep agreeing without a reservation protocol.
+ *
+ * HMAC rather than keccak256(salt || app_id): a prefix-keyed hash of a
+ * variable-length message is the textbook length-extension foot-gun, and HMAC
+ * is the primitive that already exists for "keyed digest of a message".
+ */
+function deriveSaltedRpIdString(appId: string, salt: string): `rp_${string}` {
+  const digest = createHmac("sha256", salt).update(appId).digest("hex");
+  return `rp_${digest.slice(0, RP_ID_HEX_CHARS)}` as `rp_${string}`;
+}
+
+/**
+ * True once unpredictable rp_ids are turned on for this environment. Off means
+ * new registrations keep deriving the legacy public value, so this can be
+ * rolled out (and rolled back) without touching already-registered rows.
+ */
+export function isUnpredictableRpIdEnabled(): boolean {
+  return process.env.ENABLE_UNPREDICTABLE_RP_ID === "true";
+}
+
+/**
+ * The rp_id to use for an app that is registering now.
+ *
+ * Existing rows are never re-derived — `rp_id` is the primary key of
+ * `rp_registration` and is immutable after insert (it is not in the table's
+ * Hasura update permissions), and `action_v4` rows hang off it. Every
+ * authoritative consumer already reads the stored value, so flipping the flag
+ * only affects registrations created after the flip. Apps registered under
+ * either scheme keep working.
+ *
+ * Throws when the feature is enabled but the salt is unusable. Falling back to
+ * the legacy derivation would hand out exactly the guessable ids the flag
+ * exists to stop, and would do it silently — a failed registration the
+ * developer can retry is the safe direction.
+ */
+export function resolveRpIdForNewRegistration(appId: string): `rp_${string}` {
+  if (!isUnpredictableRpIdEnabled()) {
+    return generateRpIdString(appId);
+  }
+
+  const salt = process.env.RP_ID_SALT;
+
+  if (!salt || salt.length < MIN_SALT_LENGTH) {
+    throw new Error(
+      "ENABLE_UNPREDICTABLE_RP_ID is set but RP_ID_SALT is missing or shorter " +
+        `than ${MIN_SALT_LENGTH} characters; refusing to fall back to the ` +
+        "guessable keccak256(app_id) derivation.",
+    );
+  }
+
+  return deriveSaltedRpIdString(appId, salt);
+}

--- a/web/api/helpers/rp-registration-flows.ts
+++ b/web/api/helpers/rp-registration-flows.ts
@@ -29,8 +29,8 @@ import {
   submitRotateSignerTransaction,
   submitToggleRpActiveTransaction,
 } from "@/api/helpers/rp-transactions";
+import { resolveRpIdForNewRegistration } from "@/api/helpers/rp-id";
 import {
-  generateRpIdString,
   getRpRegistryConfig,
   getStagingRpRegistryConfig,
   parseRpId,
@@ -103,7 +103,23 @@ export async function submitManagedRpRegistration({
     };
   }
 
-  const rpIdString = generateRpIdString(appId);
+  let rpIdString: string;
+  try {
+    rpIdString = resolveRpIdForNewRegistration(appId);
+  } catch (error) {
+    // Misconfigured salt. Registering under the legacy guessable derivation
+    // instead would defeat the point, so surface it and let the caller retry
+    // once the environment is fixed.
+    logger.error("Cannot derive an rp_id for registration", {
+      error,
+      app_id: appId,
+    });
+    return {
+      ok: false,
+      code: "config_error",
+      detail: "Missing required environment variables for RP Registry.",
+    };
+  }
 
   // Claim the registration slot. on_conflict with empty update_columns
   // means: if a row already exists, return null and we bail.

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RegisterRpEmptyState.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/RegisterRpEmptyState.tsx
@@ -3,7 +3,6 @@
 import { DecoratedButton } from "@/components/DecoratedButton";
 import { SpinnerIcon } from "@/components/Icons/SpinnerIcon";
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { generateRpIdString } from "@/lib/rp";
 import dynamic from "next/dynamic";
 import { useEffect, useRef, useState } from "react";
 import { SummaryField } from "./SummaryField";
@@ -68,11 +67,11 @@ export const RegisterRpEmptyState = (props: {
         <div className="flex flex-col gap-8">
           <div className="flex flex-col gap-5">
             <SummaryField label="App ID" value={props.appId} copy />
-            <SummaryField
-              label="RP ID"
-              value={generateRpIdString(props.appId)}
-              copy
-            />
+            {/* An unregistered app has no RP ID yet. It used to be rendered
+                here by deriving it from the app id, but the id is assigned at
+                registration now and publishing it in advance is what let it be
+                claimed on-chain before the app got there (H1 #3910854). */}
+            <SummaryField label="RP ID" value="—" />
             <div className="w-full min-w-0">
               <Typography variant={TYPOGRAPHY.B4} className="text-grey-500">
                 Signer address

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/Skeleton.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/WorldId/layout/Skeleton.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { TYPOGRAPHY, Typography } from "@/components/Typography";
-import { generateRpIdString } from "@/lib/rp";
 import { WORLD_ID_TABS, type WorldIdTab } from "@/lib/world-id-tabs";
 import { LegacyActionsDeprecationBanner } from "../LegacyActions/page";
 import { ActionCardSkeleton } from "../page/ActionCard/Skeleton";
@@ -44,18 +43,14 @@ export const WorldIdLayoutSkeleton = (props: {
         </Typography>
 
         {/* RpSummary's section wrappers, so the field stack lands where the
-            loaded fields (or the register empty state) will. App ID and RP ID
-            render for real in BOTH variants — the RP ID is derived from the
-            app id (uint64(keccak256)), not stored data. */}
+            loaded fields (or the register empty state) will. Only the App ID
+            renders for real — the RP ID is stored data now, so it shimmers
+            until it loads and reads "—" if the app is unregistered. */}
         <section className="flex w-full max-w-[580px] flex-col gap-4">
           <div className="flex flex-col gap-8">
             <div className="flex flex-col gap-5">
               <SummaryField label="App ID" value={props.appId} copy />
-              <SummaryField
-                label="RP ID"
-                value={generateRpIdString(props.appId)}
-                copy
-              />
+              <SummaryFieldSkeleton label="RP ID" />
               <SummaryFieldSkeleton label="Signer address" />
             </div>
           </div>

--- a/web/scenes/common/Teams/TeamId/Apps/AppId/EnableWorldId40/SelfManagedRegistrationInfo/server/index.ts
+++ b/web/scenes/common/Teams/TeamId/Apps/AppId/EnableWorldId40/SelfManagedRegistrationInfo/server/index.ts
@@ -1,10 +1,10 @@
 "use server";
 
+import { resolveRpIdForNewRegistration } from "@/api/helpers/rp-id";
 import {
-  generateRpId,
-  generateRpIdString,
   getRpRegistryConfig,
   getStagingRpRegistryConfig,
+  parseRpId,
   WORLD_CHAIN_ID,
 } from "@/api/helpers/rp-utils";
 import { logger } from "@/lib/logger";
@@ -57,8 +57,12 @@ export async function getSelfManagedRegistrationInfo(
 
     const stagingConfig = getStagingRpRegistryConfig();
 
-    const rpIdString = generateRpIdString(appId);
-    const rpIdNumeric = generateRpId(appId).toString();
+    // The developer copies rpIdNumeric into register(uint64 rpId, ...) and
+    // submits it themselves, then register_rp inserts the row. Both derive the
+    // id through this same resolver, so the number they registered is the
+    // number we store.
+    const rpIdString = resolveRpIdForNewRegistration(appId);
+    const rpIdNumeric = parseRpId(rpIdString).toString();
 
     return {
       success: true,

--- a/web/tests/api/hasura/register-rp.test.ts
+++ b/web/tests/api/hasura/register-rp.test.ts
@@ -14,6 +14,20 @@ jest.mock("@/api/helpers/rp-registration-flows", () => ({
     submitManagedRpRegistrationMock(...args),
 }));
 
+const getRpFromContractMock = jest.fn();
+jest.mock("@/api/helpers/temporal-rpc", () => ({
+  getRpFromContract: (...args: unknown[]) => getRpFromContractMock(...args),
+}));
+
+const getRpRegistryConfigMock = jest.fn();
+jest.mock("@/api/helpers/rp-utils", () => {
+  const actual = jest.requireActual("@/api/helpers/rp-utils");
+  return {
+    ...actual,
+    getRpRegistryConfig: () => getRpRegistryConfigMock(),
+  };
+});
+
 jest.mock("@/lib/logger", () => ({
   logger: {
     info: jest.fn(),
@@ -62,11 +76,28 @@ const createMockRequest = (input: Record<string, unknown>) =>
   });
 // #endregion
 
+/** Captures the rp_id the handler actually inserted. */
+let claimedRpId: string | null = null;
+
 beforeEach(() => {
   jest.clearAllMocks();
   process.env.INTERNAL_ENDPOINTS_SECRET = "internal-secret";
+  delete process.env.ENABLE_UNPREDICTABLE_RP_ID;
+  delete process.env.RP_ID_SALT;
   appIsStaging = false;
   authorizedTeam = [{ id: teamId }];
+  claimedRpId = null;
+
+  getRpRegistryConfigMock.mockReturnValue({
+    contractAddress: "0xcontract",
+    kmsRegion: "eu-west-1",
+  });
+  getRpFromContractMock.mockResolvedValue({
+    initialized: false,
+    active: false,
+    manager: `0x${"0".repeat(40)}`,
+    signer: `0x${"0".repeat(40)}`,
+  });
 
   submitManagedRpRegistrationMock.mockResolvedValue({
     ok: true,
@@ -79,32 +110,36 @@ beforeEach(() => {
     stagingStatus: null,
   });
 
-  requestMock.mockImplementation(async (query: unknown) => {
-    const operationName = getOperationName(query);
+  requestMock.mockImplementation(
+    async (query: unknown, variables?: unknown) => {
+      const operationName = getOperationName(query);
 
-    if (operationName.includes("GetAppInfo")) {
-      return {
-        app: [
-          {
-            id: appId,
-            team_id: teamId,
-            is_staging: appIsStaging,
-            app_metadata: [{ name: "Test App" }],
-          },
-        ],
-      };
-    }
+      if (operationName.includes("GetAppInfo")) {
+        return {
+          app: [
+            {
+              id: appId,
+              team_id: teamId,
+              is_staging: appIsStaging,
+              app_metadata: [{ name: "Test App" }],
+            },
+          ],
+        };
+      }
 
-    if (operationName.includes("CheckUserInApp")) {
-      return { team: authorizedTeam };
-    }
+      if (operationName.includes("CheckUserInApp")) {
+        return { team: authorizedTeam };
+      }
 
-    if (operationName.includes("ClaimRpRegistration")) {
-      return { insert_rp_registration_one: { rp_id: "rp_abc123" } };
-    }
+      if (operationName.includes("ClaimRpRegistration")) {
+        claimedRpId =
+          (variables as { rp_id?: string } | undefined)?.rp_id ?? null;
+        return { insert_rp_registration_one: { rp_id: claimedRpId } };
+      }
 
-    throw new Error(`Unexpected query: ${operationName}`);
-  });
+      throw new Error(`Unexpected query: ${operationName}`);
+    },
+  );
 });
 
 // #region Successful registration (no rollout feature flag)
@@ -149,6 +184,55 @@ describe("/api/hasura/register-rp [success]", () => {
     expect(body.status).toBe("pending");
     // Self-managed skips the managed pipeline entirely.
     expect(submitManagedRpRegistrationMock).not.toHaveBeenCalled();
+  });
+});
+// #endregion
+
+// #region Self-managed rp_id scheme changing mid-flow
+describe("/api/hasura/register-rp [self-managed scheme drift]", () => {
+  const selfManaged = () =>
+    POST(createMockRequest({ app_id: appId, mode: "self_managed" }));
+
+  it("stores the id the developer registered when the flag flipped on mid-flow", async () => {
+    // The instructions screen was served by a task with the flag OFF, so the
+    // developer registered the legacy id. This request lands on a task with the
+    // flag ON — a rolling deploy. Deriving again would store an id nobody
+    // registered and orphan their real one, and self-managed rows never time out.
+    const { generateRpIdString } = jest.requireActual("@/lib/rp");
+    const legacyId = generateRpIdString(appId);
+
+    process.env.ENABLE_UNPREDICTABLE_RP_ID = "true";
+    process.env.RP_ID_SALT = "s".repeat(32);
+
+    getRpFromContractMock.mockImplementation(async (numericRpId: bigint) => {
+      const initialized = numericRpId === BigInt(`0x${legacyId.slice(3)}`);
+      return {
+        initialized,
+        active: initialized,
+        manager: "0xDeveloperOwnedManager",
+        signer: "0xDeveloperOwnedSigner",
+      };
+    });
+
+    const res = (await selfManaged())!;
+
+    expect(res.status).toBe(200);
+    expect(claimedRpId).toBe(legacyId);
+  });
+
+  it("uses the current scheme when neither candidate is registered yet", async () => {
+    // Developer clicked Continue without doing the transaction: nothing on-chain,
+    // so the row is created under the id we would hand out now.
+    process.env.ENABLE_UNPREDICTABLE_RP_ID = "true";
+    process.env.RP_ID_SALT = "s".repeat(32);
+    const { resolveRpIdForNewRegistration } = jest.requireActual(
+      "@/api/helpers/rp-id",
+    );
+
+    const res = (await selfManaged())!;
+
+    expect(res.status).toBe(200);
+    expect(claimedRpId).toBe(resolveRpIdForNewRegistration(appId));
   });
 });
 // #endregion

--- a/web/tests/api/hasura/register-rp.test.ts
+++ b/web/tests/api/hasura/register-rp.test.ts
@@ -220,6 +220,37 @@ describe("/api/hasura/register-rp [self-managed scheme drift]", () => {
     expect(claimedRpId).toBe(legacyId);
   });
 
+  it("ignores a squatted legacy id and keeps the salted one the developer registered", async () => {
+    // Rollback: the instructions screen (flag on) showed the salted id and the
+    // developer registered it. An attacker has separately squatted the guessable
+    // legacy id. Probing legacy first would bind this app's row to the
+    // attacker's registration, which is strictly worse than the wedge the
+    // candidate lookup exists to prevent.
+    const { generateRpIdString } = jest.requireActual("@/lib/rp");
+    const legacyId = generateRpIdString(appId);
+
+    process.env.RP_ID_SALT = "s".repeat(32);
+    const { candidateRpIdsForApp } = jest.requireActual("@/api/helpers/rp-id");
+    const saltedId = candidateRpIdsForApp(appId).find(
+      (id: string) => id !== legacyId,
+    );
+
+    // BOTH are initialized on-chain: the attacker's legacy squat and the
+    // developer's own salted registration.
+    getRpFromContractMock.mockResolvedValue({
+      initialized: true,
+      active: true,
+      manager: "0xSomeManager",
+      signer: "0xSomeSigner",
+    });
+
+    const res = (await selfManaged())!;
+
+    expect(res.status).toBe(200);
+    expect(claimedRpId).toBe(saltedId);
+    expect(claimedRpId).not.toBe(legacyId);
+  });
+
   it("uses the current scheme when neither candidate is registered yet", async () => {
     // Developer clicked Continue without doing the transaction: nothing on-chain,
     // so the row is created under the id we would hand out now.

--- a/web/tests/api/hasura/register-rp.test.ts
+++ b/web/tests/api/hasura/register-rp.test.ts
@@ -193,11 +193,12 @@ describe("/api/hasura/register-rp [self-managed scheme drift]", () => {
   const selfManaged = () =>
     POST(createMockRequest({ app_id: appId, mode: "self_managed" }));
 
-  it("stores the id the developer registered when the flag flipped on mid-flow", async () => {
-    // The instructions screen was served by a task with the flag OFF, so the
-    // developer registered the legacy id. This request lands on a task with the
-    // flag ON — a rolling deploy. Deriving again would store an id nobody
-    // registered and orphan their real one, and self-managed rows never time out.
+  it("does not adopt an initialized legacy id while the feature is on", async () => {
+    // The flag is on, so the legacy id is not something we handed out. It may be a
+    // squatter's, and it is indistinguishable from a developer who registered
+    // before a roll-forward — so it is never adopted. The cost is that the
+    // roll-forward case creates a row under the salted id and needs manual
+    // cleanup; the alternative is binding the app to an attacker's rp_id.
     const { generateRpIdString } = jest.requireActual("@/lib/rp");
     const legacyId = generateRpIdString(appId);
 
@@ -209,15 +210,15 @@ describe("/api/hasura/register-rp [self-managed scheme drift]", () => {
       return {
         initialized,
         active: initialized,
-        manager: "0xDeveloperOwnedManager",
-        signer: "0xDeveloperOwnedSigner",
+        manager: "0xSomeManager",
+        signer: "0xSomeSigner",
       };
     });
 
     const res = (await selfManaged())!;
 
     expect(res.status).toBe(200);
-    expect(claimedRpId).toBe(legacyId);
+    expect(claimedRpId).not.toBe(legacyId);
   });
 
   it("ignores a squatted legacy id and keeps the salted one the developer registered", async () => {

--- a/web/tests/api/helpers/rp-id.test.ts
+++ b/web/tests/api/helpers/rp-id.test.ts
@@ -107,15 +107,19 @@ describe("candidateRpIdsForApp", () => {
     expect(candidates[1]).toBe(generateRpIdString(appId));
   });
 
-  it("puts the legacy id first but still offers the salted one after a rollback", () => {
+  it("still probes the salted id first after a rollback", () => {
     // Flag off with the salt still present: the instructions screen may have
-    // shown the salted id from a task that had the flag on.
+    // shown the salted id from a task that had the flag on. Probing the
+    // guessable legacy id first would let a squatter's registration be adopted
+    // as this app's RP, so the order must not follow the flag.
     process.env.RP_ID_SALT = salt;
+    const legacy = generateRpIdString(appId);
 
     const candidates = candidateRpIdsForApp(appId);
 
-    expect(candidates[0]).toBe(generateRpIdString(appId));
     expect(candidates).toHaveLength(2);
+    expect(candidates[0]).not.toBe(legacy);
+    expect(candidates[1]).toBe(legacy);
   });
 
   it("ignores an unusably short salt rather than deriving with it", () => {

--- a/web/tests/api/helpers/rp-id.test.ts
+++ b/web/tests/api/helpers/rp-id.test.ts
@@ -129,32 +129,16 @@ describe("candidateRpIdsForApp", () => {
     expect(candidateRpIdsForApp(appId)).toEqual([generateRpIdString(appId)]);
   });
 
-  it("probes the previous salt during a rotation drain window", () => {
-    // Rotation is the advertised remedy for a leaked salt, so performing it must
-    // be safe: a developer shown an id derived from the outgoing salt has already
-    // registered that id on-chain.
+  it("does not probe a previous salt, even when one is configured", () => {
+    // Rotation is prompted by a leak, so the old salt is exactly what an attacker
+    // may know; probing it would let them plant an id that gets adopted.
     process.env.ENABLE_UNPREDICTABLE_RP_ID = "true";
     process.env.RP_ID_SALT = salt;
     process.env.RP_ID_SALT_PREVIOUS = otherSalt;
 
-    const candidates = candidateRpIdsForApp(appId);
-
-    // Flag on, so both salted ids are eligible and legacy is not.
-    expect(candidates).toHaveLength(2);
-    expect(candidates[0]).toBe(resolveRpIdForNewRegistration(appId));
-    expect(candidates).not.toContain(generateRpIdString(appId));
-
-    // The second candidate is what the outgoing salt would have produced.
-    process.env.RP_ID_SALT = otherSalt;
-    expect(candidates[1]).toBe(resolveRpIdForNewRegistration(appId));
-  });
-
-  it("ignores an unusable previous salt", () => {
-    // Flag off here, so the list is [salted, legacy] rather than [salted].
-    process.env.RP_ID_SALT = salt;
-    process.env.RP_ID_SALT_PREVIOUS = "short";
-
-    expect(candidateRpIdsForApp(appId)).toHaveLength(2);
+    expect(candidateRpIdsForApp(appId)).toEqual([
+      resolveRpIdForNewRegistration(appId),
+    ]);
   });
 });
 // #endregion

--- a/web/tests/api/helpers/rp-id.test.ts
+++ b/web/tests/api/helpers/rp-id.test.ts
@@ -95,17 +95,17 @@ describe("candidateRpIdsForApp", () => {
     expect(candidateRpIdsForApp(appId)).toEqual([generateRpIdString(appId)]);
   });
 
-  it("puts the salted id first when the feature is on", () => {
+  it("excludes the guessable legacy id entirely when the feature is on", () => {
+    // Ordering it last is not enough: if the developer's salted register() is not
+    // visible yet, a squatted legacy id would be the first initialized candidate
+    // found and get stored as this app's rp_id.
     process.env.ENABLE_UNPREDICTABLE_RP_ID = "true";
     process.env.RP_ID_SALT = salt;
 
     const candidates = candidateRpIdsForApp(appId);
 
-    expect(candidates).toHaveLength(2);
-    expect(candidates[0]).toBe(resolveRpIdForNewRegistration(appId));
-    // The legacy id stays a candidate so a developer who registered before the
-    // flag flipped on is still matched to their own on-chain registration.
-    expect(candidates[1]).toBe(generateRpIdString(appId));
+    expect(candidates).toEqual([resolveRpIdForNewRegistration(appId)]);
+    expect(candidates).not.toContain(generateRpIdString(appId));
   });
 
   it("still probes the salted id first after a rollback", () => {
@@ -139,17 +139,18 @@ describe("candidateRpIdsForApp", () => {
 
     const candidates = candidateRpIdsForApp(appId);
 
-    expect(candidates).toHaveLength(3);
-    // Current salt wins; the guessable legacy id stays last regardless.
+    // Flag on, so both salted ids are eligible and legacy is not.
+    expect(candidates).toHaveLength(2);
     expect(candidates[0]).toBe(resolveRpIdForNewRegistration(appId));
-    expect(candidates[2]).toBe(generateRpIdString(appId));
+    expect(candidates).not.toContain(generateRpIdString(appId));
 
-    // The middle candidate is what the outgoing salt would have produced.
+    // The second candidate is what the outgoing salt would have produced.
     process.env.RP_ID_SALT = otherSalt;
     expect(candidates[1]).toBe(resolveRpIdForNewRegistration(appId));
   });
 
   it("ignores an unusable previous salt", () => {
+    // Flag off here, so the list is [salted, legacy] rather than [salted].
     process.env.RP_ID_SALT = salt;
     process.env.RP_ID_SALT_PREVIOUS = "short";
 

--- a/web/tests/api/helpers/rp-id.test.ts
+++ b/web/tests/api/helpers/rp-id.test.ts
@@ -1,4 +1,5 @@
 import {
+  candidateRpIdsForApp,
   isUnpredictableRpIdEnabled,
   resolveRpIdForNewRegistration,
 } from "@/api/helpers/rp-id";
@@ -83,6 +84,44 @@ describe("resolveRpIdForNewRegistration [flag on]", () => {
     process.env.RP_ID_SALT = otherSalt;
 
     expect(resolveRpIdForNewRegistration(appId)).not.toBe(before);
+  });
+});
+// #endregion
+
+// #region Candidate enumeration for the self-managed two-read gap
+describe("candidateRpIdsForApp", () => {
+  it("returns only the legacy id when no salt is configured", () => {
+    expect(candidateRpIdsForApp(appId)).toEqual([generateRpIdString(appId)]);
+  });
+
+  it("puts the salted id first when the feature is on", () => {
+    process.env.ENABLE_UNPREDICTABLE_RP_ID = "true";
+    process.env.RP_ID_SALT = salt;
+
+    const candidates = candidateRpIdsForApp(appId);
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0]).toBe(resolveRpIdForNewRegistration(appId));
+    // The legacy id stays a candidate so a developer who registered before the
+    // flag flipped on is still matched to their own on-chain registration.
+    expect(candidates[1]).toBe(generateRpIdString(appId));
+  });
+
+  it("puts the legacy id first but still offers the salted one after a rollback", () => {
+    // Flag off with the salt still present: the instructions screen may have
+    // shown the salted id from a task that had the flag on.
+    process.env.RP_ID_SALT = salt;
+
+    const candidates = candidateRpIdsForApp(appId);
+
+    expect(candidates[0]).toBe(generateRpIdString(appId));
+    expect(candidates).toHaveLength(2);
+  });
+
+  it("ignores an unusably short salt rather than deriving with it", () => {
+    process.env.RP_ID_SALT = "short";
+
+    expect(candidateRpIdsForApp(appId)).toEqual([generateRpIdString(appId)]);
   });
 });
 // #endregion

--- a/web/tests/api/helpers/rp-id.test.ts
+++ b/web/tests/api/helpers/rp-id.test.ts
@@ -1,0 +1,106 @@
+import {
+  isUnpredictableRpIdEnabled,
+  resolveRpIdForNewRegistration,
+} from "@/api/helpers/rp-id";
+import { parseRpId } from "@/api/helpers/rp-utils";
+import { generateRpIdString } from "@/lib/rp";
+
+// #region Test Data
+const appId = "app_00000000000000000000000000000001";
+const otherAppId = "app_00000000000000000000000000000002";
+const salt = "s".repeat(32);
+const otherSalt = "t".repeat(32);
+// #endregion
+
+beforeEach(() => {
+  delete process.env.ENABLE_UNPREDICTABLE_RP_ID;
+  delete process.env.RP_ID_SALT;
+});
+
+// #region Flag off — legacy derivation is preserved
+describe("resolveRpIdForNewRegistration [flag off]", () => {
+  it("returns the legacy public derivation so existing behaviour is unchanged", () => {
+    expect(resolveRpIdForNewRegistration(appId)).toBe(
+      generateRpIdString(appId),
+    );
+    expect(isUnpredictableRpIdEnabled()).toBe(false);
+  });
+
+  it("ignores a configured salt until the flag is set", () => {
+    process.env.RP_ID_SALT = salt;
+
+    expect(resolveRpIdForNewRegistration(appId)).toBe(
+      generateRpIdString(appId),
+    );
+  });
+
+  it('treats any value other than "true" as off', () => {
+    process.env.ENABLE_UNPREDICTABLE_RP_ID = "1";
+    process.env.RP_ID_SALT = salt;
+
+    expect(resolveRpIdForNewRegistration(appId)).toBe(
+      generateRpIdString(appId),
+    );
+  });
+});
+// #endregion
+
+// #region Flag on — unpredictable derivation
+describe("resolveRpIdForNewRegistration [flag on]", () => {
+  beforeEach(() => {
+    process.env.ENABLE_UNPREDICTABLE_RP_ID = "true";
+    process.env.RP_ID_SALT = salt;
+  });
+
+  it("no longer returns the value an attacker can compute from the app_id", () => {
+    expect(resolveRpIdForNewRegistration(appId)).not.toBe(
+      generateRpIdString(appId),
+    );
+  });
+
+  it("keeps the rp_ + 16 lowercase hex shape that parseRpId and the route guards require", () => {
+    const rpId = resolveRpIdForNewRegistration(appId);
+
+    expect(rpId).toMatch(/^rp_[0-9a-f]{16}$/);
+    // Must survive the round trip into the uint64 the registry indexes by.
+    expect(parseRpId(rpId)).toBeLessThan(1n << 64n);
+  });
+
+  it("is deterministic, which is what lets the self-managed screen and register_rp agree", () => {
+    expect(resolveRpIdForNewRegistration(appId)).toBe(
+      resolveRpIdForNewRegistration(appId),
+    );
+  });
+
+  it("gives different apps different ids", () => {
+    expect(resolveRpIdForNewRegistration(appId)).not.toBe(
+      resolveRpIdForNewRegistration(otherAppId),
+    );
+  });
+
+  it("changes the id when the salt is rotated", () => {
+    const before = resolveRpIdForNewRegistration(appId);
+    process.env.RP_ID_SALT = otherSalt;
+
+    expect(resolveRpIdForNewRegistration(appId)).not.toBe(before);
+  });
+});
+// #endregion
+
+// #region Fail closed on misconfiguration
+describe("resolveRpIdForNewRegistration [misconfigured]", () => {
+  beforeEach(() => {
+    process.env.ENABLE_UNPREDICTABLE_RP_ID = "true";
+  });
+
+  it("throws rather than silently handing out a guessable id when the salt is missing", () => {
+    expect(() => resolveRpIdForNewRegistration(appId)).toThrow(/RP_ID_SALT/);
+  });
+
+  it("throws when the salt is too short to be worth keying with", () => {
+    process.env.RP_ID_SALT = "short";
+
+    expect(() => resolveRpIdForNewRegistration(appId)).toThrow(/RP_ID_SALT/);
+  });
+});
+// #endregion

--- a/web/tests/api/helpers/rp-id.test.ts
+++ b/web/tests/api/helpers/rp-id.test.ts
@@ -16,6 +16,7 @@ const otherSalt = "t".repeat(32);
 beforeEach(() => {
   delete process.env.ENABLE_UNPREDICTABLE_RP_ID;
   delete process.env.RP_ID_SALT;
+  delete process.env.RP_ID_SALT_PREVIOUS;
 });
 
 // #region Flag off — legacy derivation is preserved
@@ -126,6 +127,33 @@ describe("candidateRpIdsForApp", () => {
     process.env.RP_ID_SALT = "short";
 
     expect(candidateRpIdsForApp(appId)).toEqual([generateRpIdString(appId)]);
+  });
+
+  it("probes the previous salt during a rotation drain window", () => {
+    // Rotation is the advertised remedy for a leaked salt, so performing it must
+    // be safe: a developer shown an id derived from the outgoing salt has already
+    // registered that id on-chain.
+    process.env.ENABLE_UNPREDICTABLE_RP_ID = "true";
+    process.env.RP_ID_SALT = salt;
+    process.env.RP_ID_SALT_PREVIOUS = otherSalt;
+
+    const candidates = candidateRpIdsForApp(appId);
+
+    expect(candidates).toHaveLength(3);
+    // Current salt wins; the guessable legacy id stays last regardless.
+    expect(candidates[0]).toBe(resolveRpIdForNewRegistration(appId));
+    expect(candidates[2]).toBe(generateRpIdString(appId));
+
+    // The middle candidate is what the outgoing salt would have produced.
+    process.env.RP_ID_SALT = otherSalt;
+    expect(candidates[1]).toBe(resolveRpIdForNewRegistration(appId));
+  });
+
+  it("ignores an unusable previous salt", () => {
+    process.env.RP_ID_SALT = salt;
+    process.env.RP_ID_SALT_PREVIOUS = "short";
+
+    expect(candidateRpIdsForApp(appId)).toHaveLength(2);
   });
 });
 // #endregion

--- a/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
+++ b/web/tests/unit/pv3-world-id-layout-freshness.test.tsx
@@ -248,10 +248,13 @@ describe("WorldIdLayout [loading boundary]", () => {
     expect(
       screen.getByRole("heading", { name: "World ID Configuration" }),
     ).toBeInTheDocument();
-    // App ID and RP ID are route-derived and identical in both loaded
-    // variants, so they render for real; only the signer value shimmers.
+    // Only the App ID is route-derived, so it renders for real; the RP ID is
+    // stored data now, so its value shimmers alongside the signer's.
     expect(screen.getByText("app_1")).toBeInTheDocument();
-    expect(screen.getByText(generateRpIdString("app_1"))).toBeInTheDocument();
+    expect(screen.getByText("RP ID")).toBeInTheDocument();
+    expect(
+      screen.queryByText(generateRpIdString("app_1")),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("Signer address")).toBeInTheDocument();
     expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
     expect(screen.queryByTestId("rp-summary")).not.toBeInTheDocument();

--- a/web/tests/unit/pv3-world-id-unregistered-summary.test.tsx
+++ b/web/tests/unit/pv3-world-id-unregistered-summary.test.tsx
@@ -52,9 +52,14 @@ it("shows the finalized configuration shape before registration", () => {
     screen.getByRole("region", { name: "World ID configuration" }),
   ).toBeInTheDocument();
   expect(screen.getByText(defaultProps.appId)).toBeInTheDocument();
+  // The RP ID is assigned at registration, so the label renders but the value
+  // is a placeholder — publishing it in advance is what let the on-chain id be
+  // claimed before the app got there (H1 #3910854).
+  expect(screen.getByText("RP ID")).toBeInTheDocument();
+  expect(screen.getByText("—")).toBeInTheDocument();
   expect(
-    screen.getByText(generateRpIdString(defaultProps.appId)),
-  ).toBeInTheDocument();
+    screen.queryByText(generateRpIdString(defaultProps.appId)),
+  ).not.toBeInTheDocument();
   expect(screen.getByText("Signer address")).toBeInTheDocument();
   expect(
     screen.getByRole("button", { name: "Register relying party" }),


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Follow-up to H1 #3910854 (the trust half is #2221). `rp_id` is `uint64(keccak256(app_id))` over a **public** `app_id`, and on-chain `register()` is permissionless, zero-fee and first-come — so anyone can harvest app_ids from `/api/v2/public/apps`, compute the rp_id of every app that hasn't migrated to World ID 4.0 yet, and claim it. Gas-only, no authentication, and `registerMany` does the whole store in one transaction. The payoff is denying a competitor's (or our own) v4 onboarding, and there is no reclaim path in the contract.

This keys the derivation with a server-side secret — `HMAC(RP_ID_SALT, app_id)` — so an unregistered app's rp_id isn't computable by anyone who doesn't hold the salt.

**Why keyed-deterministic rather than a per-app random value.** The self-managed flow derives the id **twice, independently**: `getSelfManagedRegistrationInfo` shows the developer a number, the developer submits `register(uint64 rpId, ...)` from their own wallet, and then `register_rp` derives it again to insert the row. Those two derivations agree today only because the function is deterministic. A per-app random id breaks that, and getting it back needs a reservation protocol (reserve-then-display, adopt-on-complete), a dialog reorder in both portal trees, and a collision path — `ClaimRpRegistration`'s `on_conflict` targets the `app_id` unique constraint, not the `rp_id` PK, so a PK collision surfaces as a raw constraint error today. Keyed derivation buys the same unpredictability against the same attacker with none of that. It also sidesteps the open question about whether IDKit/World App assume determinism, because it stays deterministic.

Both schemes are unpredictable to someone without the secret; the tradeoff is that the salt is one shared secret rather than per-app entropy. Rotation is the mitigation and it's cheap — rotating only changes the ids **unregistered** apps will be assigned, since registered rows keep their stored value.

All three call sites that derive an id for a new registration now go through a single `resolveRpIdForNewRegistration`, so they can't drift. Drift between two copies of the same rule — prod vs staging — was the actual bug in the related H1, so this is deliberate.

**Compatibility.** `rp_id` is `rp_registration`'s primary key, immutable after insert (it isn't in the table's Hasura update permissions), and every authoritative consumer already reads the stored value instead of re-deriving — verified across `proof-context`, `v4/verify`, `rp-status`, `app-status`, `rp-retry`, `switch-to-self-managed`, `toggle-rp-active`, the MCP tools and the admin screens. So flipping the flag only affects registrations created after the flip, apps registered under either scheme keep working, and rollback is just unsetting the flag. The `rp_` + 16-lowercase-hex shape is preserved, which `parseRpId`, `isValidRpId` and the two literal `/^rp_[0-9a-f]{16}$/` admin regexes all require.

**Rollout.** Off by default behind `ENABLE_UNPREDICTABLE_RP_ID`. Enabling it without a usable salt **fails the registration** rather than falling back to the guessable derivation — a silent fallback would hand out exactly the ids the flag exists to protect.

Also: the World ID config screen no longer prints an unregistered app's future rp_id. That was publishing the one value an attacker needs, and under a keyed derivation a client component can't compute it anyway. It shows `—` until an id is actually assigned.

## Notes for review

- **Verify before enabling in production:** nothing in this repo derives rp_id client-side except the decorative `buildMockRpContext` (mock signature `0x00..1b`, never validated server-side — `v4/verify` overwrites with the DB value), but I could not inspect `@worldcoin/idkit` or World App from here. The one to check is the integrity bundle's `aud` (`api/v4/verify/integrity-bundle.ts:443`): if any client derives rp_id locally rather than reading it from `/api/v4/proof-context`, unpredictable ids would surface as an opaque 403. That's why this ships flag-off.
- Does **not** re-derive or migrate existing rows, by design.
- Defensively pre-registering the ids of apps that haven't migrated yet — the installed base this change can't help, since their app_ids are already public and predictable forever — is a separate PR.
- `CLAUDE.md` documents a `featureFlags` object in `web/lib/feature-flags/index.ts`; that file doesn't exist on main, so this follows the actual pattern in `feature-flags/portal-v3/flag.ts` (server-only module + env switch).

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.