### PR TITLE
refactor(cron): update cleanup job to process up to 15 keys per tick and adjust timeout settings

### DIFF
--- a/hasura/metadata/cron_triggers.yaml
+++ b/hasura/metadata/cron_triggers.yaml
@@ -84,15 +84,15 @@
   comment: Once monthly (1st of month). Migrates up to 15 eligible managed RPs when ENABLE_RP_MANAGER_KEY_MIGRATION is true.
 - name: Cleanup RP manager keys
   webhook: "{{NEXT_API_URL}}/_cleanup-rp-manager-keys"
-  schedule: "*/15 * * * *"
+  schedule: "* * * * *"
   include_in_metadata: true
   payload: {}
   retry_conf:
     num_retries: 0
     retry_interval_seconds: 10
-    timeout_seconds: 60
+    timeout_seconds: 120
     tolerance_seconds: 21600
   headers:
     - name: Authorization
       value_from_env: INTERNAL_ENDPOINTS_SECRET
-  comment: Schedule deletion of one leftover per-RP manager KMS key after shared-key migration. No-ops unless ENABLE_RP_MANAGER_KEY_CLEANUP is true.
+  comment: Schedule deletion of up to 15 leftover per-RP manager KMS keys per tick after shared-key migration. No-ops unless ENABLE_RP_MANAGER_KEY_CLEANUP is true.

--- a/web/api/_cleanup-rp-manager-keys/index.ts
+++ b/web/api/_cleanup-rp-manager-keys/index.ts
@@ -14,6 +14,7 @@ import { cleanupRpManagerKeys } from "../../scripts/cleanup-rp-manager-keys";
 
 const GLOBAL_LOCK_KEY = "rp-manager-key-cleanup:run";
 const GLOBAL_LOCK_TTL_MS = 5 * 60 * 1000;
+const CLEANUP_PER_RUN = 15;
 
 type RedisLockClient = {
   set(
@@ -142,27 +143,29 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       stagingMirrorRegistry: stagingConfig
         ? { name: "staging", config: stagingConfig }
         : undefined,
-      limit: 1,
+      limit: CLEANUP_PER_RUN,
     });
 
-    const result = report.results[0];
-    if (!result) {
+    if (report.results.length === 0) {
       return new NextResponse(null, { status: 204 });
     }
 
+    const countsByStatus: Record<string, number> = {};
+    for (const result of report.results) {
+      countsByStatus[result.status] = (countsByStatus[result.status] ?? 0) + 1;
+    }
+
     logger.info("RP manager key cleanup attempt finished", {
-      rp_id: result.rpId,
-      app_id: result.appId,
-      old_manager_kms_key_arn: result.oldManagerKeyArn,
-      cleanup_status: result.status,
-      detail: result.detail,
+      candidate_count: report.candidateCount,
+      result_count: report.results.length,
+      counts_by_status: countsByStatus,
       duration_ms: Date.now() - startedAt,
     });
 
     return NextResponse.json({
-      rp_id: result.rpId,
-      outcome: result.status,
-      detail: result.detail,
+      candidate_count: report.candidateCount,
+      result_count: report.results.length,
+      counts_by_status: countsByStatus,
     });
   } catch (error) {
     logger.error("Unexpected RP manager key cleanup cron failure", {

--- a/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
+++ b/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
@@ -180,7 +180,8 @@ export const RpManagerKeyMigrationPanel = async () => {
         </h2>
         <p className="mt-0.5 text-12 text-grey-500">
           Unique key → shared key, then delete the old KMS key. The migrate job
-          runs every minute and attempts up to 15 RPs per tick.
+          runs every minute and attempts up to 15 RPs per tick. The cleanup job
+          runs every minute and schedules up to 15 old keys per tick.
         </p>
         {status && (
           <div className="mt-2 flex flex-wrap gap-1.5">

--- a/web/tests/api/_cleanup-rp-manager-keys.test.ts
+++ b/web/tests/api/_cleanup-rp-manager-keys.test.ts
@@ -70,6 +70,22 @@ const successResult = {
   expectedDeletionAt: "2026-09-11T12:00:00.000Z",
 };
 
+const secondSuccessResult = {
+  rpId: "rp_abcdef1234567890",
+  appId: "app_abcdef1234567890abcdef1234567890",
+  oldManagerKeyArn: "arn:aws:kms:eu-west-1:111111111111:key/old-key-2",
+  status: "deletion_scheduled",
+  expectedDeletionAt: "2026-09-11T12:00:00.000Z",
+};
+
+const blockedResult = {
+  rpId: "rp_fedcba0987654321",
+  appId: "app_fedcba0987654321fedcba0987654321",
+  oldManagerKeyArn: "arn:aws:kms:eu-west-1:111111111111:key/old-key-3",
+  status: "blocked",
+  detail: "RP still uses the old manager in registry primary",
+};
+
 const request = () =>
   new NextRequest("http://localhost/api/_cleanup-rp-manager-keys", {
     method: "POST",
@@ -88,8 +104,8 @@ beforeEach(async () => {
   getStagingRpRegistryConfigMock.mockReturnValue(null);
   getKMSClientMock.mockResolvedValue({});
   cleanupRpManagerKeysMock.mockResolvedValue({
-    candidateCount: 1,
-    results: [successResult],
+    candidateCount: 3,
+    results: [successResult, secondSuccessResult, blockedResult],
   });
 });
 
@@ -166,26 +182,34 @@ describe("/_cleanup-rp-manager-keys [guards]", () => {
 // #region Cleanup attempt
 
 describe("/_cleanup-rp-manager-keys [attempt]", () => {
-  it("cleans up one candidate with deployment-local configuration", async () => {
+  it("cleans up a batch with deployment-local configuration", async () => {
     const response = await POST(request());
     const body = await response.json();
 
     expect(response.status).toBe(200);
     expect(body).toEqual({
-      rp_id: RP_ID,
-      outcome: "deletion_scheduled",
+      candidate_count: 3,
+      result_count: 3,
+      counts_by_status: {
+        deletion_scheduled: 2,
+        blocked: 1,
+      },
     });
     expect(cleanupRpManagerKeysMock).toHaveBeenCalledWith(
       expect.objectContaining({
         primaryRegistry: { name: "primary", config: PRIMARY_CONFIG },
-        limit: 1,
+        limit: 15,
       }),
     );
     expect(mockLogger.info).toHaveBeenCalledWith(
       "RP manager key cleanup attempt finished",
       expect.objectContaining({
-        rp_id: RP_ID,
-        cleanup_status: "deletion_scheduled",
+        candidate_count: 3,
+        result_count: 3,
+        counts_by_status: {
+          deletion_scheduled: 2,
+          blocked: 1,
+        },
       }),
     );
     await expect(global.RedisClient?.get(GLOBAL_LOCK_KEY)).resolves.toBeNull();
@@ -204,6 +228,7 @@ describe("/_cleanup-rp-manager-keys [attempt]", () => {
           name: "staging",
           config: STAGING_CONFIG,
         },
+        limit: 15,
       }),
     );
   });


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Speeds up leftover per-RP manager KMS key cleanup.

- Runs the cleanup cron every minute and processes up to 15 keys per tick.
- Raises the Hasura webhook timeout to 120s and returns a batch status summary from `/_cleanup-rp-manager-keys`.
- Updates admin copy and unit tests for the new batch behavior.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.