### PR TITLE
feat(auth): Gmail/Outlook shortcuts on the email 2FA screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ pnpm-debug.log*
 # typescript
 *.tsbuildinfo
 **/.claude/settings.local.json
+
+# auth0 page template deploy backups
+auth0/universal-login/backup-*.html

--- a/auth0/universal-login/README.md
+++ b/auth0/universal-login/README.md
@@ -42,7 +42,8 @@ the app. The deploy script checks and warns about this.
 ## Deploying
 
 Needs a Management API token (or M2M client) with `read:branding`,
-`update:branding`, and ideally `read:custom_domains`:
+`update:branding`, and ideally `read:custom_domains`; add `delete:branding`
+if you want the `--delete` rollback to work with the same credentials:
 
 ```bash
 AUTH0_DOMAIN=worldcoin-developer-portal.eu.auth0.com \
@@ -68,3 +69,7 @@ Auth0's default page, or re-deploy a backup by copying it over
   changes.
 - Brand icons are hand-drawn compact SVGs (a red Gmail "M", a blue Outlook
   tile). Swap in official brand assets if design wants exact marks.
+- Inline `<script>` in page templates runs on this tenant: the live Universal
+  Login response sends `content-security-policy: frame-ancestors 'none'` with
+  no `script-src` (verified 2026-08-23), and Auth0 documents no CSP nonce for
+  templates. If Auth0 ever ships a strict CSP for Universal Login, revisit.

--- a/auth0/universal-login/README.md
+++ b/auth0/universal-login/README.md
@@ -1,0 +1,70 @@
+# Universal Login page template
+
+Custom page template for the Auth0-hosted login screens
+(`worldcoin-developer-portal.eu.auth0.com`). It adds Slack-style
+**Open Gmail / Open Outlook** shortcuts under the card on every screen where
+Auth0 has just emailed the user a code (the "Verify Your Identity" 2FA
+challenge, passwordless email code, and login email verification screens), so
+people don't have to hunt for their inbox while a code is waiting.
+
+Behavior, decided from the address the code was sent to:
+
+| Email domain                            | Buttons shown                        |
+| --------------------------------------- | ------------------------------------ |
+| `gmail.com`, `googlemail.com`           | Open Gmail                           |
+| `outlook.*`, `hotmail.*`, `live.*`, `msn.com` | Open Outlook (outlook.live.com) |
+| anything else (work domains)            | Both (Gmail + outlook.office.com)    |
+
+The Gmail link deep-links the exact account
+(`mail.google.com/mail/u/?authuser=<email>`), so multi-account users land in
+the right inbox. Links open in a new tab so the code entry screen stays put.
+If no email address is found on the screen, the block stays hidden.
+
+## Why this lives here and not in `web/`
+
+None of the login screens are rendered by this app — the portal redirects to
+Auth0's hosted Universal Login, and the whole flow (including the email 2FA
+challenge) is served by Auth0. The only supported way to add page content
+around the New Universal Login widget is a [page template][docs] stored in the
+tenant via the Management API. This directory is the source of truth for that
+template plus the script that applies it.
+
+[docs]: https://auth0.com/docs/customize/login-pages/universal-login/customize-templates
+
+## Prerequisite: custom domain
+
+Auth0 only renders page templates on a **verified custom domain**. Login
+currently runs on the default `worldcoin-developer-portal.eu.auth0.com`
+domain, so this template will have no visible effect until a custom domain
+(e.g. `auth.developer.worldcoin.org`) is configured on the tenant and used by
+the app. The deploy script checks and warns about this.
+
+## Deploying
+
+Needs a Management API token (or M2M client) with `read:branding`,
+`update:branding`, and ideally `read:custom_domains`:
+
+```bash
+AUTH0_DOMAIN=worldcoin-developer-portal.eu.auth0.com \
+AUTH0_MGMT_TOKEN=... \
+node deploy.mjs --dry-run   # validate + back up current template, write nothing
+```
+
+Drop `--dry-run` to deploy. The script always backs up the tenant's current
+template to `backup-<timestamp>.html` (gitignored) before writing.
+
+Rollback: `node deploy.mjs --delete` removes the custom template and restores
+Auth0's default page, or re-deploy a backup by copying it over
+`page-template.html`.
+
+## Maintenance notes
+
+- The shortcut block only activates on these Universal Login screens:
+  `mfa-email-challenge`, `email-otp-challenge`,
+  `login-passwordless-email-code`, `login-email-verification`. If Auth0
+  renames a screen the block silently stays hidden (it never breaks login).
+- The script inserts the links under the login card (`main > section`) after
+  hydration, falling back to bottom-of-page placement if the widget DOM
+  changes.
+- Brand icons are hand-drawn compact SVGs (a red Gmail "M", a blue Outlook
+  tile). Swap in official brand assets if design wants exact marks.

--- a/auth0/universal-login/deploy.mjs
+++ b/auth0/universal-login/deploy.mjs
@@ -7,7 +7,8 @@
  *
  * Instead of AUTH0_MGMT_TOKEN you can pass AUTH0_MGMT_CLIENT_ID and
  * AUTH0_MGMT_CLIENT_SECRET for a machine-to-machine client authorized for the
- * Management API (scopes: read:branding, update:branding, read:custom_domains).
+ * Management API (scopes: read:branding, update:branding, read:custom_domains,
+ * plus delete:branding if you want the --delete rollback).
  *
  * --dry-run  validates credentials, checks custom domains, and backs up the
  *            current template without writing anything to the tenant.
@@ -111,8 +112,16 @@ async function backupCurrentTemplate() {
     return;
   }
   if (!res.ok) fail(`GET current template failed: ${res.status}`);
-  const body = await res.json().catch(() => null);
-  const current = body?.body ?? (await res.text());
+  // The endpoint returns raw text/html, or JSON {body: "..."} depending on
+  // the Accept negotiation — read the stream once and handle both.
+  const raw = await res.text();
+  let current = raw;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.body === "string") current = parsed.body;
+  } catch {
+    /* raw HTML */
+  }
   const file = join(
     here,
     `backup-${new Date().toISOString().replace(/[:.]/g, "-")}.html`,

--- a/auth0/universal-login/deploy.mjs
+++ b/auth0/universal-login/deploy.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Deploys page-template.html as the tenant's Universal Login page template.
+ *
+ * Usage:
+ *   AUTH0_DOMAIN=<tenant>.auth0.com AUTH0_MGMT_TOKEN=<token> node deploy.mjs [--dry-run|--delete]
+ *
+ * Instead of AUTH0_MGMT_TOKEN you can pass AUTH0_MGMT_CLIENT_ID and
+ * AUTH0_MGMT_CLIENT_SECRET for a machine-to-machine client authorized for the
+ * Management API (scopes: read:branding, update:branding, read:custom_domains).
+ *
+ * --dry-run  validates credentials, checks custom domains, and backs up the
+ *            current template without writing anything to the tenant.
+ * --delete   removes the custom page template, restoring Auth0's default.
+ *
+ * The current template (if any) is saved to backup-<timestamp>.html before
+ * any write, so a bad deploy can be restored by re-running with the backup
+ * copied over page-template.html.
+ */
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dryRun = process.argv.includes("--dry-run");
+const doDelete = process.argv.includes("--delete");
+
+const domain = process.env.AUTH0_DOMAIN;
+if (!domain) fail("AUTH0_DOMAIN is required (e.g. my-tenant.eu.auth0.com)");
+const apiBase = `https://${domain}/api/v2`;
+
+const token = process.env.AUTH0_MGMT_TOKEN || (await clientCredentialsToken());
+
+await checkCustomDomains();
+await backupCurrentTemplate();
+
+if (dryRun) {
+  console.log("Dry run: no changes written.");
+  process.exit(0);
+}
+
+if (doDelete) {
+  const res = await mgmt("DELETE", "/branding/templates/universal-login");
+  if (!res.ok && res.status !== 404) {
+    fail(`DELETE failed: ${res.status} ${await res.text()}`);
+  }
+  console.log("Custom page template removed; tenant is back on the default.");
+  process.exit(0);
+}
+
+const template = await readFile(join(here, "page-template.html"), "utf8");
+const res = await mgmt("PUT", "/branding/templates/universal-login", {
+  headers: { "content-type": "text/html" },
+  body: template,
+});
+if (!res.ok) fail(`PUT failed: ${res.status} ${await res.text()}`);
+console.log("Page template deployed.");
+
+async function clientCredentialsToken() {
+  const id = process.env.AUTH0_MGMT_CLIENT_ID;
+  const secret = process.env.AUTH0_MGMT_CLIENT_SECRET;
+  if (!id || !secret) {
+    fail(
+      "Set AUTH0_MGMT_TOKEN, or AUTH0_MGMT_CLIENT_ID + AUTH0_MGMT_CLIENT_SECRET",
+    );
+  }
+  const res = await fetch(`https://${domain}/oauth/token`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "client_credentials",
+      client_id: id,
+      client_secret: secret,
+      audience: `${apiBase}/`,
+    }),
+  });
+  if (!res.ok) fail(`Token request failed: ${res.status} ${await res.text()}`);
+  return (await res.json()).access_token;
+}
+
+// Page templates only render on a verified custom domain — deploying without
+// one succeeds but has no visible effect, so surface that loudly.
+async function checkCustomDomains() {
+  const res = await mgmt("GET", "/custom-domains");
+  if (!res.ok) {
+    console.warn(
+      `Warning: could not check custom domains (${res.status}); ` +
+        "the template only renders on a verified custom domain.",
+    );
+    return;
+  }
+  const domains = await res.json();
+  const ready = domains.filter((d) => d.status === "ready");
+  if (ready.length === 0) {
+    console.warn(
+      "Warning: no verified custom domain on this tenant. The template will " +
+        "be stored but Universal Login will NOT render it until a custom " +
+        "domain is configured and used.",
+    );
+  } else {
+    console.log(
+      `Custom domain(s) ready: ${ready.map((d) => d.domain).join(", ")}`,
+    );
+  }
+}
+
+async function backupCurrentTemplate() {
+  const res = await mgmt("GET", "/branding/templates/universal-login");
+  if (res.status === 404) {
+    console.log("No existing custom template (tenant is on the default).");
+    return;
+  }
+  if (!res.ok) fail(`GET current template failed: ${res.status}`);
+  const body = await res.json().catch(() => null);
+  const current = body?.body ?? (await res.text());
+  const file = join(
+    here,
+    `backup-${new Date().toISOString().replace(/[:.]/g, "-")}.html`,
+  );
+  await writeFile(file, current);
+  console.log(`Existing template backed up to ${file}`);
+}
+
+function mgmt(method, path, init = {}) {
+  return fetch(`${apiBase}${path}`, {
+    method,
+    ...init,
+    headers: { authorization: `Bearer ${token}`, ...(init.headers || {}) },
+  });
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/auth0/universal-login/page-template.html
+++ b/auth0/universal-login/page-template.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="{{locale}}">
+  <head>
+    {%- auth0:head -%}
+    <title>{{ prompt.screen.texts.pageTitle }}</title>
+    <style>
+      #wld-mail-shortcuts {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 40px;
+        margin: 24px auto;
+        font-family: inherit;
+        font-size: 14px;
+      }
+      #wld-mail-shortcuts[hidden] {
+        display: none;
+      }
+      .wld-mail-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: #454545;
+        text-decoration: none;
+      }
+      .wld-mail-link:hover span,
+      .wld-mail-link:focus span {
+        text-decoration: underline;
+      }
+      .wld-mail-link svg {
+        width: 18px;
+        height: 18px;
+        flex-shrink: 0;
+      }
+    </style>
+  </head>
+  <body class="_widget-auto-layout">
+    {%- auth0:widget -%}
+    {%- assign wld_email_screens = "mfa-email-challenge,email-otp-challenge,login-passwordless-email-code,login-email-verification" | split: "," -%}
+    {%- if wld_email_screens contains prompt.screen.name -%}
+      <div id="wld-mail-shortcuts" hidden>
+        <a
+          id="wld-mail-gmail"
+          class="wld-mail-link"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Open Gmail in a new tab"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              fill="#EA4335"
+              d="M24 5.457v13.909c0 .904-.732 1.636-1.636 1.636h-3.819V11.73L12 16.64l-6.545-4.91v9.273H1.636A1.636 1.636 0 0 1 0 19.366V5.457c0-2.023 2.309-3.178 3.927-1.964L5.455 4.64 12 9.548l6.545-4.91 1.528-1.145C21.69 2.28 24 3.434 24 5.457z"
+            />
+          </svg>
+          <span>Open Gmail</span>
+        </a>
+        <a
+          id="wld-mail-outlook"
+          class="wld-mail-link"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Open Outlook in a new tab"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <rect width="24" height="24" rx="4" fill="#0078D4" />
+            <circle
+              cx="12"
+              cy="12"
+              r="6"
+              fill="none"
+              stroke="#ffffff"
+              stroke-width="3"
+            />
+          </svg>
+          <span>Open Outlook</span>
+        </a>
+      </div>
+      <script>
+        (function () {
+          "use strict";
+          try {
+            var root = document.getElementById("wld-mail-shortcuts");
+            if (!root) return;
+
+            // The address the code was sent to is always displayed on these
+            // screens; not finding one means we're somewhere unexpected, so
+            // stay hidden.
+            var scope = document.querySelector("main") || document.body;
+            var match = (scope.textContent || "").match(
+              /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/,
+            );
+            if (!match) return;
+
+            var email = match[0];
+            var firstLabel = email.split("@")[1].split(".")[0].toLowerCase();
+            var isGmail = firstLabel === "gmail" || firstLabel === "googlemail";
+            var isConsumerOutlook =
+              firstLabel === "outlook" ||
+              firstLabel === "hotmail" ||
+              firstLabel === "live" ||
+              firstLabel === "msn";
+
+            var gmailLink = document.getElementById("wld-mail-gmail");
+            var outlookLink = document.getElementById("wld-mail-outlook");
+
+            gmailLink.href =
+              "https://mail.google.com/mail/u/?authuser=" +
+              encodeURIComponent(email);
+            outlookLink.href = isConsumerOutlook
+              ? "https://outlook.live.com/mail/0/"
+              : "https://outlook.office.com/mail/";
+
+            // Known consumer domain: show only that provider. Anything else
+            // (work domains) could be hosted on either, so show both.
+            if (isGmail) outlookLink.remove();
+            if (isConsumerOutlook) gmailLink.remove();
+
+            root.hidden = false;
+
+            // Best effort: move the links directly under the login card
+            // (main > section) once the widget has hydrated. If the structure
+            // ever changes they stay at body level, which still renders.
+            window.addEventListener("load", function () {
+              setTimeout(function () {
+                try {
+                  var section = document.querySelector("main section");
+                  if (section) section.appendChild(root);
+                } catch (e) {
+                  /* keep body-level placement */
+                }
+              }, 300);
+            });
+          } catch (e) {
+            /* never break the login page */
+          }
+        })();
+      </script>
+    {%- endif -%}
+  </body>
+</html>


