### PR TITLE
feat(developer portal): store analytics in redis

### DIFF
--- a/web/api/helpers/selfie-check-analytics/eligibility.ts
+++ b/web/api/helpers/selfie-check-analytics/eligibility.ts
@@ -1,97 +1,29 @@
 import "server-only";
 
-import { logger } from "@/lib/logger";
-
-const SELFIE_CHECK_ANALYTICS_APPS_PARAMETER =
-  "whitelisted-apps/selfie-check-analytics";
-
-const normalizeAppIds = (value: unknown): string[] | null => {
-  if (Array.isArray(value)) {
-    return value
-      .filter((item): item is string => typeof item === "string")
-      .map((item) => item.trim())
-      .filter(Boolean);
-  }
-
-  // Be tolerant if the deployment parameter is accidentally created as a
-  // String instead of StringList; the source remains a comma-separated list.
-  if (typeof value === "string") {
-    return value
-      .split(",")
-      .map((item) => item.trim())
-      .filter(Boolean);
-  }
-
-  return null;
-};
-
-const readAllowlist = async (): Promise<readonly string[] | null> => {
-  const parameterStore = global.ParameterStore;
-  if (!parameterStore) return null;
-
-  let value: unknown;
-  try {
-    value = await parameterStore.getParameter<unknown>(
-      SELFIE_CHECK_ANALYTICS_APPS_PARAMETER,
-      [],
-    );
-  } catch (error) {
-    logger.warn(
-      "Failed to read the selfie-check analytics allowlist; feature remains disabled",
-      {
-        dependency: "ssm",
-        parameterName: SELFIE_CHECK_ANALYTICS_APPS_PARAMETER,
-        failureClass:
-          error instanceof Error ? error.name : "UnknownParameterStoreError",
-        error,
-      },
-    );
-    return null;
-  }
-
-  const appIds = normalizeAppIds(value);
-  if (!appIds) {
-    logger.warn(
-      "Selfie-check analytics allowlist has an invalid value; feature remains disabled",
-      {
-        dependency: "ssm",
-        parameterName: SELFIE_CHECK_ANALYTICS_APPS_PARAMETER,
-        failureClass: "InvalidParameterValue",
-      },
-    );
-    return null;
-  }
-
-  return appIds;
-};
+import { getTotalsRow } from "./redis-store";
 
 /**
- * Fail-closed rollout gate for the analytics endpoint.
- *
- * The SSM parameter is the operational kill switch: a missing/empty parameter
- * enables no apps. It is not an authorization boundary; the route separately
- * checks the authenticated user's membership and the current totals snapshot.
+ * Analytics eligibility is presence of a totals row in the live Redis
+ * snapshot. No allowlist. Missing Redis, missing metadata, or a missing
+ * row all resolve to false.
  */
