### PR TITLE
feat(sandbox): email users after access approval

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -41,6 +41,7 @@ NEXT_PUBLIC_METRICS_SERVICE_ENDPOINT=https://metrics.worldcoin.org/miniapps
 SENDGRID_API_KEY=your_sendgrid_api_key
 SENDGRID_EMAIL_FROM=your_email@example.com
 SENDGRID_TEAM_INVITE_TEMPLATE_ID=d-5cbc349e16344604813f74c1f8b0bbdc
+SENDGRID_SANDBOX_ACCESS_APPROVED_TEMPLATE_ID=d-your-sandbox-approved-template-id
 # Ops inbox notified when a developer requests Android sandbox access.
 SANDBOX_ACCESS_NOTIFY_EMAIL=sandbox.access@toolsforhumanity.com
 

--- a/web/api/admin/sandbox-requests/[id]/accept/graphql/mark-sandbox-invite-sent.generated.ts
+++ b/web/api/admin/sandbox-requests/[id]/accept/graphql/mark-sandbox-invite-sent.generated.ts
@@ -14,6 +14,11 @@ export type MarkSandboxInviteSentMutation = {
   update_sandbox_access_request?: {
     __typename?: "sandbox_access_request_mutation_response";
     affected_rows: number;
+    returning: Array<{
+      __typename?: "sandbox_access_request";
+      google_email: string;
+      user: { __typename?: "user"; name: string; email?: string | null };
+    }>;
   } | null;
 };
 
@@ -24,6 +29,13 @@ export const MarkSandboxInviteSentDocument = gql`
       _set: { accepted: true, processed_at: $processed_at }
     ) {
       affected_rows
+      returning {
+        google_email
+        user {
+          name
+          email
+        }
+      }
     }
   }
 `;

--- a/web/api/admin/sandbox-requests/[id]/accept/graphql/mark-sandbox-invite-sent.graphql
+++ b/web/api/admin/sandbox-requests/[id]/accept/graphql/mark-sandbox-invite-sent.graphql
@@ -4,5 +4,12 @@ mutation MarkSandboxInviteSent($id: String!, $processed_at: timestamptz!) {
     _set: { accepted: true, processed_at: $processed_at }
   ) {
     affected_rows
+    returning {
+      google_email
+      user {
+        name
+        email
+      }
+    }
   }
 }

--- a/web/api/admin/sandbox-requests/[id]/accept/index.ts
+++ b/web/api/admin/sandbox-requests/[id]/accept/index.ts
@@ -1,4 +1,5 @@
 import { getInternalDashboardGraphqlClientForUser } from "@/api/helpers/graphql";
+import { sendEmail } from "@/api/helpers/send-email";
 import { authenticateAdminRequest } from "@/lib/admin-auth";
 import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
@@ -32,16 +33,70 @@ export async function POST(
     );
   }
 
