### PR TITLE
chore(portal): unlink Discord from the portal

### DIFF
--- a/web/lib/constants.ts
+++ b/web/lib/constants.ts
@@ -58,6 +58,7 @@ export const JWK_TTL_USABLE = 7; // days; duration before a JWK is rotated
 export const SIMULATOR_URL = "https://simulator.worldcoin.org";
 export const TELEGRAM_DEVELOPERS_GROUP_URL = "https://t.me/worldcoindevelopers";
 export const TELEGRAM_MATEO_URL = "https://t.me/MateoSauton";
+// Unlinked from the UI while the server is compromised; kept for when it returns.
 export const DISCORD_URL = "https://discord.com/invite/worldnetwork";
 export const WORLD_STATUS_URL = "https://status.world.org/";
 export const WORLD_PRIVACY_URL = "https://world.org/privacy";

--- a/web/scenes/Onboarding/Home/page/index.tsx
+++ b/web/scenes/Onboarding/Home/page/index.tsx
@@ -207,7 +207,6 @@ const FOOTER_SOCIAL_LINKS: FooterLink[] = [
     href: "https://whatsapp.com/channel/0029VasfcwXA89MkWpeNDB41",
     label: "WhatsApp",
   },
-  { href: "https://discord.com/invite/worldnetwork", label: "Discord" },
   { href: "https://t.me/worldnetworkofficial", label: "Telegram" },
   { href: "https://youtube.com/@worldnetworkofficial", label: "YouTube" },
   { href: "https://instagram.com/world", label: "Instagram" },

--- a/web/scenes/PortalV3/layout/Shell/HelpCenterMenu.tsx
+++ b/web/scenes/PortalV3/layout/Shell/HelpCenterMenu.tsx
@@ -11,7 +11,6 @@ import {
   DropdownMenuSubTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
-  DISCORD_URL,
   DOCS_URL,
   FAQ_URL,
   TELEGRAM_DEVELOPERS_GROUP_URL,
@@ -129,12 +128,6 @@ export const HelpCenterMenu = () => {
               label="Text Mateo"
               icon="profile-menu-message"
               onSelect={track("telegram_mateo")}
-            />
-            <HelpLink
-              href={DISCORD_URL}
-              label="Join our Discord"
-              icon="profile-menu-discord"
-              onSelect={track("discord")}
             />
           </DropdownMenuGroup>
 

--- a/web/scenes/PortalV3/layout/Shell/UserPopup.tsx
+++ b/web/scenes/PortalV3/layout/Shell/UserPopup.tsx
@@ -55,7 +55,6 @@ const userPopupPreloadIcons = [
   "profile-menu-status",
   "profile-menu-telegram",
   "profile-menu-message",
-  "profile-menu-discord",
   "profile-menu-policy",
   "profile-menu-terms",
 ];


### PR DESCRIPTION
## Why

The World Discord server was compromised. Until it's safe again, the portal shouldn't be sending developers there.

## What

Removes the two places the portal links to Discord:

- **Help center menu** — the "Join our Discord" row under Community support
- **Onboarding footer** — the Discord entry in the social links row

Also drops `profile-menu-discord` from the user menu's icon preload list, so it stops fetching an icon nothing renders.

## Reversible on purpose

`DISCORD_URL` (with a comment noting why it's unlinked) and `profile-menu-discord.svg` both stay in the tree. Restoring the links means re-adding the `<HelpLink>` block, the footer entry, and the preload string — no constant or asset to resurrect.

## Verification

- `tsc --noEmit` clean, prettier clean
- Dev server on the onboarding page: zero Discord anchors in the DOM, social row reads X → Github → WhatsApp → Telegram → YouTube
- The Help center menu sits behind Auth0 and I wasn't signed in locally, so that change is verified by code review and type check only