### PR TITLE
Admin migration tracking

### DIFF
--- a/hasura/metadata/databases/databases.yaml
+++ b/hasura/metadata/databases/databases.yaml
@@ -403,10 +403,14 @@
             WHERE mode = 'managed' AND manager_kms_key_id IS NULL
           )::bigint AS managed_without_key,
           COUNT(*) FILTER (
-            WHERE mode = 'managed' AND is_unique_manager_key = true
+            WHERE mode = 'managed'
+              AND is_unique_manager_key = true
+              AND manager_kms_key_id IS NOT NULL
           )::bigint AS unique_manager_key_rps,
           COUNT(*) FILTER (
-            WHERE mode = 'managed' AND is_unique_manager_key = false
+            WHERE mode = 'managed'
+              AND is_unique_manager_key = false
+              AND manager_kms_key_id IS NOT NULL
           )::bigint AS shared_manager_key_rps,
           COUNT(*) FILTER (WHERE status = 'pending')::bigint AS status_pending,
           COUNT(*) FILTER (WHERE status = 'registered')::bigint AS status_registered,

--- a/hasura/metadata/databases/databases.yaml
+++ b/hasura/metadata/databases/databases.yaml
@@ -148,15 +148,11 @@
           type:
             scalar: bigint
             nullable: false
-        - name: distinct_manager_keys
+        - name: unique_manager_key_rps
           type:
             scalar: bigint
             nullable: false
-        - name: shared_key_groups
-          type:
-            scalar: bigint
-            nullable: false
-        - name: rps_on_shared_keys
+        - name: shared_manager_key_rps
           type:
             scalar: bigint
             nullable: false
@@ -205,9 +201,8 @@
               - self_managed_rps
               - managed_with_key
               - managed_without_key
-              - distinct_manager_keys
-              - shared_key_groups
-              - rps_on_shared_keys
+              - unique_manager_key_rps
+              - shared_manager_key_rps
               - status_pending
               - status_registered
               - status_failed
@@ -217,6 +212,127 @@
               - staging_status_failed
               - staging_status_deactivated
               - staging_status_null
+            filter: {}
+    # TODO: remove after the RP manager key migration completes
+    - name: admin_rp_manager_key_migration
+      fields:
+        - name: remaining_cron_candidates
+          type:
+            scalar: bigint
+            nullable: false
+        - name: unique_excluded_from_cron
+          type:
+            scalar: bigint
+            nullable: false
+        - name: on_shared_with_audit
+          type:
+            scalar: bigint
+            nullable: false
+        - name: on_shared_without_audit
+          type:
+            scalar: bigint
+            nullable: false
+        - name: unique_with_audit
+          type:
+            scalar: bigint
+            nullable: false
+        - name: audit_pending
+          type:
+            scalar: bigint
+            nullable: false
+        - name: audit_failed
+          type:
+            scalar: bigint
+            nullable: false
+        - name: audit_blocked
+          type:
+            scalar: bigint
+            nullable: false
+        - name: audit_ready_for_external_cleanup
+          type:
+            scalar: bigint
+            nullable: false
+        - name: audit_deletion_scheduled
+          type:
+            scalar: bigint
+            nullable: false
+        - name: audit_deleted
+          type:
+            scalar: bigint
+            nullable: false
+        - name: audit_deletion_overdue
+          type:
+            scalar: bigint
+            nullable: false
+      select_permissions:
+        - role: internal_dashboard_readonly
+          permission:
+            columns:
+              - remaining_cron_candidates
+              - unique_excluded_from_cron
+              - on_shared_with_audit
+              - on_shared_without_audit
+              - unique_with_audit
+              - audit_pending
+              - audit_failed
+              - audit_blocked
+              - audit_ready_for_external_cleanup
+              - audit_deletion_scheduled
+              - audit_deleted
+              - audit_deletion_overdue
+            filter: {}
+    # TODO: remove after the RP manager key migration completes
+    - name: admin_rp_manager_key_migration_queue
+      fields:
+        - name: kind
+          type:
+            scalar: varchar
+            nullable: false
+        - name: rp_id
+          type:
+            scalar: varchar
+            nullable: false
+        - name: app_id
+          type:
+            scalar: varchar
+            nullable: false
+        - name: app_name
+          type:
+            scalar: varchar
+            nullable: true
+        - name: updated_at
+          type:
+            scalar: timestamptz
+            nullable: true
+        - name: cleanup_status
+          type:
+            scalar: text
+            nullable: true
+        - name: last_error_detail
+          type:
+            scalar: text
+            nullable: true
+        - name: expected_deletion_at
+          type:
+            scalar: timestamptz
+            nullable: true
+        - name: total_count
+          type:
+            scalar: bigint
+            nullable: false
+      select_permissions:
+        - role: internal_dashboard_readonly
+          permission:
+            columns:
+              - kind
+              - rp_id
+              - app_id
+              - app_name
+              - updated_at
+              - cleanup_status
+              - last_error_detail
+              - expected_deletion_at
+              - total_count
             filter: {}
   native_queries:
     - root_field_name: admin_dashboard_inventory
@@ -276,14 +392,6 @@
     - root_field_name: admin_rp_inventory
       arguments: {}
       code: |
-        WITH key_counts AS (
-          SELECT
-            manager_kms_key_id,
-            COUNT(*)::bigint AS rp_count
-          FROM public.rp_registration
-          WHERE manager_kms_key_id IS NOT NULL
-          GROUP BY manager_kms_key_id
-        )
         SELECT
           COUNT(*)::bigint AS total_rps,
           COUNT(*) FILTER (WHERE mode = 'managed')::bigint AS managed_rps,
@@ -294,17 +402,12 @@
           COUNT(*) FILTER (
             WHERE mode = 'managed' AND manager_kms_key_id IS NULL
           )::bigint AS managed_without_key,
-          (
-            SELECT COUNT(*)::bigint FROM key_counts
-          ) AS distinct_manager_keys,
-          (
-            SELECT COUNT(*)::bigint FROM key_counts WHERE rp_count > 1
-          ) AS shared_key_groups,
-          (
-            SELECT COALESCE(SUM(rp_count), 0)::bigint
-            FROM key_counts
-            WHERE rp_count > 1
-          ) AS rps_on_shared_keys,
+          COUNT(*) FILTER (
+            WHERE mode = 'managed' AND is_unique_manager_key = true
+          )::bigint AS unique_manager_key_rps,
+          COUNT(*) FILTER (
+            WHERE mode = 'managed' AND is_unique_manager_key = false
+          )::bigint AS shared_manager_key_rps,
           COUNT(*) FILTER (WHERE status = 'pending')::bigint AS status_pending,
           COUNT(*) FILTER (WHERE status = 'registered')::bigint AS status_registered,
           COUNT(*) FILTER (WHERE status = 'failed')::bigint AS status_failed,
@@ -502,3 +605,171 @@
           NULL::timestamptz
         FROM users_without_teams
       returns: admin_dashboard_queue
+    # TODO: remove after the RP manager key migration completes
+    - root_field_name: admin_rp_manager_key_migration
+      arguments: {}
+      code: |
+        WITH cron_candidate AS (
+          SELECT r.rp_id
+          FROM public.rp_registration r
+          JOIN public.app a ON a.id = r.app_id
+          WHERE r.mode = 'managed'
+            AND r.status = 'registered'
+            AND r.signer_address IS NOT NULL
+            AND r.manager_kms_key_id IS NOT NULL
+            AND r.is_unique_manager_key
+            AND a.status = 'active'
+            AND NOT a.is_archived
+            AND a.deleted_at IS NULL
+        ),
+        unique_managed AS (
+          SELECT r.rp_id
+          FROM public.rp_registration r
+          WHERE r.mode = 'managed'
+            AND r.is_unique_manager_key
+            AND r.manager_kms_key_id IS NOT NULL
+        ),
+        shared_managed AS (
+          SELECT r.rp_id
+          FROM public.rp_registration r
+          WHERE r.mode = 'managed'
+            AND NOT r.is_unique_manager_key
+            AND r.manager_kms_key_id IS NOT NULL
+        ),
+        audit_counts AS (
+          SELECT
+            COUNT(*) FILTER (WHERE cleanup_status = 'pending')::bigint AS audit_pending,
+            COUNT(*) FILTER (WHERE cleanup_status = 'failed')::bigint AS audit_failed,
+            COUNT(*) FILTER (WHERE cleanup_status = 'blocked')::bigint AS audit_blocked,
+            COUNT(*) FILTER (
+              WHERE cleanup_status = 'ready_for_external_cleanup'
+            )::bigint AS audit_ready_for_external_cleanup,
+            COUNT(*) FILTER (
+              WHERE cleanup_status = 'deletion_scheduled'
+            )::bigint AS audit_deletion_scheduled,
+            COUNT(*) FILTER (WHERE cleanup_status = 'deleted')::bigint AS audit_deleted,
+            COUNT(*) FILTER (
+              WHERE cleanup_status = 'deletion_scheduled'
+                AND expected_deletion_at <= CURRENT_TIMESTAMP
+            )::bigint AS audit_deletion_overdue
+          FROM public.rp_manager_key_migration_audit
+        )
+        SELECT
+          (SELECT COUNT(*)::bigint FROM cron_candidate) AS remaining_cron_candidates,
+          (
+            SELECT COUNT(*)::bigint
+            FROM unique_managed u
+            WHERE NOT EXISTS (
+              SELECT 1 FROM cron_candidate c WHERE c.rp_id = u.rp_id
+            )
+          ) AS unique_excluded_from_cron,
+          (
+            SELECT COUNT(*)::bigint
+            FROM shared_managed s
+            WHERE EXISTS (
+              SELECT 1
+              FROM public.rp_manager_key_migration_audit m
+              WHERE m.rp_id = s.rp_id
+            )
+          ) AS on_shared_with_audit,
+          (
+            SELECT COUNT(*)::bigint
+            FROM shared_managed s
+            WHERE NOT EXISTS (
+              SELECT 1
+              FROM public.rp_manager_key_migration_audit m
+              WHERE m.rp_id = s.rp_id
+            )
+          ) AS on_shared_without_audit,
+          (
+            SELECT COUNT(*)::bigint
+            FROM public.rp_manager_key_migration_audit m
+            JOIN public.rp_registration r ON r.rp_id = m.rp_id
+            WHERE r.is_unique_manager_key
+          ) AS unique_with_audit,
+          audit_counts.audit_pending,
+          audit_counts.audit_failed,
+          audit_counts.audit_blocked,
+          audit_counts.audit_ready_for_external_cleanup,
+          audit_counts.audit_deletion_scheduled,
+          audit_counts.audit_deleted,
+          audit_counts.audit_deletion_overdue
+        FROM audit_counts
+      returns: admin_rp_manager_key_migration
+    # TODO: remove after the RP manager key migration completes
+    - root_field_name: admin_rp_manager_key_migration_queue
+      arguments: {}
+      code: |
+        WITH remaining_cron_candidate AS (
+          SELECT
+            'remaining_cron_candidate'::varchar AS kind,
+            r.rp_id,
+            r.app_id,
+            a.name AS app_name,
+            r.updated_at,
+            NULL::text AS cleanup_status,
+            NULL::text AS last_error_detail,
+            NULL::timestamptz AS expected_deletion_at,
+            COUNT(*) OVER() AS total_count
+          FROM public.rp_registration r
+          JOIN public.app a ON a.id = r.app_id
+          WHERE r.mode = 'managed'
+            AND r.status = 'registered'
+            AND r.signer_address IS NOT NULL
+            AND r.manager_kms_key_id IS NOT NULL
+            AND r.is_unique_manager_key
+            AND a.status = 'active'
+            AND NOT a.is_archived
+            AND a.deleted_at IS NULL
+          ORDER BY r.updated_at ASC, r.created_at ASC
+          LIMIT 20
+        ),
+        cleanup_needs_attention AS (
+          SELECT
+            'cleanup_needs_attention'::varchar AS kind,
+            m.rp_id,
+            m.app_id,
+            a.name AS app_name,
+            m.updated_at,
+            m.cleanup_status,
+            m.last_error_detail,
+            m.expected_deletion_at,
+            COUNT(*) OVER() AS total_count
+          FROM public.rp_manager_key_migration_audit m
+          LEFT JOIN public.app a ON a.id = m.app_id
+          WHERE m.cleanup_status IN (
+              'failed',
+              'blocked',
+              'ready_for_external_cleanup'
+            )
+            OR (
+              m.cleanup_status = 'deletion_scheduled'
+              AND m.expected_deletion_at <= CURRENT_TIMESTAMP
+            )
+          ORDER BY m.updated_at ASC, m.created_at ASC
+          LIMIT 20
+        )
+        SELECT
+          kind,
+          rp_id,
+          app_id,
+          app_name,
+          updated_at,
+          cleanup_status,
+          last_error_detail,
+          expected_deletion_at,
+          total_count
+        FROM remaining_cron_candidate
+        UNION ALL
+        SELECT
+          kind,
+          rp_id,
+          app_id,
+          app_name,
+          updated_at,
+          cleanup_status,
+          last_error_detail,
+          expected_deletion_at,
+          total_count
+        FROM cleanup_needs_attention
+      returns: admin_rp_manager_key_migration_queue

--- a/hasura/metadata/databases/default/tables/public_rp_manager_key_migration_audit.yaml
+++ b/hasura/metadata/databases/default/tables/public_rp_manager_key_migration_audit.yaml
@@ -12,6 +12,21 @@ insert_permissions:
         - old_manager_kms_key_arn
         - shared_manager_kms_key_id
 select_permissions:
+  - role: internal_dashboard_readonly
+    permission:
+      columns:
+        - rp_id
+        - app_id
+        - old_manager_kms_key_id
+        - old_manager_kms_key_arn
+        - shared_manager_kms_key_id
+        - cleanup_status
+        - last_error_detail
+        - deletion_scheduled_at
+        - expected_deletion_at
+        - created_at
+        - updated_at
+      filter: {}
   - role: service
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_rp_registration.yaml
+++ b/hasura/metadata/databases/default/tables/public_rp_registration.yaml
@@ -37,6 +37,8 @@ select_permissions:
         - app_id
         - mode
         - signer_address
+        - manager_kms_key_id
+        - is_unique_manager_key
         - status
         - operation_hash
         - staging_status

--- a/hasura/metadata/databases/default/tables/public_rp_registration.yaml
+++ b/hasura/metadata/databases/default/tables/public_rp_registration.yaml
@@ -37,7 +37,6 @@ select_permissions:
         - app_id
         - mode
         - signer_address
-        - manager_kms_key_id
         - is_unique_manager_key
         - status
         - operation_hash

--- a/web/components/AdminDashboard/RPs/search.ts
+++ b/web/components/AdminDashboard/RPs/search.ts
@@ -23,6 +23,7 @@ export type RpsSearchField =
   | "staging_status"
   | "status"
   | "team"
+  | "unique"
   | "updated";
 export type RpsSearchOperator = SearchOperator;
 export type ParsedRpsSearchToken = ParsedSearchToken<RpsSearchField>;
