### PR TITLE
feat: add cron trigger for cleanup of RP manager keys

### DIFF
--- a/hasura/metadata/cron_triggers.yaml
+++ b/hasura/metadata/cron_triggers.yaml
@@ -82,3 +82,17 @@
     - name: Authorization
       value_from_env: INTERNAL_ENDPOINTS_SECRET
   comment: Migrate one eligible managed RP from its legacy KMS manager key to the deployment shared manager key.
+- name: Cleanup RP manager keys
+  webhook: '{{NEXT_API_URL}}/_cleanup-rp-manager-keys'
+  schedule: '*/15 * * * *'
+  include_in_metadata: true
+  payload: {}
+  retry_conf:
+    num_retries: 0
+    retry_interval_seconds: 10
+    timeout_seconds: 60
+    tolerance_seconds: 21600
+  headers:
+    - name: Authorization
+      value_from_env: INTERNAL_ENDPOINTS_SECRET
+  comment: Schedule deletion of one leftover per-RP manager KMS key after shared-key migration. No-ops unless ENABLE_RP_MANAGER_KEY_CLEANUP is true.

--- a/hasura/metadata/databases/default/tables/public_rp_manager_key_migration_audit.yaml
+++ b/hasura/metadata/databases/default/tables/public_rp_manager_key_migration_audit.yaml
@@ -1,0 +1,39 @@
+table:
+  name: rp_manager_key_migration_audit
+  schema: public
+insert_permissions:
+  - role: service
+    permission:
+      check: {}
+      columns:
+        - rp_id
+        - app_id
+        - old_manager_kms_key_id
+        - old_manager_kms_key_arn
+        - shared_manager_kms_key_id
+select_permissions:
+  - role: service
+    permission:
+      columns:
+        - rp_id
+        - app_id
+        - old_manager_kms_key_id
+        - old_manager_kms_key_arn
+        - shared_manager_kms_key_id
+        - cleanup_status
+        - last_error_detail
+        - deletion_scheduled_at
+        - expected_deletion_at
+        - created_at
+        - updated_at
+      filter: {}
+update_permissions:
+  - role: service
+    permission:
+      columns:
+        - cleanup_status
+        - last_error_detail
+        - deletion_scheduled_at
+        - expected_deletion_at
+      filter: {}
+      check: {}

--- a/hasura/metadata/databases/default/tables/public_rp_manager_key_migration_audit.yaml
+++ b/hasura/metadata/databases/default/tables/public_rp_manager_key_migration_audit.yaml
@@ -35,5 +35,6 @@ update_permissions:
         - last_error_detail
         - deletion_scheduled_at
         - expected_deletion_at
+        - updated_at
       filter: {}
       check: {}

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -23,6 +23,7 @@
 - "!include public_nullifier_v4.yaml"
 - "!include public_redirect.yaml"
 - "!include public_role.yaml"
+- "!include public_rp_manager_key_migration_audit.yaml"
 - "!include public_rp_registration.yaml"
 - "!include public_sandbox_access_request.yaml"
 - "!include public_team.yaml"

--- a/hasura/migrations/default/1786507200000_create_rp_manager_key_migration_audit/down.sql
+++ b/hasura/migrations/default/1786507200000_create_rp_manager_key_migration_audit/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."rp_manager_key_migration_audit";

