### PR TITLE
feat(sandbox ios enrollment 2/4): add request schema and Hasura permissions 

### DIFF
--- a/hasura/metadata/databases/default/tables/public_sandbox_access_request_ios.yaml
+++ b/hasura/metadata/databases/default/tables/public_sandbox_access_request_ios.yaml
@@ -1,0 +1,78 @@
+table:
+  name: sandbox_access_request_ios
+  schema: public
+object_relationships:
+  - name: team
+    using:
+      foreign_key_constraint_on: team_id
+  - name: user
+    using:
+      foreign_key_constraint_on: user_id
+insert_permissions:
+  - role: service
+    permission:
+      check: {}
+      columns:
+        - asc_email
+        - portal_email
+        - team_id
+        - user_id
+select_permissions:
+  - role: internal_dashboard_readonly
+    permission:
+      columns:
+        - id
+        - user_id
+        - portal_email
+        - asc_email
+        - team_id
+        - status
+        - created_at
+        - approved_at
+        - rejection_reason
+        - revoked_at
+      filter: {}
+      allow_aggregations: true
+  - role: service
+    permission:
+      columns:
+        - id
+        - user_id
+        - asc_email
+        - status
+      filter: {}
+update_permissions:
+  - role: internal_dashboard_readonly
+    permission:
+      columns:
+        - status
+        - approved_at
+        - rejection_reason
+        - revoked_at
+      filter: {}
+      check: {}
+  # The service role's only permitted update is the re-request upsert: reopen
+  # a rejected request as a fresh pending one (values come from the proposed
+  # insert row). Every other status stays immutable to the service role, and
+  # ownership plus approval/revocation audit fields are never updatable.
+  - role: service
+    permission:
+      columns:
+        - asc_email
+        - created_at
+        - portal_email
+        - rejection_reason
+        - status
+        - team_id
+      filter:
+        status:
+          _eq: rejected
+      check:
+        status:
+          _eq: pending
+delete_permissions:
+  - role: internal_dashboard_readonly
+    permission:
+      filter:
+        status:
+          _eq: pending

--- a/hasura/metadata/databases/default/tables/public_sandbox_access_request_ios.yaml
+++ b/hasura/metadata/databases/default/tables/public_sandbox_access_request_ios.yaml
@@ -53,8 +53,10 @@ update_permissions:
       check: {}
   # The service role's only permitted update is the re-request upsert: reopen
   # a rejected request as a fresh pending one (values come from the proposed
-  # insert row). Every other status stays immutable to the service role, and
-  # ownership plus approval/revocation audit fields are never updatable.
+  # insert row). The row must belong to the JWT's X-Hasura-User-Id so a
+  # service caller cannot bulk-reopen unrelated rejected requests. Every other
+  # status stays immutable to the service role, and ownership plus
+  # approval/revocation audit fields are never updatable.
   - role: service
     permission:
       columns:
@@ -67,6 +69,8 @@ update_permissions:
       filter:
         status:
           _eq: rejected
+        user_id:
+          _eq: X-Hasura-User-Id
       check:
         status:
           _eq: pending

--- a/hasura/metadata/databases/default/tables/public_sandbox_access_request_ios.yaml
+++ b/hasura/metadata/databases/default/tables/public_sandbox_access_request_ios.yaml
@@ -51,29 +51,6 @@ update_permissions:
         - revoked_at
       filter: {}
       check: {}
-  # The service role's only permitted update is the re-request upsert: reopen
-  # a rejected request as a fresh pending one (values come from the proposed
-  # insert row). The row must belong to the JWT's X-Hasura-User-Id so a
-  # service caller cannot bulk-reopen unrelated rejected requests. Every other
-  # status stays immutable to the service role, and ownership plus
-  # approval/revocation audit fields are never updatable.
-  - role: service
-    permission:
-      columns:
-        - asc_email
-        - created_at
-        - portal_email
-        - rejection_reason
-        - status
-        - team_id
-      filter:
-        status:
-          _eq: rejected
-        user_id:
-          _eq: X-Hasura-User-Id
-      check:
-        status:
-          _eq: pending
 delete_permissions:
   - role: internal_dashboard_readonly
     permission:

--- a/hasura/metadata/databases/default/tables/public_user.yaml
+++ b/hasura/metadata/databases/default/tables/public_user.yaml
@@ -20,6 +20,13 @@ array_relationships:
         table:
           name: sandbox_access_request
           schema: public
+  - name: sandbox_access_requests_ios
+    using:
+      foreign_key_constraint_on:
+        column: user_id
+        table:
+          name: sandbox_access_request_ios
+          schema: public
 insert_permissions:
   - role: qa
     permission:

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -26,5 +26,6 @@
 - "!include public_rp_manager_key_migration_audit.yaml"
 - "!include public_rp_registration.yaml"
 - "!include public_sandbox_access_request.yaml"
+- "!include public_sandbox_access_request_ios.yaml"
 - "!include public_team.yaml"
 - "!include public_user.yaml"

--- a/hasura/migrations/default/1787346730000_create_table_public_sandbox_access_request_ios/down.sql
+++ b/hasura/migrations/default/1787346730000_create_table_public_sandbox_access_request_ios/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE "public"."sandbox_access_request_ios";
+DROP TYPE "public"."sandbox_access_request_ios_status";

--- a/hasura/migrations/default/1787346730000_create_table_public_sandbox_access_request_ios/up.sql
+++ b/hasura/migrations/default/1787346730000_create_table_public_sandbox_access_request_ios/up.sql
@@ -1,0 +1,61 @@
+CREATE TYPE "public"."sandbox_access_request_ios_status" AS ENUM (
+    'pending',
+    'approved',
+    'rejected',
+    'revoking',
+    'revoked'
+);
+
+CREATE TABLE
+    "public"."sandbox_access_request_ios" (
+        "id" varchar NOT NULL DEFAULT gen_random_friendly_id ('sbx_req'),
+        "user_id" varchar NOT NULL,
+        "team_id" varchar NOT NULL,
+        "portal_email" varchar NOT NULL,
+        "asc_email" varchar NOT NULL,
+        "status" "public"."sandbox_access_request_ios_status" NOT NULL DEFAULT 'pending',
+        "created_at" timestamptz NOT NULL DEFAULT now (),
+        "updated_at" timestamptz NOT NULL DEFAULT now (),
+        "approved_at" timestamptz,
+        "rejection_reason" varchar(500),
+        "revoked_at" timestamptz,
+        PRIMARY KEY ("id"),
+        FOREIGN KEY ("user_id") REFERENCES "public"."user" ("id") ON UPDATE restrict ON DELETE cascade,
+        FOREIGN KEY ("team_id") REFERENCES "public"."team" ("id") ON UPDATE restrict ON DELETE cascade,
+        CONSTRAINT "unique_sandbox_access_request_ios_user_id" UNIQUE ("user_id"),
+        CONSTRAINT "unique_sandbox_access_request_ios_asc_email" UNIQUE ("asc_email"),
+        CONSTRAINT "sandbox_access_request_ios_asc_email_is_canonical"
+            CHECK ("asc_email" = lower(btrim("asc_email"))),
+        CONSTRAINT "sandbox_access_request_ios_approval_audit"
+            CHECK (
+                (
+                    "status" IN ('approved', 'revoking', 'revoked')
+                    AND "approved_at" IS NOT NULL
+                )
+                OR (
+                    "status" IN ('pending', 'rejected')
+                    AND "approved_at" IS NULL
+                )
+            ),
+        CONSTRAINT "sandbox_access_request_ios_rejection_reason"
+            CHECK ("status" = 'rejected' OR "rejection_reason" IS NULL),
+        CONSTRAINT "sandbox_access_request_ios_revocation_audit"
+            CHECK (
+                (
+                    "status" = 'revoked'
+                    AND "revoked_at" IS NOT NULL
+                )
+                OR (
+                    "status" <> 'revoked'
+                    AND "revoked_at" IS NULL
+                )
+            )
+    );
+
+CREATE TRIGGER "set_public_sandbox_access_request_ios_updated_at"
+BEFORE UPDATE ON "public"."sandbox_access_request_ios"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at" ();
+
+COMMENT ON TRIGGER "set_public_sandbox_access_request_ios_updated_at" ON "public"."sandbox_access_request_ios"
+IS 'trigger to set value of column "updated_at" to current timestamp on row update';