@@ -42,6 +43,12 @@ export const RPS_SEARCH_FIELDS: Array<SearchField & { label: string }> = [
     label: "Mode",
     type: "string",
     examples: ["mode:managed"],
+  },
+  {
+    field: "unique",
+    label: "Unique manager key",
+    type: "string",
+    examples: ["unique:true"],
   },
   {
     field: "status",
@@ -107,6 +114,8 @@ const FIELD_ALIASES: Record<string, RpsSearchField> = {
   status: "status",
   team: "team",
   team_id: "team",
+  unique: "unique",
+  is_unique_manager_key: "unique",
   updated: "updated",
   updated_at: "updated",
 };

--- a/web/graphql/graphql.schema.json
+++ b/web/graphql/graphql.schema.json
@@ -13085,22 +13085,6 @@
         "description": null,
         "fields": [
           {
-            "name": "distinct_manager_keys",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "bigint",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "managed_rps",
             "description": null,
             "args": [],
@@ -13149,22 +13133,6 @@
             "deprecationReason": null
           },
           {
-            "name": "rps_on_shared_keys",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "bigint",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "self_managed_rps",
             "description": null,
             "args": [],
@@ -13181,7 +13149,7 @@
             "deprecationReason": null
           },
           {
-            "name": "shared_key_groups",
+            "name": "shared_manager_key_rps",
             "description": null,
             "args": [],
             "type": {
@@ -13342,6 +13310,22 @@
           },
           {
             "name": "total_rps",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_manager_key_rps",
             "description": null,
             "args": [],
             "type": {
@@ -13421,18 +13405,6 @@
             "deprecationReason": null
           },
           {
-            "name": "distinct_manager_keys",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "bigint_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "managed_rps",
             "description": null,
             "type": {
@@ -13469,18 +13441,6 @@
             "deprecationReason": null
           },
           {
-            "name": "rps_on_shared_keys",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "bigint_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "self_managed_rps",
             "description": null,
             "type": {
@@ -13493,7 +13453,7 @@
             "deprecationReason": null
           },
           {
-            "name": "shared_key_groups",
+            "name": "shared_manager_key_rps",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -13614,6 +13574,18 @@
           },
           {
             "name": "total_rps",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_manager_key_rps",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -13638,12 +13610,6 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "distinct_manager_keys",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "managed_rps",
             "description": "column name",
             "isDeprecated": false,
@@ -13662,19 +13628,13 @@
             "deprecationReason": null
           },
           {
-            "name": "rps_on_shared_keys",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "self_managed_rps",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "shared_key_groups",
+            "name": "shared_manager_key_rps",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -13735,6 +13695,12 @@
           },
           {
             "name": "total_rps",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_manager_key_rps",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -13749,18 +13715,6 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "distinct_manager_keys",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "managed_rps",
             "description": null,
             "type": {
@@ -13797,18 +13751,6 @@
             "deprecationReason": null
           },
           {
-            "name": "rps_on_shared_keys",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "self_managed_rps",
             "description": null,
             "type": {
@@ -13821,7 +13763,7 @@
             "deprecationReason": null
           },
           {
-            "name": "shared_key_groups",
+            "name": "shared_manager_key_rps",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -13942,6 +13884,1156 @@
           },
           {
             "name": "total_rps",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_manager_key_rps",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "admin_rp_manager_key_migration",
+        "description": null,
+        "fields": [
+          {
+            "name": "audit_blocked",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_deleted",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_deletion_overdue",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_deletion_scheduled",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_failed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_pending",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_ready_for_external_cleanup",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_shared_with_audit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_shared_without_audit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "remaining_cron_candidates",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_excluded_from_cron",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_with_audit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "admin_rp_manager_key_migration_bool_exp_bool_exp",
+        "description": "Boolean expression to filter rows from the logical model for \"admin_rp_manager_key_migration\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_rp_manager_key_migration_bool_exp_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "admin_rp_manager_key_migration_bool_exp_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_rp_manager_key_migration_bool_exp_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_blocked",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_deleted",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_deletion_overdue",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_deletion_scheduled",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_failed",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_pending",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_ready_for_external_cleanup",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_shared_with_audit",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_shared_without_audit",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "remaining_cron_candidates",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_excluded_from_cron",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_with_audit",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "admin_rp_manager_key_migration_enum_name",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "audit_blocked",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_deleted",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_deletion_overdue",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_deletion_scheduled",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_failed",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_pending",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_ready_for_external_cleanup",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_shared_with_audit",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_shared_without_audit",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "remaining_cron_candidates",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_excluded_from_cron",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_with_audit",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "admin_rp_manager_key_migration_order_by",
+        "description": "Ordering options when selecting data from \"admin_rp_manager_key_migration\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "audit_blocked",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_deleted",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_deletion_overdue",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_deletion_scheduled",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_failed",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_pending",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audit_ready_for_external_cleanup",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_shared_with_audit",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_shared_without_audit",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "remaining_cron_candidates",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_excluded_from_cron",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_with_audit",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "admin_rp_manager_key_migration_queue",
+        "description": null,
+        "fields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bigint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "admin_rp_manager_key_migration_queue_bool_exp_bool_exp",
+        "description": "Boolean expression to filter rows from the logical model for \"admin_rp_manager_key_migration_queue\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_rp_manager_key_migration_queue_bool_exp_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "admin_rp_manager_key_migration_queue_bool_exp_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_rp_manager_key_migration_queue_bool_exp_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_name",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_count",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bigint_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "admin_rp_manager_key_migration_queue_enum_name",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "app_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_name",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_count",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "admin_rp_manager_key_migration_queue_order_by",
+        "description": "Ordering options when selecting data from \"admin_rp_manager_key_migration_queue\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_name",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_count",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -49676,6 +50768,64 @@
             "deprecationReason": null
           },
           {
+            "name": "delete_rp_manager_key_migration_audit",
+            "description": "delete data from the table: \"rp_manager_key_migration_audit\"",
+            "args": [
+              {
+                "name": "where",
+                "description": "filter the rows which have to be deleted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "rp_manager_key_migration_audit_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "delete_rp_manager_key_migration_audit_by_pk",
+            "description": "delete single row from the table: \"rp_manager_key_migration_audit\"",
+            "args": [
+              {
+                "name": "rp_id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "delete_rp_registration",
             "description": "delete data from the table: \"rp_registration\"",
             "args": [
@@ -52181,6 +53331,96 @@
             "type": {
               "kind": "OBJECT",
               "name": "role",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insert_rp_manager_key_migration_audit",
+            "description": "insert data into the table: \"rp_manager_key_migration_audit\"",
+            "args": [
+              {
+                "name": "objects",
+                "description": "the rows to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "rp_manager_key_migration_audit_insert_input",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "on_conflict",
+                "description": "upsert condition",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_on_conflict",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insert_rp_manager_key_migration_audit_one",
+            "description": "insert a single row into the table: \"rp_manager_key_migration_audit\"",
+            "args": [
+              {
+                "name": "object",
+                "description": "the row to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "rp_manager_key_migration_audit_insert_input",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "on_conflict",
+                "description": "upsert condition",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_on_conflict",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit",
               "ofType": null
             },
             "isDeprecated": false,
@@ -56698,6 +57938,273 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "role_mutation_response",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_rp_manager_key_migration_audit",
+            "description": "update data of the table: \"rp_manager_key_migration_audit\"",
+            "args": [
+              {
+                "name": "_append",
+                "description": "append existing jsonb value of filtered columns with new jsonb value",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_append_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_delete_at_path",
+                "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_delete_at_path_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_delete_elem",
+                "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_delete_elem_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_delete_key",
+                "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_delete_key_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_inc",
+                "description": "increments the numeric columns with given value of the filtered values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_inc_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_prepend",
+                "description": "prepend existing jsonb value of filtered columns with new jsonb value",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_prepend_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_set",
+                "description": "sets the columns of the filtered rows to the given values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_set_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows which have to be updated",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "rp_manager_key_migration_audit_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_rp_manager_key_migration_audit_by_pk",
+            "description": "update single row of the table: \"rp_manager_key_migration_audit\"",
+            "args": [
+              {
+                "name": "_append",
+                "description": "append existing jsonb value of filtered columns with new jsonb value",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_append_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_delete_at_path",
+                "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_delete_at_path_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_delete_elem",
+                "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_delete_elem_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_delete_key",
+                "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_delete_key_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_inc",
+                "description": "increments the numeric columns with given value of the filtered values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_inc_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_prepend",
+                "description": "prepend existing jsonb value of filtered columns with new jsonb value",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_prepend_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_set",
+                "description": "sets the columns of the filtered rows to the given values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_set_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pk_columns",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "rp_manager_key_migration_audit_pk_columns_input",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_rp_manager_key_migration_audit_many",
+            "description": "update multiples rows of table: \"rp_manager_key_migration_audit\"",
+            "args": [
+              {
+                "name": "updates",
+                "description": "updates to execute, in order",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "rp_manager_key_migration_audit_updates",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "rp_manager_key_migration_audit_mutation_response",
                 "ofType": null
               }
             },
@@ -66383,6 +67890,208 @@
             "deprecationReason": null
           },
           {
+            "name": "admin_rp_manager_key_migration",
+            "description": null,
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "admin_rp_manager_key_migration_enum_name",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "admin_rp_manager_key_migration_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_rp_manager_key_migration_bool_exp_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "admin_rp_manager_key_migration",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "admin_rp_manager_key_migration_queue",
+            "description": null,
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "admin_rp_manager_key_migration_queue_enum_name",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "admin_rp_manager_key_migration_queue_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_rp_manager_key_migration_queue_bool_exp_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "admin_rp_manager_key_migration_queue",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "api_key",
             "description": "fetch data from the table: \"api_key\"",
             "args": [
@@ -71536,6 +73245,229 @@
             "deprecationReason": null
           },
           {
+            "name": "rp_manager_key_migration_audit",
+            "description": "fetch data from the table: \"rp_manager_key_migration_audit\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "rp_manager_key_migration_audit_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "rp_manager_key_migration_audit_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "rp_manager_key_migration_audit",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_manager_key_migration_audit_aggregate",
+            "description": "fetch aggregated fields from the table: \"rp_manager_key_migration_audit\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "rp_manager_key_migration_audit_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "rp_manager_key_migration_audit_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "rp_manager_key_migration_audit_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_manager_key_migration_audit_by_pk",
+            "description": "fetch data from the table: \"rp_manager_key_migration_audit\" using primary key columns",
+            "args": [
+              {
+                "name": "rp_id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "rp_registration",
             "description": "An array relationship",
             "args": [
@@ -75031,6 +76963,3478 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit",
+        "description": "columns and relationships of \"rp_manager_key_migration_audit\"",
+        "fields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_candidate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "completed_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletion_scheduled_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_attempt_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_stage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "migration_status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_arn",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "operation_hashes",
+            "description": null,
+            "args": [
+              {
+                "name": "path",
+                "description": "JSON select path",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "jsonb",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retry_after",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shared_manager_kms_key_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "skipped_registries",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit_aggregate",
+        "description": "aggregated selection of \"rp_manager_key_migration_audit\"",
+        "fields": [
+          {
+            "name": "aggregate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_aggregate_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "rp_manager_key_migration_audit",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit_aggregate_fields",
+        "description": "aggregate fields of \"rp_manager_key_migration_audit\"",
+        "fields": [
+          {
+            "name": "avg",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_avg_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count",
+            "description": null,
+            "args": [
+              {
+                "name": "columns",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "rp_manager_key_migration_audit_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "distinct",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_max_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_min_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_stddev_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_pop",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_stddev_pop_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_samp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_stddev_samp_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sum",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_sum_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_pop",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_var_pop_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_samp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_var_samp_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "variance",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit_variance_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_append_input",
+        "description": "append existing jsonb value of filtered columns with new jsonb value",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "operation_hashes",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit_avg_fields",
+        "description": "aggregate avg on columns",
+        "fields": [
+          {
+            "name": "attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_bool_exp",
+        "description": "Boolean expression to filter rows from the table \"rp_manager_key_migration_audit\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "rp_manager_key_migration_audit_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "attempt_count",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_candidate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "completed_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletion_scheduled_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_attempt_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "uuid_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_stage",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "migration_status",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_arn",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "operation_hashes",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "jsonb_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retry_after",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shared_manager_kms_key_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "skipped_registries",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_array_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "rp_manager_key_migration_audit_constraint",
+        "description": "unique or primary key constraints on table \"rp_manager_key_migration_audit\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "rp_manager_key_migration_audit_pkey",
+            "description": "unique or primary key constraint on columns \"rp_id\"",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_delete_at_path_input",
+        "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "operation_hashes",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_delete_elem_input",
+        "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "operation_hashes",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_delete_key_input",
+        "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "operation_hashes",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_inc_input",
+        "description": "input type for incrementing numeric columns in table \"rp_manager_key_migration_audit\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "attempt_count",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_insert_input",
+        "description": "input type for inserting data into table \"rp_manager_key_migration_audit\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "attempt_count",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_candidate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "completed_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletion_scheduled_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_attempt_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_stage",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "migration_status",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_arn",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "operation_hashes",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retry_after",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shared_manager_kms_key_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "skipped_registries",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit_max_fields",
+        "description": "aggregate max on columns",
+        "fields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "completed_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletion_scheduled_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_attempt_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_stage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "migration_status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_arn",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retry_after",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shared_manager_kms_key_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "skipped_registries",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit_min_fields",
+        "description": "aggregate min on columns",
+        "fields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "completed_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletion_scheduled_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_attempt_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_stage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "migration_status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_arn",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retry_after",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shared_manager_kms_key_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "skipped_registries",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit_mutation_response",
+        "description": "response of any mutation on the table \"rp_manager_key_migration_audit\"",
+        "fields": [
+          {
+            "name": "affected_rows",
+            "description": "number of rows affected by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "returning",
+            "description": "data from the rows affected by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "rp_manager_key_migration_audit",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_on_conflict",
+        "description": "on_conflict condition type for table \"rp_manager_key_migration_audit\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "constraint",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "rp_manager_key_migration_audit_constraint",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_columns",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "rp_manager_key_migration_audit_update_column",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": "[]",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "rp_manager_key_migration_audit_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_order_by",
+        "description": "Ordering options when selecting data from \"rp_manager_key_migration_audit\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "attempt_count",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_candidate",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "completed_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletion_scheduled_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_attempt_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_stage",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "migration_status",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_arn",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "operation_hashes",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retry_after",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shared_manager_kms_key_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "skipped_registries",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_pk_columns_input",
+        "description": "primary key columns input for table: rp_manager_key_migration_audit",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "rp_id",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_prepend_input",
+        "description": "prepend existing jsonb value of filtered columns with new jsonb value",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "operation_hashes",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "rp_manager_key_migration_audit_select_column",
+        "description": "select columns of table \"rp_manager_key_migration_audit\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "app_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "attempt_count",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_candidate",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "completed_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletion_scheduled_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_attempt_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_stage",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "migration_status",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_arn",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "operation_hashes",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retry_after",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shared_manager_kms_key_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "skipped_registries",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_set_input",
+        "description": "input type for updating data in table \"rp_manager_key_migration_audit\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "attempt_count",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_candidate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "completed_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletion_scheduled_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_attempt_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_stage",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "migration_status",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_arn",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "operation_hashes",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retry_after",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shared_manager_kms_key_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "skipped_registries",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit_stddev_fields",
+        "description": "aggregate stddev on columns",
+        "fields": [
+          {
+            "name": "attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit_stddev_pop_fields",
+        "description": "aggregate stddev_pop on columns",
+        "fields": [
+          {
+            "name": "attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit_stddev_samp_fields",
+        "description": "aggregate stddev_samp on columns",
+        "fields": [
+          {
+            "name": "attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_stream_cursor_input",
+        "description": "Streaming cursor of the table \"rp_manager_key_migration_audit\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "initial_value",
+            "description": "Stream column input with initial value",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "rp_manager_key_migration_audit_stream_cursor_value_input",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ordering",
+            "description": "cursor ordering",
+            "type": {
+              "kind": "ENUM",
+              "name": "cursor_ordering",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_stream_cursor_value_input",
+        "description": "Initial value of the column from where the streaming should start",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "app_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "attempt_count",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_candidate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "completed_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletion_scheduled_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_attempt_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_stage",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "migration_status",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_arn",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "operation_hashes",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retry_after",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shared_manager_kms_key_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "skipped_registries",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit_sum_fields",
+        "description": "aggregate sum on columns",
+        "fields": [
+          {
+            "name": "attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "rp_manager_key_migration_audit_update_column",
+        "description": "update columns of table \"rp_manager_key_migration_audit\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "app_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "attempt_count",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_candidate",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_status",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "completed_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletion_scheduled_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expected_deletion_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_attempt_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_detail",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "last_error_stage",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "migration_status",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_arn",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "old_manager_kms_key_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "operation_hashes",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retry_after",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shared_manager_kms_key_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "skipped_registries",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "rp_manager_key_migration_audit_updates",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_append",
+            "description": "append existing jsonb value of filtered columns with new jsonb value",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "rp_manager_key_migration_audit_append_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_delete_at_path",
+            "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "rp_manager_key_migration_audit_delete_at_path_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_delete_elem",
+            "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "rp_manager_key_migration_audit_delete_elem_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_delete_key",
+            "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "rp_manager_key_migration_audit_delete_key_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_inc",
+            "description": "increments the numeric columns with given value of the filtered values",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "rp_manager_key_migration_audit_inc_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_prepend",
+            "description": "prepend existing jsonb value of filtered columns with new jsonb value",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "rp_manager_key_migration_audit_prepend_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_set",
+            "description": "sets the columns of the filtered rows to the given values",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "rp_manager_key_migration_audit_set_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": "filter the rows which have to be updated",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "rp_manager_key_migration_audit_bool_exp",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit_var_pop_fields",
+        "description": "aggregate var_pop on columns",
+        "fields": [
+          {
+            "name": "attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit_var_samp_fields",
+        "description": "aggregate var_samp on columns",
+        "fields": [
+          {
+            "name": "attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "rp_manager_key_migration_audit_variance_fields",
+        "description": "aggregate variance on columns",
+        "fields": [
+          {
+            "name": "attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cleanup_attempt_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -81325,6 +86729,208 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "admin_rp_inventory",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "admin_rp_manager_key_migration",
+            "description": null,
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "admin_rp_manager_key_migration_enum_name",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "admin_rp_manager_key_migration_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_rp_manager_key_migration_bool_exp_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "admin_rp_manager_key_migration",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "admin_rp_manager_key_migration_queue",
+            "description": null,
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "admin_rp_manager_key_migration_queue_enum_name",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "admin_rp_manager_key_migration_queue_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "admin_rp_manager_key_migration_queue_bool_exp_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "admin_rp_manager_key_migration_queue",
                     "ofType": null
                   }
                 }
@@ -87894,6 +93500,302 @@
             "deprecationReason": null
           },
           {
+            "name": "rp_manager_key_migration_audit",
+            "description": "fetch data from the table: \"rp_manager_key_migration_audit\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "rp_manager_key_migration_audit_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "rp_manager_key_migration_audit_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "rp_manager_key_migration_audit",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_manager_key_migration_audit_aggregate",
+            "description": "fetch aggregated fields from the table: \"rp_manager_key_migration_audit\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "rp_manager_key_migration_audit_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "rp_manager_key_migration_audit_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "rp_manager_key_migration_audit_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_manager_key_migration_audit_by_pk",
+            "description": "fetch data from the table: \"rp_manager_key_migration_audit\" using primary key columns",
+            "args": [
+              {
+                "name": "rp_id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "rp_manager_key_migration_audit",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rp_manager_key_migration_audit_stream",
+            "description": "fetch data from the table in a streaming manner: \"rp_manager_key_migration_audit\"",
+            "args": [
+              {
+                "name": "batch_size",
+                "description": "maximum number of rows returned in a single batch",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "cursor",
+                "description": "cursor to stream the results returned by the query",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "rp_manager_key_migration_audit_stream_cursor_input",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "rp_manager_key_migration_audit_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "rp_manager_key_migration_audit",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "rp_registration",
             "description": "An array relationship",
             "args": [
@@ -94180,6 +100082,151 @@
                 "kind": "INPUT_OBJECT",
                 "name": "user_bool_exp",
                 "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "uuid",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "uuid_comparison_exp",
+        "description": "Boolean expression to compare columns of type \"uuid\". All fields are combined with logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_eq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_is_null",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_neq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_nin",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,

--- a/web/graphql/graphql.ts
+++ b/web/graphql/graphql.ts
@@ -39,6 +39,7 @@ export type Scalars = {
   rp_registration_status: { input: unknown; output: unknown };
   timestamp: { input: string; output: string };
   timestamptz: { input: string; output: string };
+  uuid: { input: unknown; output: unknown };
   violation_enum: { input: unknown; output: unknown };
 };
 
@@ -1806,13 +1807,11 @@ export type Admin_Dashboard_Queue_Order_By = {
 
 export type Admin_Rp_Inventory = {
   __typename?: "admin_rp_inventory";
-  distinct_manager_keys: Scalars["bigint"]["output"];
   managed_rps: Scalars["bigint"]["output"];
   managed_with_key: Scalars["bigint"]["output"];
   managed_without_key: Scalars["bigint"]["output"];
-  rps_on_shared_keys: Scalars["bigint"]["output"];
   self_managed_rps: Scalars["bigint"]["output"];
-  shared_key_groups: Scalars["bigint"]["output"];
+  shared_manager_key_rps: Scalars["bigint"]["output"];
   staging_status_deactivated: Scalars["bigint"]["output"];
   staging_status_failed: Scalars["bigint"]["output"];
   staging_status_null: Scalars["bigint"]["output"];
@@ -1823,6 +1822,7 @@ export type Admin_Rp_Inventory = {
   status_pending: Scalars["bigint"]["output"];
   status_registered: Scalars["bigint"]["output"];
   total_rps: Scalars["bigint"]["output"];
+  unique_manager_key_rps: Scalars["bigint"]["output"];
 };
 
 /** Boolean expression to filter rows from the logical model for "admin_rp_inventory". All fields are combined with a logical 'AND'. */
@@ -1830,13 +1830,11 @@ export type Admin_Rp_Inventory_Bool_Exp_Bool_Exp = {
   _and?: InputMaybe<Array<Admin_Rp_Inventory_Bool_Exp_Bool_Exp>>;
   _not?: InputMaybe<Admin_Rp_Inventory_Bool_Exp_Bool_Exp>;
   _or?: InputMaybe<Array<Admin_Rp_Inventory_Bool_Exp_Bool_Exp>>;
-  distinct_manager_keys?: InputMaybe<Bigint_Comparison_Exp>;
   managed_rps?: InputMaybe<Bigint_Comparison_Exp>;
   managed_with_key?: InputMaybe<Bigint_Comparison_Exp>;
   managed_without_key?: InputMaybe<Bigint_Comparison_Exp>;
-  rps_on_shared_keys?: InputMaybe<Bigint_Comparison_Exp>;
   self_managed_rps?: InputMaybe<Bigint_Comparison_Exp>;
-  shared_key_groups?: InputMaybe<Bigint_Comparison_Exp>;
+  shared_manager_key_rps?: InputMaybe<Bigint_Comparison_Exp>;
   staging_status_deactivated?: InputMaybe<Bigint_Comparison_Exp>;
   staging_status_failed?: InputMaybe<Bigint_Comparison_Exp>;
   staging_status_null?: InputMaybe<Bigint_Comparison_Exp>;
@@ -1847,11 +1845,10 @@ export type Admin_Rp_Inventory_Bool_Exp_Bool_Exp = {
   status_pending?: InputMaybe<Bigint_Comparison_Exp>;
   status_registered?: InputMaybe<Bigint_Comparison_Exp>;
   total_rps?: InputMaybe<Bigint_Comparison_Exp>;
+  unique_manager_key_rps?: InputMaybe<Bigint_Comparison_Exp>;
 };
 
 export enum Admin_Rp_Inventory_Enum_Name {
-  /** column name */
-  DistinctManagerKeys = "distinct_manager_keys",
   /** column name */
   ManagedRps = "managed_rps",
   /** column name */
@@ -1859,11 +1856,9 @@ export enum Admin_Rp_Inventory_Enum_Name {
   /** column name */
   ManagedWithoutKey = "managed_without_key",
   /** column name */
-  RpsOnSharedKeys = "rps_on_shared_keys",
-  /** column name */
   SelfManagedRps = "self_managed_rps",
   /** column name */
-  SharedKeyGroups = "shared_key_groups",
+  SharedManagerKeyRps = "shared_manager_key_rps",
   /** column name */
   StagingStatusDeactivated = "staging_status_deactivated",
   /** column name */
@@ -1884,17 +1879,17 @@ export enum Admin_Rp_Inventory_Enum_Name {
   StatusRegistered = "status_registered",
   /** column name */
   TotalRps = "total_rps",
+  /** column name */
+  UniqueManagerKeyRps = "unique_manager_key_rps",
 }
 
 /** Ordering options when selecting data from "admin_rp_inventory". */
 export type Admin_Rp_Inventory_Order_By = {
-  distinct_manager_keys?: InputMaybe<Order_By>;
   managed_rps?: InputMaybe<Order_By>;
   managed_with_key?: InputMaybe<Order_By>;
   managed_without_key?: InputMaybe<Order_By>;
-  rps_on_shared_keys?: InputMaybe<Order_By>;
   self_managed_rps?: InputMaybe<Order_By>;
-  shared_key_groups?: InputMaybe<Order_By>;
+  shared_manager_key_rps?: InputMaybe<Order_By>;
   staging_status_deactivated?: InputMaybe<Order_By>;
   staging_status_failed?: InputMaybe<Order_By>;
   staging_status_null?: InputMaybe<Order_By>;
@@ -1905,6 +1900,152 @@ export type Admin_Rp_Inventory_Order_By = {
   status_pending?: InputMaybe<Order_By>;
   status_registered?: InputMaybe<Order_By>;
   total_rps?: InputMaybe<Order_By>;
+  unique_manager_key_rps?: InputMaybe<Order_By>;
+};
+
+export type Admin_Rp_Manager_Key_Migration = {
+  __typename?: "admin_rp_manager_key_migration";
+  audit_blocked: Scalars["bigint"]["output"];
+  audit_deleted: Scalars["bigint"]["output"];
+  audit_deletion_overdue: Scalars["bigint"]["output"];
+  audit_deletion_scheduled: Scalars["bigint"]["output"];
+  audit_failed: Scalars["bigint"]["output"];
+  audit_pending: Scalars["bigint"]["output"];
+  audit_ready_for_external_cleanup: Scalars["bigint"]["output"];
+  on_shared_with_audit: Scalars["bigint"]["output"];
+  on_shared_without_audit: Scalars["bigint"]["output"];
+  remaining_cron_candidates: Scalars["bigint"]["output"];
+  unique_excluded_from_cron: Scalars["bigint"]["output"];
+  unique_with_audit: Scalars["bigint"]["output"];
+};
+
+/** Boolean expression to filter rows from the logical model for "admin_rp_manager_key_migration". All fields are combined with a logical 'AND'. */
+export type Admin_Rp_Manager_Key_Migration_Bool_Exp_Bool_Exp = {
+  _and?: InputMaybe<Array<Admin_Rp_Manager_Key_Migration_Bool_Exp_Bool_Exp>>;
+  _not?: InputMaybe<Admin_Rp_Manager_Key_Migration_Bool_Exp_Bool_Exp>;
+  _or?: InputMaybe<Array<Admin_Rp_Manager_Key_Migration_Bool_Exp_Bool_Exp>>;
+  audit_blocked?: InputMaybe<Bigint_Comparison_Exp>;
+  audit_deleted?: InputMaybe<Bigint_Comparison_Exp>;
+  audit_deletion_overdue?: InputMaybe<Bigint_Comparison_Exp>;
+  audit_deletion_scheduled?: InputMaybe<Bigint_Comparison_Exp>;
+  audit_failed?: InputMaybe<Bigint_Comparison_Exp>;
+  audit_pending?: InputMaybe<Bigint_Comparison_Exp>;
+  audit_ready_for_external_cleanup?: InputMaybe<Bigint_Comparison_Exp>;
+  on_shared_with_audit?: InputMaybe<Bigint_Comparison_Exp>;
+  on_shared_without_audit?: InputMaybe<Bigint_Comparison_Exp>;
+  remaining_cron_candidates?: InputMaybe<Bigint_Comparison_Exp>;
+  unique_excluded_from_cron?: InputMaybe<Bigint_Comparison_Exp>;
+  unique_with_audit?: InputMaybe<Bigint_Comparison_Exp>;
+};
+
+export enum Admin_Rp_Manager_Key_Migration_Enum_Name {
+  /** column name */
+  AuditBlocked = "audit_blocked",
+  /** column name */
+  AuditDeleted = "audit_deleted",
+  /** column name */
+  AuditDeletionOverdue = "audit_deletion_overdue",
+  /** column name */
+  AuditDeletionScheduled = "audit_deletion_scheduled",
+  /** column name */
+  AuditFailed = "audit_failed",
+  /** column name */
+  AuditPending = "audit_pending",
+  /** column name */
+  AuditReadyForExternalCleanup = "audit_ready_for_external_cleanup",
+  /** column name */
+  OnSharedWithAudit = "on_shared_with_audit",
+  /** column name */
+  OnSharedWithoutAudit = "on_shared_without_audit",
+  /** column name */
+  RemainingCronCandidates = "remaining_cron_candidates",
+  /** column name */
+  UniqueExcludedFromCron = "unique_excluded_from_cron",
+  /** column name */
+  UniqueWithAudit = "unique_with_audit",
+}
+
+/** Ordering options when selecting data from "admin_rp_manager_key_migration". */
+export type Admin_Rp_Manager_Key_Migration_Order_By = {
+  audit_blocked?: InputMaybe<Order_By>;
+  audit_deleted?: InputMaybe<Order_By>;
+  audit_deletion_overdue?: InputMaybe<Order_By>;
+  audit_deletion_scheduled?: InputMaybe<Order_By>;
+  audit_failed?: InputMaybe<Order_By>;
+  audit_pending?: InputMaybe<Order_By>;
+  audit_ready_for_external_cleanup?: InputMaybe<Order_By>;
+  on_shared_with_audit?: InputMaybe<Order_By>;
+  on_shared_without_audit?: InputMaybe<Order_By>;
+  remaining_cron_candidates?: InputMaybe<Order_By>;
+  unique_excluded_from_cron?: InputMaybe<Order_By>;
+  unique_with_audit?: InputMaybe<Order_By>;
+};
+
+export type Admin_Rp_Manager_Key_Migration_Queue = {
+  __typename?: "admin_rp_manager_key_migration_queue";
+  app_id: Scalars["String"]["output"];
+  app_name?: Maybe<Scalars["String"]["output"]>;
+  cleanup_status?: Maybe<Scalars["String"]["output"]>;
+  expected_deletion_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  kind: Scalars["String"]["output"];
+  last_error_detail?: Maybe<Scalars["String"]["output"]>;
+  rp_id: Scalars["String"]["output"];
+  total_count: Scalars["bigint"]["output"];
+  updated_at?: Maybe<Scalars["timestamptz"]["output"]>;
+};
+
+/** Boolean expression to filter rows from the logical model for "admin_rp_manager_key_migration_queue". All fields are combined with a logical 'AND'. */
+export type Admin_Rp_Manager_Key_Migration_Queue_Bool_Exp_Bool_Exp = {
+  _and?: InputMaybe<
+    Array<Admin_Rp_Manager_Key_Migration_Queue_Bool_Exp_Bool_Exp>
+  >;
+  _not?: InputMaybe<Admin_Rp_Manager_Key_Migration_Queue_Bool_Exp_Bool_Exp>;
+  _or?: InputMaybe<
+    Array<Admin_Rp_Manager_Key_Migration_Queue_Bool_Exp_Bool_Exp>
+  >;
+  app_id?: InputMaybe<String_Comparison_Exp>;
+  app_name?: InputMaybe<String_Comparison_Exp>;
+  cleanup_status?: InputMaybe<String_Comparison_Exp>;
+  expected_deletion_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  kind?: InputMaybe<String_Comparison_Exp>;
+  last_error_detail?: InputMaybe<String_Comparison_Exp>;
+  rp_id?: InputMaybe<String_Comparison_Exp>;
+  total_count?: InputMaybe<Bigint_Comparison_Exp>;
+  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+};
+
+export enum Admin_Rp_Manager_Key_Migration_Queue_Enum_Name {
+  /** column name */
+  AppId = "app_id",
+  /** column name */
+  AppName = "app_name",
+  /** column name */
+  CleanupStatus = "cleanup_status",
+  /** column name */
+  ExpectedDeletionAt = "expected_deletion_at",
+  /** column name */
+  Kind = "kind",
+  /** column name */
+  LastErrorDetail = "last_error_detail",
+  /** column name */
+  RpId = "rp_id",
+  /** column name */
+  TotalCount = "total_count",
+  /** column name */
+  UpdatedAt = "updated_at",
+}
+
+/** Ordering options when selecting data from "admin_rp_manager_key_migration_queue". */
+export type Admin_Rp_Manager_Key_Migration_Queue_Order_By = {
+  app_id?: InputMaybe<Order_By>;
+  app_name?: InputMaybe<Order_By>;
+  cleanup_status?: InputMaybe<Order_By>;
+  expected_deletion_at?: InputMaybe<Order_By>;
+  kind?: InputMaybe<Order_By>;
+  last_error_detail?: InputMaybe<Order_By>;
+  rp_id?: InputMaybe<Order_By>;
+  total_count?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
 };
 
 /** columns and relationships of "api_key" */
@@ -6710,6 +6851,10 @@ export type Mutation_Root = {
   delete_role?: Maybe<Role_Mutation_Response>;
   /** delete single row from the table: "role" */
   delete_role_by_pk?: Maybe<Role>;
+  /** delete data from the table: "rp_manager_key_migration_audit" */
+  delete_rp_manager_key_migration_audit?: Maybe<Rp_Manager_Key_Migration_Audit_Mutation_Response>;
+  /** delete single row from the table: "rp_manager_key_migration_audit" */
+  delete_rp_manager_key_migration_audit_by_pk?: Maybe<Rp_Manager_Key_Migration_Audit>;
   /** delete data from the table: "rp_registration" */
   delete_rp_registration?: Maybe<Rp_Registration_Mutation_Response>;
   /** delete single row from the table: "rp_registration" */
@@ -6827,6 +6972,10 @@ export type Mutation_Root = {
   insert_role?: Maybe<Role_Mutation_Response>;
   /** insert a single row into the table: "role" */
   insert_role_one?: Maybe<Role>;
+  /** insert data into the table: "rp_manager_key_migration_audit" */
+  insert_rp_manager_key_migration_audit?: Maybe<Rp_Manager_Key_Migration_Audit_Mutation_Response>;
+  /** insert a single row into the table: "rp_manager_key_migration_audit" */
+  insert_rp_manager_key_migration_audit_one?: Maybe<Rp_Manager_Key_Migration_Audit>;
   /** insert data into the table: "rp_registration" */
   insert_rp_registration?: Maybe<Rp_Registration_Mutation_Response>;
   /** insert a single row into the table: "rp_registration" */
@@ -7036,6 +7185,14 @@ export type Mutation_Root = {
   update_role_by_pk?: Maybe<Role>;
   /** update multiples rows of table: "role" */
   update_role_many?: Maybe<Array<Maybe<Role_Mutation_Response>>>;
+  /** update data of the table: "rp_manager_key_migration_audit" */
+  update_rp_manager_key_migration_audit?: Maybe<Rp_Manager_Key_Migration_Audit_Mutation_Response>;
+  /** update single row of the table: "rp_manager_key_migration_audit" */
+  update_rp_manager_key_migration_audit_by_pk?: Maybe<Rp_Manager_Key_Migration_Audit>;
+  /** update multiples rows of table: "rp_manager_key_migration_audit" */
+  update_rp_manager_key_migration_audit_many?: Maybe<
+    Array<Maybe<Rp_Manager_Key_Migration_Audit_Mutation_Response>>
+  >;
   /** update data of the table: "rp_registration" */
   update_rp_registration?: Maybe<Rp_Registration_Mutation_Response>;
   /** update single row of the table: "rp_registration" */
@@ -7351,6 +7508,16 @@ export type Mutation_RootDelete_RoleArgs = {
 /** mutation root */
 export type Mutation_RootDelete_Role_By_PkArgs = {
   value: Scalars["String"]["input"];
+};
+
+/** mutation root */
+export type Mutation_RootDelete_Rp_Manager_Key_Migration_AuditArgs = {
+  where: Rp_Manager_Key_Migration_Audit_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootDelete_Rp_Manager_Key_Migration_Audit_By_PkArgs = {
+  rp_id: Scalars["String"]["input"];
 };
 
 /** mutation root */
@@ -7696,6 +7863,18 @@ export type Mutation_RootInsert_RoleArgs = {
 export type Mutation_RootInsert_Role_OneArgs = {
   object: Role_Insert_Input;
   on_conflict?: InputMaybe<Role_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_Rp_Manager_Key_Migration_AuditArgs = {
+  objects: Array<Rp_Manager_Key_Migration_Audit_Insert_Input>;
+  on_conflict?: InputMaybe<Rp_Manager_Key_Migration_Audit_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_Rp_Manager_Key_Migration_Audit_OneArgs = {
+  object: Rp_Manager_Key_Migration_Audit_Insert_Input;
+  on_conflict?: InputMaybe<Rp_Manager_Key_Migration_Audit_On_Conflict>;
 };
 
 /** mutation root */
@@ -8280,6 +8459,35 @@ export type Mutation_RootUpdate_Role_By_PkArgs = {
 /** mutation root */
 export type Mutation_RootUpdate_Role_ManyArgs = {
   updates: Array<Role_Updates>;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_Rp_Manager_Key_Migration_AuditArgs = {
+  _append?: InputMaybe<Rp_Manager_Key_Migration_Audit_Append_Input>;
+  _delete_at_path?: InputMaybe<Rp_Manager_Key_Migration_Audit_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<Rp_Manager_Key_Migration_Audit_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<Rp_Manager_Key_Migration_Audit_Delete_Key_Input>;
+  _inc?: InputMaybe<Rp_Manager_Key_Migration_Audit_Inc_Input>;
+  _prepend?: InputMaybe<Rp_Manager_Key_Migration_Audit_Prepend_Input>;
+  _set?: InputMaybe<Rp_Manager_Key_Migration_Audit_Set_Input>;
+  where: Rp_Manager_Key_Migration_Audit_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_Rp_Manager_Key_Migration_Audit_By_PkArgs = {
+  _append?: InputMaybe<Rp_Manager_Key_Migration_Audit_Append_Input>;
+  _delete_at_path?: InputMaybe<Rp_Manager_Key_Migration_Audit_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<Rp_Manager_Key_Migration_Audit_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<Rp_Manager_Key_Migration_Audit_Delete_Key_Input>;
+  _inc?: InputMaybe<Rp_Manager_Key_Migration_Audit_Inc_Input>;
+  _prepend?: InputMaybe<Rp_Manager_Key_Migration_Audit_Prepend_Input>;
+  _set?: InputMaybe<Rp_Manager_Key_Migration_Audit_Set_Input>;
+  pk_columns: Rp_Manager_Key_Migration_Audit_Pk_Columns_Input;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_Rp_Manager_Key_Migration_Audit_ManyArgs = {
+  updates: Array<Rp_Manager_Key_Migration_Audit_Updates>;
 };
 
 /** mutation root */
@@ -9666,6 +9874,8 @@ export type Query_Root = {
   admin_dashboard_inventory: Array<Admin_Dashboard_Inventory>;
   admin_dashboard_queues: Array<Admin_Dashboard_Queue>;
   admin_rp_inventory: Array<Admin_Rp_Inventory>;
+  admin_rp_manager_key_migration: Array<Admin_Rp_Manager_Key_Migration>;
+  admin_rp_manager_key_migration_queue: Array<Admin_Rp_Manager_Key_Migration_Queue>;
   /** fetch data from the table: "api_key" */
   api_key: Array<Api_Key>;
   /** fetch aggregated fields from the table: "api_key" */
@@ -9803,6 +10013,12 @@ export type Query_Root = {
   role_aggregate: Role_Aggregate;
   /** fetch data from the table: "role" using primary key columns */
   role_by_pk?: Maybe<Role>;
+  /** fetch data from the table: "rp_manager_key_migration_audit" */
+  rp_manager_key_migration_audit: Array<Rp_Manager_Key_Migration_Audit>;
+  /** fetch aggregated fields from the table: "rp_manager_key_migration_audit" */
+  rp_manager_key_migration_audit_aggregate: Rp_Manager_Key_Migration_Audit_Aggregate;
+  /** fetch data from the table: "rp_manager_key_migration_audit" using primary key columns */
+  rp_manager_key_migration_audit_by_pk?: Maybe<Rp_Manager_Key_Migration_Audit>;
   /** An array relationship */
   rp_registration: Array<Rp_Registration>;
   /** An aggregate relationship */
@@ -9931,6 +10147,24 @@ export type Query_RootAdmin_Rp_InventoryArgs = {
   offset?: InputMaybe<Scalars["Int"]["input"]>;
   order_by?: InputMaybe<Array<Admin_Rp_Inventory_Order_By>>;
   where?: InputMaybe<Admin_Rp_Inventory_Bool_Exp_Bool_Exp>;
+};
+
+export type Query_RootAdmin_Rp_Manager_Key_MigrationArgs = {
+  distinct_on?: InputMaybe<Array<Admin_Rp_Manager_Key_Migration_Enum_Name>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Admin_Rp_Manager_Key_Migration_Order_By>>;
+  where?: InputMaybe<Admin_Rp_Manager_Key_Migration_Bool_Exp_Bool_Exp>;
+};
+
+export type Query_RootAdmin_Rp_Manager_Key_Migration_QueueArgs = {
+  distinct_on?: InputMaybe<
+    Array<Admin_Rp_Manager_Key_Migration_Queue_Enum_Name>
+  >;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Admin_Rp_Manager_Key_Migration_Queue_Order_By>>;
+  where?: InputMaybe<Admin_Rp_Manager_Key_Migration_Queue_Bool_Exp_Bool_Exp>;
 };
 
 export type Query_RootApi_KeyArgs = {
@@ -10398,6 +10632,26 @@ export type Query_RootRole_AggregateArgs = {
 
 export type Query_RootRole_By_PkArgs = {
   value: Scalars["String"]["input"];
+};
+
+export type Query_RootRp_Manager_Key_Migration_AuditArgs = {
+  distinct_on?: InputMaybe<Array<Rp_Manager_Key_Migration_Audit_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Rp_Manager_Key_Migration_Audit_Order_By>>;
+  where?: InputMaybe<Rp_Manager_Key_Migration_Audit_Bool_Exp>;
+};
+
+export type Query_RootRp_Manager_Key_Migration_Audit_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Rp_Manager_Key_Migration_Audit_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Rp_Manager_Key_Migration_Audit_Order_By>>;
+  where?: InputMaybe<Rp_Manager_Key_Migration_Audit_Bool_Exp>;
+};
+
+export type Query_RootRp_Manager_Key_Migration_Audit_By_PkArgs = {
+  rp_id: Scalars["String"]["input"];
 };
 
 export type Query_RootRp_RegistrationArgs = {
@@ -10872,6 +11126,475 @@ export type Role_Updates = {
 export type Rollup_App_Stats_Args = {
   _since?: InputMaybe<Scalars["timestamptz"]["input"]>;
   _until?: InputMaybe<Scalars["timestamptz"]["input"]>;
+};
+
+/** columns and relationships of "rp_manager_key_migration_audit" */
+export type Rp_Manager_Key_Migration_Audit = {
+  __typename?: "rp_manager_key_migration_audit";
+  app_id: Scalars["String"]["output"];
+  attempt_count: Scalars["Int"]["output"];
+  cleanup_attempt_count: Scalars["Int"]["output"];
+  cleanup_candidate: Scalars["Boolean"]["output"];
+  cleanup_status: Scalars["String"]["output"];
+  completed_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  created_at: Scalars["timestamptz"]["output"];
+  deletion_scheduled_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  expected_deletion_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  last_attempt_id?: Maybe<Scalars["uuid"]["output"]>;
+  last_error_detail?: Maybe<Scalars["String"]["output"]>;
+  last_error_stage?: Maybe<Scalars["String"]["output"]>;
+  migration_status: Scalars["String"]["output"];
+  old_manager_kms_key_arn: Scalars["String"]["output"];
+  old_manager_kms_key_id: Scalars["String"]["output"];
+  operation_hashes: Scalars["jsonb"]["output"];
+  retry_after?: Maybe<Scalars["timestamptz"]["output"]>;
+  rp_id: Scalars["String"]["output"];
+  shared_manager_kms_key_id: Scalars["String"]["output"];
+  skipped_registries: Array<Scalars["String"]["output"]>;
+  updated_at: Scalars["timestamptz"]["output"];
+};
+
+/** columns and relationships of "rp_manager_key_migration_audit" */
+export type Rp_Manager_Key_Migration_AuditOperation_HashesArgs = {
+  path?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+/** aggregated selection of "rp_manager_key_migration_audit" */
+export type Rp_Manager_Key_Migration_Audit_Aggregate = {
+  __typename?: "rp_manager_key_migration_audit_aggregate";
+  aggregate?: Maybe<Rp_Manager_Key_Migration_Audit_Aggregate_Fields>;
+  nodes: Array<Rp_Manager_Key_Migration_Audit>;
+};
+
+/** aggregate fields of "rp_manager_key_migration_audit" */
+export type Rp_Manager_Key_Migration_Audit_Aggregate_Fields = {
+  __typename?: "rp_manager_key_migration_audit_aggregate_fields";
+  avg?: Maybe<Rp_Manager_Key_Migration_Audit_Avg_Fields>;
+  count: Scalars["Int"]["output"];
+  max?: Maybe<Rp_Manager_Key_Migration_Audit_Max_Fields>;
+  min?: Maybe<Rp_Manager_Key_Migration_Audit_Min_Fields>;
+  stddev?: Maybe<Rp_Manager_Key_Migration_Audit_Stddev_Fields>;
+  stddev_pop?: Maybe<Rp_Manager_Key_Migration_Audit_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Rp_Manager_Key_Migration_Audit_Stddev_Samp_Fields>;
+  sum?: Maybe<Rp_Manager_Key_Migration_Audit_Sum_Fields>;
+  var_pop?: Maybe<Rp_Manager_Key_Migration_Audit_Var_Pop_Fields>;
+  var_samp?: Maybe<Rp_Manager_Key_Migration_Audit_Var_Samp_Fields>;
+  variance?: Maybe<Rp_Manager_Key_Migration_Audit_Variance_Fields>;
+};
+
+/** aggregate fields of "rp_manager_key_migration_audit" */
+export type Rp_Manager_Key_Migration_Audit_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Rp_Manager_Key_Migration_Audit_Select_Column>>;
+  distinct?: InputMaybe<Scalars["Boolean"]["input"]>;
+};
+
+/** append existing jsonb value of filtered columns with new jsonb value */
+export type Rp_Manager_Key_Migration_Audit_Append_Input = {
+  operation_hashes?: InputMaybe<Scalars["jsonb"]["input"]>;
+};
+
+/** aggregate avg on columns */
+export type Rp_Manager_Key_Migration_Audit_Avg_Fields = {
+  __typename?: "rp_manager_key_migration_audit_avg_fields";
+  attempt_count?: Maybe<Scalars["Float"]["output"]>;
+  cleanup_attempt_count?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** Boolean expression to filter rows from the table "rp_manager_key_migration_audit". All fields are combined with a logical 'AND'. */
+export type Rp_Manager_Key_Migration_Audit_Bool_Exp = {
+  _and?: InputMaybe<Array<Rp_Manager_Key_Migration_Audit_Bool_Exp>>;
+  _not?: InputMaybe<Rp_Manager_Key_Migration_Audit_Bool_Exp>;
+  _or?: InputMaybe<Array<Rp_Manager_Key_Migration_Audit_Bool_Exp>>;
+  app_id?: InputMaybe<String_Comparison_Exp>;
+  attempt_count?: InputMaybe<Int_Comparison_Exp>;
+  cleanup_attempt_count?: InputMaybe<Int_Comparison_Exp>;
+  cleanup_candidate?: InputMaybe<Boolean_Comparison_Exp>;
+  cleanup_status?: InputMaybe<String_Comparison_Exp>;
+  completed_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  deletion_scheduled_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  expected_deletion_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  last_attempt_id?: InputMaybe<Uuid_Comparison_Exp>;
+  last_error_detail?: InputMaybe<String_Comparison_Exp>;
+  last_error_stage?: InputMaybe<String_Comparison_Exp>;
+  migration_status?: InputMaybe<String_Comparison_Exp>;
+  old_manager_kms_key_arn?: InputMaybe<String_Comparison_Exp>;
+  old_manager_kms_key_id?: InputMaybe<String_Comparison_Exp>;
+  operation_hashes?: InputMaybe<Jsonb_Comparison_Exp>;
+  retry_after?: InputMaybe<Timestamptz_Comparison_Exp>;
+  rp_id?: InputMaybe<String_Comparison_Exp>;
+  shared_manager_kms_key_id?: InputMaybe<String_Comparison_Exp>;
+  skipped_registries?: InputMaybe<String_Array_Comparison_Exp>;
+  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "rp_manager_key_migration_audit" */
+export enum Rp_Manager_Key_Migration_Audit_Constraint {
+  /** unique or primary key constraint on columns "rp_id" */
+  RpManagerKeyMigrationAuditPkey = "rp_manager_key_migration_audit_pkey",
+}
+
+/** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+export type Rp_Manager_Key_Migration_Audit_Delete_At_Path_Input = {
+  operation_hashes?: InputMaybe<Array<Scalars["String"]["input"]>>;
+};
+
+/** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+export type Rp_Manager_Key_Migration_Audit_Delete_Elem_Input = {
+  operation_hashes?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+/** delete key/value pair or string element. key/value pairs are matched based on their key value */
+export type Rp_Manager_Key_Migration_Audit_Delete_Key_Input = {
+  operation_hashes?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+/** input type for incrementing numeric columns in table "rp_manager_key_migration_audit" */
+export type Rp_Manager_Key_Migration_Audit_Inc_Input = {
+  attempt_count?: InputMaybe<Scalars["Int"]["input"]>;
+  cleanup_attempt_count?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+/** input type for inserting data into table "rp_manager_key_migration_audit" */
+export type Rp_Manager_Key_Migration_Audit_Insert_Input = {
+  app_id?: InputMaybe<Scalars["String"]["input"]>;
+  attempt_count?: InputMaybe<Scalars["Int"]["input"]>;
+  cleanup_attempt_count?: InputMaybe<Scalars["Int"]["input"]>;
+  cleanup_candidate?: InputMaybe<Scalars["Boolean"]["input"]>;
+  cleanup_status?: InputMaybe<Scalars["String"]["input"]>;
+  completed_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  deletion_scheduled_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  expected_deletion_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  last_attempt_id?: InputMaybe<Scalars["uuid"]["input"]>;
+  last_error_detail?: InputMaybe<Scalars["String"]["input"]>;
+  last_error_stage?: InputMaybe<Scalars["String"]["input"]>;
+  migration_status?: InputMaybe<Scalars["String"]["input"]>;
+  old_manager_kms_key_arn?: InputMaybe<Scalars["String"]["input"]>;
+  old_manager_kms_key_id?: InputMaybe<Scalars["String"]["input"]>;
+  operation_hashes?: InputMaybe<Scalars["jsonb"]["input"]>;
+  retry_after?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  rp_id?: InputMaybe<Scalars["String"]["input"]>;
+  shared_manager_kms_key_id?: InputMaybe<Scalars["String"]["input"]>;
+  skipped_registries?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+};
+
+/** aggregate max on columns */
+export type Rp_Manager_Key_Migration_Audit_Max_Fields = {
+  __typename?: "rp_manager_key_migration_audit_max_fields";
+  app_id?: Maybe<Scalars["String"]["output"]>;
+  attempt_count?: Maybe<Scalars["Int"]["output"]>;
+  cleanup_attempt_count?: Maybe<Scalars["Int"]["output"]>;
+  cleanup_status?: Maybe<Scalars["String"]["output"]>;
+  completed_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  created_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  deletion_scheduled_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  expected_deletion_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  last_attempt_id?: Maybe<Scalars["uuid"]["output"]>;
+  last_error_detail?: Maybe<Scalars["String"]["output"]>;
+  last_error_stage?: Maybe<Scalars["String"]["output"]>;
+  migration_status?: Maybe<Scalars["String"]["output"]>;
+  old_manager_kms_key_arn?: Maybe<Scalars["String"]["output"]>;
+  old_manager_kms_key_id?: Maybe<Scalars["String"]["output"]>;
+  retry_after?: Maybe<Scalars["timestamptz"]["output"]>;
+  rp_id?: Maybe<Scalars["String"]["output"]>;
+  shared_manager_kms_key_id?: Maybe<Scalars["String"]["output"]>;
+  skipped_registries?: Maybe<Array<Scalars["String"]["output"]>>;
+  updated_at?: Maybe<Scalars["timestamptz"]["output"]>;
+};
+
+/** aggregate min on columns */
+export type Rp_Manager_Key_Migration_Audit_Min_Fields = {
+  __typename?: "rp_manager_key_migration_audit_min_fields";
+  app_id?: Maybe<Scalars["String"]["output"]>;
+  attempt_count?: Maybe<Scalars["Int"]["output"]>;
+  cleanup_attempt_count?: Maybe<Scalars["Int"]["output"]>;
+  cleanup_status?: Maybe<Scalars["String"]["output"]>;
+  completed_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  created_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  deletion_scheduled_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  expected_deletion_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  last_attempt_id?: Maybe<Scalars["uuid"]["output"]>;
+  last_error_detail?: Maybe<Scalars["String"]["output"]>;
+  last_error_stage?: Maybe<Scalars["String"]["output"]>;
+  migration_status?: Maybe<Scalars["String"]["output"]>;
+  old_manager_kms_key_arn?: Maybe<Scalars["String"]["output"]>;
+  old_manager_kms_key_id?: Maybe<Scalars["String"]["output"]>;
+  retry_after?: Maybe<Scalars["timestamptz"]["output"]>;
+  rp_id?: Maybe<Scalars["String"]["output"]>;
+  shared_manager_kms_key_id?: Maybe<Scalars["String"]["output"]>;
+  skipped_registries?: Maybe<Array<Scalars["String"]["output"]>>;
+  updated_at?: Maybe<Scalars["timestamptz"]["output"]>;
+};
+
+/** response of any mutation on the table "rp_manager_key_migration_audit" */
+export type Rp_Manager_Key_Migration_Audit_Mutation_Response = {
+  __typename?: "rp_manager_key_migration_audit_mutation_response";
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars["Int"]["output"];
+  /** data from the rows affected by the mutation */
+  returning: Array<Rp_Manager_Key_Migration_Audit>;
+};
+
+/** on_conflict condition type for table "rp_manager_key_migration_audit" */
+export type Rp_Manager_Key_Migration_Audit_On_Conflict = {
+  constraint: Rp_Manager_Key_Migration_Audit_Constraint;
+  update_columns?: Array<Rp_Manager_Key_Migration_Audit_Update_Column>;
+  where?: InputMaybe<Rp_Manager_Key_Migration_Audit_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "rp_manager_key_migration_audit". */
+export type Rp_Manager_Key_Migration_Audit_Order_By = {
+  app_id?: InputMaybe<Order_By>;
+  attempt_count?: InputMaybe<Order_By>;
+  cleanup_attempt_count?: InputMaybe<Order_By>;
+  cleanup_candidate?: InputMaybe<Order_By>;
+  cleanup_status?: InputMaybe<Order_By>;
+  completed_at?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  deletion_scheduled_at?: InputMaybe<Order_By>;
+  expected_deletion_at?: InputMaybe<Order_By>;
+  last_attempt_id?: InputMaybe<Order_By>;
+  last_error_detail?: InputMaybe<Order_By>;
+  last_error_stage?: InputMaybe<Order_By>;
+  migration_status?: InputMaybe<Order_By>;
+  old_manager_kms_key_arn?: InputMaybe<Order_By>;
+  old_manager_kms_key_id?: InputMaybe<Order_By>;
+  operation_hashes?: InputMaybe<Order_By>;
+  retry_after?: InputMaybe<Order_By>;
+  rp_id?: InputMaybe<Order_By>;
+  shared_manager_kms_key_id?: InputMaybe<Order_By>;
+  skipped_registries?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: rp_manager_key_migration_audit */
+export type Rp_Manager_Key_Migration_Audit_Pk_Columns_Input = {
+  rp_id: Scalars["String"]["input"];
+};
+
+/** prepend existing jsonb value of filtered columns with new jsonb value */
+export type Rp_Manager_Key_Migration_Audit_Prepend_Input = {
+  operation_hashes?: InputMaybe<Scalars["jsonb"]["input"]>;
+};
+
+/** select columns of table "rp_manager_key_migration_audit" */
+export enum Rp_Manager_Key_Migration_Audit_Select_Column {
+  /** column name */
+  AppId = "app_id",
+  /** column name */
+  AttemptCount = "attempt_count",
+  /** column name */
+  CleanupAttemptCount = "cleanup_attempt_count",
+  /** column name */
+  CleanupCandidate = "cleanup_candidate",
+  /** column name */
+  CleanupStatus = "cleanup_status",
+  /** column name */
+  CompletedAt = "completed_at",
+  /** column name */
+  CreatedAt = "created_at",
+  /** column name */
+  DeletionScheduledAt = "deletion_scheduled_at",
+  /** column name */
+  ExpectedDeletionAt = "expected_deletion_at",
+  /** column name */
+  LastAttemptId = "last_attempt_id",
+  /** column name */
+  LastErrorDetail = "last_error_detail",
+  /** column name */
+  LastErrorStage = "last_error_stage",
+  /** column name */
+  MigrationStatus = "migration_status",
+  /** column name */
+  OldManagerKmsKeyArn = "old_manager_kms_key_arn",
+  /** column name */
+  OldManagerKmsKeyId = "old_manager_kms_key_id",
+  /** column name */
+  OperationHashes = "operation_hashes",
+  /** column name */
+  RetryAfter = "retry_after",
+  /** column name */
+  RpId = "rp_id",
+  /** column name */
+  SharedManagerKmsKeyId = "shared_manager_kms_key_id",
+  /** column name */
+  SkippedRegistries = "skipped_registries",
+  /** column name */
+  UpdatedAt = "updated_at",
+}
+
+/** input type for updating data in table "rp_manager_key_migration_audit" */
+export type Rp_Manager_Key_Migration_Audit_Set_Input = {
+  app_id?: InputMaybe<Scalars["String"]["input"]>;
+  attempt_count?: InputMaybe<Scalars["Int"]["input"]>;
+  cleanup_attempt_count?: InputMaybe<Scalars["Int"]["input"]>;
+  cleanup_candidate?: InputMaybe<Scalars["Boolean"]["input"]>;
+  cleanup_status?: InputMaybe<Scalars["String"]["input"]>;
+  completed_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  deletion_scheduled_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  expected_deletion_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  last_attempt_id?: InputMaybe<Scalars["uuid"]["input"]>;
+  last_error_detail?: InputMaybe<Scalars["String"]["input"]>;
+  last_error_stage?: InputMaybe<Scalars["String"]["input"]>;
+  migration_status?: InputMaybe<Scalars["String"]["input"]>;
+  old_manager_kms_key_arn?: InputMaybe<Scalars["String"]["input"]>;
+  old_manager_kms_key_id?: InputMaybe<Scalars["String"]["input"]>;
+  operation_hashes?: InputMaybe<Scalars["jsonb"]["input"]>;
+  retry_after?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  rp_id?: InputMaybe<Scalars["String"]["input"]>;
+  shared_manager_kms_key_id?: InputMaybe<Scalars["String"]["input"]>;
+  skipped_registries?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+};
+
+/** aggregate stddev on columns */
+export type Rp_Manager_Key_Migration_Audit_Stddev_Fields = {
+  __typename?: "rp_manager_key_migration_audit_stddev_fields";
+  attempt_count?: Maybe<Scalars["Float"]["output"]>;
+  cleanup_attempt_count?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Rp_Manager_Key_Migration_Audit_Stddev_Pop_Fields = {
+  __typename?: "rp_manager_key_migration_audit_stddev_pop_fields";
+  attempt_count?: Maybe<Scalars["Float"]["output"]>;
+  cleanup_attempt_count?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Rp_Manager_Key_Migration_Audit_Stddev_Samp_Fields = {
+  __typename?: "rp_manager_key_migration_audit_stddev_samp_fields";
+  attempt_count?: Maybe<Scalars["Float"]["output"]>;
+  cleanup_attempt_count?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** Streaming cursor of the table "rp_manager_key_migration_audit" */
+export type Rp_Manager_Key_Migration_Audit_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Rp_Manager_Key_Migration_Audit_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Rp_Manager_Key_Migration_Audit_Stream_Cursor_Value_Input = {
+  app_id?: InputMaybe<Scalars["String"]["input"]>;
+  attempt_count?: InputMaybe<Scalars["Int"]["input"]>;
+  cleanup_attempt_count?: InputMaybe<Scalars["Int"]["input"]>;
+  cleanup_candidate?: InputMaybe<Scalars["Boolean"]["input"]>;
+  cleanup_status?: InputMaybe<Scalars["String"]["input"]>;
+  completed_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  deletion_scheduled_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  expected_deletion_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  last_attempt_id?: InputMaybe<Scalars["uuid"]["input"]>;
+  last_error_detail?: InputMaybe<Scalars["String"]["input"]>;
+  last_error_stage?: InputMaybe<Scalars["String"]["input"]>;
+  migration_status?: InputMaybe<Scalars["String"]["input"]>;
+  old_manager_kms_key_arn?: InputMaybe<Scalars["String"]["input"]>;
+  old_manager_kms_key_id?: InputMaybe<Scalars["String"]["input"]>;
+  operation_hashes?: InputMaybe<Scalars["jsonb"]["input"]>;
+  retry_after?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  rp_id?: InputMaybe<Scalars["String"]["input"]>;
+  shared_manager_kms_key_id?: InputMaybe<Scalars["String"]["input"]>;
+  skipped_registries?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+};
+
+/** aggregate sum on columns */
+export type Rp_Manager_Key_Migration_Audit_Sum_Fields = {
+  __typename?: "rp_manager_key_migration_audit_sum_fields";
+  attempt_count?: Maybe<Scalars["Int"]["output"]>;
+  cleanup_attempt_count?: Maybe<Scalars["Int"]["output"]>;
+};
+
+/** update columns of table "rp_manager_key_migration_audit" */
+export enum Rp_Manager_Key_Migration_Audit_Update_Column {
+  /** column name */
+  AppId = "app_id",
+  /** column name */
+  AttemptCount = "attempt_count",
+  /** column name */
+  CleanupAttemptCount = "cleanup_attempt_count",
+  /** column name */
+  CleanupCandidate = "cleanup_candidate",
+  /** column name */
+  CleanupStatus = "cleanup_status",
+  /** column name */
+  CompletedAt = "completed_at",
+  /** column name */
+  CreatedAt = "created_at",
+  /** column name */
+  DeletionScheduledAt = "deletion_scheduled_at",
+  /** column name */
+  ExpectedDeletionAt = "expected_deletion_at",
+  /** column name */
+  LastAttemptId = "last_attempt_id",
+  /** column name */
+  LastErrorDetail = "last_error_detail",
+  /** column name */
+  LastErrorStage = "last_error_stage",
+  /** column name */
+  MigrationStatus = "migration_status",
+  /** column name */
+  OldManagerKmsKeyArn = "old_manager_kms_key_arn",
+  /** column name */
+  OldManagerKmsKeyId = "old_manager_kms_key_id",
+  /** column name */
+  OperationHashes = "operation_hashes",
+  /** column name */
+  RetryAfter = "retry_after",
+  /** column name */
+  RpId = "rp_id",
+  /** column name */
+  SharedManagerKmsKeyId = "shared_manager_kms_key_id",
+  /** column name */
+  SkippedRegistries = "skipped_registries",
+  /** column name */
+  UpdatedAt = "updated_at",
+}
+
+export type Rp_Manager_Key_Migration_Audit_Updates = {
+  /** append existing jsonb value of filtered columns with new jsonb value */
+  _append?: InputMaybe<Rp_Manager_Key_Migration_Audit_Append_Input>;
+  /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+  _delete_at_path?: InputMaybe<Rp_Manager_Key_Migration_Audit_Delete_At_Path_Input>;
+  /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+  _delete_elem?: InputMaybe<Rp_Manager_Key_Migration_Audit_Delete_Elem_Input>;
+  /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+  _delete_key?: InputMaybe<Rp_Manager_Key_Migration_Audit_Delete_Key_Input>;
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<Rp_Manager_Key_Migration_Audit_Inc_Input>;
+  /** prepend existing jsonb value of filtered columns with new jsonb value */
+  _prepend?: InputMaybe<Rp_Manager_Key_Migration_Audit_Prepend_Input>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<Rp_Manager_Key_Migration_Audit_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: Rp_Manager_Key_Migration_Audit_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type Rp_Manager_Key_Migration_Audit_Var_Pop_Fields = {
+  __typename?: "rp_manager_key_migration_audit_var_pop_fields";
+  attempt_count?: Maybe<Scalars["Float"]["output"]>;
+  cleanup_attempt_count?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** aggregate var_samp on columns */
+export type Rp_Manager_Key_Migration_Audit_Var_Samp_Fields = {
+  __typename?: "rp_manager_key_migration_audit_var_samp_fields";
+  attempt_count?: Maybe<Scalars["Float"]["output"]>;
+  cleanup_attempt_count?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** aggregate variance on columns */
+export type Rp_Manager_Key_Migration_Audit_Variance_Fields = {
+  __typename?: "rp_manager_key_migration_audit_variance_fields";
+  attempt_count?: Maybe<Scalars["Float"]["output"]>;
+  cleanup_attempt_count?: Maybe<Scalars["Float"]["output"]>;
 };
 
 /** columns and relationships of "rp_registration" */
@@ -11564,6 +12287,8 @@ export type Subscription_Root = {
   admin_dashboard_inventory: Array<Admin_Dashboard_Inventory>;
   admin_dashboard_queues: Array<Admin_Dashboard_Queue>;
   admin_rp_inventory: Array<Admin_Rp_Inventory>;
+  admin_rp_manager_key_migration: Array<Admin_Rp_Manager_Key_Migration>;
+  admin_rp_manager_key_migration_queue: Array<Admin_Rp_Manager_Key_Migration_Queue>;
   /** fetch data from the table: "api_key" */
   api_key: Array<Api_Key>;
   /** fetch aggregated fields from the table: "api_key" */
@@ -11740,6 +12465,14 @@ export type Subscription_Root = {
   role_by_pk?: Maybe<Role>;
   /** fetch data from the table in a streaming manner: "role" */
   role_stream: Array<Role>;
+  /** fetch data from the table: "rp_manager_key_migration_audit" */
+  rp_manager_key_migration_audit: Array<Rp_Manager_Key_Migration_Audit>;
+  /** fetch aggregated fields from the table: "rp_manager_key_migration_audit" */
+  rp_manager_key_migration_audit_aggregate: Rp_Manager_Key_Migration_Audit_Aggregate;
+  /** fetch data from the table: "rp_manager_key_migration_audit" using primary key columns */
+  rp_manager_key_migration_audit_by_pk?: Maybe<Rp_Manager_Key_Migration_Audit>;
+  /** fetch data from the table in a streaming manner: "rp_manager_key_migration_audit" */
+  rp_manager_key_migration_audit_stream: Array<Rp_Manager_Key_Migration_Audit>;
   /** An array relationship */
   rp_registration: Array<Rp_Registration>;
   /** An aggregate relationship */
@@ -11892,6 +12625,24 @@ export type Subscription_RootAdmin_Rp_InventoryArgs = {
   offset?: InputMaybe<Scalars["Int"]["input"]>;
   order_by?: InputMaybe<Array<Admin_Rp_Inventory_Order_By>>;
   where?: InputMaybe<Admin_Rp_Inventory_Bool_Exp_Bool_Exp>;
+};
+
+export type Subscription_RootAdmin_Rp_Manager_Key_MigrationArgs = {
+  distinct_on?: InputMaybe<Array<Admin_Rp_Manager_Key_Migration_Enum_Name>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Admin_Rp_Manager_Key_Migration_Order_By>>;
+  where?: InputMaybe<Admin_Rp_Manager_Key_Migration_Bool_Exp_Bool_Exp>;
+};
+
+export type Subscription_RootAdmin_Rp_Manager_Key_Migration_QueueArgs = {
+  distinct_on?: InputMaybe<
+    Array<Admin_Rp_Manager_Key_Migration_Queue_Enum_Name>
+  >;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Admin_Rp_Manager_Key_Migration_Queue_Order_By>>;
+  where?: InputMaybe<Admin_Rp_Manager_Key_Migration_Queue_Bool_Exp_Bool_Exp>;
 };
 
 export type Subscription_RootApi_KeyArgs = {
@@ -12473,6 +13224,32 @@ export type Subscription_RootRole_StreamArgs = {
   batch_size: Scalars["Int"]["input"];
   cursor: Array<InputMaybe<Role_Stream_Cursor_Input>>;
   where?: InputMaybe<Role_Bool_Exp>;
+};
+
+export type Subscription_RootRp_Manager_Key_Migration_AuditArgs = {
+  distinct_on?: InputMaybe<Array<Rp_Manager_Key_Migration_Audit_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Rp_Manager_Key_Migration_Audit_Order_By>>;
+  where?: InputMaybe<Rp_Manager_Key_Migration_Audit_Bool_Exp>;
+};
+
+export type Subscription_RootRp_Manager_Key_Migration_Audit_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Rp_Manager_Key_Migration_Audit_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Rp_Manager_Key_Migration_Audit_Order_By>>;
+  where?: InputMaybe<Rp_Manager_Key_Migration_Audit_Bool_Exp>;
+};
+
+export type Subscription_RootRp_Manager_Key_Migration_Audit_By_PkArgs = {
+  rp_id: Scalars["String"]["input"];
+};
+
+export type Subscription_RootRp_Manager_Key_Migration_Audit_StreamArgs = {
+  batch_size: Scalars["Int"]["input"];
+  cursor: Array<InputMaybe<Rp_Manager_Key_Migration_Audit_Stream_Cursor_Input>>;
+  where?: InputMaybe<Rp_Manager_Key_Migration_Audit_Bool_Exp>;
 };
 
 export type Subscription_RootRp_RegistrationArgs = {
@@ -13274,6 +14051,19 @@ export type User_Updates = {
   _set?: InputMaybe<User_Set_Input>;
   /** filter the rows which have to be updated */
   where: User_Bool_Exp;
+};
+
+/** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */
+export type Uuid_Comparison_Exp = {
+  _eq?: InputMaybe<Scalars["uuid"]["input"]>;
+  _gt?: InputMaybe<Scalars["uuid"]["input"]>;
+  _gte?: InputMaybe<Scalars["uuid"]["input"]>;
+  _in?: InputMaybe<Array<Scalars["uuid"]["input"]>>;
+  _is_null?: InputMaybe<Scalars["Boolean"]["input"]>;
+  _lt?: InputMaybe<Scalars["uuid"]["input"]>;
+  _lte?: InputMaybe<Scalars["uuid"]["input"]>;
+  _neq?: InputMaybe<Scalars["uuid"]["input"]>;
+  _nin?: InputMaybe<Array<Scalars["uuid"]["input"]>>;
 };
 
 /** Boolean expression to compare columns of type "violation_enum". All fields are combined with logical 'AND'. */

--- a/web/scenes/Admin/rps/graphql/server/fetch-admin-rp-inventory.generated.ts
+++ b/web/scenes/Admin/rps/graphql/server/fetch-admin-rp-inventory.generated.ts
@@ -17,9 +17,8 @@ export type FetchAdminRpInventoryQuery = {
     self_managed_rps: number;
     managed_with_key: number;
     managed_without_key: number;
-    distinct_manager_keys: number;
-    shared_key_groups: number;
-    rps_on_shared_keys: number;
+    unique_manager_key_rps: number;
+    shared_manager_key_rps: number;
     status_pending: number;
     status_registered: number;
     status_failed: number;
@@ -40,9 +39,8 @@ export const FetchAdminRpInventoryDocument = gql`
       self_managed_rps
       managed_with_key
       managed_without_key
-      distinct_manager_keys
-      shared_key_groups
-      rps_on_shared_keys
+      unique_manager_key_rps
+      shared_manager_key_rps
       status_pending
       status_registered
       status_failed

--- a/web/scenes/Admin/rps/graphql/server/fetch-admin-rp-inventory.gql
+++ b/web/scenes/Admin/rps/graphql/server/fetch-admin-rp-inventory.gql
@@ -5,9 +5,8 @@ query FetchAdminRpInventory {
     self_managed_rps
     managed_with_key
     managed_without_key
-    distinct_manager_keys
-    shared_key_groups
-    rps_on_shared_keys
+    unique_manager_key_rps
+    shared_manager_key_rps
     status_pending
     status_registered
     status_failed

--- a/web/scenes/Admin/rps/id/page.tsx
+++ b/web/scenes/Admin/rps/id/page.tsx
@@ -14,6 +14,7 @@ import { TeamMetric } from "@/components/AdminDashboard/Teams/TeamMetric";
 import { UIModule } from "@/components/AdminDashboard/UIModule";
 
 import { fetchAdminRpDetails } from "./server/fetch-rp-details";
+import { RpManagerKeyMigrationAuditSection } from "../manager-key-migration/AuditSection";
 
 type AdminRpPageProps = {
   rpId: string;
@@ -65,7 +66,7 @@ export const AdminRpPage = async ({ rpId }: AdminRpPageProps) => {
       </UIModule>
 
       <div className="grid min-h-0 w-full grid-cols-1 gap-4 max-lg:h-auto lg:h-full lg:grid-cols-[minmax(0,7fr)_minmax(0,3fr)]">
-        <UIModule className="min-h-0 overflow-auto p-5">
+        <UIModule className="min-h-0 min-w-0 overflow-auto p-5">
           <div className="flex items-center justify-between gap-3">
             <h2 className="text-16 font-semibold text-grey-900">Overview</h2>
             <Link
@@ -94,28 +95,30 @@ export const AdminRpPage = async ({ rpId }: AdminRpPageProps) => {
                 <RpModeBadge mode={rp.mode as RpRegistrationMode} />
               </dd>
             </div>
-            <div className="flex justify-between gap-4 border-b border-grey-100 py-2">
+            <div className="grid min-w-0 gap-1 border-b border-grey-100 py-2">
               <dt className="text-grey-500">Signer address</dt>
-              <dd className="truncate font-mono text-13 font-medium text-grey-900">
+              <dd className="min-w-0 font-mono text-13 font-medium break-all text-grey-900">
                 {rp.signer_address ?? "—"}
               </dd>
             </div>
-            <div className="flex justify-between gap-4 border-b border-grey-100 py-2">
+            <div className="grid min-w-0 gap-1 border-b border-grey-100 py-2">
               <dt className="text-grey-500">Operation hash</dt>
-              <dd className="truncate font-mono text-13 font-medium text-grey-900">
+              <dd className="min-w-0 font-mono text-13 font-medium break-all text-grey-900">
                 {rp.operation_hash ?? "—"}
               </dd>
             </div>
-            <div className="flex justify-between gap-4 border-b border-grey-100 py-2">
+            <div className="grid min-w-0 gap-1 border-b border-grey-100 py-2">
               <dt className="text-grey-500">Staging operation hash</dt>
-              <dd className="truncate font-mono text-13 font-medium text-grey-900">
+              <dd className="min-w-0 font-mono text-13 font-medium break-all text-grey-900">
                 {rp.staging_operation_hash ?? "—"}
               </dd>
             </div>
           </dl>
+          {/* TODO: remove after the RP manager key migration completes */}
+          <RpManagerKeyMigrationAuditSection rpId={rp.rp_id} />
         </UIModule>
-        <div className="grid content-start gap-4">
-          <UIModule className="self-start p-5">
+        <div className="grid min-w-0 content-start gap-4 overflow-hidden">
+          <UIModule className="min-w-0 self-start overflow-hidden p-5">
             <h2 className="text-16 font-semibold text-grey-900">App</h2>
             <Link
               className="group mt-4 block min-w-0 rounded-8 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
@@ -145,7 +148,7 @@ export const AdminRpPage = async ({ rpId }: AdminRpPageProps) => {
               </div>
             </dl>
           </UIModule>
-          <UIModule className="self-start p-5">
+          <UIModule className="min-w-0 self-start overflow-hidden p-5">
             <h2 className="text-16 font-semibold text-grey-900">Owning team</h2>
             <Link
               className="group mt-4 block min-w-0 rounded-8 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"

--- a/web/scenes/Admin/rps/manager-key-migration/AuditSection.tsx
+++ b/web/scenes/Admin/rps/manager-key-migration/AuditSection.tsx
@@ -1,0 +1,132 @@
+// TODO: delete this file after the RP manager key migration completes.
+
+import {
+  fetchAdminRpManagerKeyAudit,
+  type AdminRpManagerKeyAudit,
+} from "./server/fetch-rp-migration-audit";
+import { MigrationCleanupStatus } from "./types";
+
+type AuditSectionProps = {
+  rpId: string;
+};
+
+const cleanupStatusLabels: Record<MigrationCleanupStatus, string> = {
+  [MigrationCleanupStatus.Pending]: "pending",
+  [MigrationCleanupStatus.Failed]: "failed",
+  [MigrationCleanupStatus.Blocked]: "blocked",
+  [MigrationCleanupStatus.ReadyForExternalCleanup]:
+    "ready_for_external_cleanup",
+  [MigrationCleanupStatus.DeletionScheduled]: "deletion_scheduled",
+  [MigrationCleanupStatus.Deleted]: "deleted",
+};
+
+const formatCleanupStatus = (value: string) => {
+  if (
+    Object.values(MigrationCleanupStatus).some((status) => status === value)
+  ) {
+    return cleanupStatusLabels[value as MigrationCleanupStatus];
+  }
+
+  return value;
+};
+
+const formatDate = (value: string | null) => (value ? value.slice(0, 10) : "—");
+
+const Field = ({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string | null;
+  mono?: boolean;
+}) => (
+  <div className="min-w-0 border-b border-grey-100 py-2">
+    <dt className="text-12 text-grey-500">{label}</dt>
+    <dd
+      className={
+        mono
+          ? "mt-1 font-mono text-12 font-medium break-all text-grey-900"
+          : "mt-1 text-13 font-medium break-words text-grey-900"
+      }
+      title={value ?? undefined}
+    >
+      {value ?? "—"}
+    </dd>
+  </div>
+);
+
+const AuditSectionContent = ({ data }: { data: AdminRpManagerKeyAudit }) => {
+  const keyMode = data.isUniqueManagerKey ? "Unique" : "Shared";
+
+  return (
+    <dl className="mt-3 min-w-0">
+      <Field label="Manager key mode" value={keyMode} />
+      <Field label="Current manager key" mono value={data.managerKmsKeyId} />
+      {data.audit ? (
+        <>
+          <Field
+            label="Cleanup status"
+            value={formatCleanupStatus(data.audit.cleanupStatus)}
+          />
+          <Field
+            label="Old manager key ARN"
+            mono
+            value={data.audit.oldManagerKmsKeyArn}
+          />
+          <Field label="Last error" value={data.audit.lastErrorDetail} />
+          <Field
+            label="Deletion scheduled"
+            value={formatDate(data.audit.deletionScheduledAt)}
+          />
+          <Field
+            label="Expected deletion"
+            value={formatDate(data.audit.expectedDeletionAt)}
+          />
+          {data.isUniqueManagerKey && (
+            <p className="mt-2 text-13 text-grey-500">
+              Cleanup will skip until this RP leaves the unique key.
+            </p>
+          )}
+        </>
+      ) : (
+        !data.isUniqueManagerKey && (
+          <p className="mt-2 text-13 text-grey-500">
+            No audit row (born shared or migrated before the table).
+          </p>
+        )
+      )}
+    </dl>
+  );
+};
+
+// ANCHOR: Temporary manager-key audit block in the wide RP overview column.
+export const RpManagerKeyMigrationAuditSection = async ({
+  rpId,
+}: AuditSectionProps) => {
+  let data: AdminRpManagerKeyAudit | null = null;
+  let loadError = false;
+
+  try {
+    data = await fetchAdminRpManagerKeyAudit(rpId);
+  } catch {
+    loadError = true;
+  }
+
+  return (
+    <section className="mt-6 min-w-0 border-t border-grey-100 pt-5">
+      <h3 className="text-14 font-semibold text-grey-900">
+        Manager key migration
+      </h3>
+      {loadError ? (
+        <p className="mt-2 text-13 text-grey-500">
+          Migration audit unavailable. Apply Hasura metadata, then reload.
+        </p>
+      ) : data ? (
+        <AuditSectionContent data={data} />
+      ) : (
+        <p className="mt-2 text-13 text-grey-500">RP registration not found.</p>
+      )}
+    </section>
+  );
+};

--- a/web/scenes/Admin/rps/manager-key-migration/AuditSection.tsx
+++ b/web/scenes/Admin/rps/manager-key-migration/AuditSection.tsx
@@ -62,7 +62,6 @@ const AuditSectionContent = ({ data }: { data: AdminRpManagerKeyAudit }) => {
   return (
     <dl className="mt-3 min-w-0">
       <Field label="Manager key mode" value={keyMode} />
-      <Field label="Current manager key" mono value={data.managerKmsKeyId} />
       {data.audit ? (
         <>
           <Field

--- a/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
+++ b/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
@@ -61,11 +61,10 @@ const ProcessSummary = ({
 }: {
   inventory: AdminRpManagerKeyMigrationInventory;
 }) => {
-  const needsPerson =
-    inventory.auditFailed +
-    inventory.auditBlocked +
-    inventory.auditReadyForExternalCleanup +
-    inventory.auditDeletionOverdue;
+  const scheduledNotOverdue = Math.max(
+    0,
+    inventory.auditDeletionScheduled - inventory.auditDeletionOverdue,
+  );
 
   return (
     <div className="grid gap-3">
@@ -81,6 +80,11 @@ const ProcessSummary = ({
             warn
           />
           <Stat
+            hint="Unique-key RPs the migrate job skips: not registered, missing signer, or app not active."
+            label="Job skips"
+            value={inventory.uniqueExcludedFromCron}
+          />
+          <Stat
             hint="An audit row exists but the RP still uses the old key. Cleanup will skip these."
             label="Failed, still unique"
             value={inventory.uniqueWithAudit}
@@ -94,22 +98,48 @@ const ProcessSummary = ({
         </h3>
         <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-2">
           <Stat
-            hint="Already on the shared key, old key recorded, waiting for the cleanup job."
-            label="Waiting for cleanup"
-            value={inventory.onSharedWithAudit}
+            hint="Audit rows waiting for the cleanup job to schedule KMS deletion."
+            label="Pending"
+            value={inventory.auditPending}
           />
           <Stat
-            hint="Cleanup failed, blocked, key in another AWS account, or deletion date already passed."
-            label="Needs a person"
-            value={needsPerson}
+            hint="Cleanup failed. Needs a retry or a person."
+            label="Failed"
+            value={inventory.auditFailed}
             warn
           />
           <Stat
-            hint="KMS deletion is scheduled or the old key is already gone."
-            label="Scheduled or deleted"
-            value={inventory.auditDeleted + inventory.auditDeletionScheduled}
+            hint="Cleanup stopped because the RP still uses the old key or checks failed."
+            label="Blocked"
+            value={inventory.auditBlocked}
+            warn
+          />
+          <Stat
+            hint="Old key lives in another AWS account. Portal cannot delete it."
+            label="Other AWS account"
+            value={inventory.auditReadyForExternalCleanup}
+            warn
+          />
+          <Stat
+            hint="KMS deletion is scheduled and the deletion date has not passed."
+            label="Scheduled"
+            value={scheduledNotOverdue}
+          />
+          <Stat
+            hint="KMS deletion date has passed but the key is not confirmed gone."
+            label="Overdue"
+            value={inventory.auditDeletionOverdue}
+            warn
+          />
+          <Stat
+            hint="Old per-RP KMS key is gone."
+            label="Deleted"
+            value={inventory.auditDeleted}
           />
         </div>
+        <p className="mt-2 text-12 text-grey-500">
+          Shared, no old key: {inventory.onSharedWithoutAudit}
+        </p>
       </section>
     </div>
   );
@@ -163,6 +193,14 @@ export const RpManagerKeyMigrationPanel = async () => {
             />
           </div>
         )}
+        {status &&
+          !status.flags.cleanupEnabled &&
+          status.inventory.auditPending > 0 && (
+            <p className="mt-2 text-12 text-system-error-700">
+              Cleanup job is off. Pending keys will not be scheduled for
+              deletion.
+            </p>
+          )}
       </div>
       <div className="mt-3 flex min-h-0 min-w-0 flex-1 flex-col">
         {loadError || !status ? (

--- a/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
+++ b/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
@@ -1,0 +1,178 @@
+// TODO: delete this file after the RP manager key migration completes.
+//
+// Cleanup checklist:
+// 1. Delete web/scenes/Admin/rps/manager-key-migration/.
+// 2. Remove the TODO inserts from Admin/rps/page.tsx and Admin/rps/id/page.tsx.
+// 3. Remove the native queries and logical models from databases.yaml.
+// 4. Revert internal_dashboard_readonly grants for unique/key and audit select.
+// 5. Delete web/tests/unit/admin-rp-manager-key-migration-fetch.test.ts.
+// 6. Regenerate GraphQL schema/types.
+
+import { UIModule } from "@/components/AdminDashboard/UIModule";
+
+import { QueueLists } from "./QueueLists";
+import {
+  fetchAdminRpManagerKeyMigration,
+  type AdminRpManagerKeyMigrationInventory,
+  type AdminRpManagerKeyMigrationStatus,
+} from "./server/fetch-migration-status";
+
+const FlagBadge = ({ enabled, label }: { enabled: boolean; label: string }) => (
+  <span
+    className={
+      enabled
+        ? "inline-flex rounded-full border border-system-success-300 bg-system-success-50 px-2 py-0.5 text-11 font-medium text-system-success-700"
+        : "inline-flex rounded-full border border-grey-300 bg-grey-100 px-2 py-0.5 text-11 font-medium text-grey-500"
+    }
+  >
+    {label}: {enabled ? "on" : "off"}
+  </span>
+);
+
+const Stat = ({
+  hint,
+  label,
+  value,
+  warn,
+}: {
+  hint: string;
+  label: string;
+  value: number;
+  warn?: boolean;
+}) => (
+  <div className="min-w-0" title={hint}>
+    <div className="truncate text-11 font-medium tracking-wide text-grey-400 uppercase">
+      {label}
+    </div>
+    <div
+      className={
+        warn && value > 0
+          ? "mt-0.5 text-16 font-semibold text-system-error-700"
+          : "mt-0.5 text-16 font-semibold text-grey-900"
+      }
+    >
+      {value}
+    </div>
+  </div>
+);
+
+const ProcessSummary = ({
+  inventory,
+}: {
+  inventory: AdminRpManagerKeyMigrationInventory;
+}) => {
+  const needsPerson =
+    inventory.auditFailed +
+    inventory.auditBlocked +
+    inventory.auditReadyForExternalCleanup +
+    inventory.auditDeletionOverdue;
+
+  return (
+    <div className="grid gap-3">
+      <section>
+        <h3 className="text-12 font-semibold text-grey-900">
+          1. Switch to the shared key
+        </h3>
+        <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-2">
+          <Stat
+            hint="Registered managed RPs that still have a per-RP key. The migrate job picks these."
+            label="Still to migrate"
+            value={inventory.remainingCronCandidates}
+            warn
+          />
+          <Stat
+            hint="An audit row exists but the RP still uses the old key. Cleanup will skip these."
+            label="Failed, still unique"
+            value={inventory.uniqueWithAudit}
+            warn
+          />
+        </div>
+      </section>
+      <section>
+        <h3 className="text-12 font-semibold text-grey-900">
+          2. Delete the old KMS keys
+        </h3>
+        <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-2">
+          <Stat
+            hint="Already on the shared key, old key recorded, waiting for the cleanup job."
+            label="Waiting for cleanup"
+            value={inventory.onSharedWithAudit}
+          />
+          <Stat
+            hint="Cleanup failed, blocked, key in another AWS account, or deletion date already passed."
+            label="Needs a person"
+            value={needsPerson}
+            warn
+          />
+          <Stat
+            hint="KMS deletion is scheduled or the old key is already gone."
+            label="Scheduled or deleted"
+            value={inventory.auditDeleted + inventory.auditDeletionScheduled}
+          />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+const MigrationPanelContent = ({
+  status,
+}: {
+  status: AdminRpManagerKeyMigrationStatus;
+}) => (
+  <div className="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)_minmax(0,1fr)] gap-3">
+    <ProcessSummary inventory={status.inventory} />
+    <QueueLists
+      cleanupNeedsAttention={status.cleanupNeedsAttention}
+      cleanupNeedsAttentionCount={status.cleanupNeedsAttentionCount}
+      remainingCronCandidateCount={status.remainingCronCandidateCount}
+      remainingCronCandidates={status.remainingCronCandidates}
+    />
+  </div>
+);
+
+// ANCHOR: Right-side temporary migrate/cleanup panel on /admin/rps.
+export const RpManagerKeyMigrationPanel = async () => {
+  let status: AdminRpManagerKeyMigrationStatus | null = null;
+  let loadError = false;
+
+  try {
+    status = await fetchAdminRpManagerKeyMigration();
+  } catch {
+    loadError = true;
+  }
+
+  return (
+    <UIModule className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden p-4">
+      <div className="min-w-0 shrink-0">
+        <h2 className="text-14 font-semibold text-grey-900">
+          Manager key migration
+        </h2>
+        <p className="mt-0.5 text-12 text-grey-500">
+          Unique key → shared key, then delete the old KMS key.
+        </p>
+        {status && (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            <FlagBadge
+              enabled={status.flags.migrationEnabled}
+              label="Migrate job"
+            />
+            <FlagBadge
+              enabled={status.flags.cleanupEnabled}
+              label="Cleanup job"
+            />
+          </div>
+        )}
+      </div>
+      <div className="mt-3 flex min-h-0 min-w-0 flex-1 flex-col">
+        {loadError || !status ? (
+          <p className="text-13 text-grey-500">
+            Migration status unavailable. Apply Hasura metadata, then reload.
+          </p>
+        ) : (
+          <MigrationPanelContent status={status} />
+        )}
+      </div>
+    </UIModule>
+  );
+};

--- a/web/scenes/Admin/rps/manager-key-migration/QueueLists.tsx
+++ b/web/scenes/Admin/rps/manager-key-migration/QueueLists.tsx
@@ -6,9 +6,13 @@ import { useMemo, useState } from "react";
 import type { AdminRpManagerKeyMigrationQueueItem } from "./types";
 
 const QueueItem = ({ item }: { item: AdminRpManagerKeyMigrationQueueItem }) => {
-  const detail =
-    item.cleanupStatus ??
-    (item.updatedAt ? item.updatedAt.slice(0, 10) : undefined);
+  const detail = item.cleanupStatus
+    ? item.lastErrorDetail
+      ? `${item.cleanupStatus} — ${item.lastErrorDetail}`
+      : item.cleanupStatus
+    : item.updatedAt
+      ? item.updatedAt.slice(0, 10)
+      : undefined;
 
   return (
     <Link
@@ -19,7 +23,10 @@ const QueueItem = ({ item }: { item: AdminRpManagerKeyMigrationQueueItem }) => {
         {item.rpId}
       </span>
       {detail && (
-        <span className="max-w-[45%] shrink-0 truncate text-11 text-grey-500">
+        <span
+          className="max-w-[45%] shrink-0 truncate text-11 text-grey-500"
+          title={detail}
+        >
           {detail}
         </span>
       )}

--- a/web/scenes/Admin/rps/manager-key-migration/QueueLists.tsx
+++ b/web/scenes/Admin/rps/manager-key-migration/QueueLists.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+import type { AdminRpManagerKeyMigrationQueueItem } from "./types";
+
+const QueueItem = ({ item }: { item: AdminRpManagerKeyMigrationQueueItem }) => {
+  const detail =
+    item.cleanupStatus ??
+    (item.updatedAt ? item.updatedAt.slice(0, 10) : undefined);
+
+  return (
+    <Link
+      className="flex min-w-0 items-center justify-between gap-2 px-2 py-1.5 outline-none hover:bg-grey-0 focus-visible:ring-2 focus-visible:ring-blue-500"
+      href={`/admin/rps/${item.rpId}`}
+    >
+      <span className="min-w-0 truncate font-mono text-12 font-medium text-grey-900">
+        {item.rpId}
+      </span>
+      {detail && (
+        <span className="max-w-[45%] shrink-0 truncate text-11 text-grey-500">
+          {detail}
+        </span>
+      )}
+    </Link>
+  );
+};
+
+const QueueList = ({
+  items,
+  title,
+  totalCount,
+}: {
+  items: AdminRpManagerKeyMigrationQueueItem[];
+  title: string;
+  totalCount: number;
+}) => {
+  const [query, setQuery] = useState("");
+  const normalizedQuery = query.trim().toLowerCase();
+  const isFiltering = normalizedQuery.length > 0;
+  const visibleItems = useMemo(() => {
+    if (!normalizedQuery) {
+      return items;
+    }
+
+    return items.filter((item) =>
+      item.rpId.toLowerCase().includes(normalizedQuery),
+    );
+  }, [items, normalizedQuery]);
+
+  return (
+    <section className="grid min-h-0 min-w-0 grid-rows-[auto_auto_minmax(0,1fr)] rounded-8 border border-grey-200 bg-grey-50">
+      <div className="flex items-center justify-between gap-2 border-b border-grey-200 px-3 py-2">
+        <h3 className="truncate text-13 font-semibold text-grey-900">
+          {title}
+        </h3>
+        <span className="shrink-0 text-12 font-medium text-grey-500">
+          {isFiltering ? visibleItems.length : totalCount}
+        </span>
+      </div>
+      <input
+        aria-label={`Filter ${title} by RP ID`}
+        className="border-b border-grey-200 bg-grey-0 px-3 py-1.5 font-mono text-12 text-grey-900 outline-none placeholder:font-sans placeholder:text-grey-400 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-inset"
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder="Filter by RP ID"
+        type="search"
+        value={query}
+      />
+      {visibleItems.length === 0 ? (
+        <p className="px-3 py-2 text-12 text-grey-500">
+          {isFiltering ? "No matches" : "None"}
+        </p>
+      ) : (
+        <div className="min-h-0 divide-y divide-grey-100 overflow-y-auto">
+          {visibleItems.map((item) => (
+            <QueueItem item={item} key={item.rpId} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export const QueueLists = ({
+  cleanupNeedsAttention,
+  cleanupNeedsAttentionCount,
+  remainingCronCandidateCount,
+  remainingCronCandidates,
+}: {
+  cleanupNeedsAttention: AdminRpManagerKeyMigrationQueueItem[];
+  cleanupNeedsAttentionCount: number;
+  remainingCronCandidateCount: number;
+  remainingCronCandidates: AdminRpManagerKeyMigrationQueueItem[];
+}) => (
+  <div className="contents">
+    <QueueList
+      items={remainingCronCandidates}
+      title="Still to migrate"
+      totalCount={remainingCronCandidateCount}
+    />
+    <QueueList
+      items={cleanupNeedsAttention}
+      title="Needs a person"
+      totalCount={cleanupNeedsAttentionCount}
+    />
+  </div>
+);

--- a/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-audit.generated.ts
+++ b/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-audit.generated.ts
@@ -1,0 +1,93 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type FetchAdminRpManagerKeyAuditQueryVariables = Types.Exact<{
+  rpId: Types.Scalars["String"]["input"];
+}>;
+
+export type FetchAdminRpManagerKeyAuditQuery = {
+  __typename?: "query_root";
+  rp_registration_by_pk?: {
+    __typename?: "rp_registration";
+    is_unique_manager_key: boolean;
+    manager_kms_key_id?: string | null;
+  } | null;
+  rp_manager_key_migration_audit_by_pk?: {
+    __typename?: "rp_manager_key_migration_audit";
+    rp_id: string;
+    app_id: string;
+    old_manager_kms_key_id: string;
+    old_manager_kms_key_arn: string;
+    shared_manager_kms_key_id: string;
+    cleanup_status: string;
+    last_error_detail?: string | null;
+    deletion_scheduled_at?: string | null;
+    expected_deletion_at?: string | null;
+    created_at: string;
+    updated_at: string;
+  } | null;
+};
+
+export const FetchAdminRpManagerKeyAuditDocument = gql`
+  query FetchAdminRpManagerKeyAudit($rpId: String!) {
+    rp_registration_by_pk(rp_id: $rpId) {
+      is_unique_manager_key
+      manager_kms_key_id
+    }
+    rp_manager_key_migration_audit_by_pk(rp_id: $rpId) {
+      rp_id
+      app_id
+      old_manager_kms_key_id
+      old_manager_kms_key_arn
+      shared_manager_kms_key_id
+      cleanup_status
+      last_error_detail
+      deletion_scheduled_at
+      expected_deletion_at
+      created_at
+      updated_at
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchAdminRpManagerKeyAudit(
+      variables: FetchAdminRpManagerKeyAuditQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchAdminRpManagerKeyAuditQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchAdminRpManagerKeyAuditQuery>(
+            FetchAdminRpManagerKeyAuditDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchAdminRpManagerKeyAudit",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-audit.generated.ts
+++ b/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-audit.generated.ts
@@ -13,7 +13,6 @@ export type FetchAdminRpManagerKeyAuditQuery = {
   rp_registration_by_pk?: {
     __typename?: "rp_registration";
     is_unique_manager_key: boolean;
-    manager_kms_key_id?: string | null;
   } | null;
   rp_manager_key_migration_audit_by_pk?: {
     __typename?: "rp_manager_key_migration_audit";
@@ -35,7 +34,6 @@ export const FetchAdminRpManagerKeyAuditDocument = gql`
   query FetchAdminRpManagerKeyAudit($rpId: String!) {
     rp_registration_by_pk(rp_id: $rpId) {
       is_unique_manager_key
-      manager_kms_key_id
     }
     rp_manager_key_migration_audit_by_pk(rp_id: $rpId) {
       rp_id

--- a/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-audit.gql
+++ b/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-audit.gql
@@ -1,0 +1,20 @@
+# TODO: delete this file after the RP manager key migration completes.
+query FetchAdminRpManagerKeyAudit($rpId: String!) {
+  rp_registration_by_pk(rp_id: $rpId) {
+    is_unique_manager_key
+    manager_kms_key_id
+  }
+  rp_manager_key_migration_audit_by_pk(rp_id: $rpId) {
+    rp_id
+    app_id
+    old_manager_kms_key_id
+    old_manager_kms_key_arn
+    shared_manager_kms_key_id
+    cleanup_status
+    last_error_detail
+    deletion_scheduled_at
+    expected_deletion_at
+    created_at
+    updated_at
+  }
+}

--- a/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-audit.gql
+++ b/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-audit.gql
@@ -2,7 +2,6 @@
 query FetchAdminRpManagerKeyAudit($rpId: String!) {
   rp_registration_by_pk(rp_id: $rpId) {
     is_unique_manager_key
-    manager_kms_key_id
   }
   rp_manager_key_migration_audit_by_pk(rp_id: $rpId) {
     rp_id

--- a/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-migration.generated.ts
+++ b/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-migration.generated.ts
@@ -12,18 +12,18 @@ export type FetchAdminRpManagerKeyMigrationQuery = {
   __typename?: "query_root";
   inventory: Array<{
     __typename?: "admin_rp_manager_key_migration";
-    remaining_cron_candidates: number | string;
-    unique_excluded_from_cron: number | string;
-    on_shared_with_audit: number | string;
-    on_shared_without_audit: number | string;
-    unique_with_audit: number | string;
-    audit_pending: number | string;
-    audit_failed: number | string;
-    audit_blocked: number | string;
-    audit_ready_for_external_cleanup: number | string;
-    audit_deletion_scheduled: number | string;
-    audit_deleted: number | string;
-    audit_deletion_overdue: number | string;
+    remaining_cron_candidates: number;
+    unique_excluded_from_cron: number;
+    on_shared_with_audit: number;
+    on_shared_without_audit: number;
+    unique_with_audit: number;
+    audit_pending: number;
+    audit_failed: number;
+    audit_blocked: number;
+    audit_ready_for_external_cleanup: number;
+    audit_deletion_scheduled: number;
+    audit_deleted: number;
+    audit_deletion_overdue: number;
   }>;
   queue: Array<{
     __typename?: "admin_rp_manager_key_migration_queue";
@@ -35,7 +35,7 @@ export type FetchAdminRpManagerKeyMigrationQuery = {
     cleanup_status?: string | null;
     last_error_detail?: string | null;
     expected_deletion_at?: string | null;
-    total_count: number | string;
+    total_count: number;
   }>;
 };
 

--- a/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-migration.generated.ts
+++ b/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-migration.generated.ts
@@ -1,0 +1,109 @@
+/* eslint-disable */
+import * as Types from "@/graphql/graphql";
+
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type FetchAdminRpManagerKeyMigrationQueryVariables = Types.Exact<{
+  [key: string]: never;
+}>;
+
+export type FetchAdminRpManagerKeyMigrationQuery = {
+  __typename?: "query_root";
+  inventory: Array<{
+    __typename?: "admin_rp_manager_key_migration";
+    remaining_cron_candidates: number | string;
+    unique_excluded_from_cron: number | string;
+    on_shared_with_audit: number | string;
+    on_shared_without_audit: number | string;
+    unique_with_audit: number | string;
+    audit_pending: number | string;
+    audit_failed: number | string;
+    audit_blocked: number | string;
+    audit_ready_for_external_cleanup: number | string;
+    audit_deletion_scheduled: number | string;
+    audit_deleted: number | string;
+    audit_deletion_overdue: number | string;
+  }>;
+  queue: Array<{
+    __typename?: "admin_rp_manager_key_migration_queue";
+    kind: string;
+    rp_id: string;
+    app_id: string;
+    app_name?: string | null;
+    updated_at?: string | null;
+    cleanup_status?: string | null;
+    last_error_detail?: string | null;
+    expected_deletion_at?: string | null;
+    total_count: number | string;
+  }>;
+};
+
+export const FetchAdminRpManagerKeyMigrationDocument = gql`
+  query FetchAdminRpManagerKeyMigration {
+    inventory: admin_rp_manager_key_migration {
+      remaining_cron_candidates
+      unique_excluded_from_cron
+      on_shared_with_audit
+      on_shared_without_audit
+      unique_with_audit
+      audit_pending
+      audit_failed
+      audit_blocked
+      audit_ready_for_external_cleanup
+      audit_deletion_scheduled
+      audit_deleted
+      audit_deletion_overdue
+    }
+    queue: admin_rp_manager_key_migration_queue {
+      kind
+      rp_id
+      app_id
+      app_name
+      updated_at
+      cleanup_status
+      last_error_detail
+      expected_deletion_at
+      total_count
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    FetchAdminRpManagerKeyMigration(
+      variables?: FetchAdminRpManagerKeyMigrationQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchAdminRpManagerKeyMigrationQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchAdminRpManagerKeyMigrationQuery>(
+            FetchAdminRpManagerKeyMigrationDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        "FetchAdminRpManagerKeyMigration",
+        "query",
+        variables,
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-migration.gql
+++ b/web/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-migration.gql
@@ -1,0 +1,28 @@
+# TODO: delete this file after the RP manager key migration completes.
+query FetchAdminRpManagerKeyMigration {
+  inventory: admin_rp_manager_key_migration {
+    remaining_cron_candidates
+    unique_excluded_from_cron
+    on_shared_with_audit
+    on_shared_without_audit
+    unique_with_audit
+    audit_pending
+    audit_failed
+    audit_blocked
+    audit_ready_for_external_cleanup
+    audit_deletion_scheduled
+    audit_deleted
+    audit_deletion_overdue
+  }
+  queue: admin_rp_manager_key_migration_queue {
+    kind
+    rp_id
+    app_id
+    app_name
+    updated_at
+    cleanup_status
+    last_error_detail
+    expected_deletion_at
+    total_count
+  }
+}

--- a/web/scenes/Admin/rps/manager-key-migration/server/fetch-migration-status.ts
+++ b/web/scenes/Admin/rps/manager-key-migration/server/fetch-migration-status.ts
@@ -1,0 +1,165 @@
+// TODO: delete this file after the RP manager key migration completes.
+//
+// Cleanup checklist:
+// 1. Delete web/scenes/Admin/rps/manager-key-migration/.
+// 2. Remove the TODO inserts from Admin/rps/page.tsx and Admin/rps/id/page.tsx.
+// 3. Remove the native queries and logical models from databases.yaml.
+// 4. Revert internal_dashboard_readonly grants for unique/key and audit select.
+// 5. Delete web/tests/unit/admin-rp-manager-key-migration-fetch.test.ts.
+// 6. Regenerate GraphQL schema/types.
+
+import "server-only";
+
+import { getInternalDashboardGraphqlClient } from "@/api/helpers/graphql";
+import { logger } from "@/lib/logger";
+
+import {
+  type FetchAdminRpManagerKeyMigrationQuery,
+  getSdk,
+} from "../graphql/server/fetch-admin-rp-manager-key-migration.generated";
+import {
+  MigrationQueueKind,
+  type AdminRpManagerKeyMigrationQueueItem,
+} from "../types";
+
+// #region Types
+
+export type AdminRpManagerKeyMigrationInventory = {
+  remainingCronCandidates: number;
+  uniqueExcludedFromCron: number;
+  onSharedWithAudit: number;
+  onSharedWithoutAudit: number;
+  uniqueWithAudit: number;
+  auditPending: number;
+  auditFailed: number;
+  auditBlocked: number;
+  auditReadyForExternalCleanup: number;
+  auditDeletionScheduled: number;
+  auditDeleted: number;
+  auditDeletionOverdue: number;
+};
+
+export type { AdminRpManagerKeyMigrationQueueItem };
+
+export type AdminRpManagerKeyMigrationFlags = {
+  migrationEnabled: boolean;
+  cleanupEnabled: boolean;
+};
+
+export type AdminRpManagerKeyMigrationStatus = {
+  flags: AdminRpManagerKeyMigrationFlags;
+  inventory: AdminRpManagerKeyMigrationInventory;
+  remainingCronCandidates: AdminRpManagerKeyMigrationQueueItem[];
+  cleanupNeedsAttention: AdminRpManagerKeyMigrationQueueItem[];
+  remainingCronCandidateCount: number;
+  cleanupNeedsAttentionCount: number;
+};
+
+// #endregion
+
+const toCount = (value: number | string | null | undefined): number => {
+  const count = Number(value ?? 0);
+  return Number.isFinite(count) ? count : 0;
+};
+
+const isMigrationQueueKind = (value: string): value is MigrationQueueKind =>
+  Object.values(MigrationQueueKind).some((kind) => kind === value);
+
+// ANCHOR: Map the single-row native query into dashboard inventory counters.
+export const mapMigrationInventory = (
+  inventory: FetchAdminRpManagerKeyMigrationQuery["inventory"][number],
+): AdminRpManagerKeyMigrationInventory => ({
+  remainingCronCandidates: toCount(inventory.remaining_cron_candidates),
+  uniqueExcludedFromCron: toCount(inventory.unique_excluded_from_cron),
+  onSharedWithAudit: toCount(inventory.on_shared_with_audit),
+  onSharedWithoutAudit: toCount(inventory.on_shared_without_audit),
+  uniqueWithAudit: toCount(inventory.unique_with_audit),
+  auditPending: toCount(inventory.audit_pending),
+  auditFailed: toCount(inventory.audit_failed),
+  auditBlocked: toCount(inventory.audit_blocked),
+  auditReadyForExternalCleanup: toCount(
+    inventory.audit_ready_for_external_cleanup,
+  ),
+  auditDeletionScheduled: toCount(inventory.audit_deletion_scheduled),
+  auditDeleted: toCount(inventory.audit_deleted),
+  auditDeletionOverdue: toCount(inventory.audit_deletion_overdue),
+});
+
+// ANCHOR: Split native queue rows by kind and drop unknown kinds.
+export const mapMigrationQueues = (
+  rows: FetchAdminRpManagerKeyMigrationQuery["queue"],
+): {
+  remainingCronCandidates: AdminRpManagerKeyMigrationQueueItem[];
+  cleanupNeedsAttention: AdminRpManagerKeyMigrationQueueItem[];
+  remainingCronCandidateCount: number;
+  cleanupNeedsAttentionCount: number;
+} => {
+  const remainingCronCandidates: AdminRpManagerKeyMigrationQueueItem[] = [];
+  const cleanupNeedsAttention: AdminRpManagerKeyMigrationQueueItem[] = [];
+
+  for (const row of rows) {
+    if (!isMigrationQueueKind(row.kind)) {
+      continue;
+    }
+
+    const item: AdminRpManagerKeyMigrationQueueItem = {
+      kind: row.kind,
+      rpId: row.rp_id,
+      appId: row.app_id,
+      appName: row.app_name ?? null,
+      updatedAt: row.updated_at ?? null,
+      cleanupStatus: row.cleanup_status ?? null,
+      lastErrorDetail: row.last_error_detail ?? null,
+      expectedDeletionAt: row.expected_deletion_at ?? null,
+      totalCount: toCount(row.total_count),
+    };
+
+    if (row.kind === MigrationQueueKind.RemainingCronCandidate) {
+      remainingCronCandidates.push(item);
+    } else {
+      cleanupNeedsAttention.push(item);
+    }
+  }
+
+  return {
+    remainingCronCandidates,
+    cleanupNeedsAttention,
+    remainingCronCandidateCount: remainingCronCandidates[0]?.totalCount ?? 0,
+    cleanupNeedsAttentionCount: cleanupNeedsAttention[0]?.totalCount ?? 0,
+  };
+};
+
+// ANCHOR: Read migration/cleanup feature flags from the same Next.js process env.
+export const readMigrationFeatureFlags =
+  (): AdminRpManagerKeyMigrationFlags => ({
+    migrationEnabled: process.env.ENABLE_RP_MANAGER_KEY_MIGRATION === "true",
+    cleanupEnabled: process.env.ENABLE_RP_MANAGER_KEY_CLEANUP === "true",
+  });
+
+// ANCHOR: Load migration progress counters and attention queues for the admin panel.
+export const fetchAdminRpManagerKeyMigration =
+  async (): Promise<AdminRpManagerKeyMigrationStatus> => {
+    const client = await getInternalDashboardGraphqlClient();
+
+    try {
+      const data = await getSdk(client).FetchAdminRpManagerKeyMigration();
+      const inventoryRow = data.inventory[0];
+
+      if (!inventoryRow) {
+        throw new Error("admin_rp_manager_key_migration returned no rows");
+      }
+
+      const queues = mapMigrationQueues(data.queue);
+
+      return {
+        flags: readMigrationFeatureFlags(),
+        inventory: mapMigrationInventory(inventoryRow),
+        ...queues,
+      };
+    } catch (error) {
+      logger.error("Failed to fetch admin RP manager key migration status", {
+        error,
+      });
+      throw error;
+    }
+  };

--- a/web/scenes/Admin/rps/manager-key-migration/server/fetch-rp-migration-audit.ts
+++ b/web/scenes/Admin/rps/manager-key-migration/server/fetch-rp-migration-audit.ts
@@ -9,7 +9,6 @@ import { getSdk } from "../graphql/server/fetch-admin-rp-manager-key-audit.gener
 
 export type AdminRpManagerKeyAudit = {
   isUniqueManagerKey: boolean;
-  managerKmsKeyId: string | null;
   audit: {
     rpId: string;
     appId: string;
@@ -42,7 +41,6 @@ export const fetchAdminRpManagerKeyAudit = async (
 
     return {
       isUniqueManagerKey: data.rp_registration_by_pk.is_unique_manager_key,
-      managerKmsKeyId: data.rp_registration_by_pk.manager_kms_key_id ?? null,
       audit: auditRow
         ? {
             rpId: auditRow.rp_id,

--- a/web/scenes/Admin/rps/manager-key-migration/server/fetch-rp-migration-audit.ts
+++ b/web/scenes/Admin/rps/manager-key-migration/server/fetch-rp-migration-audit.ts
@@ -1,0 +1,69 @@
+// TODO: delete this file after the RP manager key migration completes.
+
+import "server-only";
+
+import { getInternalDashboardGraphqlClient } from "@/api/helpers/graphql";
+import { logger } from "@/lib/logger";
+
+import { getSdk } from "../graphql/server/fetch-admin-rp-manager-key-audit.generated";
+
+export type AdminRpManagerKeyAudit = {
+  isUniqueManagerKey: boolean;
+  managerKmsKeyId: string | null;
+  audit: {
+    rpId: string;
+    appId: string;
+    oldManagerKmsKeyId: string;
+    oldManagerKmsKeyArn: string;
+    sharedManagerKmsKeyId: string;
+    cleanupStatus: string;
+    lastErrorDetail: string | null;
+    deletionScheduledAt: string | null;
+    expectedDeletionAt: string | null;
+    createdAt: string;
+    updatedAt: string;
+  } | null;
+};
+
+// ANCHOR: Load unique-key flag and optional audit row for one RP detail page.
+export const fetchAdminRpManagerKeyAudit = async (
+  rpId: string,
+): Promise<AdminRpManagerKeyAudit | null> => {
+  const client = await getInternalDashboardGraphqlClient();
+
+  try {
+    const data = await getSdk(client).FetchAdminRpManagerKeyAudit({ rpId });
+
+    if (!data.rp_registration_by_pk) {
+      return null;
+    }
+
+    const auditRow = data.rp_manager_key_migration_audit_by_pk;
+
+    return {
+      isUniqueManagerKey: data.rp_registration_by_pk.is_unique_manager_key,
+      managerKmsKeyId: data.rp_registration_by_pk.manager_kms_key_id ?? null,
+      audit: auditRow
+        ? {
+            rpId: auditRow.rp_id,
+            appId: auditRow.app_id,
+            oldManagerKmsKeyId: auditRow.old_manager_kms_key_id,
+            oldManagerKmsKeyArn: auditRow.old_manager_kms_key_arn,
+            sharedManagerKmsKeyId: auditRow.shared_manager_kms_key_id,
+            cleanupStatus: auditRow.cleanup_status,
+            lastErrorDetail: auditRow.last_error_detail ?? null,
+            deletionScheduledAt: auditRow.deletion_scheduled_at ?? null,
+            expectedDeletionAt: auditRow.expected_deletion_at ?? null,
+            createdAt: auditRow.created_at,
+            updatedAt: auditRow.updated_at,
+          }
+        : null,
+    };
+  } catch (error) {
+    logger.error("Failed to fetch admin RP manager key audit", {
+      error,
+      rpId,
+    });
+    throw error;
+  }
+};

--- a/web/scenes/Admin/rps/manager-key-migration/types.ts
+++ b/web/scenes/Admin/rps/manager-key-migration/types.ts
@@ -1,0 +1,35 @@
+// TODO: delete this file after the RP manager key migration completes.
+//
+// Cleanup checklist:
+// 1. Delete web/scenes/Admin/rps/manager-key-migration/.
+// 2. Remove the TODO inserts from Admin/rps/page.tsx and Admin/rps/id/page.tsx.
+// 3. Remove the native queries and logical models from databases.yaml.
+// 4. Revert internal_dashboard_readonly grants for unique/key and audit select.
+// 5. Delete web/tests/unit/admin-rp-manager-key-migration-fetch.test.ts.
+// 6. Regenerate GraphQL schema/types.
+
+export enum MigrationCleanupStatus {
+  Pending = "pending",
+  Failed = "failed",
+  Blocked = "blocked",
+  ReadyForExternalCleanup = "ready_for_external_cleanup",
+  DeletionScheduled = "deletion_scheduled",
+  Deleted = "deleted",
+}
+
+export enum MigrationQueueKind {
+  RemainingCronCandidate = "remaining_cron_candidate",
+  CleanupNeedsAttention = "cleanup_needs_attention",
+}
+
+export type AdminRpManagerKeyMigrationQueueItem = {
+  kind: MigrationQueueKind;
+  rpId: string;
+  appId: string;
+  appName: string | null;
+  updatedAt: string | null;
+  cleanupStatus: string | null;
+  lastErrorDetail: string | null;
+  expectedDeletionAt: string | null;
+  totalCount: number;
+};

--- a/web/scenes/Admin/rps/page.tsx
+++ b/web/scenes/Admin/rps/page.tsx
@@ -20,6 +20,7 @@ import { UIModule } from "@/components/AdminDashboard/UIModule";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { RpManagerKeyMigrationPanel } from "./manager-key-migration/Panel";
 import { fetchAdminRpsPage, type AdminRpInventory } from "./server/fetch-rps";
 
 type AdminRpsPageProps = {
@@ -59,15 +60,22 @@ type MetricCardProps = {
   href?: string;
   label: string;
   value: number;
+  warn?: boolean;
 };
 
-const MetricCard = ({ detail, href, label, value }: MetricCardProps) => {
+const MetricCard = ({ detail, href, label, value, warn }: MetricCardProps) => {
   const content = (
     <>
       <div className="text-11 font-medium tracking-wide text-grey-400 uppercase">
         {label}
       </div>
-      <div className="mt-2 text-24 font-semibold tracking-[-0.02em] text-grey-900">
+      <div
+        className={
+          warn && value > 0
+            ? "mt-2 text-24 font-semibold tracking-[-0.02em] text-system-error-700"
+            : "mt-2 text-24 font-semibold tracking-[-0.02em] text-grey-900"
+        }
+      >
         {value}
       </div>
       {detail && <div className="mt-1 text-12 text-grey-500">{detail}</div>}
@@ -92,71 +100,66 @@ const MetricCard = ({ detail, href, label, value }: MetricCardProps) => {
   );
 };
 
+const StatusCounts = ({
+  counts,
+  includeUnset,
+}: {
+  counts: AdminRpInventory["status"] & { unset?: number };
+  includeUnset?: boolean;
+}) => (
+  <dl className="mt-2 grid grid-cols-2 gap-2 text-13">
+    <div className="flex justify-between gap-2">
+      <dt className="text-grey-500">Pending</dt>
+      <dd className="font-medium text-grey-900">{counts.pending}</dd>
+    </div>
+    <div className="flex justify-between gap-2">
+      <dt className="text-grey-500">Registered</dt>
+      <dd className="font-medium text-grey-900">{counts.registered}</dd>
+    </div>
+    <div className="flex justify-between gap-2">
+      <dt className="text-grey-500">Failed</dt>
+      <dd className="font-medium text-grey-900">{counts.failed}</dd>
+    </div>
+    <div className="flex justify-between gap-2">
+      <dt className="text-grey-500">Deactivated</dt>
+      <dd className="font-medium text-grey-900">{counts.deactivated}</dd>
+    </div>
+    {includeUnset && (
+      <div className="col-span-2 flex justify-between gap-2">
+        <dt className="text-grey-500">Unset</dt>
+        <dd className="font-medium text-grey-900">{counts.unset}</dd>
+      </div>
+    )}
+  </dl>
+);
+
 const StatusBreakdown = ({ inventory }: { inventory: AdminRpInventory }) => (
   <div className="grid gap-3 md:grid-cols-2">
     <section className="rounded-12 border border-grey-200 bg-grey-50 p-3">
-      <h3 className="text-14 font-semibold text-grey-900">Production status</h3>
-      <dl className="mt-2 grid grid-cols-2 gap-2 text-13">
-        <div className="flex justify-between gap-2">
-          <dt className="text-grey-500">Pending</dt>
-          <dd className="font-medium text-grey-900">
-            {inventory.status.pending}
-          </dd>
-        </div>
-        <div className="flex justify-between gap-2">
-          <dt className="text-grey-500">Registered</dt>
-          <dd className="font-medium text-grey-900">
-            {inventory.status.registered}
-          </dd>
-        </div>
-        <div className="flex justify-between gap-2">
-          <dt className="text-grey-500">Failed</dt>
-          <dd className="font-medium text-grey-900">
-            {inventory.status.failed}
-          </dd>
-        </div>
-        <div className="flex justify-between gap-2">
-          <dt className="text-grey-500">Deactivated</dt>
-          <dd className="font-medium text-grey-900">
-            {inventory.status.deactivated}
-          </dd>
-        </div>
-      </dl>
+      <h3 className="text-14 font-semibold text-grey-900">
+        Production RP Registry
+      </h3>
+      <p className="mt-1 text-12 text-grey-500">
+        On-chain registration in the production registry contract.
+      </p>
+      <StatusCounts counts={inventory.status} />
     </section>
     <section className="rounded-12 border border-grey-200 bg-grey-50 p-3">
-      <h3 className="text-14 font-semibold text-grey-900">Staging status</h3>
-      <dl className="mt-2 grid grid-cols-2 gap-2 text-13">
-        <div className="flex justify-between gap-2">
-          <dt className="text-grey-500">Pending</dt>
-          <dd className="font-medium text-grey-900">
-            {inventory.stagingStatus.pending}
-          </dd>
-        </div>
-        <div className="flex justify-between gap-2">
-          <dt className="text-grey-500">Registered</dt>
-          <dd className="font-medium text-grey-900">
-            {inventory.stagingStatus.registered}
-          </dd>
-        </div>
-        <div className="flex justify-between gap-2">
-          <dt className="text-grey-500">Failed</dt>
-          <dd className="font-medium text-grey-900">
-            {inventory.stagingStatus.failed}
-          </dd>
-        </div>
-        <div className="flex justify-between gap-2">
-          <dt className="text-grey-500">Deactivated</dt>
-          <dd className="font-medium text-grey-900">
-            {inventory.stagingStatus.deactivated}
-          </dd>
-        </div>
-        <div className="col-span-2 flex justify-between gap-2">
-          <dt className="text-grey-500">Unset</dt>
-          <dd className="font-medium text-grey-900">
-            {inventory.stagingStatus.null}
-          </dd>
-        </div>
-      </dl>
+      <h3 className="text-14 font-semibold text-grey-900">
+        Staging RP Registry
+      </h3>
+      <p className="mt-1 text-12 text-grey-500">
+        Second registration of the same RP, written by the production portal so
+        staging verification can resolve it on-chain. Unset means no staging
+        registration was recorded.
+      </p>
+      <StatusCounts
+        counts={{
+          ...inventory.stagingStatus,
+          unset: inventory.stagingStatus.null,
+        }}
+        includeUnset
+      />
     </section>
   </div>
 );
@@ -192,15 +195,15 @@ export const AdminRpsPage = async ({
   }
 
   return (
-    <div className="grid min-h-0 grid-rows-[auto_1fr] gap-y-4 max-lg:h-auto lg:h-full">
-      <UIModule className="p-5">
+    <div className="grid min-h-0 gap-4 max-lg:h-auto lg:h-full lg:grid-cols-[minmax(0,1fr)_minmax(18rem,22rem)] lg:grid-rows-[auto_minmax(0,1fr)]">
+      <UIModule className="min-w-0 p-5 lg:col-start-1 lg:row-start-1">
         <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
           <div className="min-w-0">
             <h1 className="text-24 font-semibold tracking-[-0.02em] text-grey-900">
               RPs
             </h1>
             <p className="mt-2 max-w-2xl text-14 text-grey-500">
-              Browse relying party registrations and manager-key inventory.
+              Relying party registrations.
             </p>
           </div>
           <div className="rounded-12 border border-grey-200 bg-grey-50 px-3 py-2">
@@ -214,7 +217,11 @@ export const AdminRpsPage = async ({
         </div>
         <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
           <MetricCard
-            detail={`${inventory.managedWithKey} with key reference`}
+            detail={
+              inventory.managedWithoutKey > 0
+                ? `${inventory.managedWithoutKey} without a KMS key`
+                : undefined
+            }
             href="/admin/rps?query=mode%3Amanaged"
             label="Managed"
             value={inventory.managedRps}
@@ -225,21 +232,26 @@ export const AdminRpsPage = async ({
             value={inventory.selfManagedRps}
           />
           <MetricCard
-            detail={`${inventory.managedWithoutKey} managed without key`}
-            label="Distinct manager keys"
-            value={inventory.distinctManagerKeys}
+            href="/admin/rps?query=mode%3Amanaged+unique%3Atrue"
+            label="Unique manager key"
+            value={inventory.uniqueManagerKeyRps}
+            warn
           />
           <MetricCard
-            detail={`${inventory.rpsOnSharedKeys} RPs on shared keys`}
-            label="Shared key groups"
-            value={inventory.sharedKeyGroups}
+            href="/admin/rps?query=mode%3Amanaged+unique%3Afalse"
+            label="Shared manager key"
+            value={inventory.sharedManagerKeyRps}
           />
         </div>
         <div className="mt-4">
           <StatusBreakdown inventory={inventory} />
         </div>
       </UIModule>
-      <UIModule className="grid min-h-0 min-w-0 grid-rows-[auto_minmax(0,1fr)] gap-y-3 p-4 max-lg:overflow-visible lg:overflow-hidden">
+      {/* TODO: remove after the RP manager key migration completes */}
+      <div className="min-h-0 min-w-0 max-lg:order-last lg:col-start-2 lg:row-span-2 lg:row-start-1">
+        <RpManagerKeyMigrationPanel />
+      </div>
+      <UIModule className="grid min-h-0 min-w-0 grid-rows-[auto_minmax(0,1fr)] gap-y-3 p-4 max-lg:overflow-visible lg:col-start-1 lg:row-start-2 lg:overflow-hidden">
         <RpsTableControls
           columnVisibility={columnVisibility}
           currentPage={currentPage}

--- a/web/scenes/Admin/rps/server/fetch-rps.ts
+++ b/web/scenes/Admin/rps/server/fetch-rps.ts
@@ -117,6 +117,24 @@ const createFieldWhere = (
     return noResultsWhere;
   }
 
+  if (token.field === "unique") {
+    if (token.value !== "true" && token.value !== "false") {
+      return noResultsWhere;
+    }
+
+    const isUnique = token.value === "true";
+
+    if (token.operator === "!=") {
+      return { is_unique_manager_key: { _eq: !isUnique } };
+    }
+
+    if (token.operator === ":" || token.operator === "=") {
+      return { is_unique_manager_key: { _eq: isUnique } };
+    }
+
+    return noResultsWhere;
+  }
+
   if (token.field === "status") {
     if (!RP_STATUSES.has(token.value)) {
       return noResultsWhere;
@@ -292,13 +310,11 @@ const toCount = (value: number | string | null | undefined): number => {
 };
 
 export type AdminRpInventory = {
-  distinctManagerKeys: number;
   managedRps: number;
-  managedWithKey: number;
   managedWithoutKey: number;
-  rpsOnSharedKeys: number;
   selfManagedRps: number;
-  sharedKeyGroups: number;
+  sharedManagerKeyRps: number;
+  uniqueManagerKeyRps: number;
   stagingStatus: {
     deactivated: number;
     failed: number;
@@ -318,13 +334,11 @@ export type AdminRpInventory = {
 export const mapAdminRpInventory = (
   inventory: FetchAdminRpInventoryQuery["admin_rp_inventory"][number],
 ): AdminRpInventory => ({
-  distinctManagerKeys: toCount(inventory.distinct_manager_keys),
   managedRps: toCount(inventory.managed_rps),
-  managedWithKey: toCount(inventory.managed_with_key),
   managedWithoutKey: toCount(inventory.managed_without_key),
-  rpsOnSharedKeys: toCount(inventory.rps_on_shared_keys),
   selfManagedRps: toCount(inventory.self_managed_rps),
-  sharedKeyGroups: toCount(inventory.shared_key_groups),
+  sharedManagerKeyRps: toCount(inventory.shared_manager_key_rps),
+  uniqueManagerKeyRps: toCount(inventory.unique_manager_key_rps),
   stagingStatus: {
     deactivated: toCount(inventory.staging_status_deactivated),
     failed: toCount(inventory.staging_status_failed),

--- a/web/tests/unit/admin-rp-manager-key-migration-fetch.test.ts
+++ b/web/tests/unit/admin-rp-manager-key-migration-fetch.test.ts
@@ -273,7 +273,6 @@ describe("admin RP manager key migration fetch", () => {
     mockFetchAdminRpManagerKeyAudit.mockResolvedValue({
       rp_registration_by_pk: {
         is_unique_manager_key: false,
-        manager_kms_key_id: "arn:aws:kms:eu-west-1:1:key/shared",
       },
       rp_manager_key_migration_audit_by_pk: {
         rp_id: "rp_eeeeeeeeeeeeeeee",
@@ -294,7 +293,6 @@ describe("admin RP manager key migration fetch", () => {
       fetchAdminRpManagerKeyAudit("rp_eeeeeeeeeeeeeeee"),
     ).resolves.toEqual({
       isUniqueManagerKey: false,
-      managerKmsKeyId: "arn:aws:kms:eu-west-1:1:key/shared",
       audit: {
         rpId: "rp_eeeeeeeeeeeeeeee",
         appId: "app_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
@@ -315,7 +313,6 @@ describe("admin RP manager key migration fetch", () => {
     mockFetchAdminRpManagerKeyAudit.mockResolvedValue({
       rp_registration_by_pk: {
         is_unique_manager_key: false,
-        manager_kms_key_id: "arn:aws:kms:eu-west-1:1:key/shared",
       },
       rp_manager_key_migration_audit_by_pk: null,
     });
@@ -324,7 +321,6 @@ describe("admin RP manager key migration fetch", () => {
       fetchAdminRpManagerKeyAudit("rp_ffffffffffffffff"),
     ).resolves.toEqual({
       isUniqueManagerKey: false,
-      managerKmsKeyId: "arn:aws:kms:eu-west-1:1:key/shared",
       audit: null,
     });
   });

--- a/web/tests/unit/admin-rp-manager-key-migration-fetch.test.ts
+++ b/web/tests/unit/admin-rp-manager-key-migration-fetch.test.ts
@@ -1,0 +1,342 @@
+const mockFetchAdminRpManagerKeyMigration = jest.fn();
+const mockFetchAdminRpManagerKeyAudit = jest.fn();
+
+jest.mock("server-only", () => ({}));
+
+jest.mock("@/api/helpers/graphql", () => ({
+  getInternalDashboardGraphqlClient: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock(
+  "@/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-migration.generated",
+  () => ({
+    getSdk: () => ({
+      FetchAdminRpManagerKeyMigration: mockFetchAdminRpManagerKeyMigration,
+    }),
+  }),
+);
+
+jest.mock(
+  "@/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-audit.generated",
+  () => ({
+    getSdk: () => ({
+      FetchAdminRpManagerKeyAudit: mockFetchAdminRpManagerKeyAudit,
+    }),
+  }),
+);
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+import { logger } from "@/lib/logger";
+import {
+  fetchAdminRpManagerKeyMigration,
+  mapMigrationInventory,
+  mapMigrationQueues,
+  readMigrationFeatureFlags,
+} from "@/scenes/Admin/rps/manager-key-migration/server/fetch-migration-status";
+import { fetchAdminRpManagerKeyAudit } from "@/scenes/Admin/rps/manager-key-migration/server/fetch-rp-migration-audit";
+import { MigrationQueueKind } from "@/scenes/Admin/rps/manager-key-migration/types";
+
+describe("admin RP manager key migration fetch", () => {
+  const originalMigrationFlag = process.env.ENABLE_RP_MANAGER_KEY_MIGRATION;
+  const originalCleanupFlag = process.env.ENABLE_RP_MANAGER_KEY_CLEANUP;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.ENABLE_RP_MANAGER_KEY_MIGRATION;
+    delete process.env.ENABLE_RP_MANAGER_KEY_CLEANUP;
+  });
+
+  afterAll(() => {
+    if (originalMigrationFlag === undefined) {
+      delete process.env.ENABLE_RP_MANAGER_KEY_MIGRATION;
+    } else {
+      process.env.ENABLE_RP_MANAGER_KEY_MIGRATION = originalMigrationFlag;
+    }
+
+    if (originalCleanupFlag === undefined) {
+      delete process.env.ENABLE_RP_MANAGER_KEY_CLEANUP;
+    } else {
+      process.env.ENABLE_RP_MANAGER_KEY_CLEANUP = originalCleanupFlag;
+    }
+  });
+
+  it("maps inventory counters including bigint strings", () => {
+    expect(
+      mapMigrationInventory({
+        remaining_cron_candidates: "17",
+        unique_excluded_from_cron: 2,
+        on_shared_with_audit: "55",
+        on_shared_without_audit: 72,
+        unique_with_audit: "3",
+        audit_pending: 58,
+        audit_failed: "1",
+        audit_blocked: 0,
+        audit_ready_for_external_cleanup: "4",
+        audit_deletion_scheduled: 5,
+        audit_deleted: "6",
+        audit_deletion_overdue: 1,
+      }),
+    ).toEqual({
+      remainingCronCandidates: 17,
+      uniqueExcludedFromCron: 2,
+      onSharedWithAudit: 55,
+      onSharedWithoutAudit: 72,
+      uniqueWithAudit: 3,
+      auditPending: 58,
+      auditFailed: 1,
+      auditBlocked: 0,
+      auditReadyForExternalCleanup: 4,
+      auditDeletionScheduled: 5,
+      auditDeleted: 6,
+      auditDeletionOverdue: 1,
+    });
+  });
+
+  it("splits queue rows by kind and ignores unknown kinds", () => {
+    expect(
+      mapMigrationQueues([
+        {
+          kind: MigrationQueueKind.RemainingCronCandidate,
+          rp_id: "rp_aaaaaaaaaaaaaaaa",
+          app_id: "app_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          app_name: "Alpha",
+          updated_at: "2026-08-13T00:00:00.000Z",
+          cleanup_status: null,
+          last_error_detail: null,
+          expected_deletion_at: null,
+          total_count: "17",
+        },
+        {
+          kind: "unknown_kind",
+          rp_id: "rp_bbbbbbbbbbbbbbbb",
+          app_id: "app_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          app_name: "Ignore",
+          updated_at: null,
+          cleanup_status: null,
+          last_error_detail: null,
+          expected_deletion_at: null,
+          total_count: 1,
+        },
+        {
+          kind: MigrationQueueKind.CleanupNeedsAttention,
+          rp_id: "rp_cccccccccccccccc",
+          app_id: "app_cccccccccccccccccccccccccccccccc",
+          app_name: "Blocked",
+          updated_at: "2026-08-12T00:00:00.000Z",
+          cleanup_status: "blocked",
+          last_error_detail: "tag mismatch",
+          expected_deletion_at: null,
+          total_count: 2,
+        },
+      ]),
+    ).toEqual({
+      remainingCronCandidates: [
+        {
+          kind: MigrationQueueKind.RemainingCronCandidate,
+          rpId: "rp_aaaaaaaaaaaaaaaa",
+          appId: "app_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          appName: "Alpha",
+          updatedAt: "2026-08-13T00:00:00.000Z",
+          cleanupStatus: null,
+          lastErrorDetail: null,
+          expectedDeletionAt: null,
+          totalCount: 17,
+        },
+      ],
+      cleanupNeedsAttention: [
+        {
+          kind: MigrationQueueKind.CleanupNeedsAttention,
+          rpId: "rp_cccccccccccccccc",
+          appId: "app_cccccccccccccccccccccccccccccccc",
+          appName: "Blocked",
+          updatedAt: "2026-08-12T00:00:00.000Z",
+          cleanupStatus: "blocked",
+          lastErrorDetail: "tag mismatch",
+          expectedDeletionAt: null,
+          totalCount: 2,
+        },
+      ],
+      remainingCronCandidateCount: 17,
+      cleanupNeedsAttentionCount: 2,
+    });
+  });
+
+  it("reads feature flags only when set to true", () => {
+    expect(readMigrationFeatureFlags()).toEqual({
+      migrationEnabled: false,
+      cleanupEnabled: false,
+    });
+
+    process.env.ENABLE_RP_MANAGER_KEY_MIGRATION = "true";
+    process.env.ENABLE_RP_MANAGER_KEY_CLEANUP = "false";
+
+    expect(readMigrationFeatureFlags()).toEqual({
+      migrationEnabled: true,
+      cleanupEnabled: false,
+    });
+  });
+
+  it("fetches and maps migration status", async () => {
+    process.env.ENABLE_RP_MANAGER_KEY_CLEANUP = "true";
+    mockFetchAdminRpManagerKeyMigration.mockResolvedValue({
+      inventory: [
+        {
+          remaining_cron_candidates: 17,
+          unique_excluded_from_cron: 0,
+          on_shared_with_audit: 55,
+          on_shared_without_audit: 72,
+          unique_with_audit: 3,
+          audit_pending: 58,
+          audit_failed: 0,
+          audit_blocked: 0,
+          audit_ready_for_external_cleanup: 0,
+          audit_deletion_scheduled: 0,
+          audit_deleted: 0,
+          audit_deletion_overdue: 0,
+        },
+      ],
+      queue: [
+        {
+          kind: MigrationQueueKind.RemainingCronCandidate,
+          rp_id: "rp_dddddddddddddddd",
+          app_id: "app_dddddddddddddddddddddddddddddddd",
+          app_name: "Stuck",
+          updated_at: "2026-08-11T00:00:00.000Z",
+          cleanup_status: null,
+          last_error_detail: null,
+          expected_deletion_at: null,
+          total_count: 17,
+        },
+      ],
+    });
+
+    await expect(fetchAdminRpManagerKeyMigration()).resolves.toEqual({
+      flags: {
+        migrationEnabled: false,
+        cleanupEnabled: true,
+      },
+      inventory: {
+        remainingCronCandidates: 17,
+        uniqueExcludedFromCron: 0,
+        onSharedWithAudit: 55,
+        onSharedWithoutAudit: 72,
+        uniqueWithAudit: 3,
+        auditPending: 58,
+        auditFailed: 0,
+        auditBlocked: 0,
+        auditReadyForExternalCleanup: 0,
+        auditDeletionScheduled: 0,
+        auditDeleted: 0,
+        auditDeletionOverdue: 0,
+      },
+      remainingCronCandidates: [
+        expect.objectContaining({
+          rpId: "rp_dddddddddddddddd",
+          totalCount: 17,
+        }),
+      ],
+      cleanupNeedsAttention: [],
+      remainingCronCandidateCount: 17,
+      cleanupNeedsAttentionCount: 0,
+    });
+  });
+
+  it("throws when the inventory native query returns no rows", async () => {
+    mockFetchAdminRpManagerKeyMigration.mockResolvedValue({
+      inventory: [],
+      queue: [],
+    });
+
+    await expect(fetchAdminRpManagerKeyMigration()).rejects.toThrow(
+      "admin_rp_manager_key_migration returned no rows",
+    );
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("rethrows GraphQL errors from the migration status query", async () => {
+    mockFetchAdminRpManagerKeyMigration.mockRejectedValue(
+      new Error("hasura unavailable"),
+    );
+
+    await expect(fetchAdminRpManagerKeyMigration()).rejects.toThrow(
+      "hasura unavailable",
+    );
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("maps RP audit detail when an audit row exists", async () => {
+    mockFetchAdminRpManagerKeyAudit.mockResolvedValue({
+      rp_registration_by_pk: {
+        is_unique_manager_key: false,
+        manager_kms_key_id: "arn:aws:kms:eu-west-1:1:key/shared",
+      },
+      rp_manager_key_migration_audit_by_pk: {
+        rp_id: "rp_eeeeeeeeeeeeeeee",
+        app_id: "app_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        old_manager_kms_key_id: "old-key",
+        old_manager_kms_key_arn: "arn:aws:kms:eu-west-1:1:key/old",
+        shared_manager_kms_key_id: "arn:aws:kms:eu-west-1:1:key/shared",
+        cleanup_status: "pending",
+        last_error_detail: null,
+        deletion_scheduled_at: null,
+        expected_deletion_at: null,
+        created_at: "2026-08-10T00:00:00.000Z",
+        updated_at: "2026-08-11T00:00:00.000Z",
+      },
+    });
+
+    await expect(
+      fetchAdminRpManagerKeyAudit("rp_eeeeeeeeeeeeeeee"),
+    ).resolves.toEqual({
+      isUniqueManagerKey: false,
+      managerKmsKeyId: "arn:aws:kms:eu-west-1:1:key/shared",
+      audit: {
+        rpId: "rp_eeeeeeeeeeeeeeee",
+        appId: "app_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        oldManagerKmsKeyId: "old-key",
+        oldManagerKmsKeyArn: "arn:aws:kms:eu-west-1:1:key/old",
+        sharedManagerKmsKeyId: "arn:aws:kms:eu-west-1:1:key/shared",
+        cleanupStatus: "pending",
+        lastErrorDetail: null,
+        deletionScheduledAt: null,
+        expectedDeletionAt: null,
+        createdAt: "2026-08-10T00:00:00.000Z",
+        updatedAt: "2026-08-11T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("returns audit null when the RP has no audit row", async () => {
+    mockFetchAdminRpManagerKeyAudit.mockResolvedValue({
+      rp_registration_by_pk: {
+        is_unique_manager_key: false,
+        manager_kms_key_id: "arn:aws:kms:eu-west-1:1:key/shared",
+      },
+      rp_manager_key_migration_audit_by_pk: null,
+    });
+
+    await expect(
+      fetchAdminRpManagerKeyAudit("rp_ffffffffffffffff"),
+    ).resolves.toEqual({
+      isUniqueManagerKey: false,
+      managerKmsKeyId: "arn:aws:kms:eu-west-1:1:key/shared",
+      audit: null,
+    });
+  });
+
+  it("returns null when the RP does not exist", async () => {
+    mockFetchAdminRpManagerKeyAudit.mockResolvedValue({
+      rp_registration_by_pk: null,
+      rp_manager_key_migration_audit_by_pk: null,
+    });
+
+    await expect(
+      fetchAdminRpManagerKeyAudit("rp_0000000000000000"),
+    ).resolves.toBeNull();
+  });
+});

--- a/web/tests/unit/admin-rp-manager-key-migration-fetch.test.ts
+++ b/web/tests/unit/admin-rp-manager-key-migration-fetch.test.ts
@@ -32,6 +32,7 @@ jest.mock("@/lib/logger", () => ({
 }));
 
 import { logger } from "@/lib/logger";
+import type { FetchAdminRpManagerKeyMigrationQuery } from "@/scenes/Admin/rps/manager-key-migration/graphql/server/fetch-admin-rp-manager-key-migration.generated";
 import {
   fetchAdminRpManagerKeyMigration,
   mapMigrationInventory,
@@ -80,7 +81,7 @@ describe("admin RP manager key migration fetch", () => {
         audit_deletion_scheduled: 5,
         audit_deleted: "6",
         audit_deletion_overdue: 1,
-      }),
+      } as unknown as FetchAdminRpManagerKeyMigrationQuery["inventory"][number]),
     ).toEqual({
       remainingCronCandidates: 17,
       uniqueExcludedFromCron: 2,
@@ -133,7 +134,7 @@ describe("admin RP manager key migration fetch", () => {
           expected_deletion_at: null,
           total_count: 2,
         },
-      ]),
+      ] as unknown as FetchAdminRpManagerKeyMigrationQuery["queue"]),
     ).toEqual({
       remainingCronCandidates: [
         {

--- a/web/tests/unit/admin-rps-fetch.test.ts
+++ b/web/tests/unit/admin-rps-fetch.test.ts
@@ -83,6 +83,19 @@ describe("admin RPs query mapping", () => {
     expect(createRpsWhere("status:bogus")).toEqual({ rp_id: { _in: [] } });
   });
 
+  it("filters managed RPs by unique vs shared manager key", () => {
+    expect(createRpsWhere("unique:true")).toEqual({
+      is_unique_manager_key: { _eq: true },
+    });
+    expect(createRpsWhere("unique:false")).toEqual({
+      is_unique_manager_key: { _eq: false },
+    });
+    expect(createRpsWhere("unique!=true")).toEqual({
+      is_unique_manager_key: { _eq: false },
+    });
+    expect(createRpsWhere("unique:maybe")).toEqual({ rp_id: { _in: [] } });
+  });
+
   it("applies inequality operators to mode and status enums", () => {
     expect(createRpsWhere("mode!=managed")).toEqual({
       mode: { _neq: "managed" },
@@ -171,13 +184,12 @@ describe("admin RPs query mapping", () => {
   it("maps inventory aggregate counts without exposing key identifiers", () => {
     expect(
       mapAdminRpInventory({
-        distinct_manager_keys: 3,
         managed_rps: 10,
         managed_with_key: 8,
         managed_without_key: 2,
-        rps_on_shared_keys: 4,
         self_managed_rps: 5,
-        shared_key_groups: 1,
+        shared_manager_key_rps: 7,
+        unique_manager_key_rps: 3,
         staging_status_deactivated: 0,
         staging_status_failed: 1,
         staging_status_null: 6,
@@ -190,13 +202,11 @@ describe("admin RPs query mapping", () => {
         total_rps: 15,
       }),
     ).toEqual({
-      distinctManagerKeys: 3,
       managedRps: 10,
-      managedWithKey: 8,
       managedWithoutKey: 2,
-      rpsOnSharedKeys: 4,
       selfManagedRps: 5,
-      sharedKeyGroups: 1,
+      sharedManagerKeyRps: 7,
+      uniqueManagerKeyRps: 3,
       stagingStatus: {
         deactivated: 0,
         failed: 1,

--- a/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
+++ b/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
@@ -128,3 +128,27 @@ describe("internal dashboard detail permissions", () => {
     expect(inheritedRoles.trim()).toBe("[]");
   });
 });
+
+describe("admin RP inventory native query", () => {
+  it("counts unique and shared manager keys only when a KMS key exists", () => {
+    const databases = readFileSync(
+      path.join(tablesPath, "../../databases.yaml"),
+      "utf8",
+    );
+    const start = databases.indexOf("root_field_name: admin_rp_inventory");
+    const end = databases.indexOf("returns: admin_rp_inventory", start);
+    const sql = databases.slice(start, end);
+
+    const uniqueFilter = sql.match(
+      /COUNT\(\*\) FILTER \(\s*WHERE[\s\S]*?\)::bigint AS unique_manager_key_rps/,
+    )?.[0];
+    const sharedFilter = sql.match(
+      /COUNT\(\*\) FILTER \(\s*WHERE[\s\S]*?\)::bigint AS shared_manager_key_rps/,
+    )?.[0];
+
+    expect(uniqueFilter).toContain("is_unique_manager_key = true");
+    expect(uniqueFilter).toContain("manager_kms_key_id IS NOT NULL");
+    expect(sharedFilter).toContain("is_unique_manager_key = false");
+    expect(sharedFilter).toContain("manager_kms_key_id IS NOT NULL");
+  });
+});

--- a/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
+++ b/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
@@ -58,6 +58,7 @@ describe("internal dashboard detail permissions", () => {
     expect(permission).toContain("- signer_address");
     expect(permission).toContain("- operation_hash");
     expect(permission).toContain("- staging_operation_hash");
+    expect(permission).toContain("- is_unique_manager_key");
     expect(permission).toContain("allow_aggregations: true");
     expect(permission).not.toContain("- manager_kms_key_id");
   });


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

This PR adds a temporary admin tracker for the RP manager-key migration so ops can see remaining unique-key RPs and cleanup that needs a person.

- Adds a panel on `/admin/rps` and an audit section on RP detail. Inventory counts unique vs shared keys (`is_unique_manager_key`) instead of distinct KMS ids.
- Grants `internal_dashboard_readonly` select on those key fields and the audit table. Apply Hasura metadata before the panel can load.
- Adds unit tests for inventory mapping and migration status mapping.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.


---

<img width="1788" height="1325" alt="image" src="https://github.com/user-attachments/assets/b59bc4f6-5a2f-40e6-a5bf-cd700bef2a27" />