--- a/hasura/migrations/default/1786507200000_create_rp_manager_key_migration_audit/up.sql
+++ b/hasura/migrations/default/1786507200000_create_rp_manager_key_migration_audit/up.sql
@@ -1,0 +1,50 @@
+CREATE TABLE "public"."rp_manager_key_migration_audit" (
+  "rp_id" varchar(50) NOT NULL,
+  "app_id" varchar(50) NOT NULL,
+  "old_manager_kms_key_id" text NOT NULL,
+  "old_manager_kms_key_arn" text NOT NULL,
+  "shared_manager_kms_key_id" text NOT NULL,
+  "cleanup_status" text NOT NULL DEFAULT 'pending',
+  "last_error_detail" text,
+  "deletion_scheduled_at" timestamptz,
+  "expected_deletion_at" timestamptz,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("rp_id"),
+  CONSTRAINT "rp_manager_key_migration_audit_cleanup_status_check" CHECK (
+    "cleanup_status" IN (
+      'pending',
+      'failed',
+      'blocked',
+      'ready_for_external_cleanup',
+      'deletion_scheduled',
+      'deleted'
+    )
+  ),
+  CONSTRAINT "rp_manager_key_migration_audit_old_key_arn_key"
+    UNIQUE ("old_manager_kms_key_arn")
+);
+
+-- No foreign keys by design: this audit and KMS cleanup handoff must survive
+-- deletion of the operational app or RP registration rows.
+
+CREATE INDEX "rp_manager_key_migration_audit_cleanup_queue_idx"
+  ON "public"."rp_manager_key_migration_audit" (
+    "cleanup_status",
+    "expected_deletion_at",
+    "updated_at"
+  );
+
+CREATE TRIGGER "set_public_rp_manager_key_migration_audit_updated_at"
+BEFORE UPDATE ON "public"."rp_manager_key_migration_audit"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+
+COMMENT ON TABLE "public"."rp_manager_key_migration_audit" IS
+  'Maps a migrated RP to its old per-RP manager KMS key for later cleanup.';
+
+COMMENT ON COLUMN "public"."rp_manager_key_migration_audit"."old_manager_kms_key_id" IS
+  'The exact KMS identifier stored on rp_registration before migration.';
+
+COMMENT ON COLUMN "public"."rp_manager_key_migration_audit"."old_manager_kms_key_arn" IS
+  'Canonical ARN of the old per-RP KMS key used for cleanup and account ownership checks.';

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -11,3 +11,6 @@ README.md
 .env*
 scripts/*
 !scripts/migrate-rp-manager-to-shared-key.ts
+!scripts/rp-manager-key-migration/**
+!scripts/cleanup-rp-manager-keys.ts
+!scripts/rp-manager-key-cleanup/**

--- a/web/.env.example
+++ b/web/.env.example
@@ -93,6 +93,9 @@ RP_REGISTRY_MANAGER_KMS_KEY_ID=
 ENABLE_SHARED_KEY_RP_REGISTRATION=
 # Enables the protected Hasura cron that migrates one legacy managed RP per run.
 ENABLE_RP_MANAGER_KEY_MIGRATION=
+# Enables the protected Hasura cron that deletes old per-RP manager KMS keys.
+# Keep this false until migration has finished and ENABLE_RP_MANAGER_KEY_MIGRATION is off.
+ENABLE_RP_MANAGER_KEY_CLEANUP=
 RP_REGISTRY_ENTRYPOINT_ADDRESS=0x0000000071727De22E5E9d8BAf0edAc6f37da032
 RP_REGISTRY_SAFE_4337_MODULE_ADDRESS=0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226
 RP_REGISTRY_KMS_REGION=eu-west-1

--- a/web/api/_cleanup-rp-manager-keys/index.ts
+++ b/web/api/_cleanup-rp-manager-keys/index.ts
@@ -1,0 +1,182 @@
+import { getAPIServiceGraphqlClient } from "@/api/helpers/graphql";
+import { getKMSClient } from "@/api/helpers/kms";
+import {
+  getRpRegistryConfig,
+  getStagingRpRegistryConfig,
+} from "@/api/helpers/rp-utils";
+import { protectInternalEndpoint } from "@/api/helpers/utils";
+import { logger } from "@/lib/logger";
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "node:crypto";
+import { cleanupRpManagerKeys } from "../../scripts/cleanup-rp-manager-keys";
+
+// #region Constants and types
+
+const GLOBAL_LOCK_KEY = "rp-manager-key-cleanup:run";
+const GLOBAL_LOCK_TTL_MS = 5 * 60 * 1000;
+
+type RedisLockClient = {
+  set(
+    key: string,
+    value: string,
+    px: "PX",
+    ttlMs: number,
+    nx: "NX",
+  ): Promise<"OK" | null>;
+  eval(
+    script: string,
+    numberOfKeys: number,
+    ...args: Array<string | number>
+  ): Promise<unknown>;
+};
+
+// #endregion
+
+// #region Lock helpers
+
+async function acquireGlobalLock(): Promise<
+  | { status: "acquired"; owner: string; redis: RedisLockClient }
+  | { status: "busy" }
+  | { status: "unavailable"; error?: unknown }
+> {
+  const redis = global.RedisClient as RedisLockClient | undefined;
+  if (!redis) {
+    return { status: "unavailable" };
+  }
+
+  const owner = randomUUID();
+
+  try {
+    const result = await redis.set(
+      GLOBAL_LOCK_KEY,
+      owner,
+      "PX",
+      GLOBAL_LOCK_TTL_MS,
+      "NX",
+    );
+
+    if (result === "OK") {
+      return { status: "acquired", owner, redis };
+    }
+
+    return { status: "busy" };
+  } catch (error) {
+    return { status: "unavailable", error };
+  }
+}
+
+async function releaseGlobalLock(
+  redis: RedisLockClient,
+  owner: string,
+): Promise<void> {
+  try {
+    await redis.eval(
+      `if redis.call("get", KEYS[1]) == ARGV[1] then
+         return redis.call("del", KEYS[1])
+       end
+       return 0`,
+      1,
+      GLOBAL_LOCK_KEY,
+      owner,
+    );
+  } catch (error) {
+    logger.warn("Failed to release RP manager key cleanup lock", {
+      error,
+    });
+  }
+}
+
+// #endregion
+
+// #region Endpoint
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const { isAuthenticated, errorResponse } = protectInternalEndpoint(request);
+  if (!isAuthenticated) {
+    return errorResponse!;
+  }
+
+  if (process.env.ENABLE_RP_MANAGER_KEY_CLEANUP !== "true") {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  if (process.env.ENABLE_RP_MANAGER_KEY_MIGRATION === "true") {
+    logger.info("RP manager key cleanup skipped because migration is enabled");
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const lock = await acquireGlobalLock();
+  if (lock.status === "busy") {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  if (lock.status === "unavailable") {
+    logger.error("Redis unavailable for RP manager key cleanup", {
+      error: lock.error,
+    });
+
+    return NextResponse.json(
+      { error: "cleanup_dependency_unavailable" },
+      { status: 503 },
+    );
+  }
+
+  const startedAt = Date.now();
+
+  try {
+    const primaryConfig = getRpRegistryConfig();
+    const isProduction = process.env.NEXT_PUBLIC_APP_ENV === "production";
+    const stagingConfig = isProduction ? getStagingRpRegistryConfig() : null;
+
+    if (!primaryConfig || (isProduction && !stagingConfig)) {
+      throw new Error("RP manager key cleanup configuration is incomplete");
+    }
+
+    const graphqlClient = await getAPIServiceGraphqlClient();
+    const kmsClient = await getKMSClient(primaryConfig.kmsRegion);
+
+    const report = await cleanupRpManagerKeys({
+      graphqlClient,
+      kmsClient,
+      primaryRegistry: { name: "primary", config: primaryConfig },
+      stagingMirrorRegistry: stagingConfig
+        ? { name: "staging", config: stagingConfig }
+        : undefined,
+      limit: 1,
+    });
+
+    const result = report.results[0];
+    if (!result) {
+      return new NextResponse(null, { status: 204 });
+    }
+
+    logger.info("RP manager key cleanup attempt finished", {
+      rp_id: result.rpId,
+      app_id: result.appId,
+      old_manager_kms_key_arn: result.oldManagerKeyArn,
+      cleanup_status: result.status,
+      detail: result.detail,
+      duration_ms: Date.now() - startedAt,
+    });
+
+    return NextResponse.json({
+      rp_id: result.rpId,
+      outcome: result.status,
+      detail: result.detail,
+    });
+  } catch (error) {
+    logger.error("Unexpected RP manager key cleanup cron failure", {
+      error,
+      duration_ms: Date.now() - startedAt,
+    });
+
+    return NextResponse.json(
+      { error: "cleanup_dependency_unavailable" },
+      { status: 503 },
+    );
+  } finally {
+    await releaseGlobalLock(lock.redis, lock.owner);
+  }
+}
+
+// #endregion

--- a/web/app/api/%5Fcleanup-rp-manager-keys/route.ts
+++ b/web/app/api/%5Fcleanup-rp-manager-keys/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "@/api/_cleanup-rp-manager-keys";

--- a/web/scripts/cleanup-rp-manager-keys.ts
+++ b/web/scripts/cleanup-rp-manager-keys.ts
@@ -1,0 +1,61 @@
+import "server-only";
+
+import {
+  CleanupStatus,
+  assertValidRpManagerKeyCleanupInput,
+  determineCleanupPlan,
+  loadCleanupCandidates,
+  recordCleanupOutcome,
+  type RpManagerKeyCleanupInput,
+  type RpManagerKeyCleanupItemResult,
+  type RpManagerKeyCleanupReport,
+} from "./rp-manager-key-cleanup/actions";
+import { executeCleanupPlan } from "./rp-manager-key-cleanup/helpers";
+
+export type {
+  RpManagerKeyCleanupInput,
+  RpManagerKeyCleanupItemResult,
+  RpManagerKeyCleanupRegistry,
+  RpManagerKeyCleanupReport,
+} from "./rp-manager-key-cleanup/actions";
+
+export { CleanupStatus, PlanStep } from "./rp-manager-key-cleanup/actions";
+
+// ANCHOR: Validate the input and clean up each eligible old RP manager key.
+export async function cleanupRpManagerKeys(
+  input: RpManagerKeyCleanupInput,
+): Promise<RpManagerKeyCleanupReport> {
+  assertValidRpManagerKeyCleanupInput(input);
+
+  const candidates = await loadCleanupCandidates(input);
+  const results: RpManagerKeyCleanupItemResult[] = [];
+
+  for (const candidate of candidates) {
+    try {
+      const cleanupPlan = await determineCleanupPlan(input, candidate);
+      const result = await executeCleanupPlan(input, candidate, cleanupPlan);
+      results.push(result);
+    } catch (error) {
+      const failureReason =
+        error instanceof Error ? error.message : "Unknown error";
+
+      await recordCleanupOutcome(input, candidate, {
+        status: CleanupStatus.Failed,
+        detail: failureReason,
+      });
+
+      results.push({
+        rpId: candidate.rp_id,
+        appId: candidate.app_id,
+        oldManagerKeyArn: candidate.old_manager_kms_key_arn,
+        status: CleanupStatus.Failed,
+        detail: failureReason,
+      });
+    }
+  }
+
+  return {
+    candidateCount: candidates.length,
+    results,
+  };
+}

--- a/web/scripts/migrate-rp-manager-to-shared-key.ts
+++ b/web/scripts/migrate-rp-manager-to-shared-key.ts
@@ -15,6 +15,7 @@ import { logger } from "@/lib/logger";
 import type { KMSClient } from "@aws-sdk/client-kms";
 import { gql, type GraphQLClient } from "graphql-request";
 import { randomUUID } from "node:crypto";
+import { insertMigrationAuditRecord } from "./rp-manager-key-migration/insert-migration-audit-record";
 
 // #region Types
 
@@ -39,6 +40,7 @@ export type RpManagerMigrationInput = {
 };
 
 export type RpManagerMigrationFailureStage =
+  | "write_audit"
   | "load_old_key"
   | "read_registry"
   | "conflict"
@@ -127,76 +129,6 @@ const MIGRATION_CANDIDATE_FIELDS = gql`
     staging_status
     staging_operation_hash
     updated_at
-  }
-`;
-
-const GET_MIGRATION_CANDIDATES = gql`
-  ${MIGRATION_CANDIDATE_FIELDS}
-  query GetRpManagerMigrationCandidates {
-    rp_registration(
-      where: {
-        mode: { _eq: managed }
-        status: { _eq: registered }
-        signer_address: { _is_null: false }
-        manager_kms_key_id: { _is_null: false }
-        is_unique_manager_key: { _eq: true }
-        app: {
-          status: { _eq: "active" }
-          is_archived: { _eq: false }
-          deleted_at: { _is_null: true }
-        }
-      }
-      order_by: { created_at: asc }
-    ) {
-      ...RpManagerMigrationCandidate
-    }
-  }
-`;
-
-const GET_MIGRATION_CANDIDATES_BY_ID = gql`
-  ${MIGRATION_CANDIDATE_FIELDS}
-  query GetRpManagerMigrationCandidatesById($rp_ids: [String!]!) {
-    rp_registration(
-      where: {
-        rp_id: { _in: $rp_ids }
-        mode: { _eq: managed }
-        status: { _eq: registered }
-        signer_address: { _is_null: false }
-        manager_kms_key_id: { _is_null: false }
-        is_unique_manager_key: { _eq: true }
-        app: {
-          status: { _eq: "active" }
-          is_archived: { _eq: false }
-          deleted_at: { _is_null: true }
-        }
-      }
-      order_by: { created_at: asc }
-    ) {
-      ...RpManagerMigrationCandidate
-    }
-  }
-`;
-
-const FINALIZE_MIGRATION = gql`
-  mutation FinalizeRpManagerMigration(
-    $rp_id: String!
-    $old_manager_key_id: String!
-    $shared_manager_key_id: String!
-  ) {
-    update_rp_registration(
-      where: {
-        rp_id: { _eq: $rp_id }
-        mode: { _eq: managed }
-        manager_kms_key_id: { _eq: $old_manager_key_id }
-        is_unique_manager_key: { _eq: true }
-      }
-      _set: {
-        manager_kms_key_id: $shared_manager_key_id
-        is_unique_manager_key: false
-      }
-    ) {
-      affected_rows
-    }
   }
 `;
 
@@ -306,12 +238,53 @@ async function loadCandidates(
 
   const response = rpIds
     ? await graphqlClient.request<CandidateQueryResult, { rp_ids: string[] }>(
-        GET_MIGRATION_CANDIDATES_BY_ID,
+        gql`
+          ${MIGRATION_CANDIDATE_FIELDS}
+          query GetRpManagerMigrationCandidatesById($rp_ids: [String!]!) {
+            rp_registration(
+              where: {
+                rp_id: { _in: $rp_ids }
+                mode: { _eq: managed }
+                status: { _eq: registered }
+                signer_address: { _is_null: false }
+                manager_kms_key_id: { _is_null: false }
+                is_unique_manager_key: { _eq: true }
+                app: {
+                  status: { _eq: "active" }
+                  is_archived: { _eq: false }
+                  deleted_at: { _is_null: true }
+                }
+              }
+              order_by: { created_at: asc }
+            ) {
+              ...RpManagerMigrationCandidate
+            }
+          }
+        `,
         { rp_ids: [...new Set(rpIds)] },
       )
-    : await graphqlClient.request<CandidateQueryResult>(
-        GET_MIGRATION_CANDIDATES,
-      );
+    : await graphqlClient.request<CandidateQueryResult>(gql`
+        ${MIGRATION_CANDIDATE_FIELDS}
+        query GetRpManagerMigrationCandidates {
+          rp_registration(
+            where: {
+              mode: { _eq: managed }
+              status: { _eq: registered }
+              signer_address: { _is_null: false }
+              manager_kms_key_id: { _is_null: false }
+              is_unique_manager_key: { _eq: true }
+              app: {
+                status: { _eq: "active" }
+                is_archived: { _eq: false }
+                deleted_at: { _is_null: true }
+              }
+            }
+            order_by: { created_at: asc }
+          ) {
+            ...RpManagerMigrationCandidate
+          }
+        }
+      `);
 
   return response.rp_registration;
 }
@@ -408,6 +381,24 @@ async function migrateCandidate(
   }
 
   const rpId = parseRpId(candidate.rp_id);
+
+  try {
+    await insertMigrationAuditRecord({
+      graphqlClient: context.graphqlClient,
+      rpId: candidate.rp_id,
+      appId: candidate.app_id,
+      oldManagerKeyId: candidate.manager_kms_key_id,
+      sharedManagerKeyId: context.sharedManagerKeyId,
+      kmsRegion: context.primaryRegistry.config.kmsRegion,
+    });
+  } catch (error) {
+    return failedResult(
+      candidate,
+      operationHashes,
+      "write_audit",
+      errorMessage(error),
+    );
+  }
 
   let oldManagerAddress: string;
   try {
@@ -622,11 +613,35 @@ async function migrateCandidate(
         old_manager_key_id: string;
         shared_manager_key_id: string;
       }
-    >(FINALIZE_MIGRATION, {
-      rp_id: candidate.rp_id,
-      old_manager_key_id: candidate.manager_kms_key_id,
-      shared_manager_key_id: context.sharedManagerKeyId,
-    });
+    >(
+      gql`
+        mutation FinalizeRpManagerMigration(
+          $rp_id: String!
+          $old_manager_key_id: String!
+          $shared_manager_key_id: String!
+        ) {
+          update_rp_registration(
+            where: {
+              rp_id: { _eq: $rp_id }
+              mode: { _eq: managed }
+              manager_kms_key_id: { _eq: $old_manager_key_id }
+              is_unique_manager_key: { _eq: true }
+            }
+            _set: {
+              manager_kms_key_id: $shared_manager_key_id
+              is_unique_manager_key: false
+            }
+          ) {
+            affected_rows
+          }
+        }
+      `,
+      {
+        rp_id: candidate.rp_id,
+        old_manager_key_id: candidate.manager_kms_key_id,
+        shared_manager_key_id: context.sharedManagerKeyId,
+      },
+    );
 
     if (response.update_rp_registration?.affected_rows !== 1) {
       return failedResult(

--- a/web/scripts/rp-manager-key-cleanup/actions.ts
+++ b/web/scripts/rp-manager-key-cleanup/actions.ts
@@ -1,0 +1,649 @@
+import "server-only";
+
+import { getEthAddressFromKMS } from "@/api/helpers/kms-eth";
+import {
+  isValidRpId,
+  parseRpId,
+  type RpRegistryConfig,
+} from "@/api/helpers/rp-utils";
+import { getRpFromContract } from "@/api/helpers/temporal-rpc";
+import { logger } from "@/lib/logger";
+import {
+  DescribeKeyCommand,
+  type KeyMetadata,
+  type KMSClient,
+  ListResourceTagsCommand,
+  ScheduleKeyDeletionCommand,
+} from "@aws-sdk/client-kms";
+import { gql, type GraphQLClient } from "graphql-request";
+
+// #region Public types
+
+export type RpManagerKeyCleanupRegistry = {
+  name: string;
+  config: RpRegistryConfig;
+};
+
+export type RpManagerKeyCleanupInput = {
+  graphqlClient: GraphQLClient;
+  kmsClient: KMSClient;
+  primaryRegistry: RpManagerKeyCleanupRegistry;
+  stagingMirrorRegistry?: RpManagerKeyCleanupRegistry;
+  rpIds?: readonly string[];
+  limit?: number;
+  deletionWindowInDays?: number;
+};
+
+export enum CleanupStatus {
+  Pending = "pending",
+  Failed = "failed",
+  Blocked = "blocked",
+  ReadyForExternalCleanup = "ready_for_external_cleanup",
+  DeletionScheduled = "deletion_scheduled",
+  Deleted = "deleted",
+}
+
+export type RpManagerKeyCleanupItemResult = {
+  rpId: string;
+  appId: string;
+  oldManagerKeyArn: string;
+  status:
+    | CleanupStatus.Blocked
+    | CleanupStatus.ReadyForExternalCleanup
+    | CleanupStatus.DeletionScheduled
+    | CleanupStatus.Deleted
+    | CleanupStatus.Failed
+    | "skipped";
+  detail?: string;
+  expectedDeletionAt?: string;
+};
+
+export type RpManagerKeyCleanupReport = {
+  candidateCount: number;
+  results: RpManagerKeyCleanupItemResult[];
+};
+
+// #endregion
+
+// #region Internal types
+
+export type ManagerKeyCleanupCandidate = {
+  rp_id: string;
+  app_id: string;
+  old_manager_kms_key_id: string;
+  old_manager_kms_key_arn: string;
+  shared_manager_kms_key_id: string;
+  cleanup_status: CleanupStatus;
+};
+
+type CleanupCandidatesResult = {
+  rp_manager_key_migration_audit: ManagerKeyCleanupCandidate[];
+};
+
+type ManagerKeyReferenceStateResult = {
+  rp_registration: Array<{
+    manager_kms_key_id: string | null;
+    is_unique_manager_key: boolean;
+    staging_status: string | null;
+  }>;
+  old_key_references: Array<{ rp_id: string }>;
+  duplicate_audits: Array<{ rp_id: string }>;
+};
+
+type UpdateAuditResult = {
+  update_rp_manager_key_migration_audit_by_pk: {
+    rp_id: string;
+  } | null;
+};
+
+export enum PlanStep {
+  Skip = "skip",
+  MarkAsBlocked = "mark_as_blocked",
+  MarkAsReadyForExternalCleanup = "mark_as_ready_for_external_cleanup",
+  ScheduleDeletion = "schedule_deletion",
+  RecordExistingDeletionSchedule = "record_existing_deletion_schedule",
+  MarkAsDeleted = "mark_as_deleted",
+}
+
+export type ManagerKeyCleanupPlan =
+  | { nextStep: PlanStep.Skip; reason: string }
+  | { nextStep: PlanStep.MarkAsBlocked; reason: string }
+  | { nextStep: PlanStep.MarkAsReadyForExternalCleanup }
+  | { nextStep: PlanStep.ScheduleDeletion }
+  | { nextStep: PlanStep.RecordExistingDeletionSchedule; deletionDate: string }
+  | { nextStep: PlanStep.MarkAsDeleted };
+
+// #endregion
+
+// #region Actions
+
+const DEFAULT_DELETION_WINDOW_DAYS = 30;
+const DEFAULT_CANDIDATE_LIMIT = 1;
+
+// ANCHOR: Compare two Ethereum addresses without checksum casing differences.
+function addressesEqual(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+// ANCHOR: Check whether KMS reports that a requested key no longer exists.
+function isKmsNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "NotFoundException"
+  );
+}
+
+// ANCHOR: Reject invalid cleanup limits, deletion windows, and RP IDs.
+export function assertValidRpManagerKeyCleanupInput(
+  input: RpManagerKeyCleanupInput,
+): void {
+  const limit = input.limit ?? DEFAULT_CANDIDATE_LIMIT;
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error("limit must be a positive integer");
+  }
+
+  const deletionWindow =
+    input.deletionWindowInDays ?? DEFAULT_DELETION_WINDOW_DAYS;
+  if (
+    !Number.isInteger(deletionWindow) ||
+    deletionWindow < 7 ||
+    deletionWindow > 30
+  ) {
+    throw new Error("deletionWindowInDays must be between 7 and 30");
+  }
+
+  for (const rpId of input.rpIds ?? []) {
+    if (!isValidRpId(rpId)) {
+      throw new Error(`Invalid RP ID: ${rpId}`);
+    }
+  }
+}
+
+// ANCHOR: Load audit rows whose cleanup status is pending, failed, or due.
+export async function loadCleanupCandidates(
+  input: RpManagerKeyCleanupInput,
+): Promise<ManagerKeyCleanupCandidate[]> {
+  if (input.rpIds?.length === 0) {
+    return [];
+  }
+
+  const variables = {
+    now: new Date().toISOString(),
+    limit: input.limit ?? DEFAULT_CANDIDATE_LIMIT,
+    retryable_cleanup_statuses: [CleanupStatus.Pending, CleanupStatus.Failed],
+    deletion_scheduled_status: CleanupStatus.DeletionScheduled,
+  };
+
+  const candidateFields = gql`
+    fragment RpManagerKeyCleanupCandidate on rp_manager_key_migration_audit {
+      rp_id
+      app_id
+      old_manager_kms_key_id
+      old_manager_kms_key_arn
+      shared_manager_kms_key_id
+      cleanup_status
+    }
+  `;
+
+  if (input.rpIds) {
+    const response = await input.graphqlClient.request<
+      CleanupCandidatesResult,
+      {
+        rp_ids: string[];
+        now: string;
+        limit: number;
+        retryable_cleanup_statuses: CleanupStatus[];
+        deletion_scheduled_status: CleanupStatus;
+      }
+    >(
+      gql`
+        ${candidateFields}
+        query GetRpManagerKeyCleanupCandidatesById(
+          $rp_ids: [String!]!
+          $now: timestamptz!
+          $limit: Int!
+          $retryable_cleanup_statuses: [String!]!
+          $deletion_scheduled_status: String!
+        ) {
+          rp_manager_key_migration_audit(
+            where: {
+              rp_id: { _in: $rp_ids }
+              _or: [
+                { cleanup_status: { _in: $retryable_cleanup_statuses } }
+                {
+                  cleanup_status: { _eq: $deletion_scheduled_status }
+                  expected_deletion_at: { _lte: $now }
+                }
+              ]
+            }
+            order_by: [{ updated_at: asc }, { created_at: asc }]
+            limit: $limit
+          ) {
+            ...RpManagerKeyCleanupCandidate
+          }
+        }
+      `,
+      {
+        ...variables,
+        rp_ids: [...new Set(input.rpIds)],
+      },
+    );
+
+    return response.rp_manager_key_migration_audit;
+  }
+
+  const response = await input.graphqlClient.request<
+    CleanupCandidatesResult,
+    {
+      now: string;
+      limit: number;
+      retryable_cleanup_statuses: CleanupStatus[];
+      deletion_scheduled_status: CleanupStatus;
+    }
+  >(
+    gql`
+      ${candidateFields}
+      query GetRpManagerKeyCleanupCandidates(
+        $now: timestamptz!
+        $limit: Int!
+        $retryable_cleanup_statuses: [String!]!
+        $deletion_scheduled_status: String!
+      ) {
+        rp_manager_key_migration_audit(
+          where: {
+            _or: [
+              { cleanup_status: { _in: $retryable_cleanup_statuses } }
+              {
+                cleanup_status: { _eq: $deletion_scheduled_status }
+                expected_deletion_at: { _lte: $now }
+              }
+            ]
+          }
+          order_by: [{ updated_at: asc }, { created_at: asc }]
+          limit: $limit
+        ) {
+          ...RpManagerKeyCleanupCandidate
+        }
+      }
+    `,
+    variables,
+  );
+
+  return response.rp_manager_key_migration_audit;
+}
+
+// ANCHOR: Load KMS metadata required by cleanup ownership and type checks.
+async function loadKeyMetadata(
+  kmsClient: KMSClient,
+  keyId: string,
+): Promise<KeyMetadata> {
+  const { KeyMetadata: metadata } = await kmsClient.send(
+    new DescribeKeyCommand({ KeyId: keyId }),
+  );
+
+  if (!metadata?.Arn || !metadata.AWSAccountId) {
+    throw new Error(`KMS returned incomplete metadata for ${keyId}`);
+  }
+
+  return metadata;
+}
+
+// ANCHOR: Skip in-flight migrations and block duplicate old-key audit rows.
+async function findDatabaseCleanupPlan(
+  input: RpManagerKeyCleanupInput,
+  candidate: ManagerKeyCleanupCandidate,
+): Promise<
+  | Extract<ManagerKeyCleanupPlan, { nextStep: PlanStep.Skip }>
+  | Extract<ManagerKeyCleanupPlan, { nextStep: PlanStep.MarkAsBlocked }>
+  | { stagingStatus: string | null }
+> {
+  const state = await input.graphqlClient.request<
+    ManagerKeyReferenceStateResult,
+    {
+      rp_id: string;
+      old_key_references: string[];
+      old_manager_key_arn: string;
+    }
+  >(
+    gql`
+      query GetRpManagerKeyCleanupDatabaseState(
+        $rp_id: String!
+        $old_key_references: [String!]!
+        $old_manager_key_arn: String!
+      ) {
+        rp_registration(where: { rp_id: { _eq: $rp_id } }) {
+          manager_kms_key_id
+          is_unique_manager_key
+          staging_status
+        }
+        old_key_references: rp_registration(
+          where: { manager_kms_key_id: { _in: $old_key_references } }
+          limit: 2
+        ) {
+          rp_id
+        }
+        duplicate_audits: rp_manager_key_migration_audit(
+          where: { old_manager_kms_key_arn: { _eq: $old_manager_key_arn } }
+          limit: 2
+        ) {
+          rp_id
+        }
+      }
+    `,
+    {
+      rp_id: candidate.rp_id,
+      old_key_references: [
+        ...new Set([
+          candidate.old_manager_kms_key_id,
+          candidate.old_manager_kms_key_arn,
+        ]),
+      ],
+      old_manager_key_arn: candidate.old_manager_kms_key_arn,
+    },
+  );
+
+  if (state.old_key_references.length > 0) {
+    return {
+      nextStep: PlanStep.Skip,
+      reason: "The old manager key is still referenced by an RP registration",
+    };
+  }
+
+  if (state.duplicate_audits.length !== 1) {
+    return {
+      nextStep: PlanStep.MarkAsBlocked,
+      reason:
+        "The old manager key is referenced by multiple migration audit rows",
+    };
+  }
+
+  return {
+    stagingStatus: state.rp_registration[0]?.staging_status ?? null,
+  };
+}
+
+// ANCHOR: Block cleanup when a registry still uses the old manager address.
+async function findRegistryCleanupBlocker(
+  input: RpManagerKeyCleanupInput,
+  candidate: ManagerKeyCleanupCandidate,
+  stagingStatus: string | null,
+): Promise<Extract<
+  ManagerKeyCleanupPlan,
+  { nextStep: PlanStep.MarkAsBlocked }
+> | null> {
+  const [sharedManagerAddress, oldManagerAddress] = await Promise.all([
+    getEthAddressFromKMS(input.kmsClient, candidate.shared_manager_kms_key_id),
+    getEthAddressFromKMS(input.kmsClient, candidate.old_manager_kms_key_arn),
+  ]);
+  const rpId = parseRpId(candidate.rp_id);
+  const registries = [
+    { registry: input.primaryRegistry, primary: true },
+    ...(input.stagingMirrorRegistry
+      ? [{ registry: input.stagingMirrorRegistry, primary: false }]
+      : []),
+  ];
+
+  for (const { registry, primary } of registries) {
+    const rp = await getRpFromContract(rpId, registry.config.contractAddress);
+
+    if (!rp.initialized) {
+      if (!primary && stagingStatus === null) {
+        continue;
+      }
+
+      return {
+        nextStep: PlanStep.MarkAsBlocked,
+        reason: `RP is not initialized in registry ${registry.name}`,
+      };
+    }
+
+    if (addressesEqual(rp.manager, oldManagerAddress)) {
+      return {
+        nextStep: PlanStep.MarkAsBlocked,
+        reason: `RP still uses the old manager in registry ${registry.name}`,
+      };
+    }
+  }
+
+  return null;
+}
+
+// ANCHOR: Block cleanup when the old key is a protected key or the wrong type.
+async function findProtectedOrInvalidKeyBlocker(
+  input: RpManagerKeyCleanupInput,
+  candidate: ManagerKeyCleanupCandidate,
+  oldManagerKey: KeyMetadata,
+): Promise<
+  | Extract<ManagerKeyCleanupPlan, { nextStep: PlanStep.MarkAsBlocked }>
+  | { currentAccountId: string }
+> {
+  const protectedManagerKeys = await Promise.all([
+    loadKeyMetadata(input.kmsClient, candidate.shared_manager_kms_key_id),
+    loadKeyMetadata(
+      input.kmsClient,
+      input.primaryRegistry.config.safeOwnerKmsKeyId,
+    ),
+    ...(input.stagingMirrorRegistry
+      ? [
+          loadKeyMetadata(
+            input.kmsClient,
+            input.stagingMirrorRegistry.config.safeOwnerKmsKeyId,
+          ),
+        ]
+      : []),
+  ]);
+
+  if (protectedManagerKeys.some((key) => key.Arn === oldManagerKey.Arn)) {
+    return {
+      nextStep: PlanStep.MarkAsBlocked,
+      reason: "The old manager key is a protected shared or Safe owner key",
+    };
+  }
+
+  if (
+    oldManagerKey.KeySpec !== "ECC_SECG_P256K1" ||
+    oldManagerKey.KeyUsage !== "SIGN_VERIFY"
+  ) {
+    return {
+      nextStep: PlanStep.MarkAsBlocked,
+      reason: "The old manager key is not an ECC signing key",
+    };
+  }
+
+  const currentAccountId = protectedManagerKeys[0].AWSAccountId;
+  if (!currentAccountId) {
+    throw new Error("KMS did not return the current AWS account ID");
+  }
+
+  return {
+    currentAccountId,
+  };
+}
+
+// ANCHOR: Choose deletion, external handoff, or tag-based blocking for a safe key.
+async function determineKmsCleanupPlan(
+  input: RpManagerKeyCleanupInput,
+  candidate: ManagerKeyCleanupCandidate,
+  oldManagerKey: KeyMetadata,
+  currentAccountId: string,
+): Promise<ManagerKeyCleanupPlan> {
+  if (oldManagerKey.KeyState === "PendingDeletion") {
+    if (!oldManagerKey.DeletionDate) {
+      throw new Error("PendingDeletion key has no deletion date");
+    }
+
+    return {
+      nextStep: PlanStep.RecordExistingDeletionSchedule,
+      deletionDate: oldManagerKey.DeletionDate.toISOString(),
+    };
+  }
+
+  if (oldManagerKey.AWSAccountId !== currentAccountId) {
+    return {
+      nextStep: PlanStep.MarkAsReadyForExternalCleanup,
+    };
+  }
+
+  const { Tags = [] } = await input.kmsClient.send(
+    new ListResourceTagsCommand({ KeyId: oldManagerKey.Arn }),
+  );
+  const tags = new Map(Tags.map((tag) => [tag.TagKey, tag.TagValue]));
+
+  if (
+    tags.get("app") !== "developer-portal" ||
+    tags.get("rpId") !== candidate.rp_id
+  ) {
+    return {
+      nextStep: PlanStep.MarkAsBlocked,
+      reason: "The old manager key does not have the expected ownership tags",
+    };
+  }
+
+  return {
+    nextStep: PlanStep.ScheduleDeletion,
+  };
+}
+
+// ANCHOR: Run all safety checks and select the next cleanup action.
+export async function determineCleanupPlan(
+  input: RpManagerKeyCleanupInput,
+  candidate: ManagerKeyCleanupCandidate,
+): Promise<ManagerKeyCleanupPlan> {
+  const databasePlan = await findDatabaseCleanupPlan(input, candidate);
+
+  if ("nextStep" in databasePlan) {
+    return databasePlan;
+  }
+
+  let oldManagerKey: KeyMetadata;
+
+  try {
+    oldManagerKey = await loadKeyMetadata(
+      input.kmsClient,
+      candidate.old_manager_kms_key_arn,
+    );
+  } catch (error) {
+    if (
+      isKmsNotFound(error) &&
+      candidate.cleanup_status === CleanupStatus.DeletionScheduled
+    ) {
+      return {
+        nextStep: PlanStep.MarkAsDeleted,
+      };
+    }
+
+    throw error;
+  }
+
+  const protectedOrInvalid = await findProtectedOrInvalidKeyBlocker(
+    input,
+    candidate,
+    oldManagerKey,
+  );
+  if ("nextStep" in protectedOrInvalid) {
+    return protectedOrInvalid;
+  }
+
+  const registryBlocker = await findRegistryCleanupBlocker(
+    input,
+    candidate,
+    databasePlan.stagingStatus,
+  );
+  if (registryBlocker) {
+    return registryBlocker;
+  }
+
+  return determineKmsCleanupPlan(
+    input,
+    candidate,
+    oldManagerKey,
+    protectedOrInvalid.currentAccountId,
+  );
+}
+
+// ANCHOR: Schedule the old manager key for deletion after the configured waiting period.
+export async function scheduleOldKeyDeletion(
+  input: RpManagerKeyCleanupInput,
+  candidate: ManagerKeyCleanupCandidate,
+): Promise<string> {
+  const response = await input.kmsClient.send(
+    new ScheduleKeyDeletionCommand({
+      KeyId: candidate.old_manager_kms_key_arn,
+      PendingWindowInDays:
+        input.deletionWindowInDays ?? DEFAULT_DELETION_WINDOW_DAYS,
+    }),
+  );
+
+  if (!response.DeletionDate) {
+    throw new Error("KMS did not return the scheduled deletion date");
+  }
+
+  return response.DeletionDate.toISOString();
+}
+
+// ANCHOR: Persist the final status and details of one cleanup attempt.
+export async function recordCleanupOutcome(
+  input: RpManagerKeyCleanupInput,
+  candidate: ManagerKeyCleanupCandidate,
+  outcome: {
+    status: Exclude<RpManagerKeyCleanupItemResult["status"], "skipped">;
+    detail?: string;
+    deletionScheduledAt?: string;
+    expectedDeletionAt?: string;
+  },
+): Promise<void> {
+  const response = await input.graphqlClient.request<
+    UpdateAuditResult,
+    {
+      rp_id: string;
+      cleanup_status: CleanupStatus;
+      last_error_detail?: string;
+      deletion_scheduled_at?: string;
+      expected_deletion_at?: string;
+    }
+  >(
+    gql`
+      mutation RecordRpManagerKeyCleanupOutcome(
+        $rp_id: String!
+        $cleanup_status: String!
+        $last_error_detail: String
+        $deletion_scheduled_at: timestamptz
+        $expected_deletion_at: timestamptz
+      ) {
+        update_rp_manager_key_migration_audit_by_pk(
+          pk_columns: { rp_id: $rp_id }
+          _set: {
+            cleanup_status: $cleanup_status
+            last_error_detail: $last_error_detail
+            deletion_scheduled_at: $deletion_scheduled_at
+            expected_deletion_at: $expected_deletion_at
+          }
+        ) {
+          rp_id
+        }
+      }
+    `,
+    {
+      rp_id: candidate.rp_id,
+      cleanup_status: outcome.status,
+      last_error_detail: outcome.detail,
+      deletion_scheduled_at: outcome.deletionScheduledAt,
+      expected_deletion_at: outcome.expectedDeletionAt,
+    },
+  );
+
+  if (!response.update_rp_manager_key_migration_audit_by_pk) {
+    throw new Error("Cleanup audit row no longer exists");
+  }
+
+  logger.info("RP manager key cleanup outcome recorded", {
+    rp_id: candidate.rp_id,
+    old_manager_kms_key_arn: candidate.old_manager_kms_key_arn,
+    cleanup_status: outcome.status,
+    detail: outcome.detail,
+  });
+}
+
+// #endregion

--- a/web/scripts/rp-manager-key-cleanup/actions.ts
+++ b/web/scripts/rp-manager-key-cleanup/actions.ts
@@ -646,4 +646,37 @@ export async function recordCleanupOutcome(
   });
 }
 
+// ANCHOR: Move a still-referenced row to the back of the cleanup queue.
+export async function touchSkippedCleanupCandidate(
+  input: RpManagerKeyCleanupInput,
+  candidate: ManagerKeyCleanupCandidate,
+): Promise<void> {
+  const response = await input.graphqlClient.request<
+    UpdateAuditResult,
+    { rp_id: string; updated_at: string }
+  >(
+    gql`
+      mutation TouchSkippedRpManagerKeyCleanup(
+        $rp_id: String!
+        $updated_at: timestamptz!
+      ) {
+        update_rp_manager_key_migration_audit_by_pk(
+          pk_columns: { rp_id: $rp_id }
+          _set: { updated_at: $updated_at }
+        ) {
+          rp_id
+        }
+      }
+    `,
+    {
+      rp_id: candidate.rp_id,
+      updated_at: new Date().toISOString(),
+    },
+  );
+
+  if (!response.update_rp_manager_key_migration_audit_by_pk) {
+    throw new Error("Cleanup audit row no longer exists");
+  }
+}
+
 // #endregion

--- a/web/scripts/rp-manager-key-cleanup/helpers.ts
+++ b/web/scripts/rp-manager-key-cleanup/helpers.ts
@@ -6,6 +6,7 @@ import {
   PlanStep,
   recordCleanupOutcome,
   scheduleOldKeyDeletion,
+  touchSkippedCleanupCandidate,
   type ManagerKeyCleanupCandidate,
   type ManagerKeyCleanupPlan,
   type RpManagerKeyCleanupInput,
@@ -26,6 +27,7 @@ export async function executeCleanupPlan(
 
   switch (plan.nextStep) {
     case PlanStep.Skip:
+      await touchSkippedCleanupCandidate(input, candidate);
       logger.info("RP manager key cleanup skipped", {
         rp_id: candidate.rp_id,
         old_manager_kms_key_arn: candidate.old_manager_kms_key_arn,

--- a/web/scripts/rp-manager-key-cleanup/helpers.ts
+++ b/web/scripts/rp-manager-key-cleanup/helpers.ts
@@ -1,0 +1,94 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import {
+  CleanupStatus,
+  PlanStep,
+  recordCleanupOutcome,
+  scheduleOldKeyDeletion,
+  type ManagerKeyCleanupCandidate,
+  type ManagerKeyCleanupPlan,
+  type RpManagerKeyCleanupInput,
+  type RpManagerKeyCleanupItemResult,
+} from "./actions";
+
+// ANCHOR: Execute the cleanup action selected after all safety checks.
+export async function executeCleanupPlan(
+  input: RpManagerKeyCleanupInput,
+  candidate: ManagerKeyCleanupCandidate,
+  plan: ManagerKeyCleanupPlan,
+): Promise<RpManagerKeyCleanupItemResult> {
+  const base = {
+    rpId: candidate.rp_id,
+    appId: candidate.app_id,
+    oldManagerKeyArn: candidate.old_manager_kms_key_arn,
+  };
+
+  switch (plan.nextStep) {
+    case PlanStep.Skip:
+      logger.info("RP manager key cleanup skipped", {
+        rp_id: candidate.rp_id,
+        old_manager_kms_key_arn: candidate.old_manager_kms_key_arn,
+        detail: plan.reason,
+      });
+      return {
+        ...base,
+        status: "skipped",
+        detail: plan.reason,
+      };
+
+    case PlanStep.MarkAsBlocked:
+      await recordCleanupOutcome(input, candidate, {
+        status: CleanupStatus.Blocked,
+        detail: plan.reason,
+      });
+      return {
+        ...base,
+        status: CleanupStatus.Blocked,
+        detail: plan.reason,
+      };
+
+    case PlanStep.MarkAsReadyForExternalCleanup:
+      await recordCleanupOutcome(input, candidate, {
+        status: CleanupStatus.ReadyForExternalCleanup,
+      });
+      return {
+        ...base,
+        status: CleanupStatus.ReadyForExternalCleanup,
+      };
+
+    case PlanStep.MarkAsDeleted:
+      await recordCleanupOutcome(input, candidate, {
+        status: CleanupStatus.Deleted,
+      });
+      return {
+        ...base,
+        status: CleanupStatus.Deleted,
+      };
+
+    case PlanStep.RecordExistingDeletionSchedule:
+      await recordCleanupOutcome(input, candidate, {
+        status: CleanupStatus.DeletionScheduled,
+        expectedDeletionAt: plan.deletionDate,
+      });
+      return {
+        ...base,
+        status: CleanupStatus.DeletionScheduled,
+        expectedDeletionAt: plan.deletionDate,
+      };
+
+    case PlanStep.ScheduleDeletion: {
+      const deletionDate = await scheduleOldKeyDeletion(input, candidate);
+      await recordCleanupOutcome(input, candidate, {
+        status: CleanupStatus.DeletionScheduled,
+        deletionScheduledAt: new Date().toISOString(),
+        expectedDeletionAt: deletionDate,
+      });
+      return {
+        ...base,
+        status: CleanupStatus.DeletionScheduled,
+        expectedDeletionAt: deletionDate,
+      };
+    }
+  }
+}

--- a/web/scripts/rp-manager-key-migration/insert-migration-audit-record.ts
+++ b/web/scripts/rp-manager-key-migration/insert-migration-audit-record.ts
@@ -1,0 +1,79 @@
+import "server-only";
+
+import { resolveKeyId } from "@/api/helpers/kms";
+import { gql, type GraphQLClient } from "graphql-request";
+
+type InsertMigrationAuditRecordInput = {
+  graphqlClient: GraphQLClient;
+  rpId: string;
+  appId: string;
+  oldManagerKeyId: string;
+  sharedManagerKeyId: string;
+  kmsRegion: string;
+};
+
+type InsertMigrationAuditRecordResult = {
+  insert_rp_manager_key_migration_audit_one: {
+    rp_id: string;
+  } | null;
+};
+
+// ANCHOR: Persist the old manager key before migration overwrites rp_registration.
+export async function insertMigrationAuditRecord({
+  graphqlClient,
+  rpId,
+  appId,
+  oldManagerKeyId,
+  sharedManagerKeyId,
+  kmsRegion,
+}: InsertMigrationAuditRecordInput): Promise<void> {
+  const oldManagerKeyArn = resolveKeyId(oldManagerKeyId, kmsRegion);
+
+  if (!oldManagerKeyArn.startsWith("arn:aws:kms:")) {
+    throw new Error("Could not resolve the old manager KMS key to an ARN");
+  }
+
+  await graphqlClient.request<
+    InsertMigrationAuditRecordResult,
+    {
+      rp_id: string;
+      app_id: string;
+      old_manager_kms_key_id: string;
+      old_manager_kms_key_arn: string;
+      shared_manager_kms_key_id: string;
+    }
+  >(
+    gql`
+      mutation InsertRpManagerKeyMigrationAuditRecord(
+        $rp_id: String!
+        $app_id: String!
+        $old_manager_kms_key_id: String!
+        $old_manager_kms_key_arn: String!
+        $shared_manager_kms_key_id: String!
+      ) {
+        insert_rp_manager_key_migration_audit_one(
+          object: {
+            rp_id: $rp_id
+            app_id: $app_id
+            old_manager_kms_key_id: $old_manager_kms_key_id
+            old_manager_kms_key_arn: $old_manager_kms_key_arn
+            shared_manager_kms_key_id: $shared_manager_kms_key_id
+          }
+          on_conflict: {
+            constraint: rp_manager_key_migration_audit_pkey
+            update_columns: []
+          }
+        ) {
+          rp_id
+        }
+      }
+    `,
+    {
+      rp_id: rpId,
+      app_id: appId,
+      old_manager_kms_key_id: oldManagerKeyId,
+      old_manager_kms_key_arn: oldManagerKeyArn,
+      shared_manager_kms_key_id: sharedManagerKeyId,
+    },
+  );
+}

--- a/web/tests/api/_cleanup-rp-manager-keys.test.ts
+++ b/web/tests/api/_cleanup-rp-manager-keys.test.ts
@@ -1,0 +1,224 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// #region Mocks
+
+jest.mock("server-only", () => ({}));
+
+const protectInternalEndpointMock = jest.fn();
+jest.mock("@/api/helpers/utils", () => ({
+  protectInternalEndpoint: (...args: unknown[]) =>
+    protectInternalEndpointMock(...args),
+}));
+
+const getAPIServiceGraphqlClientMock = jest.fn();
+jest.mock("@/api/helpers/graphql", () => ({
+  getAPIServiceGraphqlClient: (...args: unknown[]) =>
+    getAPIServiceGraphqlClientMock(...args),
+}));
+
+const getKMSClientMock = jest.fn();
+jest.mock("@/api/helpers/kms", () => ({
+  getKMSClient: (...args: unknown[]) => getKMSClientMock(...args),
+}));
+
+const getRpRegistryConfigMock = jest.fn();
+const getStagingRpRegistryConfigMock = jest.fn();
+jest.mock("@/api/helpers/rp-utils", () => ({
+  getRpRegistryConfig: (...args: unknown[]) => getRpRegistryConfigMock(...args),
+  getStagingRpRegistryConfig: (...args: unknown[]) =>
+    getStagingRpRegistryConfigMock(...args),
+}));
+
+const cleanupRpManagerKeysMock = jest.fn();
+jest.mock("../../scripts/cleanup-rp-manager-keys", () => ({
+  cleanupRpManagerKeys: (...args: unknown[]) =>
+    cleanupRpManagerKeysMock(...args),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { POST } from "@/api/_cleanup-rp-manager-keys";
+
+const { logger: mockLogger } = jest.requireMock("@/lib/logger") as {
+  logger: { info: jest.Mock; warn: jest.Mock; error: jest.Mock };
+};
+
+// #endregion
+
+// #region Test data
+
+const RP_ID = "rp_1234567890abcdef";
+const APP_ID = "app_1234567890abcdef1234567890abcdef";
+const OLD_KEY_ARN = "arn:aws:kms:eu-west-1:111111111111:key/old-key";
+const GLOBAL_LOCK_KEY = "rp-manager-key-cleanup:run";
+const PRIMARY_CONFIG = {
+  kmsRegion: "eu-west-1",
+  contractAddress: "0x1111111111111111111111111111111111111111",
+};
+const STAGING_CONFIG = {
+  kmsRegion: "eu-west-1",
+  contractAddress: "0x2222222222222222222222222222222222222222",
+};
+
+const successResult = {
+  rpId: RP_ID,
+  appId: APP_ID,
+  oldManagerKeyArn: OLD_KEY_ARN,
+  status: "deletion_scheduled",
+  expectedDeletionAt: "2026-09-11T12:00:00.000Z",
+};
+
+const request = () =>
+  new NextRequest("http://localhost/api/_cleanup-rp-manager-keys", {
+    method: "POST",
+  });
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  await global.RedisClient?.flushall();
+  process.env.ENABLE_RP_MANAGER_KEY_CLEANUP = "true";
+  process.env.ENABLE_RP_MANAGER_KEY_MIGRATION = "false";
+  process.env.NEXT_PUBLIC_APP_ENV = "staging";
+
+  protectInternalEndpointMock.mockReturnValue({ isAuthenticated: true });
+  getAPIServiceGraphqlClientMock.mockResolvedValue({});
+  getRpRegistryConfigMock.mockReturnValue(PRIMARY_CONFIG);
+  getStagingRpRegistryConfigMock.mockReturnValue(null);
+  getKMSClientMock.mockResolvedValue({});
+  cleanupRpManagerKeysMock.mockResolvedValue({
+    candidateCount: 1,
+    results: [successResult],
+  });
+});
+
+// #endregion
+
+// #region Guards
+
+describe("/_cleanup-rp-manager-keys [guards]", () => {
+  it("returns the internal authentication error", async () => {
+    protectInternalEndpointMock.mockReturnValue({
+      isAuthenticated: false,
+      errorResponse: new NextResponse(null, { status: 403 }),
+    });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(403);
+    expect(cleanupRpManagerKeysMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 204 when cleanup is disabled", async () => {
+    process.env.ENABLE_RP_MANAGER_KEY_CLEANUP = "false";
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(204);
+    expect(cleanupRpManagerKeysMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 204 when migration is still enabled", async () => {
+    process.env.ENABLE_RP_MANAGER_KEY_MIGRATION = "true";
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(204);
+    expect(cleanupRpManagerKeysMock).not.toHaveBeenCalled();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "RP manager key cleanup skipped because migration is enabled",
+    );
+  });
+
+  it("returns 204 when another invocation owns the global lock", async () => {
+    await global.RedisClient?.set(GLOBAL_LOCK_KEY, "another-owner");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(204);
+    expect(cleanupRpManagerKeysMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when Redis is unavailable", async () => {
+    const redis = global.RedisClient;
+    global.RedisClient = undefined;
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(503);
+    global.RedisClient = redis;
+  });
+
+  it("fails closed when the staging registry config is missing in production", async () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "production";
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(503);
+    expect(cleanupRpManagerKeysMock).not.toHaveBeenCalled();
+    await expect(global.RedisClient?.get(GLOBAL_LOCK_KEY)).resolves.toBeNull();
+  });
+});
+
+// #endregion
+
+// #region Cleanup attempt
+
+describe("/_cleanup-rp-manager-keys [attempt]", () => {
+  it("cleans up one candidate with deployment-local configuration", async () => {
+    const response = await POST(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      rp_id: RP_ID,
+      outcome: "deletion_scheduled",
+    });
+    expect(cleanupRpManagerKeysMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        primaryRegistry: { name: "primary", config: PRIMARY_CONFIG },
+        limit: 1,
+      }),
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "RP manager key cleanup attempt finished",
+      expect.objectContaining({
+        rp_id: RP_ID,
+        cleanup_status: "deletion_scheduled",
+      }),
+    );
+    await expect(global.RedisClient?.get(GLOBAL_LOCK_KEY)).resolves.toBeNull();
+  });
+
+  it("passes the staging mirror to cleanup in production", async () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "production";
+    getStagingRpRegistryConfigMock.mockReturnValue(STAGING_CONFIG);
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(cleanupRpManagerKeysMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stagingMirrorRegistry: {
+          name: "staging",
+          config: STAGING_CONFIG,
+        },
+      }),
+    );
+  });
+
+  it("returns 204 when there is no cleanup candidate", async () => {
+    cleanupRpManagerKeysMock.mockResolvedValue({
+      candidateCount: 0,
+      results: [],
+    });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(204);
+    await expect(global.RedisClient?.get(GLOBAL_LOCK_KEY)).resolves.toBeNull();
+  });
+});
+
+// #endregion

--- a/web/tests/scripts/cleanup-rp-manager-keys.test.ts
+++ b/web/tests/scripts/cleanup-rp-manager-keys.test.ts
@@ -99,6 +99,7 @@ let databaseState: {
   duplicate_audits: [{ rp_id: RP_ID }],
 };
 let recordedOutcomes: Array<Record<string, unknown>> = [];
+let skippedTouches: Array<Record<string, unknown>> = [];
 
 const graphqlRequestMock = jest.fn();
 const graphqlClient = {
@@ -132,6 +133,11 @@ function arrangeGraphql(): void {
           return databaseState;
         case "RecordRpManagerKeyCleanupOutcome":
           recordedOutcomes.push(variables as Record<string, unknown>);
+          return {
+            update_rp_manager_key_migration_audit_by_pk: { rp_id: RP_ID },
+          };
+        case "TouchSkippedRpManagerKeyCleanup":
+          skippedTouches.push(variables as Record<string, unknown>);
           return {
             update_rp_manager_key_migration_audit_by_pk: { rp_id: RP_ID },
           };
@@ -212,6 +218,7 @@ beforeEach(() => {
     duplicate_audits: [{ rp_id: RP_ID }],
   };
   recordedOutcomes = [];
+  skippedTouches = [];
 
   arrangeGraphql();
   arrangeCurrentAccountKms();
@@ -273,6 +280,12 @@ describe("cleanupRpManagerKeys [pipeline]", () => {
     expect(getRpFromContractMock).not.toHaveBeenCalled();
     expect(kmsSendMock).not.toHaveBeenCalled();
     expect(recordedOutcomes).toEqual([]);
+    expect(skippedTouches).toEqual([
+      {
+        rp_id: RP_ID,
+        updated_at: expect.any(String),
+      },
+    ]);
     expect(report.results[0]).toEqual(
       expect.objectContaining({
         status: "skipped",

--- a/web/tests/scripts/cleanup-rp-manager-keys.test.ts
+++ b/web/tests/scripts/cleanup-rp-manager-keys.test.ts
@@ -1,0 +1,449 @@
+import type { RpRegistryConfig } from "@/api/helpers/rp-utils";
+import {
+  DescribeKeyCommand,
+  ListResourceTagsCommand,
+  ScheduleKeyDeletionCommand,
+  type KMSClient,
+} from "@aws-sdk/client-kms";
+import type { DocumentNode } from "graphql";
+import type { GraphQLClient } from "graphql-request";
+
+// #region Mocks
+
+jest.mock("server-only", () => ({}));
+
+const getEthAddressFromKMSMock = jest.fn();
+jest.mock("@/api/helpers/kms-eth", () => ({
+  getEthAddressFromKMS: (...args: unknown[]) =>
+    getEthAddressFromKMSMock(...args),
+}));
+
+const getRpFromContractMock = jest.fn();
+jest.mock("@/api/helpers/temporal-rpc", () => ({
+  getRpFromContract: (...args: unknown[]) => getRpFromContractMock(...args),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import {
+  CleanupStatus,
+  cleanupRpManagerKeys,
+} from "../../scripts/cleanup-rp-manager-keys";
+
+// #endregion
+
+// #region Test data
+
+const RP_ID = "rp_1234567890abcdef";
+const APP_ID = "app_1234567890abcdef1234567890abcdef";
+const OLD_KEY_ID = "old-key-id";
+const OLD_KEY_ARN = "arn:aws:kms:eu-west-1:111111111111:key/old-key";
+const SHARED_KEY_ARN = "arn:aws:kms:eu-west-1:111111111111:key/shared-key";
+const SAFE_OWNER_KEY_ARN =
+  "arn:aws:kms:eu-west-1:111111111111:key/safe-owner-key";
+const STAGING_SAFE_OWNER_KEY_ARN =
+  "arn:aws:kms:eu-west-1:111111111111:key/staging-safe-owner-key";
+const OLD_MANAGER = "0x1111111111111111111111111111111111111111";
+const SHARED_MANAGER = "0x2222222222222222222222222222222222222222";
+const CUSTOMER_MANAGER = "0x4444444444444444444444444444444444444444";
+const DELETION_DATE = new Date("2026-09-11T12:00:00.000Z");
+
+const makeConfig = (contractAddress: string): RpRegistryConfig => ({
+  safeOwnerKmsKeyId: SAFE_OWNER_KEY_ARN,
+  contractAddress,
+  safeAddress: "0x5555555555555555555555555555555555555555",
+  entryPointAddress: "0x6666666666666666666666666666666666666666",
+  safe4337ModuleAddress: "0x7777777777777777777777777777777777777777",
+  kmsRegion: "eu-west-1",
+  domainSeparator: `0x${"88".repeat(32)}`,
+  updateRpTypehash: `0x${"99".repeat(32)}`,
+  credentialSchemaIssuerRegistryAddress:
+    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+});
+
+const primaryConfig = makeConfig("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+const stagingConfig = {
+  ...makeConfig("0xcccccccccccccccccccccccccccccccccccccccc"),
+  safeOwnerKmsKeyId: STAGING_SAFE_OWNER_KEY_ARN,
+};
+
+const candidate = {
+  rp_id: RP_ID,
+  app_id: APP_ID,
+  old_manager_kms_key_id: OLD_KEY_ID,
+  old_manager_kms_key_arn: OLD_KEY_ARN,
+  shared_manager_kms_key_id: SHARED_KEY_ARN,
+  cleanup_status: CleanupStatus.Pending,
+};
+
+let candidates = [candidate];
+let databaseState: {
+  rp_registration: Array<{
+    manager_kms_key_id: string | null;
+    is_unique_manager_key: boolean;
+    staging_status: string | null;
+  }>;
+  old_key_references: Array<{ rp_id: string }>;
+  duplicate_audits: Array<{ rp_id: string }>;
+} = {
+  rp_registration: [
+    {
+      manager_kms_key_id: SHARED_KEY_ARN,
+      is_unique_manager_key: false,
+      staging_status: null,
+    },
+  ],
+  old_key_references: [],
+  duplicate_audits: [{ rp_id: RP_ID }],
+};
+let recordedOutcomes: Array<Record<string, unknown>> = [];
+
+const graphqlRequestMock = jest.fn();
+const graphqlClient = {
+  request: graphqlRequestMock,
+} as unknown as GraphQLClient;
+
+const kmsSendMock = jest.fn();
+const kmsClient = { send: kmsSendMock } as unknown as KMSClient;
+
+function operationName(document: string | DocumentNode): string | undefined {
+  if (typeof document === "string") {
+    return document.match(/(?:query|mutation)\s+(\w+)/)?.[1];
+  }
+
+  const operation = document.definitions.find(
+    (definition) => definition.kind === "OperationDefinition",
+  );
+  return operation?.kind === "OperationDefinition"
+    ? operation.name?.value
+    : undefined;
+}
+
+function arrangeGraphql(): void {
+  graphqlRequestMock.mockImplementation(
+    async (document: string | DocumentNode, variables?: unknown) => {
+      switch (operationName(document)) {
+        case "GetRpManagerKeyCleanupCandidates":
+        case "GetRpManagerKeyCleanupCandidatesById":
+          return { rp_manager_key_migration_audit: candidates };
+        case "GetRpManagerKeyCleanupDatabaseState":
+          return databaseState;
+        case "RecordRpManagerKeyCleanupOutcome":
+          recordedOutcomes.push(variables as Record<string, unknown>);
+          return {
+            update_rp_manager_key_migration_audit_by_pk: { rp_id: RP_ID },
+          };
+        default:
+          throw new Error(`Unexpected operation: ${operationName(document)}`);
+      }
+    },
+  );
+}
+
+function kmsMetadata(
+  keyId: string,
+  overrides: Record<string, unknown> = {},
+): { KeyMetadata: Record<string, unknown> } {
+  return {
+    KeyMetadata: {
+      Arn: keyId,
+      AWSAccountId: "111111111111",
+      KeySpec: "ECC_SECG_P256K1",
+      KeyUsage: "SIGN_VERIFY",
+      KeyState: "Enabled",
+      ...overrides,
+    },
+  };
+}
+
+function arrangeCurrentAccountKms(
+  oldKeyOverrides: Record<string, unknown> = {},
+  tags: Array<{ TagKey: string; TagValue: string }> = [
+    { TagKey: "app", TagValue: "developer-portal" },
+    { TagKey: "rpId", TagValue: RP_ID },
+  ],
+): void {
+  kmsSendMock.mockImplementation(async (command: unknown) => {
+    if (command instanceof DescribeKeyCommand) {
+      const keyId = command.input.KeyId ?? "";
+      if (keyId === OLD_KEY_ARN) {
+        return kmsMetadata(OLD_KEY_ARN, oldKeyOverrides);
+      }
+      return kmsMetadata(keyId);
+    }
+
+    if (command instanceof ListResourceTagsCommand) {
+      return { Tags: tags };
+    }
+
+    if (command instanceof ScheduleKeyDeletionCommand) {
+      return { DeletionDate: DELETION_DATE };
+    }
+
+    throw new Error(`Unexpected KMS command: ${String(command)}`);
+  });
+}
+
+const primaryOnly = {
+  graphqlClient,
+  kmsClient,
+  primaryRegistry: { name: "primary", config: primaryConfig },
+};
+
+const withStagingMirror = {
+  ...primaryOnly,
+  stagingMirrorRegistry: { name: "staging", config: stagingConfig },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  candidates = [candidate];
+  databaseState = {
+    rp_registration: [
+      {
+        manager_kms_key_id: SHARED_KEY_ARN,
+        is_unique_manager_key: false,
+        staging_status: null,
+      },
+    ],
+    old_key_references: [],
+    duplicate_audits: [{ rp_id: RP_ID }],
+  };
+  recordedOutcomes = [];
+
+  arrangeGraphql();
+  arrangeCurrentAccountKms();
+  getEthAddressFromKMSMock.mockImplementation(
+    async (_client: unknown, keyId: string) =>
+      keyId === SHARED_KEY_ARN ? SHARED_MANAGER : OLD_MANAGER,
+  );
+  getRpFromContractMock.mockResolvedValue({
+    initialized: true,
+    manager: SHARED_MANAGER,
+  });
+});
+
+// #endregion
+
+// #region Pipeline outcomes
+
+describe("cleanupRpManagerKeys [pipeline]", () => {
+  it("validates and schedules a current-account key with a 30-day window", async () => {
+    const report = await cleanupRpManagerKeys(primaryOnly);
+
+    expect(kmsSendMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: {
+          KeyId: OLD_KEY_ARN,
+          PendingWindowInDays: 30,
+        },
+      }),
+    );
+    expect(report.results).toEqual([
+      {
+        rpId: RP_ID,
+        appId: APP_ID,
+        oldManagerKeyArn: OLD_KEY_ARN,
+        status: CleanupStatus.DeletionScheduled,
+        expectedDeletionAt: DELETION_DATE.toISOString(),
+      },
+    ]);
+  });
+
+  it("hands a key from another AWS account to external cleanup", async () => {
+    arrangeCurrentAccountKms({ AWSAccountId: "222222222222" });
+
+    const report = await cleanupRpManagerKeys(primaryOnly);
+
+    expect(kmsSendMock).not.toHaveBeenCalledWith(
+      expect.any(ScheduleKeyDeletionCommand),
+    );
+    expect(report.results[0]?.status).toBe(
+      CleanupStatus.ReadyForExternalCleanup,
+    );
+  });
+
+  it("skips without writing status while the old key is still referenced", async () => {
+    databaseState.old_key_references = [{ rp_id: RP_ID }];
+
+    const report = await cleanupRpManagerKeys(primaryOnly);
+
+    expect(getRpFromContractMock).not.toHaveBeenCalled();
+    expect(kmsSendMock).not.toHaveBeenCalled();
+    expect(recordedOutcomes).toEqual([]);
+    expect(report.results[0]).toEqual(
+      expect.objectContaining({
+        status: "skipped",
+        detail: "The old manager key is still referenced by an RP registration",
+      }),
+    );
+  });
+
+  it("schedules deletion when the RP registration row is gone", async () => {
+    databaseState.rp_registration = [];
+
+    const report = await cleanupRpManagerKeys(primaryOnly);
+
+    expect(report.results[0]?.status).toBe(CleanupStatus.DeletionScheduled);
+    expect(kmsSendMock).toHaveBeenCalledWith(
+      expect.any(ScheduleKeyDeletionCommand),
+    );
+  });
+
+  it("schedules deletion after a self-managed transfer away from the old key", async () => {
+    databaseState.rp_registration = [
+      {
+        manager_kms_key_id: null,
+        is_unique_manager_key: false,
+        staging_status: null,
+      },
+    ];
+    getRpFromContractMock.mockResolvedValue({
+      initialized: true,
+      manager: CUSTOMER_MANAGER,
+    });
+
+    const report = await cleanupRpManagerKeys(primaryOnly);
+
+    expect(report.results[0]?.status).toBe(CleanupStatus.DeletionScheduled);
+  });
+
+  it("schedules deletion when the staging mirror was never registered", async () => {
+    getRpFromContractMock.mockImplementation(
+      async (_rpId: bigint, contractAddress: string) => {
+        if (contractAddress === stagingConfig.contractAddress) {
+          return {
+            initialized: false,
+            manager: "0x0000000000000000000000000000000000000000",
+          };
+        }
+        return { initialized: true, manager: SHARED_MANAGER };
+      },
+    );
+
+    const report = await cleanupRpManagerKeys(withStagingMirror);
+
+    expect(report.results[0]?.status).toBe(CleanupStatus.DeletionScheduled);
+  });
+
+  it("blocks when the staging mirror is missing but the database has a staging status", async () => {
+    databaseState.rp_registration[0]!.staging_status = "registered";
+    getRpFromContractMock.mockImplementation(
+      async (_rpId: bigint, contractAddress: string) => {
+        if (contractAddress === stagingConfig.contractAddress) {
+          return {
+            initialized: false,
+            manager: "0x0000000000000000000000000000000000000000",
+          };
+        }
+        return { initialized: true, manager: SHARED_MANAGER };
+      },
+    );
+
+    const report = await cleanupRpManagerKeys(withStagingMirror);
+
+    expect(kmsSendMock).not.toHaveBeenCalledWith(
+      expect.any(ScheduleKeyDeletionCommand),
+    );
+    expect(report.results[0]).toEqual(
+      expect.objectContaining({
+        status: CleanupStatus.Blocked,
+        detail: "RP is not initialized in registry staging",
+      }),
+    );
+  });
+
+  it("blocks when the old key tags do not match this RP", async () => {
+    arrangeCurrentAccountKms({}, [
+      { TagKey: "app", TagValue: "developer-portal" },
+      { TagKey: "rpId", TagValue: "rp_fedcba0987654321" },
+    ]);
+
+    const report = await cleanupRpManagerKeys(primaryOnly);
+
+    expect(kmsSendMock).not.toHaveBeenCalledWith(
+      expect.any(ScheduleKeyDeletionCommand),
+    );
+    expect(report.results[0]?.status).toBe(CleanupStatus.Blocked);
+  });
+
+  it("blocks when the old key is the shared manager key", async () => {
+    candidates = [{ ...candidate, old_manager_kms_key_arn: SHARED_KEY_ARN }];
+    kmsSendMock.mockImplementation(async (command: unknown) => {
+      if (command instanceof DescribeKeyCommand) {
+        return kmsMetadata(command.input.KeyId ?? "");
+      }
+      throw new Error("No destructive command expected for a protected key");
+    });
+
+    const report = await cleanupRpManagerKeys(primaryOnly);
+
+    expect(report.results[0]).toEqual(
+      expect.objectContaining({
+        status: CleanupStatus.Blocked,
+        detail: "The old manager key is a protected shared or Safe owner key",
+      }),
+    );
+  });
+
+  it("blocks when the old key is not an ECC signing key", async () => {
+    arrangeCurrentAccountKms({
+      KeySpec: "RSA_2048",
+      KeyUsage: "ENCRYPT_DECRYPT",
+    });
+
+    const report = await cleanupRpManagerKeys(primaryOnly);
+
+    expect(kmsSendMock).not.toHaveBeenCalledWith(
+      expect.any(ScheduleKeyDeletionCommand),
+    );
+    expect(report.results[0]?.status).toBe(CleanupStatus.Blocked);
+  });
+
+  it("recovers when KMS already has the key in PendingDeletion", async () => {
+    arrangeCurrentAccountKms({
+      KeyState: "PendingDeletion",
+      DeletionDate: DELETION_DATE,
+    });
+
+    const report = await cleanupRpManagerKeys(primaryOnly);
+
+    expect(
+      kmsSendMock.mock.calls.some(
+        ([command]) => command instanceof ScheduleKeyDeletionCommand,
+      ),
+    ).toBe(false);
+    expect(report.results[0]).toEqual(
+      expect.objectContaining({
+        status: CleanupStatus.DeletionScheduled,
+        expectedDeletionAt: DELETION_DATE.toISOString(),
+      }),
+    );
+  });
+
+  it("marks the audit deleted after a scheduled key disappears from KMS", async () => {
+    candidates = [
+      { ...candidate, cleanup_status: CleanupStatus.DeletionScheduled },
+    ];
+    kmsSendMock.mockImplementation(async (command: unknown) => {
+      if (command instanceof DescribeKeyCommand) {
+        const keyId = command.input.KeyId;
+        if (keyId === OLD_KEY_ARN) {
+          const error = new Error("Key not found");
+          error.name = "NotFoundException";
+          throw error;
+        }
+        return kmsMetadata(keyId ?? "");
+      }
+      throw new Error("Unexpected KMS command");
+    });
+
+    const report = await cleanupRpManagerKeys(primaryOnly);
+
+    expect(report.results[0]?.status).toBe(CleanupStatus.Deleted);
+  });
+});
+
+// #endregion

--- a/web/tests/scripts/migrate-rp-manager-to-shared-key.test.ts
+++ b/web/tests/scripts/migrate-rp-manager-to-shared-key.test.ts
@@ -50,6 +50,7 @@ const OLD_KEY_ID = "arn:aws:kms:eu-west-1:111111111111:key/old-key";
 const SECOND_OLD_KEY_ID =
   "arn:aws:kms:eu-west-1:111111111111:key/second-old-key";
 const SHARED_KEY_ID = "arn:aws:kms:eu-west-1:111111111111:key/shared-key";
+const ATTEMPT_ID = "12345678-1234-4234-8234-123456789abc";
 const OLD_MANAGER = "0x1111111111111111111111111111111111111111";
 const SHARED_MANAGER = "0x2222222222222222222222222222222222222222";
 const SIGNER = "0x3333333333333333333333333333333333333333";
@@ -209,7 +210,7 @@ describe("migrateRpManagersToSharedKey [successful migrations]", () => {
       kmsClient,
       sharedManagerKeyId: SHARED_KEY_ID,
       ...deploymentWithStagingMirror,
-      attemptId: "attempt-123",
+      attemptId: ATTEMPT_ID,
       pollIntervalMs: 0,
     });
 
@@ -224,8 +225,15 @@ describe("migrateRpManagersToSharedKey [successful migrations]", () => {
         kmsClient,
       }),
     );
-    expect(graphqlRequestMock).toHaveBeenCalledTimes(2);
+    expect(graphqlRequestMock).toHaveBeenCalledTimes(3);
     expect(graphqlRequestMock.mock.calls[1][1]).toEqual({
+      rp_id: RP_ID,
+      app_id: APP_ID,
+      old_manager_kms_key_id: OLD_KEY_ID,
+      old_manager_kms_key_arn: OLD_KEY_ID,
+      shared_manager_kms_key_id: SHARED_KEY_ID,
+    });
+    expect(graphqlRequestMock.mock.calls[2][1]).toEqual({
       rp_id: RP_ID,
       old_manager_key_id: OLD_KEY_ID,
       shared_manager_key_id: SHARED_KEY_ID,
@@ -244,7 +252,7 @@ describe("migrateRpManagersToSharedKey [successful migrations]", () => {
     expect(mockLogger.info).toHaveBeenCalledWith(
       "RP manager key migration completed",
       expect.objectContaining({
-        attempt_id: "attempt-123",
+        attempt_id: ATTEMPT_ID,
         rp_id: RP_ID,
         app_id: APP_ID,
         migrated_registries: ["production", "staging"],
@@ -440,7 +448,7 @@ describe("migrateRpManagersToSharedKey [registry configurations]", () => {
     });
 
     expect(submitTransferManagerTransactionMock).not.toHaveBeenCalled();
-    expect(graphqlRequestMock).toHaveBeenCalledTimes(1);
+    expect(graphqlRequestMock).toHaveBeenCalledTimes(2);
     expect(report.results[0]).toEqual(
       expect.objectContaining({
         status: "failed",
@@ -491,7 +499,7 @@ describe("migrateRpManagersToSharedKey [registry configurations]", () => {
     });
 
     expect(submitTransferManagerTransactionMock).not.toHaveBeenCalled();
-    expect(graphqlRequestMock).toHaveBeenCalledTimes(1);
+    expect(graphqlRequestMock).toHaveBeenCalledTimes(2);
     expect(report.results[0]).toEqual(
       expect.objectContaining({
         status: "failed",
@@ -500,7 +508,7 @@ describe("migrateRpManagersToSharedKey [registry configurations]", () => {
     );
   });
 
-  it("does not update the database if an initially absent mirror appears during migration", async () => {
+  it("does not update the registration if an initially absent mirror appears during migration", async () => {
     arrangeGraphql([{ ...candidate, staging_status: null }]);
     arrangeRegistryQueues({
       [productionConfig.contractAddress]: [
@@ -517,7 +525,7 @@ describe("migrateRpManagersToSharedKey [registry configurations]", () => {
       ...deploymentWithStagingMirror,
     });
 
-    expect(graphqlRequestMock).toHaveBeenCalledTimes(1);
+    expect(graphqlRequestMock).toHaveBeenCalledTimes(2);
     expect(report.results[0]).toEqual(
       expect.objectContaining({
         status: "failed",
@@ -532,7 +540,33 @@ describe("migrateRpManagersToSharedKey [registry configurations]", () => {
 // #region Failure isolation and safety guards
 
 describe("migrateRpManagersToSharedKey [safety guards]", () => {
-  it("does not submit or update the database when a registry has an unexpected manager", async () => {
+  it("does not start migration when the audit record cannot be written", async () => {
+    graphqlRequestMock
+      .mockResolvedValueOnce({ rp_registration: [candidate] })
+      .mockRejectedValueOnce(new Error("audit database unavailable"));
+
+    const report = await migrateRpManagersToSharedKey({
+      graphqlClient,
+      kmsClient,
+      sharedManagerKeyId: SHARED_KEY_ID,
+      ...deploymentWithPrimaryOnly,
+    });
+
+    expect(getEthAddressFromKMSMock).toHaveBeenCalledTimes(1);
+    expect(getRpFromContractMock).not.toHaveBeenCalled();
+    expect(submitTransferManagerTransactionMock).not.toHaveBeenCalled();
+    expect(report.results[0]).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        failure: {
+          stage: "write_audit",
+          detail: "audit database unavailable",
+        },
+      }),
+    );
+  });
+
+  it("does not submit or update the registration when a registry has an unexpected manager", async () => {
     arrangeGraphql();
     arrangeRegistryQueues({
       [productionConfig.contractAddress]: [
@@ -548,7 +582,7 @@ describe("migrateRpManagersToSharedKey [safety guards]", () => {
     });
 
     expect(submitTransferManagerTransactionMock).not.toHaveBeenCalled();
-    expect(graphqlRequestMock).toHaveBeenCalledTimes(1);
+    expect(graphqlRequestMock).toHaveBeenCalledTimes(2);
     expect(report.results[0]).toEqual(
       expect.objectContaining({
         status: "failed",
@@ -558,7 +592,7 @@ describe("migrateRpManagersToSharedKey [safety guards]", () => {
     );
   });
 
-  it("does not update the database when transaction submission fails", async () => {
+  it("does not update the registration when transaction submission fails", async () => {
     arrangeGraphql();
     arrangeRegistryQueues({
       [productionConfig.contractAddress]: [makeOnChainRp()],
@@ -575,7 +609,7 @@ describe("migrateRpManagersToSharedKey [safety guards]", () => {
       ...deploymentWithStagingMirror,
     });
 
-    expect(graphqlRequestMock).toHaveBeenCalledTimes(1);
+    expect(graphqlRequestMock).toHaveBeenCalledTimes(2);
     expect(report.results[0]).toEqual(
       expect.objectContaining({
         status: "failed",
@@ -584,7 +618,7 @@ describe("migrateRpManagersToSharedKey [safety guards]", () => {
     );
   });
 
-  it("keeps the database unchanged when the second registry fails after the first one succeeds", async () => {
+  it("keeps the registration unchanged when the second registry fails after the first one succeeds", async () => {
     arrangeGraphql();
     arrangeRegistryQueues({
       [productionConfig.contractAddress]: [
@@ -606,7 +640,7 @@ describe("migrateRpManagersToSharedKey [safety guards]", () => {
     });
 
     expect(submitTransferManagerTransactionMock).toHaveBeenCalledTimes(2);
-    expect(graphqlRequestMock).toHaveBeenCalledTimes(1);
+    expect(graphqlRequestMock).toHaveBeenCalledTimes(2);
     expect(report.results[0]).toEqual(
       expect.objectContaining({
         status: "failed",
@@ -617,7 +651,7 @@ describe("migrateRpManagersToSharedKey [safety guards]", () => {
     );
   });
 
-  it("does not update the database when on-chain confirmation times out", async () => {
+  it("does not update the registration when on-chain confirmation times out", async () => {
     arrangeGraphql();
     arrangeRegistryQueues({
       [productionConfig.contractAddress]: [makeOnChainRp(), makeOnChainRp()],
@@ -631,7 +665,7 @@ describe("migrateRpManagersToSharedKey [safety guards]", () => {
       confirmationTimeoutMs: 0,
     });
 
-    expect(graphqlRequestMock).toHaveBeenCalledTimes(1);
+    expect(graphqlRequestMock).toHaveBeenCalledTimes(2);
     expect(report.results[0]).toEqual(
       expect.objectContaining({
         status: "failed",
@@ -643,7 +677,7 @@ describe("migrateRpManagersToSharedKey [safety guards]", () => {
     );
   });
 
-  it("does not update the database when final verification detects a signer change", async () => {
+  it("does not update the registration when final verification detects a signer change", async () => {
     arrangeGraphql();
     arrangeRegistryQueues({
       [productionConfig.contractAddress]: [
@@ -661,7 +695,7 @@ describe("migrateRpManagersToSharedKey [safety guards]", () => {
       pollIntervalMs: 0,
     });
 
-    expect(graphqlRequestMock).toHaveBeenCalledTimes(1);
+    expect(graphqlRequestMock).toHaveBeenCalledTimes(2);
     expect(report.results[0]).toEqual(
       expect.objectContaining({
         status: "failed",
@@ -717,7 +751,7 @@ describe("migrateRpManagersToSharedKey [safety guards]", () => {
       pollIntervalMs: 0,
     });
 
-    expect(graphqlRequestMock.mock.calls[1][1]).toEqual({
+    expect(graphqlRequestMock.mock.calls[2][1]).toEqual({
       rp_id: RP_ID,
       old_manager_key_id: OLD_KEY_ID,
       shared_manager_key_id: SHARED_KEY_ID,


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

This PR records each RP's old manager KMS key before shared-key migration overwrites `rp_registration.manager_kms_key_id`, and adds a gated cleanup path that can schedule deletion of those leftover keys.

- Adds `rp_manager_key_migration_audit` with no foreign keys, so the mapping survives deletion of the app or RP row. Access is service-role only (insert/select/update). The row stores the old key id, ARN from `resolveKeyId`, shared key id, and cleanup status (`pending`, `failed`, `blocked`, `ready_for_external_cleanup`, `deletion_scheduled`, `deleted`).
- Inserts the audit row before any on-chain work. A failed insert is `write_audit` and skips migration. Primary-key `on_conflict` is do-nothing, so retries keep the first old-key row.
- Adds `POST /api/_cleanup-rp-manager-keys` behind `protectInternalEndpoint`, with a Redis run lock. A Hasura cron calls it every 15 minutes (60s timeout, 0 retries). The handler returns 204 unless `ENABLE_RP_MANAGER_KEY_CLEANUP` is `true`, and also returns 204 while `ENABLE_RP_MANAGER_KEY_MIGRATION` is `true`.
- Cleanup decides from live DB, contract, and KMS state. It skips without writing status if the old key is still referenced on any `rp_registration`. Keys in another AWS account are marked `ready_for_external_cleanup`. Current-account keys tagged `app=developer-portal` and `rpId=<rp>` are scheduled for deletion with a 30-day pending window.
- Allowlists the new scripts in `web/.dockerignore` and documents `ENABLE_RP_MANAGER_KEY_CLEANUP` in `.env.example`.
- Adds unit tests for cleanup API guards, cleanup plan branches, and the migration `write_audit` fail-closed path.

This PR does not enable cleanup. A companion change in `world-id-deploy` (https://github.com/worldcoin/world-id-deploy/pull/565) wires `ENABLE_RP_MANAGER_KEY_CLEANUP` (false in staging and production) and adds `kms:ListResourceTags` on the tagged-key task-role policy.

This PR does not backfill audit rows for RPs already migrated before the table exists.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.


---

<details>
<summary>Algorythm</summary>

```mermaid
flowchart TD
  start[Load audit rows:<br/>pending, failed,<br/>or deletion already due] --> each{For each old key}

  each --> dbRef{Is this old key still<br/>stored on any RP row?}
  dbRef -->|yes| skip[Skip this run.<br/>Leave the audit row unchanged]
  dbRef -->|no| dup{Do several audit rows<br/>point at the same old key?}
  dup -->|yes| blocked[Mark blocked]
  dup -->|no| kmsFind{Can KMS find this key?}

  kmsFind -->|not found, and we already<br/>scheduled deletion| deleted[Mark deleted]
  kmsFind -->|not found otherwise,<br/>or KMS errors| failed[Mark failed]
  kmsFind -->|found| protected{Is it the shared manager key<br/>or a Safe owner key?}

  protected -->|yes| blocked
  protected -->|no| ecc{Is it an ECC signing key?}
  ecc -->|no| blocked
  ecc -->|yes| chainMissing{Is the RP missing on the main chain,<br/>or missing on staging while the DB<br/>still has a staging status?}

  chainMissing -->|yes| blocked
  chainMissing -->|no| chainOld{Does any chain still use<br/>this old key as manager?}
  chainOld -->|yes| blocked
  chainOld -->|no| pending{Is KMS already waiting<br/>to delete this key?}

  pending -->|yes| scheduled[Keep deletion_scheduled<br/>and store the existing date]
  pending -->|no| otherAcct{Is the key in another<br/>AWS account?}

  otherAcct -->|yes| external[Mark ready for<br/>external cleanup]
  otherAcct -->|no| tags{Do tags say<br/>app = developer-portal<br/>and this RP?}

  tags -->|no| blocked
  tags -->|yes| delete[Ask KMS to delete it<br/>in 30 days.<br/>Mark deletion_scheduled]

  skip --> each
  blocked --> each
  failed --> each
  deleted --> each
  scheduled --> each
  external --> each
  delete --> each

```
</details>