### PR TITLE
Enhance RP manager key migration process

### DIFF
--- a/hasura/metadata/cron_triggers.yaml
+++ b/hasura/metadata/cron_triggers.yaml
@@ -70,7 +70,7 @@
   comment: Deactivate the managed RP signer on-chain for soft-deleted apps whose RP is still live (reconciles delete-time failures and backfills apps deleted before delete-time deactivation existed).
 - name: Migrate RP manager keys
   webhook: '{{NEXT_API_URL}}/_migrate-rp-manager-keys'
-  schedule: '*/15 * * * *'
+  schedule: '* * * * *'
   include_in_metadata: true
   payload: {}
   retry_conf:
@@ -81,7 +81,7 @@
   headers:
     - name: Authorization
       value_from_env: INTERNAL_ENDPOINTS_SECRET
-  comment: Migrate one eligible managed RP from its legacy KMS manager key to the deployment shared manager key.
+  comment: Migrate up to 15 eligible managed RPs from their legacy KMS manager keys to the deployment shared manager key.
 - name: Cleanup RP manager keys
   webhook: '{{NEXT_API_URL}}/_cleanup-rp-manager-keys'
   schedule: '*/15 * * * *'

--- a/web/api/_migrate-rp-manager-keys/index.ts
+++ b/web/api/_migrate-rp-manager-keys/index.ts
@@ -198,6 +198,22 @@ async function touchForCooldown(
   }
 }
 
+async function applyCandidateCooldown(
+  client: GraphQLClient,
+  candidate: Candidate,
+  attemptId: string,
+): Promise<void> {
+  try {
+    await touchForCooldown(client, candidate, attemptId);
+  } catch (error) {
+    logger.warn("Failed to apply RP migration cooldown", {
+      error,
+      attempt_id: attemptId,
+      ...candidateIdentity(candidate),
+    });
+  }
+}
+
 // #endregion
 
 // #region Endpoint
@@ -357,10 +373,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         retainRpIds.add(candidate.rp_id);
       }
 
-      if (!result || result.status === "failed") {
-        await touchForCooldown(client, candidate, attemptId);
-      }
-
       const outcome = result?.status ?? "ineligible";
       const operationHashes = result?.operationHashes ?? {};
 
@@ -377,6 +389,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         retain_rp_lock: retainRpLock,
         ...(result?.status === "failed" ? { failure: result.failure } : {}),
       });
+    }
+
+    for (const { candidate } of locked) {
+      const result = resultsByRpId.get(candidate.rp_id);
+      if (!result || result.status === "failed") {
+        await applyCandidateCooldown(client, candidate, attemptId);
+      }
     }
 
     const succeededRpIds = resultLogs
@@ -433,15 +452,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     if (client) {
       for (const { candidate } of locked) {
-        try {
-          await touchForCooldown(client, candidate, attemptId ?? randomUUID());
-        } catch (cooldownError) {
-          logger.warn("Failed to apply RP migration cooldown", {
-            error: cooldownError,
-            attempt_id: attemptId,
-            ...candidateIdentity(candidate),
-          });
-        }
+        await applyCandidateCooldown(
+          client,
+          candidate,
+          attemptId ?? randomUUID(),
+        );
       }
     }
 

--- a/web/api/_migrate-rp-manager-keys/index.ts
+++ b/web/api/_migrate-rp-manager-keys/index.ts
@@ -22,13 +22,32 @@ import { migrateRpManagersToSharedKey } from "../../scripts/migrate-rp-manager-t
 const GLOBAL_LOCK_KEY = "rp-manager-key-migration:run";
 const GLOBAL_LOCK_TTL_MS = 5 * 60 * 1000; // 5 min
 const FAILURE_COOLDOWN_MS = RP_MIGRATION_LOCK_TTL_MS;
-const CANDIDATE_BATCH_SIZE = 10;
+const MIGRATE_PER_RUN = 15;
+const CANDIDATE_FETCH_LIMIT = 20;
 
 type Candidate = {
   rp_id: string;
   app_id: string;
   manager_kms_key_id: string;
 };
