### PR TITLE
Update RP manager key migration schedule and documentation

### DIFF
--- a/hasura/metadata/cron_triggers.yaml
+++ b/hasura/metadata/cron_triggers.yaml
@@ -70,7 +70,7 @@
   comment: Deactivate the managed RP signer on-chain for soft-deleted apps whose RP is still live (reconciles delete-time failures and backfills apps deleted before delete-time deactivation existed).
 - name: Migrate RP manager keys
   webhook: '{{NEXT_API_URL}}/_migrate-rp-manager-keys'
-  schedule: '* * * * *'
+  schedule: '0 0 * * *'
   include_in_metadata: true
   payload: {}
   retry_conf:
@@ -81,7 +81,7 @@
   headers:
     - name: Authorization
       value_from_env: INTERNAL_ENDPOINTS_SECRET
-  comment: Migrate up to 15 eligible managed RPs from their legacy KMS manager keys to the deployment shared manager key.
+  comment: Once daily. Migrates up to 15 eligible managed RPs when ENABLE_RP_MANAGER_KEY_MIGRATION is true.
 - name: Cleanup RP manager keys
   webhook: '{{NEXT_API_URL}}/_cleanup-rp-manager-keys'
   schedule: '*/15 * * * *'

--- a/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
+++ b/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
@@ -180,7 +180,7 @@ export const RpManagerKeyMigrationPanel = async () => {
         </h2>
         <p className="mt-0.5 text-12 text-grey-500">
           Unique key → shared key, then delete the old KMS key. The migrate job
-          runs every minute and attempts up to 15 RPs per tick.
+          runs once a day and attempts up to 15 RPs per tick.
         </p>
         {status && (
           <div className="mt-2 flex flex-wrap gap-1.5">


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

- Changed the cron trigger for migrating RP manager keys to run once daily instead of every minute.
- Updated comments in the cron triggers configuration and the admin panel to reflect the new migration frequency and clarify the conditions under which the migration occurs.


## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