-export const isSelfieCheckAnalyticsEnabledForApp = async (
-  appId: string,
-): Promise<boolean> => {
-  const appIds = await readAllowlist();
-  return appIds?.includes(appId) ?? false;
+export const checkEligibility = async (appId: string): Promise<boolean> => {
+  try {
+    return (await getTotalsRow(appId)) !== null;
+  } catch {
+    return false;
+  }
 };
 
 /**
- * Filters to the allowlisted subset with a single parameter read, for callers
- * that gate several apps at once (e.g. sidebar navigation). Fail-closed: any
- * allowlist failure yields an empty result.
+ * Batch variant for the portal shell, which gates the sidebar tab for every
+ * app it loaded. Each ID is an independent totals-row lookup.
  */
 export const filterSelfieCheckAnalyticsEnabledApps = async (
   appIds: readonly string[],
 ): Promise<string[]> => {
   if (appIds.length === 0) return [];
 
-  const allowlist = await readAllowlist();
-  if (!allowlist) return [];
-
-  const allowed = new Set(allowlist);
-  return appIds.filter((appId) => allowed.has(appId));
+  const eligible = await Promise.all(appIds.map(checkEligibility));
+  return appIds.filter((_, index) => eligible[index]);
 };

--- a/web/api/helpers/selfie-check-analytics/redis-store.ts
+++ b/web/api/helpers/selfie-check-analytics/redis-store.ts
@@ -1,0 +1,382 @@
+import "server-only";
+
+/**
+ * Shared Redis storage for analytics tables. S3 is only the CSV exporter;
+ * runtime eligibility is presence in the snapshot referenced by `meta`.
+ *
+ *   selfie-check-analytics:v2:{<dataset>}:meta
+ *   selfie-check-analytics:v2:{<dataset>}:refresh-lock
+ *   selfie-check-analytics:v2:<dataset>:<snapshotUID>:<appId>
+ */
+
+import { logger } from "@/lib/logger";
+import { createHash, randomUUID } from "node:crypto";
+import type { TableObjectDescriptor } from "./s3";
+
+const KEY_PREFIX = "selfie-check-analytics:v2";
+
+const LOCK_TTL_MS = 60_000;
+const META_TTL_SECONDS = 24 * 60 * 60;
+// Rows must outlive meta so a live pointer never references expired keys.
+const ROW_TTL_SECONDS = 25 * 60 * 60;
+const MAX_CONCURRENT_PUBLISH_WRITES = 32;
+
+export type AnalyticsDataset = "totals" | "daily";
+
+/** Redis itself failed or the publisher lost its lock mid-publication. */
+export class AnalyticsRedisUnavailableError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "AnalyticsRedisUnavailableError";
+  }
+}
+
+/** Redis answered, but with data that must not be trusted or published. */
+export class AnalyticsRedisDataError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "AnalyticsRedisDataError";
+  }
+}
+
+export type AnalyticsRefreshLock = Readonly<{
+  dataset: AnalyticsDataset;
+  owner: string;
+}>;
+
+export type AnalyticsDatasetMetadata = Readonly<{
+  dataset: AnalyticsDataset;
+  snapshotUID: string;
+  appCount: number;
+  publishedAt: string;
+  lastCheckedAt: string;
+  source: Readonly<{
+    etag?: string;
+    identity: string;
+    key: string;
+    dataAsOf: string;
+    lastModified: string;
+    sizeBytes: number;
+  }>;
+}>;
+
+const metadataKey = (dataset: AnalyticsDataset) =>
+  `${KEY_PREFIX}:{${dataset}}:metadata`;
+
+const lockKey = (dataset: AnalyticsDataset) =>
+  `${KEY_PREFIX}:{${dataset}}:refresh-lock`;
+
+const rowKey = (
+  dataset: AnalyticsDataset,
+  snapshotUID: string,
+  appId: string,
+) => `${KEY_PREFIX}:${dataset}:${snapshotUID}:${appId}`;
+
+export const createSnapshotUID = (sourceIdentity: string): string =>
+  createHash("sha256").update(sourceIdentity).digest("hex");
+
+const requireRedis = () => {
+  const redis = global.RedisClient;
+  if (!redis) {
+    throw new AnalyticsRedisUnavailableError("Redis client is not configured");
+  }
+  return redis;
+};
+
+const parseDatasetMetadata = (raw: string): AnalyticsDatasetMetadata | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  const candidate = parsed as AnalyticsDatasetMetadata;
+  const looksValid =
+    candidate !== null &&
+    typeof candidate === "object" &&
+    typeof candidate.snapshotUID === "string" &&
+    candidate.snapshotUID.length > 0 &&
+    typeof candidate.appCount === "number" &&
+    typeof candidate.lastCheckedAt === "string" &&
+    typeof candidate.source === "object" &&
+    candidate.source !== null &&
+    typeof candidate.source.identity === "string";
+
+  return looksValid ? candidate : null;
+};
+
+const mapInBatches = async <T>(
+  items: readonly T[],
+  batchSize: number,
+  write: (item: T) => Promise<void>,
+): Promise<void> => {
+  for (let index = 0; index < items.length; index += batchSize) {
+    await Promise.all(items.slice(index, index + batchSize).map(write));
+  }
+};
+
+// #region Refresh lock
+
+export const tryAcquireAnalyticsRefreshLock = async (
+  dataset: AnalyticsDataset,
+): Promise<AnalyticsRefreshLock | null> => {
+  const redis = global.RedisClient;
+  if (!redis) return null;
+
+  const owner = randomUUID();
+  try {
+    const result = await redis.set(
+      lockKey(dataset),
+      owner,
+      "PX",
+      LOCK_TTL_MS,
+      "NX",
+    );
+    return result === "OK" ? { dataset, owner } : null;
+  } catch (error) {
+    logger.warn("Failed to acquire the analytics refresh lock", {
+      dependency: "redis",
+      dataset,
+      failureClass: error instanceof Error ? error.name : "UnknownRedisError",
+      error,
+    });
+    return null;
+  }
+};
+
+export const releaseAnalyticsRefreshLock = async (
+  lock: AnalyticsRefreshLock,
+): Promise<void> => {
+  const redis = global.RedisClient;
+  if (!redis) return;
+
+  try {
+    await redis.eval(
+      `if redis.call("get", KEYS[1]) == ARGV[1] then
+         return redis.call("del", KEYS[1])
+       end
+       return 0`,
+      1,
+      lockKey(lock.dataset),
+      lock.owner,
+    );
+  } catch (error) {
+    logger.warn("Failed to release the analytics refresh lock", {
+      dependency: "redis",
+      dataset: lock.dataset,
+      failureClass: error instanceof Error ? error.name : "UnknownRedisError",
+      error,
+    });
+  }
+};
+
+// #endregion
+
+// #region Reads
+
+export const getDatasetMetadata = async (
+  dataset: AnalyticsDataset,
+): Promise<AnalyticsDatasetMetadata | null> => {
+  const redis = requireRedis();
+
+  let raw: string | null;
+  try {
+    raw = await redis.get(metadataKey(dataset));
+  } catch (error) {
+    throw new AnalyticsRedisUnavailableError(
+      "Failed to read the analytics dataset metadata",
+      { cause: error },
+    );
+  }
+  if (raw === null) return null;
+
+  const meta = parseDatasetMetadata(raw);
+  if (!meta) {
+    throw new AnalyticsRedisDataError("Analytics dataset metadata is corrupt");
+  }
+  return meta;
+};
+
+export const getAppFromRedis = async <TRecord>(
+  dataset: AnalyticsDataset,
+  snapshotUID: string,
+  appId: string,
+): Promise<TRecord | null> => {
+  const redis = requireRedis();
+
+  let raw: string | null;
+  try {
+    raw = await redis.get(rowKey(dataset, snapshotUID, appId));
+  } catch (error) {
+    throw new AnalyticsRedisUnavailableError(
+      "Failed to read an analytics record",
+      { cause: error },
+    );
+  }
+  if (raw === null) return null;
+
+  try {
+    return JSON.parse(raw) as TRecord;
+  } catch (error) {
+    throw new AnalyticsRedisDataError("Analytics record is corrupt", {
+      cause: error,
+    });
+  }
+};
+
+export const getTotalsRow = async <TRecord>(
+  appId: string,
+): Promise<TRecord | null> => {
+  const meta = await getDatasetMetadata("totals");
+  if (!meta) return null;
+  return getAppFromRedis<TRecord>("totals", meta.snapshotUID, appId);
+};
+
+export const appExistsInRedis = async (
+  dataset: AnalyticsDataset,
+  snapshotUID: string,
+  appId: string,
+): Promise<boolean> => {
+  const redis = requireRedis();
+
+  try {
+    return (await redis.exists(rowKey(dataset, snapshotUID, appId))) === 1;
+  } catch (error) {
+    throw new AnalyticsRedisUnavailableError(
+      "Failed to check an analytics record",
+      { cause: error },
+    );
+  }
+};
+
+// #endregion
+
+// #region Publication
+
+/**
+ * Writes every record under a content-addressed snapshot UID, then atomically
+ * points `meta` at that snapshot. Callers must hold the refresh lock.
+ * Old snapshot keys are left to expire; they are unreachable once `meta`
+ * moves, so they cannot grant eligibility.
+ */
+export const publishAnalyticsSnapshot = async (params: {
+  dataset: AnalyticsDataset;
+  lock: AnalyticsRefreshLock;
+  records: ReadonlyMap<string, unknown>;
+  source: TableObjectDescriptor;
+}): Promise<void> => {
+  const { dataset, lock, records, source } = params;
+
+  if (records.size === 0) {
+    throw new AnalyticsRedisDataError(
+      "Refusing to publish an empty analytics snapshot",
+    );
+  }
+
+  const redis = requireRedis();
+  const snapshotUID = createSnapshotUID(source.identity);
+
+  const existingRaw = await redis.get(metadataKey(dataset));
+  const existing = existingRaw ? parseDatasetMetadata(existingRaw) : null;
+  if (existing && existing.snapshotUID !== snapshotUID) {
+    const incomingIsNewer =
+      source.dataAsOf.toISOString() > existing.source.dataAsOf ||
+      (source.dataAsOf.toISOString() === existing.source.dataAsOf &&
+        source.lastModified.toISOString() > existing.source.lastModified);
+    if (!incomingIsNewer) {
+      logger.warn("Skipped publishing a stale analytics snapshot", {
+        dependency: "redis",
+        dataset,
+        incomingIdentity: source.identity,
+        currentIdentity: existing.source.identity,
+      });
+      return;
+    }
+  }
+
+  await mapInBatches(
+    Array.from(records.entries()),
+    MAX_CONCURRENT_PUBLISH_WRITES,
+    async ([appId, record]) => {
+      const result = await redis.set(
+        rowKey(dataset, snapshotUID, appId),
+        JSON.stringify(record),
+        "EX",
+        ROW_TTL_SECONDS,
+      );
+      if (result !== "OK") {
+        throw new AnalyticsRedisUnavailableError(
+          "Failed to write an analytics record",
+        );
+      }
+    },
+  );
+
+  const nowIso = new Date().toISOString();
+  const meta: AnalyticsDatasetMetadata = {
+    dataset,
+    snapshotUID,
+    appCount: records.size,
+    publishedAt: nowIso,
+    lastCheckedAt: nowIso,
+    source: {
+      etag: source.etag,
+      identity: source.identity,
+      key: source.key,
+      dataAsOf: source.dataAsOf.toISOString(),
+      lastModified: source.lastModified.toISOString(),
+      sizeBytes: source.sizeBytes,
+    },
+  };
+
+  // Same-slot EVAL: do not expose this snapshot unless we still own the lock.
+  const committed = await redis.eval(
+    `if redis.call("get", KEYS[1]) ~= ARGV[1] then
+       return 0
+     end
+     redis.call("set", KEYS[2], ARGV[2], "EX", ARGV[3])
+     return 1`,
+    2,
+    lockKey(dataset),
+    metadataKey(dataset),
+    lock.owner,
+    JSON.stringify(meta),
+    String(META_TTL_SECONDS),
+  );
+  if (committed !== 1) {
+    throw new AnalyticsRedisUnavailableError(
+      "Lost the analytics refresh lock before publishing the snapshot",
+    );
+  }
+};
+
+/**
+ * Updates lastCheckedAt on the live dataset metadata without rewriting app
+ * keys. Returns false when metadata is absent, corrupt, expired, or for a
+ * different S3 object — callers republish instead.
+ */
+export const markDatasetChecked = async (
+  dataset: AnalyticsDataset,
+  sourceIdentity: string,
+  lastCheckedAt: string,
+): Promise<boolean> => {
+  const redis = requireRedis();
+
+  const raw = await redis.get(metadataKey(dataset));
+  const meta = raw ? parseDatasetMetadata(raw) : null;
+  if (!meta || meta.source.identity !== sourceIdentity) return false;
+
+  const remainingTtlMs = await redis.pttl(metadataKey(dataset));
+  if (remainingTtlMs <= 0) return false;
+
+  await redis.set(
+    metadataKey(dataset),
+    JSON.stringify({ ...meta, lastCheckedAt }),
+    "PX",
+    remainingTtlMs,
+  );
+  return true;
+};
+
+// #endregion

