### PR TITLE
fix(portal): fix sandbox banner sizing

### DIFF
--- a/web/scenes/PortalV3/layout/Shell/SandboxButton.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SandboxButton.tsx
@@ -247,7 +247,7 @@ export const SandboxButton = (props: {
           name="world-id-sandbox-app-icon"
           className="size-8 shrink-0 drop-shadow-sm"
         />
-        <span className="grid min-w-0 flex-1 gap-y-0.5">
+        <span className="grid min-w-0 flex-1 gap-y-0">
           <span className="font-world text-13 font-medium whitespace-nowrap text-portal-text">
             World ID Sandbox
           </span>

--- a/web/scenes/PortalV3/layout/Shell/SandboxButton.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SandboxButton.tsx
@@ -237,7 +237,7 @@ export const SandboxButton = (props: {
         onClick={openDialog}
         aria-haspopup="dialog"
         className={clsx(
-          "group/sandbox flex shrink-0 items-center gap-x-3 rounded-[10px] px-3 py-2 text-left outline-hidden transition-colors hover:bg-portal-border focus-visible:ring-2 focus-visible:ring-grey-300 focus-visible:ring-offset-2 focus-visible:ring-offset-portal-canvas",
+          "group/sandbox flex shrink-0 items-center gap-x-2 rounded-[10px] px-2 py-2 text-left outline-hidden transition-colors hover:bg-portal-border focus-visible:ring-2 focus-visible:ring-grey-300 focus-visible:ring-offset-2 focus-visible:ring-offset-portal-canvas",
           props.className,
         )}
       >
@@ -245,13 +245,13 @@ export const SandboxButton = (props: {
                 home screen all show the same mark. */}
         <Icon
           name="world-id-sandbox-app-icon"
-          className="size-9 shrink-0 drop-shadow-sm"
+          className="size-8 shrink-0 drop-shadow-sm"
         />
         <span className="grid min-w-0 flex-1 gap-y-0.5">
-          <span className="font-world text-13 font-medium text-portal-text">
+          <span className="font-world text-13 font-medium whitespace-nowrap text-portal-text">
             World ID Sandbox
           </span>
-          <span className="font-world text-11 text-portal-muted">
+          <span className="font-world text-11 whitespace-nowrap text-portal-muted">
             Install the test build
           </span>
         </span>

--- a/web/scenes/PortalV3/layout/Shell/SandboxButton.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SandboxButton.tsx
@@ -257,7 +257,7 @@ export const SandboxButton = (props: {
         </span>
         <span
           aria-hidden
-          className="-mr-[5px] font-world text-13 text-portal-subtle transition-transform duration-200 group-hover/sandbox:translate-x-0.5"
+          className="mr-0 font-world text-13 text-portal-subtle transition-transform duration-200 group-hover/sandbox:translate-x-0.5"
         >
           →
         </span>

--- a/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
@@ -505,7 +505,7 @@ export const SidebarNav = (props: {
       {!ids && !teamId ? (
         <div className="mt-auto pt-3 group-data-[collapsible=icon]:hidden">
           <SandboxButton
-            className="-ml-1 w-[calc(100%_+_8px)]"
+            className="-ml-1 w-[calc(100%_+_13px)]"
             initialRequest={props.initialSandboxRequest}
           />
         </div>
@@ -514,7 +514,7 @@ export const SidebarNav = (props: {
       {teamId ? (
         <div className="mt-auto px-4 pt-3 pb-3 group-data-[collapsible=icon]:hidden">
           <SandboxButton
-            className="-ml-1 w-[calc(100%_+_8px)]"
+            className="-ml-1 w-[calc(100%_+_13px)]"
             teamId={teamId}
             initialRequest={props.initialSandboxRequest}
           />

--- a/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
@@ -512,7 +512,7 @@ export const SidebarNav = (props: {
       ) : null}
 
       {teamId ? (
-        <div className="mt-auto px-4 pt-3 pb-3 group-data-[collapsible=icon]:hidden">
+        <div className="mt-auto px-4 pt-3 pb-1 group-data-[collapsible=icon]:hidden">
           <SandboxButton
             className="-ml-3 w-[calc(100%_+_21px)]"
             teamId={teamId}

--- a/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
+++ b/web/scenes/PortalV3/layout/Shell/SidebarNav.tsx
@@ -514,7 +514,7 @@ export const SidebarNav = (props: {
       {teamId ? (
         <div className="mt-auto px-4 pt-3 pb-3 group-data-[collapsible=icon]:hidden">
           <SandboxButton
-            className="-ml-1 w-[calc(100%_+_13px)]"
+            className="-ml-3 w-[calc(100%_+_21px)]"
             teamId={teamId}
             initialRequest={props.initialSandboxRequest}
           />

--- a/web/tests/unit/pv3-sidebar-section-nav.test.tsx
+++ b/web/tests/unit/pv3-sidebar-section-nav.test.tsx
@@ -337,6 +337,14 @@ describe("v3 SidebarNav [Figma navigation contract]", () => {
 
 // #region persistent app context
 describe("v3 SidebarNav [persistent app context]", () => {
+  it("keeps the team sandbox tile close to the profile footer", () => {
+    renderSidebar();
+
+    expect(
+      screen.getByRole("button", { name: /World ID Sandbox/i }).parentElement,
+    ).toHaveClass("pb-1");
+  });
+
   it("highlights Projects on the canonical team page with the view-grid icon", () => {
     useParams.mockReturnValue({ teamId });
     usePathname.mockReturnValue(`/teams/${teamId}`);

--- a/web/tests/unit/sandbox-button.test.tsx
+++ b/web/tests/unit/sandbox-button.test.tsx
@@ -93,6 +93,23 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
+// #region Sidebar banner layout
+describe("SandboxButton [sidebar banner layout]", () => {
+  it("keeps both labels on one line inside the narrow sidebar", () => {
+    render(<SandboxButton />);
+
+    const button = screen.getByRole("button", { name: /World ID Sandbox/ });
+    expect(button).toHaveClass("gap-x-2", "px-2");
+    expect(screen.getByText("World ID Sandbox")).toHaveClass(
+      "whitespace-nowrap",
+    );
+    expect(screen.getByText("Install the test build")).toHaveClass(
+      "whitespace-nowrap",
+    );
+  });
+});
+// #endregion
+
 // #region Persistent request confirmation
 describe("SandboxButton [android request confirmation]", () => {
   it("does not present team-scoped iOS enrollment without an active team", async () => {

--- a/web/tests/unit/sandbox-button.test.tsx
+++ b/web/tests/unit/sandbox-button.test.tsx
@@ -106,6 +106,9 @@ describe("SandboxButton [sidebar banner layout]", () => {
     expect(screen.getByText("Install the test build")).toHaveClass(
       "whitespace-nowrap",
     );
+    expect(screen.getByText("World ID Sandbox").parentElement).toHaveClass(
+      "gap-y-0",
+    );
   });
 
   it("keeps the hover arrow inset from the banner edge", () => {

--- a/web/tests/unit/sandbox-button.test.tsx
+++ b/web/tests/unit/sandbox-button.test.tsx
@@ -107,6 +107,13 @@ describe("SandboxButton [sidebar banner layout]", () => {
       "whitespace-nowrap",
     );
   });
+
+  it("keeps the hover arrow inset from the banner edge", () => {
+    render(<SandboxButton />);
+
+    const button = screen.getByRole("button", { name: /World ID Sandbox/ });
+    expect(button.lastElementChild).toHaveClass("mr-0");
+  });
 });
 // #endregion
 


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Keeps the World ID Sandbox banner readable and balanced in the redesigned 220px sidebar without changing the sidebar width or surrounding navigation.

- reduces the banner padding, item gap, and app icon size
- keeps both banner labels on one line and removes their extra 2px vertical gap
- widens the banner right edge by 5px and adds 5px of arrow clearance for the hover animation
- widens the team-route tile to the left so the Sandbox logo aligns at x=20px with the sidebar navigation icons
- preserves the arrow animation and existing dialog behavior
- adds regression coverage for the compact layout, label gap, and arrow inset

## Verification

- 1,595 unit/API tests passed
- TypeScript type check passed
- Prettier formatting check passed
- Verified in the local browser at a 220px sidebar width with no overflow
- Measured team tile at x=12–204px, Sandbox logo at x=20px, and 0px label gap
- Measured 6px arrow-to-edge clearance during the 2px hover animation

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.


Before:
<img width="225" height="198" alt="image" src="https://github.com/user-attachments/assets/d99c69a1-7b40-4050-8e7e-b98e088d19d5" />


After:
<img width="225" height="198" alt="image" src="https://github.com/user-attachments/assets/7a376c1e-0c2a-4932-8934-4338267348b2" />