--- a/hasura/migrations/default/1787346730000_create_table_public_sandbox_access_request_ios/up.sql
+++ b/hasura/migrations/default/1787346730000_create_table_public_sandbox_access_request_ios/up.sql
@@ -1,5 +1,6 @@
 CREATE TYPE "public"."sandbox_access_request_ios_status" AS ENUM (
     'pending',
+    'approving',
     'approved',
     'rejected',
     'revoking',
@@ -33,7 +34,7 @@ CREATE TABLE
                     AND "approved_at" IS NOT NULL
                 )
                 OR (
-                    "status" IN ('pending', 'rejected')
+                    "status" IN ('pending', 'approving', 'rejected')
                     AND "approved_at" IS NULL
                 )
             ),

--- a/web/api/mcp/graphql/app-context.generated.ts
+++ b/web/api/mcp/graphql/app-context.generated.ts
@@ -84,7 +84,7 @@ export type McpAppContextQuery = {
       status: unknown;
       signer_address?: string | null;
       manager_kms_key_id?: string | null;
-      updated_at: unknown;
+      updated_at: string;
       staging_status?: unknown | null;
       actions_v4: Array<{
         __typename?: "action_v4";

--- a/web/graphql-codegen.types.js
+++ b/web/graphql-codegen.types.js
@@ -22,7 +22,7 @@ module.exports = {
       _text: "any",
       bigint: "number",
       sandbox_access_request_ios_status:
-        "'pending' | 'approved' | 'rejected' | 'revoking' | 'revoked'",
+        "'pending' | 'approving' | 'approved' | 'rejected' | 'revoking' | 'revoked'",
     },
   },
 

--- a/web/graphql-codegen.types.js
+++ b/web/graphql-codegen.types.js
@@ -21,6 +21,8 @@ module.exports = {
       numeric: "string",
       _text: "any",
       bigint: "number",
+      sandbox_access_request_ios_status:
+        "'pending' | 'approved' | 'rejected' | 'revoking' | 'revoked'",
     },
   },
 