### PR DESCRIPTION
## PR Type

- [X] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Slack shows **Open Gmail / Open Outlook** buttons while you wait for an emailed sign-in code. This adds the same affordance to the portal's "Verify Your Identity" email 2FA screen.

That screen isn't rendered by this app — login (including the email challenge) is Auth0's hosted Universal Login on `worldcoin-developer-portal.eu.auth0.com`, and the only supported way to add content around the widget is a tenant **page template**. This PR adds that template plus tooling as `auth0/universal-login/`:

- `page-template.html` — Auth0's default template skeleton plus a shortcut block that activates only on emailed-code screens (`mfa-email-challenge`, `email-otp-challenge`, `login-passwordless-email-code`, `login-email-verification`). It reads the address the code was sent to from the rendered screen:
  - `gmail.com` / `googlemail.com` → **Open Gmail** only
  - `outlook.*` / `hotmail.*` / `live.*` / `msn.com` → **Open Outlook** only (outlook.live.com)
  - anything else (work domains) → both, with Outlook pointing at outlook.office.com
  - no address found → block stays hidden; every failure path is try/caught so login can never break
- The Gmail link deep-links the exact account (`mail.google.com/mail/u/?authuser=<email>`); links open in a new tab so the code input stays put.
- `deploy.mjs` — zero-dependency script: backs up the tenant's current template, warns if no verified custom domain, `--dry-run` / `--delete` (rollback) flags.

## Rollout caveat

Auth0 only renders page templates on a **verified custom domain**. Login currently runs on the default `eu.auth0.com` domain, so deploying this is a no-op until a custom domain (e.g. `auth.developer.worldcoin.org`) is configured on the tenant — details in the README. Merging is safe either way; nothing in the app's runtime changes.

## Verification

Exercised the real template block in a local replica of the branded screen (`main > section` structure probed from the live login page): all four provider cases produce the expected buttons/links, the block relocates under the card after hydration with a body-level fallback, and icon/label centering measured exact (Δ0px). Icons are compact hand-drawn SVGs (red Gmail "M", blue Outlook tile) — swap for official assets if design wants exact marks.