### PR TITLE
chore(portal): drop the DISCORD_URL comment

### DIFF
--- a/web/lib/constants.ts
+++ b/web/lib/constants.ts
@@ -58,7 +58,6 @@ export const JWK_TTL_USABLE = 7; // days; duration before a JWK is rotated
 export const SIMULATOR_URL = "https://simulator.worldcoin.org";
 export const TELEGRAM_DEVELOPERS_GROUP_URL = "https://t.me/worldcoindevelopers";
 export const TELEGRAM_MATEO_URL = "https://t.me/MateoSauton";
-// Unlinked from the UI while the server is compromised; kept for when it returns.
 export const DISCORD_URL = "https://discord.com/invite/worldnetwork";
 export const WORLD_STATUS_URL = "https://status.world.org/";
 export const WORLD_PRIVACY_URL = "https://world.org/privacy";


### PR DESCRIPTION
Follow-up to #2257, addressing @Takaros999's review comment on `web/lib/constants.ts` ("no need for this").

Removes the comment above `DISCORD_URL`. The constant and the `profile-menu-discord.svg` asset stay put — the reason they're kept is recorded in #2257 rather than in the source.

One deleted line; `tsc --noEmit` and prettier both clean.