--- a/web/graphql/graphql.schema.json
+++ b/web/graphql/graphql.schema.json
@@ -50942,6 +50942,64 @@
             "deprecationReason": null
           },
           {
+            "name": "delete_sandbox_access_request_ios",
+            "description": "delete data from the table: \"sandbox_access_request_ios\"",
+            "args": [
+              {
+                "name": "where",
+                "description": "filter the rows which have to be deleted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "sandbox_access_request_ios_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sandbox_access_request_ios_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "delete_sandbox_access_request_ios_by_pk",
+            "description": "delete single row from the table: \"sandbox_access_request_ios\"",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sandbox_access_request_ios",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "delete_team",
             "description": "delete data from the table: \"team\"",
             "args": [
@@ -53560,6 +53618,96 @@
             "type": {
               "kind": "OBJECT",
               "name": "sandbox_access_request_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insert_sandbox_access_request_ios",
+            "description": "insert data into the table: \"sandbox_access_request_ios\"",
+            "args": [
+              {
+                "name": "objects",
+                "description": "the rows to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "sandbox_access_request_ios_insert_input",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "on_conflict",
+                "description": "upsert condition",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "sandbox_access_request_ios_on_conflict",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sandbox_access_request_ios_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insert_sandbox_access_request_ios_one",
+            "description": "insert a single row into the table: \"sandbox_access_request_ios\"",
+            "args": [
+              {
+                "name": "object",
+                "description": "the row to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "sandbox_access_request_ios_insert_input",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "on_conflict",
+                "description": "upsert condition",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "sandbox_access_request_ios_on_conflict",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sandbox_access_request_ios",
               "ofType": null
             },
             "isDeprecated": false,
@@ -58412,6 +58560,129 @@
               "kind": "OBJECT",
               "name": "sandbox_access_request",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_sandbox_access_request_ios",
+            "description": "update data of the table: \"sandbox_access_request_ios\"",
+            "args": [
+              {
+                "name": "_set",
+                "description": "sets the columns of the filtered rows to the given values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "sandbox_access_request_ios_set_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows which have to be updated",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "sandbox_access_request_ios_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sandbox_access_request_ios_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_sandbox_access_request_ios_by_pk",
+            "description": "update single row of the table: \"sandbox_access_request_ios\"",
+            "args": [
+              {
+                "name": "_set",
+                "description": "sets the columns of the filtered rows to the given values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "sandbox_access_request_ios_set_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pk_columns",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "sandbox_access_request_ios_pk_columns_input",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sandbox_access_request_ios",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_sandbox_access_request_ios_many",
+            "description": "update multiples rows of table: \"sandbox_access_request_ios\"",
+            "args": [
+              {
+                "name": "updates",
+                "description": "updates to execute, in order",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "sandbox_access_request_ios_updates",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "sandbox_access_request_ios_mutation_response",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -73914,6 +74185,229 @@
             "deprecationReason": null
           },
           {
+            "name": "sandbox_access_request_ios",
+            "description": "fetch data from the table: \"sandbox_access_request_ios\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "sandbox_access_request_ios_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "sandbox_access_request_ios_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "sandbox_access_request_ios_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "sandbox_access_request_ios",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sandbox_access_request_ios_aggregate",
+            "description": "fetch aggregated fields from the table: \"sandbox_access_request_ios\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "sandbox_access_request_ios_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "sandbox_access_request_ios_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "sandbox_access_request_ios_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "sandbox_access_request_ios_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sandbox_access_request_ios_by_pk",
+            "description": "fetch data from the table: \"sandbox_access_request_ios\" using primary key columns",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sandbox_access_request_ios",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "team",
             "description": "fetch data from the table: \"team\"",
             "args": [
@@ -84425,6 +84919,2490 @@
       },
       {
         "kind": "OBJECT",
+        "name": "sandbox_access_request_ios",
+        "description": "columns and relationships of \"sandbox_access_request_ios\"",
+        "fields": [
+          {
+            "name": "approved_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "asc_email",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "portal_email",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rejection_reason",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revoked_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "sandbox_access_request_ios_status",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "team",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "user",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "sandbox_access_request_ios_aggregate",
+        "description": "aggregated selection of \"sandbox_access_request_ios\"",
+        "fields": [
+          {
+            "name": "aggregate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sandbox_access_request_ios_aggregate_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "sandbox_access_request_ios",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_aggregate_bool_exp",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "count",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sandbox_access_request_ios_aggregate_bool_exp_count",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_aggregate_bool_exp_count",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "arguments",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "sandbox_access_request_ios_select_column",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "distinct",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "filter",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sandbox_access_request_ios_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "predicate",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "Int_comparison_exp",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "sandbox_access_request_ios_aggregate_fields",
+        "description": "aggregate fields of \"sandbox_access_request_ios\"",
+        "fields": [
+          {
+            "name": "count",
+            "description": null,
+            "args": [
+              {
+                "name": "columns",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "sandbox_access_request_ios_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "distinct",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sandbox_access_request_ios_max_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sandbox_access_request_ios_min_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_aggregate_order_by",
+        "description": "order by aggregate values of table \"sandbox_access_request_ios\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "count",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sandbox_access_request_ios_max_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sandbox_access_request_ios_min_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_arr_rel_insert_input",
+        "description": "input type for inserting array relation for remote table \"sandbox_access_request_ios\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "data",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "sandbox_access_request_ios_insert_input",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_conflict",
+            "description": "upsert condition",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sandbox_access_request_ios_on_conflict",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_bool_exp",
+        "description": "Boolean expression to filter rows from the table \"sandbox_access_request_ios\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "sandbox_access_request_ios_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sandbox_access_request_ios_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "sandbox_access_request_ios_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "approved_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "asc_email",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "portal_email",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rejection_reason",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revoked_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sandbox_access_request_ios_status_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "team_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "user_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "sandbox_access_request_ios_constraint",
+        "description": "unique or primary key constraints on table \"sandbox_access_request_ios\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "sandbox_access_request_ios_pkey",
+            "description": "unique or primary key constraint on columns \"id\"",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_sandbox_access_request_ios_asc_email",
+            "description": "unique or primary key constraint on columns \"asc_email\"",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unique_sandbox_access_request_ios_user_id",
+            "description": "unique or primary key constraint on columns \"user_id\"",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_insert_input",
+        "description": "input type for inserting data into table \"sandbox_access_request_ios\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "approved_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "asc_email",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "portal_email",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rejection_reason",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revoked_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "sandbox_access_request_ios_status",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "team_obj_rel_insert_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "user_obj_rel_insert_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "sandbox_access_request_ios_max_fields",
+        "description": "aggregate max on columns",
+        "fields": [
+          {
+            "name": "approved_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "asc_email",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "portal_email",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rejection_reason",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revoked_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "sandbox_access_request_ios_status",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_max_order_by",
+        "description": "order by max() on columns of table \"sandbox_access_request_ios\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "approved_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "asc_email",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "portal_email",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rejection_reason",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revoked_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "sandbox_access_request_ios_min_fields",
+        "description": "aggregate min on columns",
+        "fields": [
+          {
+            "name": "approved_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "asc_email",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "portal_email",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rejection_reason",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revoked_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "sandbox_access_request_ios_status",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_min_order_by",
+        "description": "order by min() on columns of table \"sandbox_access_request_ios\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "approved_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "asc_email",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "portal_email",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rejection_reason",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revoked_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "sandbox_access_request_ios_mutation_response",
+        "description": "response of any mutation on the table \"sandbox_access_request_ios\"",
+        "fields": [
+          {
+            "name": "affected_rows",
+            "description": "number of rows affected by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "returning",
+            "description": "data from the rows affected by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "sandbox_access_request_ios",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_on_conflict",
+        "description": "on_conflict condition type for table \"sandbox_access_request_ios\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "constraint",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "sandbox_access_request_ios_constraint",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_columns",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "sandbox_access_request_ios_update_column",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": "[]",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sandbox_access_request_ios_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_order_by",
+        "description": "Ordering options when selecting data from \"sandbox_access_request_ios\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "approved_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "asc_email",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "portal_email",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rejection_reason",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revoked_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "team_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "user_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_pk_columns_input",
+        "description": "primary key columns input for table: sandbox_access_request_ios",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "sandbox_access_request_ios_select_column",
+        "description": "select columns of table \"sandbox_access_request_ios\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "approved_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "asc_email",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "portal_email",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rejection_reason",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revoked_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_set_input",
+        "description": "input type for updating data in table \"sandbox_access_request_ios\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "approved_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "asc_email",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "portal_email",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rejection_reason",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revoked_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "sandbox_access_request_ios_status",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "sandbox_access_request_ios_status",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_status_comparison_exp",
+        "description": "Boolean expression to compare columns of type \"sandbox_access_request_ios_status\". All fields are combined with logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_eq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "sandbox_access_request_ios_status",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "sandbox_access_request_ios_status",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "sandbox_access_request_ios_status",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "sandbox_access_request_ios_status",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_is_null",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "sandbox_access_request_ios_status",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "sandbox_access_request_ios_status",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_neq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "sandbox_access_request_ios_status",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_nin",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "sandbox_access_request_ios_status",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_stream_cursor_input",
+        "description": "Streaming cursor of the table \"sandbox_access_request_ios\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "initial_value",
+            "description": "Stream column input with initial value",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "sandbox_access_request_ios_stream_cursor_value_input",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ordering",
+            "description": "cursor ordering",
+            "type": {
+              "kind": "ENUM",
+              "name": "cursor_ordering",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_stream_cursor_value_input",
+        "description": "Initial value of the column from where the streaming should start",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "approved_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "asc_email",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "portal_email",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rejection_reason",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revoked_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "sandbox_access_request_ios_status",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "sandbox_access_request_ios_update_column",
+        "description": "update columns of table \"sandbox_access_request_ios\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "approved_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "asc_email",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "portal_email",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rejection_reason",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revoked_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "sandbox_access_request_ios_updates",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_set",
+            "description": "sets the columns of the filtered rows to the given values",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sandbox_access_request_ios_set_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": "filter the rows which have to be updated",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "sandbox_access_request_ios_bool_exp",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "sandbox_access_request_max_fields",
         "description": "aggregate max on columns",
         "fields": [
@@ -94315,6 +97293,302 @@
             "deprecationReason": null
           },
           {
+            "name": "sandbox_access_request_ios",
+            "description": "fetch data from the table: \"sandbox_access_request_ios\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "sandbox_access_request_ios_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "sandbox_access_request_ios_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "sandbox_access_request_ios_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "sandbox_access_request_ios",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sandbox_access_request_ios_aggregate",
+            "description": "fetch aggregated fields from the table: \"sandbox_access_request_ios\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "sandbox_access_request_ios_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "sandbox_access_request_ios_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "sandbox_access_request_ios_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "sandbox_access_request_ios_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sandbox_access_request_ios_by_pk",
+            "description": "fetch data from the table: \"sandbox_access_request_ios\" using primary key columns",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sandbox_access_request_ios",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sandbox_access_request_ios_stream",
+            "description": "fetch data from the table in a streaming manner: \"sandbox_access_request_ios\"",
+            "args": [
+              {
+                "name": "batch_size",
+                "description": "maximum number of rows returned in a single batch",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "cursor",
+                "description": "cursor to stream the results returned by the query",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "sandbox_access_request_ios_stream_cursor_input",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "sandbox_access_request_ios_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "sandbox_access_request_ios",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sandbox_access_request_stream",
             "description": "fetch data from the table in a streaming manner: \"sandbox_access_request\"",
             "args": [
@@ -98225,6 +101499,200 @@
             "deprecationReason": null
           },
           {
+            "name": "sandbox_access_requests_ios",
+            "description": "An array relationship",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "sandbox_access_request_ios_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "sandbox_access_request_ios_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "sandbox_access_request_ios_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "sandbox_access_request_ios",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sandbox_access_requests_ios_aggregate",
+            "description": "An aggregate relationship",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "sandbox_access_request_ios_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "sandbox_access_request_ios_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "sandbox_access_request_ios_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "sandbox_access_request_ios_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "team",
             "description": "An object relationship",
             "args": [],
@@ -98628,6 +102096,30 @@
             "deprecationReason": null
           },
           {
+            "name": "sandbox_access_requests_ios",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sandbox_access_request_ios_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sandbox_access_requests_ios_aggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sandbox_access_request_ios_aggregate_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "team",
             "description": null,
             "type": {
@@ -98847,6 +102339,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "sandbox_access_request_arr_rel_insert_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sandbox_access_requests_ios",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sandbox_access_request_ios_arr_rel_insert_input",
               "ofType": null
             },
             "defaultValue": null,
@@ -99453,6 +102957,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "sandbox_access_request_aggregate_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sandbox_access_requests_ios_aggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sandbox_access_request_ios_aggregate_order_by",
               "ofType": null
             },
             "defaultValue": null,

--- a/web/graphql/graphql.ts
+++ b/web/graphql/graphql.ts
@@ -38,8 +38,20 @@ export type Scalars = {
   rp_registration_mode: { input: unknown; output: unknown };
   rp_registration_status: { input: unknown; output: unknown };
   sandbox_access_request_ios_status: {
-    input: "pending" | "approved" | "rejected" | "revoking" | "revoked";
-    output: "pending" | "approved" | "rejected" | "revoking" | "revoked";
+    input:
+      | "pending"
+      | "approving"
+      | "approved"
+      | "rejected"
+      | "revoking"
+      | "revoked";
+    output:
+      | "pending"
+      | "approving"
+      | "approved"
+      | "rejected"
+      | "revoking"
+      | "revoked";
   };
   timestamp: { input: string; output: string };
   timestamptz: { input: string; output: string };

--- a/web/graphql/graphql.ts
+++ b/web/graphql/graphql.ts
@@ -37,6 +37,10 @@ export type Scalars = {
   review_status_enum: { input: unknown; output: unknown };
   rp_registration_mode: { input: unknown; output: unknown };
   rp_registration_status: { input: unknown; output: unknown };
+  sandbox_access_request_ios_status: {
+    input: "pending" | "approved" | "rejected" | "revoking" | "revoked";
+    output: "pending" | "approved" | "rejected" | "revoking" | "revoked";
+  };
   timestamp: { input: string; output: string };
   timestamptz: { input: string; output: string };
   uuid: { input: unknown; output: unknown };
@@ -6863,6 +6867,10 @@ export type Mutation_Root = {
   delete_sandbox_access_request?: Maybe<Sandbox_Access_Request_Mutation_Response>;
   /** delete single row from the table: "sandbox_access_request" */
   delete_sandbox_access_request_by_pk?: Maybe<Sandbox_Access_Request>;
+  /** delete data from the table: "sandbox_access_request_ios" */
+  delete_sandbox_access_request_ios?: Maybe<Sandbox_Access_Request_Ios_Mutation_Response>;
+  /** delete single row from the table: "sandbox_access_request_ios" */
+  delete_sandbox_access_request_ios_by_pk?: Maybe<Sandbox_Access_Request_Ios>;
   /** delete data from the table: "team" */
   delete_team?: Maybe<Team_Mutation_Response>;
   /** delete single row from the table: "team" */
@@ -6982,6 +6990,10 @@ export type Mutation_Root = {
   insert_rp_registration_one?: Maybe<Rp_Registration>;
   /** insert data into the table: "sandbox_access_request" */
   insert_sandbox_access_request?: Maybe<Sandbox_Access_Request_Mutation_Response>;
+  /** insert data into the table: "sandbox_access_request_ios" */
+  insert_sandbox_access_request_ios?: Maybe<Sandbox_Access_Request_Ios_Mutation_Response>;
+  /** insert a single row into the table: "sandbox_access_request_ios" */
+  insert_sandbox_access_request_ios_one?: Maybe<Sandbox_Access_Request_Ios>;
   /** insert a single row into the table: "sandbox_access_request" */
   insert_sandbox_access_request_one?: Maybe<Sandbox_Access_Request>;
   /** insert data into the table: "team" */
@@ -7205,6 +7217,14 @@ export type Mutation_Root = {
   update_sandbox_access_request?: Maybe<Sandbox_Access_Request_Mutation_Response>;
   /** update single row of the table: "sandbox_access_request" */
   update_sandbox_access_request_by_pk?: Maybe<Sandbox_Access_Request>;
+  /** update data of the table: "sandbox_access_request_ios" */
+  update_sandbox_access_request_ios?: Maybe<Sandbox_Access_Request_Ios_Mutation_Response>;
+  /** update single row of the table: "sandbox_access_request_ios" */
+  update_sandbox_access_request_ios_by_pk?: Maybe<Sandbox_Access_Request_Ios>;
+  /** update multiples rows of table: "sandbox_access_request_ios" */
+  update_sandbox_access_request_ios_many?: Maybe<
+    Array<Maybe<Sandbox_Access_Request_Ios_Mutation_Response>>
+  >;
   /** update multiples rows of table: "sandbox_access_request" */
   update_sandbox_access_request_many?: Maybe<
     Array<Maybe<Sandbox_Access_Request_Mutation_Response>>
@@ -7537,6 +7557,16 @@ export type Mutation_RootDelete_Sandbox_Access_RequestArgs = {
 
 /** mutation root */
 export type Mutation_RootDelete_Sandbox_Access_Request_By_PkArgs = {
+  id: Scalars["String"]["input"];
+};
+
+/** mutation root */
+export type Mutation_RootDelete_Sandbox_Access_Request_IosArgs = {
+  where: Sandbox_Access_Request_Ios_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootDelete_Sandbox_Access_Request_Ios_By_PkArgs = {
   id: Scalars["String"]["input"];
 };
 
@@ -7893,6 +7923,18 @@ export type Mutation_RootInsert_Rp_Registration_OneArgs = {
 export type Mutation_RootInsert_Sandbox_Access_RequestArgs = {
   objects: Array<Sandbox_Access_Request_Insert_Input>;
   on_conflict?: InputMaybe<Sandbox_Access_Request_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_Sandbox_Access_Request_IosArgs = {
+  objects: Array<Sandbox_Access_Request_Ios_Insert_Input>;
+  on_conflict?: InputMaybe<Sandbox_Access_Request_Ios_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_Sandbox_Access_Request_Ios_OneArgs = {
+  object: Sandbox_Access_Request_Ios_Insert_Input;
+  on_conflict?: InputMaybe<Sandbox_Access_Request_Ios_On_Conflict>;
 };
 
 /** mutation root */
@@ -8517,6 +8559,23 @@ export type Mutation_RootUpdate_Sandbox_Access_RequestArgs = {
 export type Mutation_RootUpdate_Sandbox_Access_Request_By_PkArgs = {
   _set?: InputMaybe<Sandbox_Access_Request_Set_Input>;
   pk_columns: Sandbox_Access_Request_Pk_Columns_Input;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_Sandbox_Access_Request_IosArgs = {
+  _set?: InputMaybe<Sandbox_Access_Request_Ios_Set_Input>;
+  where: Sandbox_Access_Request_Ios_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_Sandbox_Access_Request_Ios_By_PkArgs = {
+  _set?: InputMaybe<Sandbox_Access_Request_Ios_Set_Input>;
+  pk_columns: Sandbox_Access_Request_Ios_Pk_Columns_Input;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_Sandbox_Access_Request_Ios_ManyArgs = {
+  updates: Array<Sandbox_Access_Request_Ios_Updates>;
 };
 
 /** mutation root */
@@ -10031,6 +10090,12 @@ export type Query_Root = {
   sandbox_access_request_aggregate: Sandbox_Access_Request_Aggregate;
   /** fetch data from the table: "sandbox_access_request" using primary key columns */
   sandbox_access_request_by_pk?: Maybe<Sandbox_Access_Request>;
+  /** fetch data from the table: "sandbox_access_request_ios" */
+  sandbox_access_request_ios: Array<Sandbox_Access_Request_Ios>;
+  /** fetch aggregated fields from the table: "sandbox_access_request_ios" */
+  sandbox_access_request_ios_aggregate: Sandbox_Access_Request_Ios_Aggregate;
+  /** fetch data from the table: "sandbox_access_request_ios" using primary key columns */
+  sandbox_access_request_ios_by_pk?: Maybe<Sandbox_Access_Request_Ios>;
   /** fetch data from the table: "team" */
   team: Array<Team>;
   /** fetch aggregated fields from the table: "team" */
@@ -10691,6 +10756,26 @@ export type Query_RootSandbox_Access_Request_AggregateArgs = {
 };
 
 export type Query_RootSandbox_Access_Request_By_PkArgs = {
+  id: Scalars["String"]["input"];
+};
+
+export type Query_RootSandbox_Access_Request_IosArgs = {
+  distinct_on?: InputMaybe<Array<Sandbox_Access_Request_Ios_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Sandbox_Access_Request_Ios_Order_By>>;
+  where?: InputMaybe<Sandbox_Access_Request_Ios_Bool_Exp>;
+};
+
+export type Query_RootSandbox_Access_Request_Ios_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Sandbox_Access_Request_Ios_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Sandbox_Access_Request_Ios_Order_By>>;
+  where?: InputMaybe<Sandbox_Access_Request_Ios_Bool_Exp>;
+};
+
+export type Query_RootSandbox_Access_Request_Ios_By_PkArgs = {
   id: Scalars["String"]["input"];
 };
 
@@ -12105,6 +12190,333 @@ export type Sandbox_Access_Request_Insert_Input = {
   user_id?: InputMaybe<Scalars["String"]["input"]>;
 };
 
+/** columns and relationships of "sandbox_access_request_ios" */
+export type Sandbox_Access_Request_Ios = {
+  __typename?: "sandbox_access_request_ios";
+  approved_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  asc_email: Scalars["String"]["output"];
+  created_at: Scalars["timestamptz"]["output"];
+  id: Scalars["String"]["output"];
+  portal_email: Scalars["String"]["output"];
+  rejection_reason?: Maybe<Scalars["String"]["output"]>;
+  revoked_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  status: Scalars["sandbox_access_request_ios_status"]["output"];
+  /** An object relationship */
+  team: Team;
+  team_id: Scalars["String"]["output"];
+  updated_at: Scalars["timestamptz"]["output"];
+  /** An object relationship */
+  user: User;
+  user_id: Scalars["String"]["output"];
+};
+
+/** aggregated selection of "sandbox_access_request_ios" */
+export type Sandbox_Access_Request_Ios_Aggregate = {
+  __typename?: "sandbox_access_request_ios_aggregate";
+  aggregate?: Maybe<Sandbox_Access_Request_Ios_Aggregate_Fields>;
+  nodes: Array<Sandbox_Access_Request_Ios>;
+};
+
+export type Sandbox_Access_Request_Ios_Aggregate_Bool_Exp = {
+  count?: InputMaybe<Sandbox_Access_Request_Ios_Aggregate_Bool_Exp_Count>;
+};
+
+export type Sandbox_Access_Request_Ios_Aggregate_Bool_Exp_Count = {
+  arguments?: InputMaybe<Array<Sandbox_Access_Request_Ios_Select_Column>>;
+  distinct?: InputMaybe<Scalars["Boolean"]["input"]>;
+  filter?: InputMaybe<Sandbox_Access_Request_Ios_Bool_Exp>;
+  predicate: Int_Comparison_Exp;
+};
+
+/** aggregate fields of "sandbox_access_request_ios" */
+export type Sandbox_Access_Request_Ios_Aggregate_Fields = {
+  __typename?: "sandbox_access_request_ios_aggregate_fields";
+  count: Scalars["Int"]["output"];
+  max?: Maybe<Sandbox_Access_Request_Ios_Max_Fields>;
+  min?: Maybe<Sandbox_Access_Request_Ios_Min_Fields>;
+};
+
+/** aggregate fields of "sandbox_access_request_ios" */
+export type Sandbox_Access_Request_Ios_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Sandbox_Access_Request_Ios_Select_Column>>;
+  distinct?: InputMaybe<Scalars["Boolean"]["input"]>;
+};
+
+/** order by aggregate values of table "sandbox_access_request_ios" */
+export type Sandbox_Access_Request_Ios_Aggregate_Order_By = {
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Sandbox_Access_Request_Ios_Max_Order_By>;
+  min?: InputMaybe<Sandbox_Access_Request_Ios_Min_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "sandbox_access_request_ios" */
+export type Sandbox_Access_Request_Ios_Arr_Rel_Insert_Input = {
+  data: Array<Sandbox_Access_Request_Ios_Insert_Input>;
+  /** upsert condition */
+  on_conflict?: InputMaybe<Sandbox_Access_Request_Ios_On_Conflict>;
+};
+
+/** Boolean expression to filter rows from the table "sandbox_access_request_ios". All fields are combined with a logical 'AND'. */
+export type Sandbox_Access_Request_Ios_Bool_Exp = {
+  _and?: InputMaybe<Array<Sandbox_Access_Request_Ios_Bool_Exp>>;
+  _not?: InputMaybe<Sandbox_Access_Request_Ios_Bool_Exp>;
+  _or?: InputMaybe<Array<Sandbox_Access_Request_Ios_Bool_Exp>>;
+  approved_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  asc_email?: InputMaybe<String_Comparison_Exp>;
+  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  id?: InputMaybe<String_Comparison_Exp>;
+  portal_email?: InputMaybe<String_Comparison_Exp>;
+  rejection_reason?: InputMaybe<String_Comparison_Exp>;
+  revoked_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  status?: InputMaybe<Sandbox_Access_Request_Ios_Status_Comparison_Exp>;
+  team?: InputMaybe<Team_Bool_Exp>;
+  team_id?: InputMaybe<String_Comparison_Exp>;
+  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  user?: InputMaybe<User_Bool_Exp>;
+  user_id?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "sandbox_access_request_ios" */
+export enum Sandbox_Access_Request_Ios_Constraint {
+  /** unique or primary key constraint on columns "id" */
+  SandboxAccessRequestIosPkey = "sandbox_access_request_ios_pkey",
+  /** unique or primary key constraint on columns "asc_email" */
+  UniqueSandboxAccessRequestIosAscEmail = "unique_sandbox_access_request_ios_asc_email",
+  /** unique or primary key constraint on columns "user_id" */
+  UniqueSandboxAccessRequestIosUserId = "unique_sandbox_access_request_ios_user_id",
+}
+
+/** input type for inserting data into table "sandbox_access_request_ios" */
+export type Sandbox_Access_Request_Ios_Insert_Input = {
+  approved_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  asc_email?: InputMaybe<Scalars["String"]["input"]>;
+  created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  portal_email?: InputMaybe<Scalars["String"]["input"]>;
+  rejection_reason?: InputMaybe<Scalars["String"]["input"]>;
+  revoked_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  status?: InputMaybe<Scalars["sandbox_access_request_ios_status"]["input"]>;
+  team?: InputMaybe<Team_Obj_Rel_Insert_Input>;
+  team_id?: InputMaybe<Scalars["String"]["input"]>;
+  updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  user?: InputMaybe<User_Obj_Rel_Insert_Input>;
+  user_id?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+/** aggregate max on columns */
+export type Sandbox_Access_Request_Ios_Max_Fields = {
+  __typename?: "sandbox_access_request_ios_max_fields";
+  approved_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  asc_email?: Maybe<Scalars["String"]["output"]>;
+  created_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  id?: Maybe<Scalars["String"]["output"]>;
+  portal_email?: Maybe<Scalars["String"]["output"]>;
+  rejection_reason?: Maybe<Scalars["String"]["output"]>;
+  revoked_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  status?: Maybe<Scalars["sandbox_access_request_ios_status"]["output"]>;
+  team_id?: Maybe<Scalars["String"]["output"]>;
+  updated_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  user_id?: Maybe<Scalars["String"]["output"]>;
+};
+
+/** order by max() on columns of table "sandbox_access_request_ios" */
+export type Sandbox_Access_Request_Ios_Max_Order_By = {
+  approved_at?: InputMaybe<Order_By>;
+  asc_email?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  portal_email?: InputMaybe<Order_By>;
+  rejection_reason?: InputMaybe<Order_By>;
+  revoked_at?: InputMaybe<Order_By>;
+  status?: InputMaybe<Order_By>;
+  team_id?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+  user_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Sandbox_Access_Request_Ios_Min_Fields = {
+  __typename?: "sandbox_access_request_ios_min_fields";
+  approved_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  asc_email?: Maybe<Scalars["String"]["output"]>;
+  created_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  id?: Maybe<Scalars["String"]["output"]>;
+  portal_email?: Maybe<Scalars["String"]["output"]>;
+  rejection_reason?: Maybe<Scalars["String"]["output"]>;
+  revoked_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  status?: Maybe<Scalars["sandbox_access_request_ios_status"]["output"]>;
+  team_id?: Maybe<Scalars["String"]["output"]>;
+  updated_at?: Maybe<Scalars["timestamptz"]["output"]>;
+  user_id?: Maybe<Scalars["String"]["output"]>;
+};
+
+/** order by min() on columns of table "sandbox_access_request_ios" */
+export type Sandbox_Access_Request_Ios_Min_Order_By = {
+  approved_at?: InputMaybe<Order_By>;
+  asc_email?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  portal_email?: InputMaybe<Order_By>;
+  rejection_reason?: InputMaybe<Order_By>;
+  revoked_at?: InputMaybe<Order_By>;
+  status?: InputMaybe<Order_By>;
+  team_id?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+  user_id?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "sandbox_access_request_ios" */
+export type Sandbox_Access_Request_Ios_Mutation_Response = {
+  __typename?: "sandbox_access_request_ios_mutation_response";
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars["Int"]["output"];
+  /** data from the rows affected by the mutation */
+  returning: Array<Sandbox_Access_Request_Ios>;
+};
+
+/** on_conflict condition type for table "sandbox_access_request_ios" */
+export type Sandbox_Access_Request_Ios_On_Conflict = {
+  constraint: Sandbox_Access_Request_Ios_Constraint;
+  update_columns?: Array<Sandbox_Access_Request_Ios_Update_Column>;
+  where?: InputMaybe<Sandbox_Access_Request_Ios_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "sandbox_access_request_ios". */
+export type Sandbox_Access_Request_Ios_Order_By = {
+  approved_at?: InputMaybe<Order_By>;
+  asc_email?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  portal_email?: InputMaybe<Order_By>;
+  rejection_reason?: InputMaybe<Order_By>;
+  revoked_at?: InputMaybe<Order_By>;
+  status?: InputMaybe<Order_By>;
+  team?: InputMaybe<Team_Order_By>;
+  team_id?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+  user?: InputMaybe<User_Order_By>;
+  user_id?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: sandbox_access_request_ios */
+export type Sandbox_Access_Request_Ios_Pk_Columns_Input = {
+  id: Scalars["String"]["input"];
+};
+
+/** select columns of table "sandbox_access_request_ios" */
+export enum Sandbox_Access_Request_Ios_Select_Column {
+  /** column name */
+  ApprovedAt = "approved_at",
+  /** column name */
+  AscEmail = "asc_email",
+  /** column name */
+  CreatedAt = "created_at",
+  /** column name */
+  Id = "id",
+  /** column name */
+  PortalEmail = "portal_email",
+  /** column name */
+  RejectionReason = "rejection_reason",
+  /** column name */
+  RevokedAt = "revoked_at",
+  /** column name */
+  Status = "status",
+  /** column name */
+  TeamId = "team_id",
+  /** column name */
+  UpdatedAt = "updated_at",
+  /** column name */
+  UserId = "user_id",
+}
+
+/** input type for updating data in table "sandbox_access_request_ios" */
+export type Sandbox_Access_Request_Ios_Set_Input = {
+  approved_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  asc_email?: InputMaybe<Scalars["String"]["input"]>;
+  created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  portal_email?: InputMaybe<Scalars["String"]["input"]>;
+  rejection_reason?: InputMaybe<Scalars["String"]["input"]>;
+  revoked_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  status?: InputMaybe<Scalars["sandbox_access_request_ios_status"]["input"]>;
+  team_id?: InputMaybe<Scalars["String"]["input"]>;
+  updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  user_id?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+/** Boolean expression to compare columns of type "sandbox_access_request_ios_status". All fields are combined with logical 'AND'. */
+export type Sandbox_Access_Request_Ios_Status_Comparison_Exp = {
+  _eq?: InputMaybe<Scalars["sandbox_access_request_ios_status"]["input"]>;
+  _gt?: InputMaybe<Scalars["sandbox_access_request_ios_status"]["input"]>;
+  _gte?: InputMaybe<Scalars["sandbox_access_request_ios_status"]["input"]>;
+  _in?: InputMaybe<
+    Array<Scalars["sandbox_access_request_ios_status"]["input"]>
+  >;
+  _is_null?: InputMaybe<Scalars["Boolean"]["input"]>;
+  _lt?: InputMaybe<Scalars["sandbox_access_request_ios_status"]["input"]>;
+  _lte?: InputMaybe<Scalars["sandbox_access_request_ios_status"]["input"]>;
+  _neq?: InputMaybe<Scalars["sandbox_access_request_ios_status"]["input"]>;
+  _nin?: InputMaybe<
+    Array<Scalars["sandbox_access_request_ios_status"]["input"]>
+  >;
+};
+
+/** Streaming cursor of the table "sandbox_access_request_ios" */
+export type Sandbox_Access_Request_Ios_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Sandbox_Access_Request_Ios_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Sandbox_Access_Request_Ios_Stream_Cursor_Value_Input = {
+  approved_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  asc_email?: InputMaybe<Scalars["String"]["input"]>;
+  created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  portal_email?: InputMaybe<Scalars["String"]["input"]>;
+  rejection_reason?: InputMaybe<Scalars["String"]["input"]>;
+  revoked_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  status?: InputMaybe<Scalars["sandbox_access_request_ios_status"]["input"]>;
+  team_id?: InputMaybe<Scalars["String"]["input"]>;
+  updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  user_id?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+/** update columns of table "sandbox_access_request_ios" */
+export enum Sandbox_Access_Request_Ios_Update_Column {
+  /** column name */
+  ApprovedAt = "approved_at",
+  /** column name */
+  AscEmail = "asc_email",
+  /** column name */
+  CreatedAt = "created_at",
+  /** column name */
+  Id = "id",
+  /** column name */
+  PortalEmail = "portal_email",
+  /** column name */
+  RejectionReason = "rejection_reason",
+  /** column name */
+  RevokedAt = "revoked_at",
+  /** column name */
+  Status = "status",
+  /** column name */
+  TeamId = "team_id",
+  /** column name */
+  UpdatedAt = "updated_at",
+  /** column name */
+  UserId = "user_id",
+}
+
+export type Sandbox_Access_Request_Ios_Updates = {
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<Sandbox_Access_Request_Ios_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: Sandbox_Access_Request_Ios_Bool_Exp;
+};
+
 /** aggregate max on columns */
 export type Sandbox_Access_Request_Max_Fields = {
   __typename?: "sandbox_access_request_max_fields";
@@ -12487,6 +12899,14 @@ export type Subscription_Root = {
   sandbox_access_request_aggregate: Sandbox_Access_Request_Aggregate;
   /** fetch data from the table: "sandbox_access_request" using primary key columns */
   sandbox_access_request_by_pk?: Maybe<Sandbox_Access_Request>;
+  /** fetch data from the table: "sandbox_access_request_ios" */
+  sandbox_access_request_ios: Array<Sandbox_Access_Request_Ios>;
+  /** fetch aggregated fields from the table: "sandbox_access_request_ios" */
+  sandbox_access_request_ios_aggregate: Sandbox_Access_Request_Ios_Aggregate;
+  /** fetch data from the table: "sandbox_access_request_ios" using primary key columns */
+  sandbox_access_request_ios_by_pk?: Maybe<Sandbox_Access_Request_Ios>;
+  /** fetch data from the table in a streaming manner: "sandbox_access_request_ios" */
+  sandbox_access_request_ios_stream: Array<Sandbox_Access_Request_Ios>;
   /** fetch data from the table in a streaming manner: "sandbox_access_request" */
   sandbox_access_request_stream: Array<Sandbox_Access_Request>;
   /** fetch data from the table: "team" */
@@ -13298,6 +13718,32 @@ export type Subscription_RootSandbox_Access_Request_By_PkArgs = {
   id: Scalars["String"]["input"];
 };
 
+export type Subscription_RootSandbox_Access_Request_IosArgs = {
+  distinct_on?: InputMaybe<Array<Sandbox_Access_Request_Ios_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Sandbox_Access_Request_Ios_Order_By>>;
+  where?: InputMaybe<Sandbox_Access_Request_Ios_Bool_Exp>;
+};
+
+export type Subscription_RootSandbox_Access_Request_Ios_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Sandbox_Access_Request_Ios_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Sandbox_Access_Request_Ios_Order_By>>;
+  where?: InputMaybe<Sandbox_Access_Request_Ios_Bool_Exp>;
+};
+
+export type Subscription_RootSandbox_Access_Request_Ios_By_PkArgs = {
+  id: Scalars["String"]["input"];
+};
+
+export type Subscription_RootSandbox_Access_Request_Ios_StreamArgs = {
+  batch_size: Scalars["Int"]["input"];
+  cursor: Array<InputMaybe<Sandbox_Access_Request_Ios_Stream_Cursor_Input>>;
+  where?: InputMaybe<Sandbox_Access_Request_Ios_Bool_Exp>;
+};
+
 export type Subscription_RootSandbox_Access_Request_StreamArgs = {
   batch_size: Scalars["Int"]["input"];
   cursor: Array<InputMaybe<Sandbox_Access_Request_Stream_Cursor_Input>>;
@@ -13754,6 +14200,10 @@ export type User = {
   sandbox_access_requests: Array<Sandbox_Access_Request>;
   /** An aggregate relationship */
   sandbox_access_requests_aggregate: Sandbox_Access_Request_Aggregate;
+  /** An array relationship */
+  sandbox_access_requests_ios: Array<Sandbox_Access_Request_Ios>;
+  /** An aggregate relationship */
+  sandbox_access_requests_ios_aggregate: Sandbox_Access_Request_Ios_Aggregate;
   /** An object relationship */
   team?: Maybe<Team>;
   team_id?: Maybe<Scalars["String"]["output"]>;
@@ -13797,6 +14247,24 @@ export type UserSandbox_Access_Requests_AggregateArgs = {
   where?: InputMaybe<Sandbox_Access_Request_Bool_Exp>;
 };
 
+/** columns and relationships of "user" */
+export type UserSandbox_Access_Requests_IosArgs = {
+  distinct_on?: InputMaybe<Array<Sandbox_Access_Request_Ios_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Sandbox_Access_Request_Ios_Order_By>>;
+  where?: InputMaybe<Sandbox_Access_Request_Ios_Bool_Exp>;
+};
+
+/** columns and relationships of "user" */
+export type UserSandbox_Access_Requests_Ios_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Sandbox_Access_Request_Ios_Select_Column>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<Sandbox_Access_Request_Ios_Order_By>>;
+  where?: InputMaybe<Sandbox_Access_Request_Ios_Bool_Exp>;
+};
+
 /** aggregated selection of "user" */
 export type User_Aggregate = {
   __typename?: "user_aggregate";
@@ -13836,6 +14304,8 @@ export type User_Bool_Exp = {
   posthog_id?: InputMaybe<String_Comparison_Exp>;
   sandbox_access_requests?: InputMaybe<Sandbox_Access_Request_Bool_Exp>;
   sandbox_access_requests_aggregate?: InputMaybe<Sandbox_Access_Request_Aggregate_Bool_Exp>;
+  sandbox_access_requests_ios?: InputMaybe<Sandbox_Access_Request_Ios_Bool_Exp>;
+  sandbox_access_requests_ios_aggregate?: InputMaybe<Sandbox_Access_Request_Ios_Aggregate_Bool_Exp>;
   team?: InputMaybe<Team_Bool_Exp>;
   team_id?: InputMaybe<String_Comparison_Exp>;
   updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
@@ -13867,6 +14337,7 @@ export type User_Insert_Input = {
   name?: InputMaybe<Scalars["String"]["input"]>;
   posthog_id?: InputMaybe<Scalars["String"]["input"]>;
   sandbox_access_requests?: InputMaybe<Sandbox_Access_Request_Arr_Rel_Insert_Input>;
+  sandbox_access_requests_ios?: InputMaybe<Sandbox_Access_Request_Ios_Arr_Rel_Insert_Input>;
   team?: InputMaybe<Team_Obj_Rel_Insert_Input>;
   team_id?: InputMaybe<Scalars["String"]["input"]>;
   updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
@@ -13939,6 +14410,7 @@ export type User_Order_By = {
   name?: InputMaybe<Order_By>;
   posthog_id?: InputMaybe<Order_By>;
   sandbox_access_requests_aggregate?: InputMaybe<Sandbox_Access_Request_Aggregate_Order_By>;
+  sandbox_access_requests_ios_aggregate?: InputMaybe<Sandbox_Access_Request_Ios_Aggregate_Order_By>;
   team?: InputMaybe<Team_Order_By>;
   team_id?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;

--- a/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
+++ b/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
@@ -227,6 +227,7 @@ describe("internal dashboard detail permissions", () => {
       "utf8",
     );
 
+    expect(migration).toContain("'approving'");
     expect(migration).toContain("'revoking'");
     expect(migration).toContain("'revoked'");
     expect(migration).toContain('lower(btrim("asc_email"))');

--- a/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
+++ b/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
@@ -161,12 +161,7 @@ describe("internal dashboard detail permissions", () => {
       metadata.indexOf("update_permissions:"),
       metadata.indexOf("delete_permissions:"),
     );
-    const serviceUpdateStart = updateSection.indexOf("  - role: service");
-    const dashboardUpdatePermission = updateSection.slice(
-      0,
-      serviceUpdateStart,
-    );
-    const serviceUpdatePermission = updateSection.slice(serviceUpdateStart);
+    const dashboardUpdatePermission = updateSection;
     const deleteSection = metadata.slice(
       metadata.indexOf("delete_permissions:"),
     );
@@ -185,22 +180,9 @@ describe("internal dashboard detail permissions", () => {
     expect(dashboardUpdatePermission).not.toContain("- asc_email");
     expect(dashboardUpdatePermission).not.toContain("- portal_email");
 
-    // The service role's only update is the re-request upsert: it may reopen
-    // a rejected request as pending, but never touch ownership or the
-    // approval/revocation audit fields, and never rows in any other status.
-    expect(serviceUpdateStart).toBeGreaterThan(-1);
-    expect(serviceUpdatePermission).toContain("- asc_email");
-    expect(serviceUpdatePermission).toContain("- portal_email");
-    expect(serviceUpdatePermission).toContain("- team_id");
-    expect(serviceUpdatePermission).toContain("- status");
-    expect(serviceUpdatePermission).toContain("- rejection_reason");
-    expect(serviceUpdatePermission).toContain("- created_at");
-    expect(serviceUpdatePermission).not.toContain("- user_id");
-    expect(serviceUpdatePermission).not.toContain("- approved_at");
-    expect(serviceUpdatePermission).not.toContain("- revoked_at");
-    expect(serviceUpdatePermission).toContain("_eq: rejected");
-    expect(serviceUpdatePermission).toContain("X-Hasura-User-Id");
-    expect(serviceUpdatePermission).toContain("_eq: pending");
+    // Portal requests are insert-only. In particular, the service role cannot
+    // reopen a rejected row and erase an admin decision.
+    expect(updateSection).not.toContain("- role: service");
     expect(deleteSection).toContain("_eq: pending");
     expect(deleteSection).not.toContain("role: service");
     expect(metadata).toContain("- name: team");

--- a/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
+++ b/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
@@ -148,6 +148,103 @@ describe("internal dashboard detail permissions", () => {
     expect(deleteSection).not.toContain("role: service");
   });
 
+  it("limits iOS sandbox request writes to enrollment workflow fields", () => {
+    const metadata = readFileSync(
+      path.join(tablesPath, "public_sandbox_access_request_ios.yaml"),
+      "utf8",
+    );
+    const insertSection = metadata.slice(
+      metadata.indexOf("insert_permissions:"),
+      metadata.indexOf("select_permissions:"),
+    );
+    const updateSection = metadata.slice(
+      metadata.indexOf("update_permissions:"),
+      metadata.indexOf("delete_permissions:"),
+    );
+    const serviceUpdateStart = updateSection.indexOf("  - role: service");
+    const dashboardUpdatePermission = updateSection.slice(
+      0,
+      serviceUpdateStart,
+    );
+    const serviceUpdatePermission = updateSection.slice(serviceUpdateStart);
+    const deleteSection = metadata.slice(
+      metadata.indexOf("delete_permissions:"),
+    );
+
+    expect(insertSection).toContain("- asc_email");
+    expect(insertSection).toContain("- portal_email");
+    expect(insertSection).toContain("- team_id");
+    expect(insertSection).toContain("- user_id");
+    expect(insertSection).not.toContain("- status");
+    expect(dashboardUpdatePermission).toContain("- status");
+    expect(dashboardUpdatePermission).toContain("- approved_at");
+    expect(dashboardUpdatePermission).toContain("- rejection_reason");
+    expect(dashboardUpdatePermission).toContain("- revoked_at");
+    expect(dashboardUpdatePermission).not.toContain("- approved_by");
+    expect(dashboardUpdatePermission).not.toContain("- revoked_by");
+    expect(dashboardUpdatePermission).not.toContain("- asc_email");
+    expect(dashboardUpdatePermission).not.toContain("- portal_email");
+
+    // The service role's only update is the re-request upsert: it may reopen
+    // a rejected request as pending, but never touch ownership or the
+    // approval/revocation audit fields, and never rows in any other status.
+    expect(serviceUpdateStart).toBeGreaterThan(-1);
+    expect(serviceUpdatePermission).toContain("- asc_email");
+    expect(serviceUpdatePermission).toContain("- portal_email");
+    expect(serviceUpdatePermission).toContain("- team_id");
+    expect(serviceUpdatePermission).toContain("- status");
+    expect(serviceUpdatePermission).toContain("- rejection_reason");
+    expect(serviceUpdatePermission).toContain("- created_at");
+    expect(serviceUpdatePermission).not.toContain("- user_id");
+    expect(serviceUpdatePermission).not.toContain("- approved_at");
+    expect(serviceUpdatePermission).not.toContain("- revoked_at");
+    expect(serviceUpdatePermission).toContain("_eq: rejected");
+    expect(serviceUpdatePermission).toContain("_eq: pending");
+    expect(deleteSection).toContain("_eq: pending");
+    expect(deleteSection).not.toContain("role: service");
+    expect(metadata).toContain("- name: team");
+    expect(metadata).toContain("foreign_key_constraint_on: team_id");
+    expect(metadata).toContain("- revoked_at");
+    expect(metadata).not.toContain("- approved_by");
+    expect(metadata).not.toContain("- revoked_by");
+    const serviceSelectPermission = metadata.slice(
+      metadata.indexOf(
+        "  - role: service",
+        metadata.indexOf("select_permissions:"),
+      ),
+      metadata.indexOf("update_permissions:"),
+    );
+    expect(serviceSelectPermission).not.toContain("- revoked_at");
+    expect(serviceSelectPermission).not.toContain("- revoked_by");
+  });
+
+  it("creates the complete iOS access-request schema in one migration", () => {
+    const migration = readFileSync(
+      path.join(
+        tablesPath,
+        "../../../../migrations/default/1787346730000_create_table_public_sandbox_access_request_ios/up.sql",
+      ),
+      "utf8",
+    );
+
+    expect(migration).toContain("'revoking'");
+    expect(migration).toContain("'revoked'");
+    expect(migration).toContain('lower(btrim("asc_email"))');
+    expect(migration).toContain(
+      'CONSTRAINT "unique_sandbox_access_request_ios_asc_email"',
+    );
+    expect(migration).toContain(
+      'CONSTRAINT "sandbox_access_request_ios_asc_email_is_canonical"',
+    );
+    expect(migration).toContain('"approved_at" IS NOT NULL');
+    expect(migration).toContain('"revoked_at" IS NOT NULL');
+    expect(migration).toContain('"revoked_at" IS NULL');
+    expect(migration).not.toContain('"approved_by"');
+    expect(migration).not.toContain('"revoked_by"');
+    expect(migration).toContain("\"status\" = 'rejected'");
+    expect(migration).toContain('"rejection_reason" IS NULL');
+  });
+
   it("does not define elevated internal dashboard roles", () => {
     const inheritedRoles = readFileSync(
       path.join(tablesPath, "../../../inherited_roles.yaml"),

--- a/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
+++ b/web/tests/unit/hasura-internal-dashboard-permissions.test.ts
@@ -199,6 +199,7 @@ describe("internal dashboard detail permissions", () => {
     expect(serviceUpdatePermission).not.toContain("- approved_at");
     expect(serviceUpdatePermission).not.toContain("- revoked_at");
     expect(serviceUpdatePermission).toContain("_eq: rejected");
+    expect(serviceUpdatePermission).toContain("X-Hasura-User-Id");
     expect(serviceUpdatePermission).toContain("_eq: pending");
     expect(deleteSection).toContain("_eq: pending");
     expect(deleteSection).not.toContain("role: service");


### PR DESCRIPTION
## What

- Add the iOS sandbox access request migration and Hasura metadata.
- Defines service and internal dashboard permission boundaries.
- Add focused schema and permission tests.

## Why
Self Explanatory. Creates the new role in hasura and gql schema for creating requests `service` and accepting them `internal_user_readonly`

## Generated files

This PR includes generated GraphQL schema and type artifacts caused by the new table, isolated in a separate commit.
