### PR TITLE
fix(portal): align sidebar icons with labels

### DIFF
--- a/web/scenes/PortalV3/layout/Shell/NavItem.tsx
+++ b/web/scenes/PortalV3/layout/Shell/NavItem.tsx
@@ -59,7 +59,11 @@ export const NavItem = (props: {
           onClick={onNavigate}
           aria-current={active ? "page" : undefined}
         >
-          {icon ? <span className="shrink-0 text-current">{icon}</span> : null}
+          {icon ? (
+            <span className="shrink-0 -translate-y-[2px] text-current">
+              {icon}
+            </span>
+          ) : null}
           <span>{label}</span>
         </Link>
       </SidebarMenuButton>

--- a/web/tests/unit/pv3-sidebar-section-nav.test.tsx
+++ b/web/tests/unit/pv3-sidebar-section-nav.test.tsx
@@ -268,6 +268,19 @@ describe("v3 SidebarNav [Figma navigation contract]", () => {
     noLink("Get verified");
   });
 
+  it("optically aligns every navigation icon with its label", () => {
+    renderSidebar([teamId], { appId, enabled: true });
+
+    const iconLinks = screen
+      .getAllByRole("link")
+      .filter((item) => item.querySelector("img"));
+
+    expect(iconLinks.length).toBeGreaterThan(0);
+    for (const item of iconLinks) {
+      expect(item.firstElementChild).toHaveClass("-translate-y-[2px]");
+    }
+  });
+
   it.each([
     [base, "Dashboard"],
     [`${base}/world-id`, "Dashboard"],


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Lift portal sidebar navigation icons by 2px so their visible ink aligns with adjacent World Pro labels. Add rendered-component regression coverage for every current navigation icon, including the feature-gated Analytics row.

## Verification

- pnpm test:unit -- --no-cache (821 passed)
- pnpm test:api -- --no-cache (818 passed, 1 skipped)
- npx tsc --noEmit
- pnpm format:check

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.