### PR TITLE
fix(sandbox ios enrollment 1/4): tighten Android request permissions and admin display

### DIFF
--- a/hasura/metadata/databases/default/tables/public_sandbox_access_request.yaml
+++ b/hasura/metadata/databases/default/tables/public_sandbox_access_request.yaml
@@ -12,8 +12,6 @@ insert_permissions:
       columns:
         - google_email
         - user_id
-        - accepted
-        - processed_at
 select_permissions:
   - role: internal_dashboard_readonly
     permission:
@@ -46,13 +44,17 @@ update_permissions:
         - processed_at
       filter: {}
       check: {}
+  # Hasura exposes `on_conflict` only when the caller also has update
+  # permission. The service mutation uses `update_columns: []` strictly for
+  # idempotent insert-or-ignore behavior, so keep ordinary service updates
+  # unusable with a filter that cannot match this table's non-null primary key.
   - role: service
     permission:
       columns:
-        - accepted
-        - processed_at
         - google_email
-      filter: {}
+      filter:
+        id:
+          _is_null: true
       check: {}
 delete_permissions:
   # Rejection deletes only pending requests so the developer can submit again.
@@ -61,6 +63,3 @@ delete_permissions:
       filter:
         accepted:
           _eq: false
-  - role: service
-    permission:
-      filter: {}

--- a/web/scenes/Admin/sandbox-requests/page.tsx
+++ b/web/scenes/Admin/sandbox-requests/page.tsx
@@ -80,14 +80,9 @@ export const AdminSandboxRequestsPage = async () => {
                       <div className="truncate text-16 font-medium text-grey-900">
                         {request.googleEmail}
                       </div>
-                      <div className="mt-1 truncate text-13 text-grey-700">
-                        {request.userName ?? request.userId}
+                      <div className="mt-0.5 truncate text-12 text-grey-500">
+                        {request.userEmail ?? "—"}
                       </div>
-                      {request.userEmail && (
-                        <div className="mt-0.5 truncate text-12 text-grey-500">
-                          {request.userEmail}
-                        </div>
-                      )}
                     </div>
                     <StatusBadge accepted={request.accepted} />
                   </div>
@@ -125,7 +120,6 @@ export const AdminSandboxRequestsPage = async () => {
               <thead>
                 <tr className="border-b border-grey-200 text-11 font-medium tracking-wide text-grey-400 uppercase">
                   <th className="px-3 py-2">Google email</th>
-                  <th className="px-3 py-2">User</th>
                   <th className="px-3 py-2">User email</th>
                   <th className="px-3 py-2">Status</th>
                   <th className="px-3 py-2">Requested</th>
@@ -141,9 +135,6 @@ export const AdminSandboxRequestsPage = async () => {
                   >
                     <td className="px-3 py-2.5 font-medium text-grey-900">
                       {request.googleEmail}
-                    </td>
-                    <td className="px-3 py-2.5">
-                      {request.userName ?? request.userId}
                     </td>
                     <td className="px-3 py-2.5">{request.userEmail ?? "—"}</td>
                     <td className="px-3 py-2.5">

--- a/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
+++ b/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
@@ -117,6 +117,35 @@ describe("internal dashboard detail permissions", () => {
     expect(permission).not.toContain("- google_email");
     expect(permission).not.toContain("- user_id");
     expect(metadata).not.toContain("internal_dashboard_sandbox_writer");
+
+    const insertSection = metadata.slice(
+      metadata.indexOf("insert_permissions:"),
+      metadata.indexOf("select_permissions:"),
+    );
+    expect(insertSection).toContain("- google_email");
+    expect(insertSection).toContain("- user_id");
+    expect(insertSection).not.toContain("- accepted");
+    expect(insertSection).not.toContain("- processed_at");
+
+    const updateSection = metadata.slice(
+      updatePermissionsStart,
+      metadata.indexOf("delete_permissions:"),
+    );
+    const serviceUpdateStart = updateSection.indexOf("  - role: service");
+    const serviceUpdatePermission = updateSection.slice(serviceUpdateStart);
+    const deleteSection = metadata.slice(
+      metadata.indexOf("delete_permissions:"),
+    );
+
+    // The service role needs an update permission for Hasura to expose the
+    // no-op `on_conflict` used by the insert mutation. Its impossible primary
+    // key filter prevents the role from updating an existing request.
+    expect(serviceUpdateStart).toBeGreaterThan(-1);
+    expect(serviceUpdatePermission).toContain("- google_email");
+    expect(serviceUpdatePermission).not.toContain("- accepted");
+    expect(serviceUpdatePermission).not.toContain("- processed_at");
+    expect(serviceUpdatePermission).toContain("_is_null: true");
+    expect(deleteSection).not.toContain("role: service");
   });
 
   it("does not define elevated internal dashboard roles", () => {


### PR DESCRIPTION
## What

- Tighten Android sandbox request service permissions for safe insert-or-ignore behavior.
- Remove unnecessary user identity display from the Android admin request table.
- Add focused metadata assertions for the permission boundary.

## Why
Currently the android requests table shows user email instead of the unique user ID even when the fetch returns a value. Since portal_email is already a column in the table, this became redundant. the PR removes the user id field from the table entirely