+
+type AcquiredRpLock = Extract<
+  Awaited<ReturnType<typeof acquireRpMigrationLock>>,
+  { status: "acquired" }
+>;
+
+type LockedCandidate = {
+  candidate: Candidate;
+  rpLock: AcquiredRpLock;
+};
+
+function candidateIdentity(candidate: Candidate) {
+  return {
+    rp_id: candidate.rp_id,
+    app_id: candidate.app_id,
+    old_manager_kms_key_id: candidate.manager_kms_key_id,
+  };
+}
 
 type CandidateQueryResult = {
   rp_registration: Candidate[];
@@ -160,21 +179,21 @@ async function releaseGlobalLock(
 
 async function touchForCooldown(
   client: GraphQLClient,
-  rpId: string,
+  candidate: Candidate,
   attemptId: string,
 ): Promise<void> {
   const result = await client.request<
     TouchResult,
     { rp_id: string; updated_at: string }
   >(TOUCH_FAILED_CANDIDATE, {
-    rp_id: rpId,
+    rp_id: candidate.rp_id,
     updated_at: new Date().toISOString(),
   });
 
   if (result.update_rp_registration?.affected_rows !== 1) {
     logger.warn("Failed RP migration candidate changed before cooldown", {
       attempt_id: attemptId,
-      rp_id: rpId,
+      ...candidateIdentity(candidate),
     });
   }
 }
@@ -193,6 +212,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const lock = await acquireGlobalLock();
   if (lock.status === "busy") {
+    logger.info("RP manager key migration skipped, global lock held");
     return new NextResponse(null, { status: 204 });
   }
 
@@ -208,12 +228,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   let client: GraphQLClient | null = null;
-  let candidate: Candidate | null = null;
   let attemptId: string | null = null;
-  let rpLock: Awaited<ReturnType<typeof acquireRpMigrationLock>> | null = null;
+  const locked: LockedCandidate[] = [];
+  const retainRpIds = new Set<string>();
   let migrationInvocationStarted = false;
-  let keepRpLockForInFlightOp = false;
   let lockedCandidatesSkipped = 0;
+  const skippedLocked: Candidate[] = [];
   const startedAt = Date.now();
 
   try {
@@ -232,7 +252,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const candidates = await client.request<
       CandidateQueryResult,
       { before: string; limit: number }
-    >(GET_NEXT_CANDIDATES, { before, limit: CANDIDATE_BATCH_SIZE });
+    >(GET_NEXT_CANDIDATES, { before, limit: CANDIDATE_FETCH_LIMIT });
 
     if (candidates.rp_registration.length === 0) {
       return new NextResponse(null, { status: 204 });
@@ -241,16 +261,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     attemptId = randomUUID();
 
     for (const next of candidates.rp_registration) {
+      if (locked.length >= MIGRATE_PER_RUN) {
+        break;
+      }
+
       const lockAttempt = await acquireRpMigrationLock(next.rp_id);
       if (lockAttempt.status === "busy") {
         lockedCandidatesSkipped += 1;
+        skippedLocked.push(next);
         continue;
       }
       if (lockAttempt.status === "unavailable") {
         logger.error("Redis unavailable for RP manager migration per-RP lock", {
           error: lockAttempt.error,
           attempt_id: attemptId,
-          rp_id: next.rp_id,
+          ...candidateIdentity(next),
         });
 
         return NextResponse.json(
@@ -259,27 +284,29 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         );
       }
 
-      candidate = next;
-      rpLock = lockAttempt;
-      break;
+      locked.push({ candidate: next, rpLock: lockAttempt });
     }
 
-    if (!candidate || rpLock?.status !== "acquired") {
+    if (locked.length === 0) {
       logger.info("No unlocked RP manager migration candidate available", {
         attempt_id: attemptId,
         candidate_count: candidates.rp_registration.length,
         locked_candidates_skipped: lockedCandidatesSkipped,
+        skipped_locked: skippedLocked.map(candidateIdentity),
       });
 
       return new NextResponse(null, { status: 204 });
     }
 
-    logger.info("RP manager key migration attempt started", {
+    const rpIds = locked.map((item) => item.candidate.rp_id);
+
+    logger.info("RP manager key migration batch started", {
       attempt_id: attemptId,
-      rp_id: candidate.rp_id,
-      app_id: candidate.app_id,
-      old_manager_kms_key_id: candidate.manager_kms_key_id,
+      rp_ids: rpIds,
+      candidate_count: locked.length,
       locked_candidates_skipped: lockedCandidatesSkipped,
+      candidates: locked.map((item) => candidateIdentity(item.candidate)),
+      skipped_locked: skippedLocked.map(candidateIdentity),
     });
 
     const kmsClient = await getKMSClient(primaryConfig.kmsRegion);
@@ -293,71 +320,137 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       stagingMirrorRegistry: stagingConfig
         ? { name: "staging", config: stagingConfig }
         : undefined,
-      rpIds: [candidate.rp_id],
+      rpIds,
       attemptId,
       pollIntervalMs: 2_000,
       confirmationTimeoutMs: 15_000,
+      concurrency: MIGRATE_PER_RUN,
     });
 
-    const result = report.results[0];
+    const resultsByRpId = new Map(
+      report.results.map((result) => [result.rpId, result]),
+    );
+    const responseItems: Array<{
+      rp_id: string;
+      outcome: string;
+      operation_hashes: Record<string, string>;
+    }> = [];
+    const resultLogs: Array<{
+      rp_id: string;
+      app_id: string;
+      old_manager_kms_key_id: string;
+      outcome: string;
+      operation_hashes: Record<string, string>;
+      skipped_registries: string[];
+      retain_rp_lock: boolean;
+      failure?: { stage: string; detail: string };
+    }> = [];
 
-    const settled =
-      result?.status === "migrated" || result?.status === "already_migrated";
+    for (const { candidate } of locked) {
+      const result = resultsByRpId.get(candidate.rp_id);
+      const settled =
+        result?.status === "migrated" || result?.status === "already_migrated";
+      const retainRpLock =
+        !settled && migrationMayHaveInFlightOperation(result);
 
-    keepRpLockForInFlightOp =
-      !settled && migrationMayHaveInFlightOperation(result);
+      if (retainRpLock) {
+        retainRpIds.add(candidate.rp_id);
+      }
 
-    if (!result || result.status === "failed") {
-      await touchForCooldown(client, candidate.rp_id, attemptId);
+      if (!result || result.status === "failed") {
+        await touchForCooldown(client, candidate, attemptId);
+      }
+
+      const outcome = result?.status ?? "ineligible";
+      const operationHashes = result?.operationHashes ?? {};
+
+      responseItems.push({
+        rp_id: candidate.rp_id,
+        outcome,
+        operation_hashes: operationHashes,
+      });
+      resultLogs.push({
+        ...candidateIdentity(candidate),
+        outcome,
+        operation_hashes: operationHashes,
+        skipped_registries: result?.skippedRegistries ?? [],
+        retain_rp_lock: retainRpLock,
+        ...(result?.status === "failed" ? { failure: result.failure } : {}),
+      });
     }
 
-    const outcome = result?.status ?? "ineligible";
-
-    logger.info("RP manager key migration attempt finished", {
+    const succeededRpIds = resultLogs
+      .filter(
+        (item) =>
+          item.outcome === "migrated" || item.outcome === "already_migrated",
+      )
+      .map((item) => item.rp_id);
+    const failedRpIds = resultLogs
+      .filter((item) => item.outcome === "failed")
+      .map((item) => item.rp_id);
+    const ineligibleRpIds = resultLogs
+      .filter((item) => item.outcome === "ineligible")
+      .map((item) => item.rp_id);
+    const batchOutcome =
+      failedRpIds.length + ineligibleRpIds.length === 0
+        ? "all_succeeded"
+        : succeededRpIds.length === 0
+          ? "all_failed"
+          : "partial_failure";
+    const batchLog = {
       attempt_id: attemptId,
-      rp_id: candidate.rp_id,
-      app_id: candidate.app_id,
-      old_manager_kms_key_id: candidate.manager_kms_key_id,
-      operation_hashes: result?.operationHashes ?? {},
-      skipped_registries: result?.skippedRegistries ?? [],
-      outcome,
-      failure: result?.status === "failed" ? result.failure : undefined,
+      batch_outcome: batchOutcome,
+      rp_ids: rpIds,
+      succeeded_rp_ids: succeededRpIds,
+      failed_rp_ids: failedRpIds,
+      ineligible_rp_ids: ineligibleRpIds,
+      candidate_count: locked.length,
+      succeeded_count: succeededRpIds.length,
+      failed_count: failedRpIds.length,
+      ineligible_count: ineligibleRpIds.length,
       locked_candidates_skipped: lockedCandidatesSkipped,
-      retain_rp_lock: keepRpLockForInFlightOp,
+      skipped_locked: skippedLocked.map(candidateIdentity),
+      retained_rp_locks: [...retainRpIds],
       duration_ms: Date.now() - startedAt,
-    });
+      results: resultLogs,
+    };
 
-    return NextResponse.json({
-      rp_id: candidate.rp_id,
-      outcome,
-      operation_hashes: result?.operationHashes ?? {},
-    });
+    if (batchOutcome === "all_succeeded") {
+      logger.info("RP manager key migration batch finished", batchLog);
+    } else if (batchOutcome === "partial_failure") {
+      logger.warn("RP manager key migration batch finished", batchLog);
+    } else {
+      logger.error("RP manager key migration batch finished", batchLog);
+    }
+
+    return NextResponse.json({ results: responseItems });
   } catch (error) {
     if (migrationInvocationStarted) {
-      keepRpLockForInFlightOp = true;
+      for (const { candidate } of locked) {
+        retainRpIds.add(candidate.rp_id);
+      }
     }
 
-    if (client && candidate) {
-      try {
-        await touchForCooldown(
-          client,
-          candidate.rp_id,
-          attemptId ?? randomUUID(),
-        );
-      } catch (cooldownError) {
-        logger.warn("Failed to apply RP migration cooldown", {
-          error: cooldownError,
-          attempt_id: attemptId,
-          rp_id: candidate.rp_id,
-        });
+    if (client) {
+      for (const { candidate } of locked) {
+        try {
+          await touchForCooldown(client, candidate, attemptId ?? randomUUID());
+        } catch (cooldownError) {
+          logger.warn("Failed to apply RP migration cooldown", {
+            error: cooldownError,
+            attempt_id: attemptId,
+            ...candidateIdentity(candidate),
+          });
+        }
       }
     }
 
     logger.error("Unexpected RP manager migration cron failure", {
       error,
       attempt_id: attemptId,
-      rp_id: candidate?.rp_id,
-      old_manager_kms_key_id: candidate?.manager_kms_key_id,
+      rp_ids: locked.map((item) => item.candidate.rp_id),
+      candidates: locked.map((item) => candidateIdentity(item.candidate)),
+      migration_invocation_started: migrationInvocationStarted,
       duration_ms: Date.now() - startedAt,
     });
 
@@ -366,17 +459,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       { status: 503 },
     );
   } finally {
-    if (
-      rpLock?.status === "acquired" &&
-      candidate &&
-      !keepRpLockForInFlightOp
-    ) {
-      await releaseRpMigrationLock(
-        rpLock.redis,
-        candidate.rp_id,
-        rpLock.owner,
-        attemptId,
-      );
+    for (const { candidate, rpLock } of locked) {
+      if (!retainRpIds.has(candidate.rp_id)) {
+        await releaseRpMigrationLock(
+          rpLock.redis,
+          candidate.rp_id,
+          rpLock.owner,
+          attemptId,
+        );
+      }
     }
     await releaseGlobalLock(lock.redis, lock.owner, attemptId);
   }

--- a/web/api/helpers/rp-manager-key-migration.ts
+++ b/web/api/helpers/rp-manager-key-migration.ts
@@ -157,7 +157,10 @@ export function migrationMayHaveInFlightOperation(
 ): boolean {
   if (!result || result.status !== "failed") return false;
   if (Object.keys(result.operationHashes ?? {}).length > 0) return true;
-  return result.failure?.stage === "submit_transfer";
+  return (
+    result.failure?.stage === "submit_transfer" ||
+    result.failure?.stage === "unexpected"
+  );
 }
 
 /**

--- a/web/package.json
+++ b/web/package.json
@@ -171,7 +171,7 @@
     "test:e2e": "playwright test",
     "test:integration": "node tests/verifyHasuraIsUp.js && jest tests/integration --runInBand",
     "test:integration:server": "docker compose -f ../docker-compose-test.yaml up --abort-on-container-exit",
-    "test:unit": "jest tests/unit lib/schema --maxWorkers=2",
+    "test:unit": "jest tests/unit tests/scripts lib/schema --maxWorkers=2",
     "typecheck": "tsc"
   },
   "version": "0.1.0"

--- a/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
+++ b/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
@@ -179,7 +179,8 @@ export const RpManagerKeyMigrationPanel = async () => {
           Manager key migration
         </h2>
         <p className="mt-0.5 text-12 text-grey-500">
-          Unique key → shared key, then delete the old KMS key.
+          Unique key → shared key, then delete the old KMS key. The migrate job
+          runs every minute and attempts up to 15 RPs per tick.
         </p>
         {status && (
           <div className="mt-2 flex flex-wrap gap-1.5">

--- a/web/scenes/Admin/rps/manager-key-migration/QueueLists.tsx
+++ b/web/scenes/Admin/rps/manager-key-migration/QueueLists.tsx
@@ -19,8 +19,15 @@ const QueueItem = ({ item }: { item: AdminRpManagerKeyMigrationQueueItem }) => {
       className="flex min-w-0 items-center justify-between gap-2 px-2 py-1.5 outline-none hover:bg-grey-0 focus-visible:ring-2 focus-visible:ring-blue-500"
       href={`/admin/rps/${item.rpId}`}
     >
-      <span className="min-w-0 truncate font-mono text-12 font-medium text-grey-900">
-        {item.rpId}
+      <span className="min-w-0">
+        <span className="block truncate font-mono text-12 font-medium text-grey-900">
+          {item.rpId}
+        </span>
+        {(item.appName || item.appId) && (
+          <span className="block truncate text-11 text-grey-500">
+            {item.appName ?? item.appId}
+          </span>
+        )}
       </span>
       {detail && (
         <span

--- a/web/scripts/migrate-rp-manager-to-shared-key.ts
+++ b/web/scripts/migrate-rp-manager-to-shared-key.ts
@@ -37,6 +37,7 @@ export type RpManagerMigrationInput = {
   attemptId?: string;
   pollIntervalMs?: number;
   confirmationTimeoutMs?: number;
+  concurrency?: number;
 };
 
 export type RpManagerMigrationFailureStage =
@@ -47,7 +48,8 @@ export type RpManagerMigrationFailureStage =
   | "submit_transfer"
   | "wait_for_confirmation"
   | "verify_final_state"
-  | "update_database";
+  | "update_database"
+  | "unexpected";
 
 export type RpManagerMigrationItemResult = {
   rpId: string;
@@ -138,6 +140,7 @@ const MIGRATION_CANDIDATE_FIELDS = gql`
 
 const DEFAULT_POLL_INTERVAL_MS = 2_000;
 const DEFAULT_CONFIRMATION_TIMEOUT_MS = 120_000;
+const DEFAULT_CONCURRENCY = 1;
 
 function addressesEqual(left: string, right: string): boolean {
   return left.toLowerCase() === right.toLowerCase();
@@ -195,6 +198,39 @@ function assertValidInput(input: RpManagerMigrationInput): void {
   if ((input.confirmationTimeoutMs ?? DEFAULT_CONFIRMATION_TIMEOUT_MS) < 0) {
     throw new Error("confirmationTimeoutMs must not be negative");
   }
+
+  const concurrency = input.concurrency ?? DEFAULT_CONCURRENCY;
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error("concurrency must be an integer >= 1");
+  }
+}
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) {
+        return;
+      }
+      results[index] = await mapper(items[index]);
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
 }
 
 async function sleep(ms: number): Promise<void> {
@@ -212,8 +248,11 @@ function failedResult(
     attempt_id: candidate.attempt_id,
     rp_id: candidate.rp_id,
     app_id: candidate.app_id,
+    old_manager_kms_key_id: candidate.manager_kms_key_id,
     stage,
     detail,
+    operation_hashes: operationHashes,
+    skipped_registries: skippedRegistries,
   });
 
   return {
@@ -669,7 +708,9 @@ async function migrateCandidate(
     attempt_id: candidate.attempt_id,
     rp_id: candidate.rp_id,
     app_id: candidate.app_id,
+    old_manager_kms_key_id: candidate.manager_kms_key_id,
     status,
+    operation_hashes: operationHashes,
     migrated_registries: Object.keys(operationHashes),
     skipped_registries: skippedRegistries,
   });
@@ -700,8 +741,9 @@ async function migrateCandidate(
  * If that configuration contains a staging mirror, the migration verifies and
  * migrates it too; historical RPs that genuinely predate the mirror may skip
  * it. The function never schedules old KMS keys for deletion. Run only one
- * instance at a time and prevent concurrent manager operations for the
- * selected RPs while it runs.
+ * invocation at a time. Candidates inside one invocation may migrate in
+ * parallel when concurrency > 1. Prevent concurrent manager operations for
+ * the selected RPs while it runs.
  */
 export async function migrateRpManagersToSharedKey(
   input: RpManagerMigrationInput,
@@ -710,6 +752,7 @@ export async function migrateRpManagersToSharedKey(
 
   const sharedManagerKeyId = input.sharedManagerKeyId.trim();
   const attemptId = input.attemptId ?? randomUUID();
+  const concurrency = input.concurrency ?? DEFAULT_CONCURRENCY;
   const sharedManagerAddress = await getEthAddressFromKMS(
     input.kmsClient,
     sharedManagerKeyId,
@@ -728,15 +771,18 @@ export async function migrateRpManagersToSharedKey(
       input.confirmationTimeoutMs ?? DEFAULT_CONFIRMATION_TIMEOUT_MS,
   };
 
-  const results: RpManagerMigrationItemResult[] = [];
-  for (const candidate of candidates) {
-    results.push(
-      await migrateCandidate(context, {
-        ...candidate,
-        attempt_id: attemptId,
-      }),
-    );
-  }
+  const results = await mapWithConcurrency(
+    candidates,
+    concurrency,
+    async (candidate) => {
+      const withAttempt = { ...candidate, attempt_id: attemptId };
+      try {
+        return await migrateCandidate(context, withAttempt);
+      } catch (error) {
+        return failedResult(withAttempt, {}, "unexpected", errorMessage(error));
+      }
+    },
+  );
 
   return {
     sharedManagerKeyId,

--- a/web/tests/api/_migrate-rp-manager-keys.test.ts
+++ b/web/tests/api/_migrate-rp-manager-keys.test.ts
@@ -549,6 +549,104 @@ describe("/_migrate-rp-manager-keys [attempt]", () => {
     );
   });
 
+  it("does not retain settled RP locks when a cooldown write fails", async () => {
+    const failedRpId = "rp_aaaabbbbccccdddd";
+    const failedAppId = "app_aaaabbbbccccddddaaaabbbbccccdddd";
+    const otherFailedRpId = "rp_1111222233334444";
+    const otherFailedAppId = "app_11112222333344441111222233334444";
+    const failedLockKey = `rp-manager-key-migration:rp:${failedRpId}`;
+    const otherFailedLockKey = `rp-manager-key-migration:rp:${otherFailedRpId}`;
+
+    arrangeCandidates([
+      candidate,
+      {
+        rp_id: failedRpId,
+        app_id: failedAppId,
+        manager_kms_key_id: OLD_KEY,
+      },
+      {
+        rp_id: otherFailedRpId,
+        app_id: otherFailedAppId,
+        manager_kms_key_id: OLD_KEY,
+      },
+    ]);
+    migrateRpManagersToSharedKeyMock.mockResolvedValue({
+      candidateCount: 3,
+      results: [
+        successResult,
+        {
+          ...successResult,
+          rpId: failedRpId,
+          appId: failedAppId,
+          status: "failed" as const,
+          eligibleForCleanup: false,
+          operationHashes: {},
+          failure: { stage: "read_registry", detail: "RPC unavailable" },
+        },
+        {
+          ...successResult,
+          rpId: otherFailedRpId,
+          appId: otherFailedAppId,
+          status: "failed" as const,
+          eligibleForCleanup: false,
+          operationHashes: {},
+          failure: { stage: "read_registry", detail: "RPC unavailable" },
+        },
+      ],
+    });
+    graphqlRequestMock
+      .mockRejectedValueOnce(new Error("Hasura unavailable"))
+      .mockResolvedValueOnce({
+        update_rp_registration: { affected_rows: 1 },
+      });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      results: [
+        {
+          rp_id: RP_ID,
+          outcome: "migrated",
+          operation_hashes: { primary: "0xoperation" },
+        },
+        {
+          rp_id: failedRpId,
+          outcome: "failed",
+          operation_hashes: {},
+        },
+        {
+          rp_id: otherFailedRpId,
+          outcome: "failed",
+          operation_hashes: {},
+        },
+      ],
+    });
+    await expect(global.RedisClient?.get(RP_LOCK_KEY)).resolves.toBeNull();
+    await expect(global.RedisClient?.get(failedLockKey)).resolves.toBeNull();
+    await expect(
+      global.RedisClient?.get(otherFailedLockKey),
+    ).resolves.toBeNull();
+    expect(
+      graphqlRequestMock.mock.calls.slice(1).map((call) => call[1]),
+    ).toEqual([
+      expect.objectContaining({ rp_id: failedRpId }),
+      expect.objectContaining({ rp_id: otherFailedRpId }),
+    ]);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "Failed to apply RP migration cooldown",
+      expect.objectContaining({
+        rp_id: failedRpId,
+        app_id: failedAppId,
+        old_manager_kms_key_id: OLD_KEY,
+      }),
+    );
+    expect(mockLogger.error).not.toHaveBeenCalledWith(
+      "Unexpected RP manager migration cron failure",
+      expect.anything(),
+    );
+  });
+
   it("holds the per-RP lock for the duration of the migration and releases it", async () => {
     arrangeCandidate();
     migrateRpManagersToSharedKeyMock.mockImplementation(async () => {

--- a/web/tests/api/_migrate-rp-manager-keys.test.ts
+++ b/web/tests/api/_migrate-rp-manager-keys.test.ts
@@ -151,6 +151,9 @@ describe("/_migrate-rp-manager-keys [guards]", () => {
 
     expect(response.status).toBe(204);
     expect(getAPIServiceGraphqlClientMock).not.toHaveBeenCalled();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "RP manager key migration skipped, global lock held",
+    );
   });
 
   it("fails closed when Redis is unavailable", async () => {
@@ -190,7 +193,7 @@ describe("/_migrate-rp-manager-keys [guards]", () => {
 // #region Migration attempt
 
 describe("/_migrate-rp-manager-keys [attempt]", () => {
-  it("migrates exactly one candidate with deployment-local configuration", async () => {
+  it("migrates locked candidates with deployment-local configuration", async () => {
     arrangeCandidate();
 
     const response = await POST(request());
@@ -202,20 +205,55 @@ describe("/_migrate-rp-manager-keys [attempt]", () => {
         sharedManagerKeyId: SHARED_KEY,
         pollIntervalMs: 2_000,
         confirmationTimeoutMs: 15_000,
+        concurrency: 15,
         attemptId: expect.any(String),
       }),
     );
     const attemptId = migrateRpManagersToSharedKeyMock.mock.calls[0][0]
       .attemptId as string;
     expect(mockLogger.info).toHaveBeenCalledWith(
-      "RP manager key migration attempt started",
-      expect.objectContaining({ attempt_id: attemptId, rp_id: RP_ID }),
+      "RP manager key migration batch started",
+      expect.objectContaining({
+        attempt_id: attemptId,
+        rp_ids: [RP_ID],
+        candidates: [
+          {
+            rp_id: RP_ID,
+            app_id: APP_ID,
+            old_manager_kms_key_id: OLD_KEY,
+          },
+        ],
+      }),
     );
     expect(mockLogger.info).toHaveBeenCalledWith(
-      "RP manager key migration attempt finished",
-      expect.objectContaining({ attempt_id: attemptId, rp_id: RP_ID }),
+      "RP manager key migration batch finished",
+      expect.objectContaining({
+        attempt_id: attemptId,
+        batch_outcome: "all_succeeded",
+        rp_ids: [RP_ID],
+        succeeded_rp_ids: [RP_ID],
+        failed_rp_ids: [],
+        results: [
+          expect.objectContaining({
+            rp_id: RP_ID,
+            app_id: APP_ID,
+            old_manager_kms_key_id: OLD_KEY,
+            outcome: "migrated",
+            operation_hashes: { primary: "0xoperation" },
+          }),
+        ],
+      }),
     );
     expect(graphqlRequestMock).toHaveBeenCalledTimes(1);
+    await expect(response.json()).resolves.toEqual({
+      results: [
+        {
+          rp_id: RP_ID,
+          outcome: "migrated",
+          operation_hashes: { primary: "0xoperation" },
+        },
+      ],
+    });
     await expect(global.RedisClient?.get(GLOBAL_LOCK_KEY)).resolves.toBeNull();
   });
 
@@ -228,7 +266,7 @@ describe("/_migrate-rp-manager-keys [attempt]", () => {
       before: string;
       limit: number;
     };
-    expect(variables.limit).toBeGreaterThan(1);
+    expect(variables.limit).toBe(20);
     const cooldownMs = Date.now() - Date.parse(variables.before);
     expect(cooldownMs).toBeGreaterThanOrEqual(RP_MIGRATION_LOCK_TTL_MS);
   });
@@ -339,15 +377,176 @@ describe("/_migrate-rp-manager-keys [attempt]", () => {
 
     expect(response.status).toBe(200);
     expect(migrateRpManagersToSharedKeyMock).toHaveBeenCalledWith(
-      expect.objectContaining({ rpIds: [secondRpId] }),
+      expect.objectContaining({ rpIds: [secondRpId], concurrency: 15 }),
     );
-    await expect(response.json()).resolves.toEqual(
-      expect.objectContaining({ rp_id: secondRpId, outcome: "migrated" }),
-    );
+    await expect(response.json()).resolves.toEqual({
+      results: [
+        {
+          rp_id: secondRpId,
+          outcome: "migrated",
+          operation_hashes: { primary: "0xoperation" },
+        },
+      ],
+    });
     await expect(global.RedisClient?.get(RP_LOCK_KEY)).resolves.toBe(
       "other-owner",
     );
     await expect(global.RedisClient?.get(secondLockKey)).resolves.toBeNull();
+  });
+
+  it("migrates every unlocked candidate in one invocation", async () => {
+    const secondRpId = "rp_abcdef1234567890";
+    const secondAppId = "app_abcdef1234567890abcdef1234567890";
+    const secondLockKey = `rp-manager-key-migration:rp:${secondRpId}`;
+    const secondCandidate = {
+      rp_id: secondRpId,
+      app_id: secondAppId,
+      manager_kms_key_id: OLD_KEY,
+    };
+
+    arrangeCandidates([candidate, secondCandidate]);
+    migrateRpManagersToSharedKeyMock.mockResolvedValue({
+      candidateCount: 2,
+      results: [
+        successResult,
+        {
+          ...successResult,
+          rpId: secondRpId,
+          appId: secondAppId,
+        },
+      ],
+    });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(migrateRpManagersToSharedKeyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rpIds: [RP_ID, secondRpId],
+        concurrency: 15,
+      }),
+    );
+    await expect(response.json()).resolves.toEqual({
+      results: [
+        {
+          rp_id: RP_ID,
+          outcome: "migrated",
+          operation_hashes: { primary: "0xoperation" },
+        },
+        {
+          rp_id: secondRpId,
+          outcome: "migrated",
+          operation_hashes: { primary: "0xoperation" },
+        },
+      ],
+    });
+    await expect(global.RedisClient?.get(RP_LOCK_KEY)).resolves.toBeNull();
+    await expect(global.RedisClient?.get(secondLockKey)).resolves.toBeNull();
+  });
+
+  it("releases, retains, or cools down per-RP locks independently in a mixed batch", async () => {
+    const pendingRpId = "rp_abcdef1234567890";
+    const pendingAppId = "app_abcdef1234567890abcdef1234567890";
+    const failedRpId = "rp_aaaabbbbccccdddd";
+    const failedAppId = "app_aaaabbbbccccddddaaaabbbbccccdddd";
+    const pendingLockKey = `rp-manager-key-migration:rp:${pendingRpId}`;
+    const failedLockKey = `rp-manager-key-migration:rp:${failedRpId}`;
+
+    arrangeCandidates([
+      candidate,
+      {
+        rp_id: pendingRpId,
+        app_id: pendingAppId,
+        manager_kms_key_id: OLD_KEY,
+      },
+      {
+        rp_id: failedRpId,
+        app_id: failedAppId,
+        manager_kms_key_id: OLD_KEY,
+      },
+    ]);
+    migrateRpManagersToSharedKeyMock.mockResolvedValue({
+      candidateCount: 3,
+      results: [
+        successResult,
+        {
+          ...successResult,
+          rpId: pendingRpId,
+          appId: pendingAppId,
+          status: "failed" as const,
+          eligibleForCleanup: false,
+          operationHashes: { primary: "0xpending" },
+          failure: {
+            stage: "wait_for_confirmation",
+            detail: "Timed out waiting for manager update",
+          },
+        },
+        {
+          ...successResult,
+          rpId: failedRpId,
+          appId: failedAppId,
+          status: "failed" as const,
+          eligibleForCleanup: false,
+          operationHashes: {},
+          failure: { stage: "read_registry", detail: "RPC unavailable" },
+        },
+      ],
+    });
+    graphqlRequestMock.mockResolvedValue({
+      update_rp_registration: { affected_rows: 1 },
+    });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    await expect(global.RedisClient?.get(RP_LOCK_KEY)).resolves.toBeNull();
+    await expect(global.RedisClient?.get(pendingLockKey)).resolves.toEqual(
+      expect.any(String),
+    );
+    await expect(global.RedisClient?.get(failedLockKey)).resolves.toBeNull();
+    const cooldownCalls = graphqlRequestMock.mock.calls.slice(1);
+    expect(cooldownCalls.map((call) => call[1])).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ rp_id: pendingRpId }),
+        expect.objectContaining({ rp_id: failedRpId }),
+      ]),
+    );
+    expect(cooldownCalls).toHaveLength(2);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "RP manager key migration batch finished",
+      expect.objectContaining({
+        batch_outcome: "partial_failure",
+        succeeded_rp_ids: [RP_ID],
+        failed_rp_ids: [pendingRpId, failedRpId],
+        results: expect.arrayContaining([
+          expect.objectContaining({
+            rp_id: RP_ID,
+            app_id: APP_ID,
+            old_manager_kms_key_id: OLD_KEY,
+            outcome: "migrated",
+          }),
+          expect.objectContaining({
+            rp_id: pendingRpId,
+            app_id: pendingAppId,
+            old_manager_kms_key_id: OLD_KEY,
+            outcome: "failed",
+            operation_hashes: { primary: "0xpending" },
+            retain_rp_lock: true,
+            failure: expect.objectContaining({
+              stage: "wait_for_confirmation",
+            }),
+          }),
+          expect.objectContaining({
+            rp_id: failedRpId,
+            app_id: failedAppId,
+            old_manager_kms_key_id: OLD_KEY,
+            outcome: "failed",
+            retain_rp_lock: false,
+            failure: expect.objectContaining({ stage: "read_registry" }),
+          }),
+        ]),
+      }),
+    );
   });
 
   it("holds the per-RP lock for the duration of the migration and releases it", async () => {
@@ -398,12 +597,23 @@ describe("/_migrate-rp-manager-keys [attempt]", () => {
     expect(ttlMs).toBeGreaterThan(30 * 60 * 1000);
   });
 
-  it("retains the per-RP lock when the migration invocation throws", async () => {
-    arrangeCandidate();
+  it("retains every per-RP lock when the migration invocation throws", async () => {
+    const secondRpId = "rp_abcdef1234567890";
+    const secondAppId = "app_abcdef1234567890abcdef1234567890";
+    const secondLockKey = `rp-manager-key-migration:rp:${secondRpId}`;
+
+    arrangeCandidates([
+      candidate,
+      {
+        rp_id: secondRpId,
+        app_id: secondAppId,
+        manager_kms_key_id: OLD_KEY,
+      },
+    ]);
     migrateRpManagersToSharedKeyMock.mockRejectedValue(
       new Error("unexpected migration failure"),
     );
-    graphqlRequestMock.mockResolvedValueOnce({
+    graphqlRequestMock.mockResolvedValue({
       update_rp_registration: { affected_rows: 1 },
     });
 
@@ -413,8 +623,31 @@ describe("/_migrate-rp-manager-keys [attempt]", () => {
     await expect(global.RedisClient?.get(RP_LOCK_KEY)).resolves.toEqual(
       expect.any(String),
     );
+    await expect(global.RedisClient?.get(secondLockKey)).resolves.toEqual(
+      expect.any(String),
+    );
     const ttlMs = await global.RedisClient?.pttl(RP_LOCK_KEY);
     expect(ttlMs).toBeGreaterThan(30 * 60 * 1000);
+    await expect(global.RedisClient?.get(GLOBAL_LOCK_KEY)).resolves.toBeNull();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Unexpected RP manager migration cron failure",
+      expect.objectContaining({
+        rp_ids: [RP_ID, secondRpId],
+        candidates: [
+          {
+            rp_id: RP_ID,
+            app_id: APP_ID,
+            old_manager_kms_key_id: OLD_KEY,
+          },
+          {
+            rp_id: secondRpId,
+            app_id: secondAppId,
+            old_manager_kms_key_id: OLD_KEY,
+          },
+        ],
+        migration_invocation_started: true,
+      }),
+    );
   });
 
   it("releases the per-RP lock when failure happens before any transfer submit", async () => {
@@ -439,6 +672,23 @@ describe("/_migrate-rp-manager-keys [attempt]", () => {
 
     expect(response.status).toBe(200);
     await expect(global.RedisClient?.get(RP_LOCK_KEY)).resolves.toBeNull();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "RP manager key migration batch finished",
+      expect.objectContaining({
+        batch_outcome: "all_failed",
+        failed_rp_ids: [RP_ID],
+        succeeded_rp_ids: [],
+        results: [
+          expect.objectContaining({
+            rp_id: RP_ID,
+            app_id: APP_ID,
+            old_manager_kms_key_id: OLD_KEY,
+            outcome: "failed",
+            failure: expect.objectContaining({ stage: "read_registry" }),
+          }),
+        ],
+      }),
+    );
   });
 
   it("reports ineligible when the candidate is no longer eligible after the lock", async () => {
@@ -456,11 +706,30 @@ describe("/_migrate-rp-manager-keys [attempt]", () => {
 
     expect(response.status).toBe(200);
     expect(body).toEqual({
-      rp_id: RP_ID,
-      outcome: "ineligible",
-      operation_hashes: {},
+      results: [
+        {
+          rp_id: RP_ID,
+          outcome: "ineligible",
+          operation_hashes: {},
+        },
+      ],
     });
     await expect(global.RedisClient?.get(RP_LOCK_KEY)).resolves.toBeNull();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "RP manager key migration batch finished",
+      expect.objectContaining({
+        batch_outcome: "all_failed",
+        ineligible_rp_ids: [RP_ID],
+        results: [
+          expect.objectContaining({
+            rp_id: RP_ID,
+            app_id: APP_ID,
+            old_manager_kms_key_id: OLD_KEY,
+            outcome: "ineligible",
+          }),
+        ],
+      }),
+    );
   });
 });
 

--- a/web/tests/scripts/migrate-rp-manager-to-shared-key.test.ts
+++ b/web/tests/scripts/migrate-rp-manager-to-shared-key.test.ts
@@ -255,6 +255,12 @@ describe("migrateRpManagersToSharedKey [successful migrations]", () => {
         attempt_id: ATTEMPT_ID,
         rp_id: RP_ID,
         app_id: APP_ID,
+        old_manager_kms_key_id: OLD_KEY_ID,
+        status: "migrated",
+        operation_hashes: {
+          production: "0xproduction-operation",
+          staging: "0xstaging-operation",
+        },
         migrated_registries: ["production", "staging"],
         skipped_registries: [],
       }),
@@ -939,6 +945,153 @@ describe("migrateRpManagersToSharedKey [input]", () => {
 
     expect(getEthAddressFromKMSMock).not.toHaveBeenCalled();
     expect(graphqlRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-positive concurrency before making external calls", async () => {
+    await expect(
+      migrateRpManagersToSharedKey({
+        graphqlClient,
+        kmsClient,
+        sharedManagerKeyId: SHARED_KEY_ID,
+        ...deploymentWithStagingMirror,
+        concurrency: 0,
+      }),
+    ).rejects.toThrow("concurrency must be an integer >= 1");
+
+    expect(getEthAddressFromKMSMock).not.toHaveBeenCalled();
+    expect(graphqlRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a fractional concurrency before making external calls", async () => {
+    await expect(
+      migrateRpManagersToSharedKey({
+        graphqlClient,
+        kmsClient,
+        sharedManagerKeyId: SHARED_KEY_ID,
+        ...deploymentWithStagingMirror,
+        concurrency: 1.5,
+      }),
+    ).rejects.toThrow("concurrency must be an integer >= 1");
+
+    expect(getEthAddressFromKMSMock).not.toHaveBeenCalled();
+    expect(graphqlRequestMock).not.toHaveBeenCalled();
+  });
+});
+
+// #endregion
+
+// #region Concurrency
+
+describe("migrateRpManagersToSharedKey [concurrency]", () => {
+  const firstRpId = BigInt("0x" + RP_ID.slice(3));
+  const secondRpId = BigInt("0x" + SECOND_RP_ID.slice(3));
+
+  it("migrates candidates sequentially when concurrency is omitted", async () => {
+    arrangeGraphql([candidate, secondCandidate]);
+    let inFlight = 0;
+    let maxInFlight = 0;
+    getRpFromContractMock.mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      inFlight -= 1;
+      return makeOnChainRp({ manager: SHARED_MANAGER });
+    });
+
+    const report = await migrateRpManagersToSharedKey({
+      graphqlClient,
+      kmsClient,
+      sharedManagerKeyId: SHARED_KEY_ID,
+      ...deploymentWithStagingMirror,
+      rpIds: [RP_ID, SECOND_RP_ID],
+    });
+
+    expect(maxInFlight).toBe(1);
+    expect(report.results.map((result) => result.rpId)).toEqual([
+      RP_ID,
+      SECOND_RP_ID,
+    ]);
+    expect(
+      report.results.every((result) => result.status === "already_migrated"),
+    ).toBe(true);
+  });
+
+  it("migrates candidates concurrently when concurrency is greater than 1", async () => {
+    arrangeGraphql([candidate, secondCandidate]);
+    let firstStarted!: () => void;
+    let secondStarted!: () => void;
+    const firstEntered = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    const secondEntered = new Promise<void>((resolve) => {
+      secondStarted = resolve;
+    });
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    getRpFromContractMock.mockImplementation(async (rpId: bigint) => {
+      if (rpId === firstRpId) {
+        firstStarted();
+      } else if (rpId === secondRpId) {
+        secondStarted();
+      }
+      await gate;
+      return makeOnChainRp({ manager: SHARED_MANAGER });
+    });
+
+    const running = migrateRpManagersToSharedKey({
+      graphqlClient,
+      kmsClient,
+      sharedManagerKeyId: SHARED_KEY_ID,
+      ...deploymentWithStagingMirror,
+      rpIds: [RP_ID, SECOND_RP_ID],
+      concurrency: 2,
+    });
+
+    await Promise.all([firstEntered, secondEntered]);
+    release();
+    const report = await running;
+
+    expect(report.results.map((result) => result.rpId)).toEqual([
+      RP_ID,
+      SECOND_RP_ID,
+    ]);
+    expect(
+      report.results.every((result) => result.status === "already_migrated"),
+    ).toBe(true);
+  });
+
+  it("continues remaining candidates when one candidate fails", async () => {
+    arrangeGraphql([candidate, secondCandidate]);
+    getRpFromContractMock.mockImplementation(async (rpId: bigint) => {
+      if (rpId === firstRpId) {
+        throw new Error("RPC unavailable");
+      }
+      return makeOnChainRp({ manager: SHARED_MANAGER });
+    });
+
+    const report = await migrateRpManagersToSharedKey({
+      graphqlClient,
+      kmsClient,
+      sharedManagerKeyId: SHARED_KEY_ID,
+      ...deploymentWithStagingMirror,
+      rpIds: [RP_ID, SECOND_RP_ID],
+      concurrency: 2,
+    });
+
+    expect(report.results).toEqual([
+      expect.objectContaining({
+        rpId: RP_ID,
+        status: "failed",
+        failure: expect.objectContaining({ stage: "read_registry" }),
+      }),
+      expect.objectContaining({
+        rpId: SECOND_RP_ID,
+        status: "already_migrated",
+      }),
+    ]);
   });
 });
 


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

This PR migrates up to 15 RP manager keys per cron tick so the unique-key backlog can finish in hours instead of weeks.

- Runs `_migrate-rp-manager-keys` every minute with concurrency 15 under the existing global lock; per-RP lock, cooldown, and in-flight retain stay per candidate.
- Logs each batch as `all_succeeded`, `partial_failure`, or `all_failed` with `rp_id`, `app_id`, and the old manager key.
- Adds unit tests for batch locking, mixed outcomes, and concurrency.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.