+  const sendgridApiKey = process.env.SENDGRID_API_KEY;
+  const emailFrom = process.env.SENDGRID_EMAIL_FROM;
+  const templateId = process.env.SENDGRID_SANDBOX_ACCESS_APPROVED_TEMPLATE_ID;
+  if (!sendgridApiKey || !emailFrom || !templateId) {
+    logger.error("Sandbox approval email is not configured", {
+      hasApiKey: Boolean(sendgridApiKey),
+      hasFrom: Boolean(emailFrom),
+      hasTemplateId: Boolean(templateId),
+    });
+    return NextResponse.json(
+      { error: "Sandbox approval email is not configured" },
+      { status: 503 },
+    );
+  }
+
   try {
     const client = await getInternalDashboardGraphqlClientForUser(admin);
     const result = await getSdk(client).MarkSandboxInviteSent({
       id,
       processed_at: new Date().toISOString(),
     });
+    const update = result.update_sandbox_access_request;
+
+    if (update?.affected_rows === 0) {
+      return NextResponse.json({ success: true, changed: false });
+    }
+
+    const approvedRequest = update?.returning[0];
+    if (update?.affected_rows !== 1 || !approvedRequest) {
+      throw new Error("Sandbox approval did not return the updated request");
+    }
+
+    const username =
+      approvedRequest.user?.name?.trim() ||
+      approvedRequest.user?.email ||
+      approvedRequest.google_email;
+
+    try {
+      await sendEmail({
+        apiKey: sendgridApiKey,
+        from: emailFrom,
+        to: approvedRequest.google_email,
+        templateId,
+        templateData: {
+          username,
+          approved_email: approvedRequest.google_email,
+        },
+      });
+    } catch (error) {
+      logger.error("Failed to send sandbox approval email", {
+        requestId: id,
+        googleEmail: approvedRequest.google_email,
+        adminSubject: admin.subject,
+        error,
+      });
+      return NextResponse.json(
+        { error: "Unable to send sandbox approval email" },
+        { status: 503 },
+      );
+    }
 
     return NextResponse.json({
       success: true,
-      changed: result.update_sandbox_access_request?.affected_rows === 1,
+      changed: true,
     });
   } catch (error) {
     logger.error("Failed to approve sandbox request", {

--- a/web/tests/api/admin/sandbox-requests.test.ts
+++ b/web/tests/api/admin/sandbox-requests.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from "next/server";
 // #region Mocks
 const authenticateAdminRequest = jest.fn();
 const MarkSandboxInviteSent = jest.fn();
+const sendEmail = jest.fn();
 
 jest.mock("@/lib/admin-auth", () => ({
   authenticateAdminRequest: (...args: unknown[]) =>
@@ -11,6 +12,10 @@ jest.mock("@/lib/admin-auth", () => ({
 
 jest.mock("@/api/helpers/graphql", () => ({
   getInternalDashboardGraphqlClientForUser: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock("@/api/helpers/send-email", () => ({
+  sendEmail: (...args: unknown[]) => sendEmail(...args),
 }));
 
 jest.mock(
@@ -29,6 +34,7 @@ import { POST } from "@/api/admin/sandbox-requests/[id]/accept";
 
 // #region Test Data
 const REQUEST_ID = "sbxreq_abc123";
+const GOOGLE_EMAIL = "tester@gmail.com";
 const admin = {
   email: "admin@example.com",
   role: "internal_dashboard_readonly",
@@ -48,10 +54,27 @@ const createContext = (id = REQUEST_ID) => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
+  process.env.SENDGRID_API_KEY = "sg-test-key";
+  process.env.SENDGRID_EMAIL_FROM = "no-reply@worldcoin.org";
+  process.env.SENDGRID_SANDBOX_ACCESS_APPROVED_TEMPLATE_ID =
+    "d-sandbox-approved";
+
   authenticateAdminRequest.mockResolvedValue(admin);
   MarkSandboxInviteSent.mockResolvedValue({
-    update_sandbox_access_request: { affected_rows: 1 },
+    update_sandbox_access_request: {
+      affected_rows: 1,
+      returning: [
+        {
+          google_email: GOOGLE_EMAIL,
+          user: {
+            name: "Test Developer",
+            email: "developer@example.com",
+          },
+        },
+      ],
+    },
   });
+  sendEmail.mockResolvedValue(true);
 });
 
 // #region POST /api/admin/sandbox-requests/[id]/accept
@@ -63,6 +86,7 @@ describe("POST /api/admin/sandbox-requests/[id]/accept", () => {
 
     expect(response.status).toBe(401);
     expect(MarkSandboxInviteSent).not.toHaveBeenCalled();
+    expect(sendEmail).not.toHaveBeenCalled();
   });
 
   it("rejects an invalid sandbox request id", async () => {
@@ -73,9 +97,23 @@ describe("POST /api/admin/sandbox-requests/[id]/accept", () => {
 
     expect(response.status).toBe(400);
     expect(MarkSandboxInviteSent).not.toHaveBeenCalled();
+    expect(sendEmail).not.toHaveBeenCalled();
   });
 
-  it("allows an authenticated dashboard reader to approve a pending request", async () => {
+  it("returns 503 without changing the request when email is not configured", async () => {
+    delete process.env.SENDGRID_SANDBOX_ACCESS_APPROVED_TEMPLATE_ID;
+
+    const response = await POST(createRequest(), createContext());
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "Sandbox approval email is not configured",
+    });
+    expect(MarkSandboxInviteSent).not.toHaveBeenCalled();
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("approves a pending request and emails the approved Google account", async () => {
     const response = await POST(createRequest(), createContext());
 
     expect(response.status).toBe(200);
@@ -84,17 +122,69 @@ describe("POST /api/admin/sandbox-requests/[id]/accept", () => {
       id: REQUEST_ID,
       processed_at: expect.any(String),
     });
+    expect(sendEmail).toHaveBeenCalledWith({
+      apiKey: "sg-test-key",
+      from: "no-reply@worldcoin.org",
+      to: GOOGLE_EMAIL,
+      templateId: "d-sandbox-approved",
+      templateData: {
+        username: "Test Developer",
+        approved_email: GOOGLE_EMAIL,
+      },
+    });
+    expect(MarkSandboxInviteSent.mock.invocationCallOrder[0]).toBeLessThan(
+      sendEmail.mock.invocationCallOrder[0],
+    );
   });
 
   it("treats an already processed request as an idempotent success", async () => {
     MarkSandboxInviteSent.mockResolvedValue({
-      update_sandbox_access_request: { affected_rows: 0 },
+      update_sandbox_access_request: { affected_rows: 0, returning: [] },
     });
 
     const response = await POST(createRequest(), createContext());
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ success: true, changed: false });
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("uses the portal login email when the user name is blank", async () => {
+    MarkSandboxInviteSent.mockResolvedValue({
+      update_sandbox_access_request: {
+        affected_rows: 1,
+        returning: [
+          {
+            google_email: GOOGLE_EMAIL,
+            user: { name: " ", email: "developer@example.com" },
+          },
+        ],
+      },
+    });
+
+    const response = await POST(createRequest(), createContext());
+
+    expect(response.status).toBe(200);
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateData: {
+          username: "developer@example.com",
+          approved_email: GOOGLE_EMAIL,
+        },
+      }),
+    );
+  });
+
+  it("returns 503 after claiming the request when SendGrid fails", async () => {
+    sendEmail.mockRejectedValue(new Error("sendgrid down"));
+
+    const response = await POST(createRequest(), createContext());
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "Unable to send sandbox approval email",
+    });
+    expect(MarkSandboxInviteSent).toHaveBeenCalled();
   });
 
   it("returns 503 when the backend update fails", async () => {
@@ -106,6 +196,7 @@ describe("POST /api/admin/sandbox-requests/[id]/accept", () => {
     expect(await response.json()).toEqual({
       error: "Unable to update sandbox request",
     });
+    expect(sendEmail).not.toHaveBeenCalled();
   });
 });
 // #endregion


### PR DESCRIPTION
## Summary

- send the finalized SendGrid dynamic template after an admin atomically approves a pending sandbox access request
- populate `username` from the portal user and `approved_email` from the approved Google account
- keep approval idempotent so concurrent or repeated admin actions do not send duplicate emails
- document the new template ID environment variable and cover configuration, success, fallback, idempotency, and failure paths

## Impact

Developers receive an email at the approved Google account once sandbox access is granted in the admin dashboard.

## Validation

- `pnpm exec jest tests/api/admin/sandbox-requests.test.ts --runInBand --no-cache --watchman=false` (8 tests passed)
- `pnpm exec tsc --noEmit`
- targeted Prettier check for changed source and test files
- `git diff --check`
- pre-push secret scan

## Note

The full formatting check is currently blocked by `scenes/PortalV3/layout/Shell/SandboxButton.tsx` from the latest upstream `main` commit; that file is outside this PR and was left untouched.