--- a/web/api/v2/apps/[app_id]/selfie-check-analytics/index.ts
+++ b/web/api/v2/apps/[app_id]/selfie-check-analytics/index.ts
@@ -1,4 +1,4 @@
-import { isSelfieCheckAnalyticsEnabledForApp } from "@/api/helpers/selfie-check-analytics/eligibility";
+import { checkEligibility } from "@/api/helpers/selfie-check-analytics/eligibility";
 import {
   loadLatestDailyTableSnapshot,
   loadLatestTotalsTableSnapshot,
@@ -152,7 +152,7 @@ export async function GET(
     });
   }
 
-  if (!(await isSelfieCheckAnalyticsEnabledForApp(appId))) {
+  if (!(await checkEligibility(appId))) {
     return errorResponse({
       status: 404,
       code: "not_found",
@@ -216,7 +216,7 @@ export async function GET(
 
   if (!response) {
     logger.warn(
-      "Whitelisted selfie-check analytics app is absent from the snapshot",
+      "Eligible selfie-check analytics app is absent from the snapshot",
       {
         appId,
         dataset,

--- a/web/app/(portal)/teams/[teamId]/apps/[appId]/analytics/page.tsx
+++ b/web/app/(portal)/teams/[teamId]/apps/[appId]/analytics/page.tsx
@@ -1,4 +1,4 @@
-import { isSelfieCheckAnalyticsEnabledForApp } from "@/api/helpers/selfie-check-analytics/eligibility";
+import { checkEligibility } from "@/api/helpers/selfie-check-analytics/eligibility";
 import { ErrorPage } from "@/components/ErrorPage";
 import { generateMetaTitle } from "@/lib/genarate-title";
 import { MetricsFrame } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/MetricsFrame";
@@ -16,9 +16,9 @@ export default async function Page(props: Props) {
   const { appId } = await props.params;
 
   // The parent app layout already renders non-members as "App not found";
-  // members outside the analytics rollout get an explicit Forbidden screen.
-  if (!(await isSelfieCheckAnalyticsEnabledForApp(appId))) {
-    return <ErrorPage statusCode={403} title="Forbidden" />;
+  // apps without a totals row are the same 404 so the tab cannot leak.
+  if (!(await checkEligibility(appId))) {
+    return <ErrorPage statusCode={404} title="Not found" />;
   }
 
   return <MetricsFrame appId={appId} />;


### PR DESCRIPTION
## PR Type

- [X] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

- Implements a redis store `redis-store.ts` that provisions versioned keys for the metadata of the newest table parsed from the s3 bucket and the analytics themselves, keyed by app id

Two types of keys
- selfie-check-analytics:v1:total:<snapshotUID>:<app_id>
- selfie-check-analytics:v1:daily:<snapshotUID>:<app_id>

`snapshotUID` is a hash of the source metadata of the newest s3 object, specifically the etag and unique key. this means that different csvs will always have different snapshotKeys in that part so we can tell if the data being shown is fresh or not

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
