### PR TITLE
ci: align e2e-tests with the action versions used by the rest of ci-app-router.yml

### DIFF
--- a/.github/workflows/ci-app-router.yml
+++ b/.github/workflows/ci-app-router.yml
@@ -184,8 +184,8 @@ jobs:
         working-directory: web
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
 
@@ -197,7 +197,7 @@ jobs:
           docker compose -f ../docker-compose.yaml up -d
 
       - name: Set up Node 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"


### PR DESCRIPTION
## PR Type

- [x] Regular Task

## Description

`ci-app-router.yml` defines seven jobs. Six of them (`lint`, `build`, `docker-build`, `api-tests`, `integration-tests`, `unit-tests`) pin `actions/checkout@v4`, `pnpm/action-setup@v4` and `actions/setup-node@v4`. The `e2e-tests` job alone is still on `actions/checkout@v2`, `pnpm/action-setup@v2` and `actions/setup-node@v3` — it looks like it was simply missed when the rest of the file was bumped.

Those majors run on the retired Node 12 / Node 16 action runtimes, so every pull-request run of this workflow emits deprecation warnings for that one job while the other six are clean.

This aligns `e2e-tests` with the file's own convention. No inputs change: the job already passes `version: 9` to `pnpm/action-setup`, and the same `node-version: 20` / `cache: "pnpm"` / `cache-dependency-path: web/pnpm-lock.yaml` to `setup-node`, as `integration-tests` does. After this change the setup steps of the two jobs are identical.

Scope is intentionally limited to the three stale pins. `satackey/action-docker-layer-caching@v0.0.11` is left as-is — it is used identically by `integration-tests`, and changing it is a separate decision.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.

<sub>No tests or docs apply — this only changes pinned action versions in CI configuration.</sub>
