### PR TITLE
fix(portal): ui fix color swap due to tailwind merge override

### DIFF
--- a/web/scenes/Onboarding/CreateTeam/page/Form/index.tsx
+++ b/web/scenes/Onboarding/CreateTeam/page/Form/index.tsx
@@ -164,7 +164,7 @@ export const Form = () => {
           disabled={!isValid}
           loading={isPending}
           aria-describedby={!termsAccepted ? "terms-consent-hint" : undefined}
-          className="h-12 w-full cursor-pointer px-6 disabled:bg-portal-ink text-white disabled:opacity-40"
+          className="h-12 w-full cursor-pointer px-6 text-white disabled:bg-portal-ink disabled:opacity-40"
         >
           {isPending ? "Creating team…" : "Create team"}
         </InkButton>

--- a/web/scenes/Onboarding/CreateTeam/page/Form/index.tsx
+++ b/web/scenes/Onboarding/CreateTeam/page/Form/index.tsx
@@ -164,7 +164,7 @@ export const Form = () => {
           disabled={!isValid}
           loading={isPending}
           aria-describedby={!termsAccepted ? "terms-consent-hint" : undefined}
-          className="h-12 w-full cursor-pointer px-6 text-14 disabled:bg-portal-ink disabled:text-white disabled:opacity-40"
+          className="h-12 w-full cursor-pointer px-6 disabled:bg-portal-ink text-white disabled:opacity-40"
         >
           {isPending ? "Creating team…" : "Create team"}
         </InkButton>


### PR DESCRIPTION
## Summary
Create Team submit label flipped to black when the button enabled, so white-on-ink became black-on-black and looked broken.

Cause: a text-14 override was wiping InkButton’s text-white via twMerge.
Fix: drop the size override and keep the label white

<img width="1713" height="1032" alt="image" src="https://github.com/user-attachments/assets/1a5125ef-c7f0-44d5-9443-fc050377b74a" />
