### PR TITLE
feat: add Redis storage for analytics snapshots

### DIFF
--- a/web/api/helpers/selfie-check-analytics/redis-store.ts
+++ b/web/api/helpers/selfie-check-analytics/redis-store.ts
@@ -1,0 +1,408 @@
+import "server-only";
+
+import { appIdRegex } from "@/lib/schema";
+import {
+  pickDailyRow,
+  pickTotalsRow,
+  type DailyRow,
+  type TotalsRow,
+} from "@/lib/selfie-check-analytics";
+import { randomUUID } from "node:crypto";
+import type { TableObjectDescriptor } from "./s3";
+
+/**
+ * Storage only: callers supply parsed CSV records; this module never reads S3.
+ * Rows and app membership are immutable within a publication. The metadata
+ * pointer becomes visible only after every write succeeds. Retention/cleanup
+ * and integration with the refresh job are separate follow-up work.
+ */
+const KEY_PREFIX = "selfie-check-analytics";
+const REFRESH_LOCK_TTL_MS = 120_000;
+const WRITE_BATCH_SIZE = 32;
+
+export type AnalyticsDataset = "total" | "daily";
+
+export const analyticsRedisKeys = {
+  data: (dataset: AnalyticsDataset, appId: string, snapshotId: string) =>
+    `${KEY_PREFIX}:${appId}:${dataset}:${dataset === "total" ? "row" : "rows"}:${snapshotId}`,
+  metadata: (dataset: AnalyticsDataset) => `${KEY_PREFIX}:{${dataset}}:meta`,
+  refreshLock: (dataset: AnalyticsDataset) =>
+    `${KEY_PREFIX}:{${dataset}}:refresh-lock`,
+  // Membership distinguishes an absent app from an evicted/missing row and
+  // lets a future cleanup job enumerate one snapshot without scanning Redis.
+  apps: (dataset: AnalyticsDataset, snapshotId: string) =>
+    `${KEY_PREFIX}:${dataset}:apps:${snapshotId}`,
+};
+
+type SnapshotSource = Omit<
+  TableObjectDescriptor,
+  "dataAsOf" | "lastModified"
+> & {
+  dataAsOf: string;
+  lastModified: string;
+};
+
+export type AnalyticsSnapshotMetadata = Readonly<{
+  schemaVersion: 1;
+  dataset: AnalyticsDataset;
+  snapshotId: string;
+  appCount: number;
+  loadedAt: string;
+  lastCheckedAt: string;
+  isFallback: boolean;
+  source: Readonly<SnapshotSource>;
+}>;
+
+export type AnalyticsAppSnapshot<T> = Readonly<{
+  data: T;
+  metadata: AnalyticsSnapshotMetadata;
+}>;
+
+export type AnalyticsRefreshLock = Readonly<{
+  dataset: AnalyticsDataset;
+  owner: string;
+}>;
+
+type SnapshotPublication = {
+  lock: AnalyticsRefreshLock;
+  source: TableObjectDescriptor;
+} & (
+  | { dataset: "total"; records: ReadonlyMap<string, TotalsRow> }
+  | { dataset: "daily"; records: ReadonlyMap<string, readonly DailyRow[]> }
+);
+
+export class AnalyticsRedisUnavailableError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "AnalyticsRedisUnavailableError";
+  }
+}
+
+export class AnalyticsRedisDataError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "AnalyticsRedisDataError";
+  }
+}
+
+export class AnalyticsSnapshotConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AnalyticsSnapshotConflictError";
+  }
+}
+
+async function redisCall<T>(
+  operation: (redis: NonNullable<typeof global.RedisClient>) => Promise<T>,
+): Promise<T> {
+  const redis = global.RedisClient;
+  if (!redis) {
+    throw new AnalyticsRedisUnavailableError("Redis client is not configured");
+  }
+  try {
+    return await operation(redis);
+  } catch (cause) {
+    throw new AnalyticsRedisUnavailableError(
+      "Analytics Redis operation failed",
+      {
+        cause,
+      },
+    );
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.length > 0;
+
+const isIsoTimestamp = (value: unknown): value is string => {
+  if (typeof value !== "string") return false;
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) && date.toISOString() === value;
+};
+
+function parseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch (cause) {
+    throw new AnalyticsRedisDataError("Invalid analytics JSON", { cause });
+  }
+}
+
+function parseMetadata(
+  raw: string,
+  dataset: AnalyticsDataset,
+): AnalyticsSnapshotMetadata {
+  const value = parseJson(raw);
+  const source = isRecord(value) ? value.source : null;
+  if (
+    !isRecord(value) ||
+    !isRecord(source) ||
+    value.schemaVersion !== 1 ||
+    value.dataset !== dataset ||
+    !isNonEmptyString(value.snapshotId) ||
+    !Number.isSafeInteger(value.appCount) ||
+    (value.appCount as number) <= 0 ||
+    !isIsoTimestamp(value.loadedAt) ||
+    !isIsoTimestamp(value.lastCheckedAt) ||
+    typeof value.isFallback !== "boolean" ||
+    !isNonEmptyString(source.bucket) ||
+    !isNonEmptyString(source.region) ||
+    !isNonEmptyString(source.key) ||
+    !isNonEmptyString(source.identity) ||
+    (source.etag !== undefined && typeof source.etag !== "string") ||
+    !isIsoTimestamp(source.dataAsOf) ||
+    !isIsoTimestamp(source.lastModified) ||
+    !Number.isSafeInteger(source.sizeBytes) ||
+    (source.sizeBytes as number) <= 0
+  ) {
+    throw new AnalyticsRedisDataError(`Invalid ${dataset} snapshot metadata`);
+  }
+  return value as AnalyticsSnapshotMetadata;
+}
+
+function validateTotals(value: unknown, appId: string): TotalsRow {
+  const row = pickTotalsRow(value);
+  if (!appIdRegex.test(appId) || !row || row.appId !== appId) {
+    throw new AnalyticsRedisDataError(`Invalid totals row for ${appId}`);
+  }
+  return row;
+}
+
+function validateDaily(value: unknown, appId: string): readonly DailyRow[] {
+  if (!appIdRegex.test(appId) || !Array.isArray(value) || value.length === 0) {
+    throw new AnalyticsRedisDataError(`Invalid daily rows for ${appId}`);
+  }
+  const seen = new Set<string>();
+  return value.map((item) => {
+    const row = pickDailyRow(item);
+    if (!row || row.appId !== appId) {
+      throw new AnalyticsRedisDataError(`Invalid daily row for ${appId}`);
+    }
+    const key = JSON.stringify([row.day, row.os_name]);
+    if (seen.has(key)) {
+      throw new AnalyticsRedisDataError(`Duplicate daily row for ${appId}`);
+    }
+    seen.add(key);
+    return row;
+  });
+}
+
+export async function getAnalyticsSnapshotMetadata(
+  dataset: AnalyticsDataset,
+): Promise<AnalyticsSnapshotMetadata | null> {
+  const raw = await redisCall((redis) =>
+    redis.get(analyticsRedisKeys.metadata(dataset)),
+  );
+  return raw === null ? null : parseMetadata(raw, dataset);
+}
+
+async function getAppSnapshot<T>(
+  dataset: AnalyticsDataset,
+  appId: string,
+  validate: (value: unknown, appId: string) => T,
+): Promise<AnalyticsAppSnapshot<T> | null> {
+  if (!appIdRegex.test(appId)) {
+    throw new AnalyticsRedisDataError("Invalid analytics app ID");
+  }
+  const metadata = await getAnalyticsSnapshotMetadata(dataset);
+  if (!metadata) {
+    throw new AnalyticsRedisUnavailableError(
+      `No published ${dataset} snapshot`,
+    );
+  }
+  const raw = await redisCall((redis) =>
+    redis.get(analyticsRedisKeys.data(dataset, appId, metadata.snapshotId)),
+  );
+  if (raw !== null) return { data: validate(parseJson(raw), appId), metadata };
+
+  const appsKey = analyticsRedisKeys.apps(dataset, metadata.snapshotId);
+  const [isMember, appCount] = await Promise.all([
+    redisCall((redis) => redis.sismember(appsKey, appId)),
+    redisCall((redis) => redis.scard(appsKey)),
+  ]);
+  if (isMember || appCount !== metadata.appCount) {
+    throw new AnalyticsRedisDataError(`Incomplete ${dataset} snapshot`);
+  }
+  return null;
+}
+
+export const getTotalsForApp = (
+  appId: string,
+): Promise<AnalyticsAppSnapshot<TotalsRow> | null> =>
+  getAppSnapshot("total", appId, validateTotals);
+
+export const getDailyForApp = (
+  appId: string,
+): Promise<AnalyticsAppSnapshot<readonly DailyRow[]> | null> =>
+  getAppSnapshot("daily", appId, validateDaily);
+
+/** The lease bounds a refresh; an expired owner cannot publish or release it. */
+export async function tryAcquireAnalyticsRefreshLock(
+  dataset: AnalyticsDataset,
+): Promise<AnalyticsRefreshLock | null> {
+  const owner = randomUUID();
+  const result = await redisCall((redis) =>
+    redis.set(
+      analyticsRedisKeys.refreshLock(dataset),
+      owner,
+      "PX",
+      REFRESH_LOCK_TTL_MS,
+      "NX",
+    ),
+  );
+  return result === "OK" ? { dataset, owner } : null;
+}
+
+export async function releaseAnalyticsRefreshLock(
+  lock: AnalyticsRefreshLock,
+): Promise<boolean> {
+  const result = await redisCall((redis) =>
+    redis.eval(
+      `if redis.call('GET', KEYS[1]) == ARGV[1] then
+         return redis.call('DEL', KEYS[1])
+       end
+       return 0`,
+      1,
+      analyticsRedisKeys.refreshLock(lock.dataset),
+      lock.owner,
+    ),
+  );
+  return result === 1;
+}
+
+/**
+ * Publishes one dataset under the supplied lease; the caller releases the lease
+ * in finally. Each attempt gets a fresh ID even when its S3 identity is unchanged,
+ * so a delayed writer can never overwrite another attempt's staged/live rows.
+ */
+export async function publishAnalyticsSnapshot(
+  publication: SnapshotPublication,
+): Promise<AnalyticsSnapshotMetadata> {
+  const { dataset, lock, source, records } = publication;
+  if (lock.dataset !== dataset) {
+    throw new AnalyticsSnapshotConflictError(
+      "Refresh lock belongs to another dataset",
+    );
+  }
+  if (records.size === 0) {
+    throw new AnalyticsRedisDataError(
+      "Cannot publish an empty analytics snapshot",
+    );
+  }
+
+  const lockKey = analyticsRedisKeys.refreshLock(dataset);
+  const metadataKey = analyticsRedisKeys.metadata(dataset);
+  const owner = await redisCall((redis) => redis.get(lockKey));
+  if (owner !== lock.owner) {
+    throw new AnalyticsSnapshotConflictError("Analytics refresh lock was lost");
+  }
+  const previousRaw = await redisCall((redis) => redis.get(metadataKey));
+  const previous =
+    previousRaw === null ? null : parseMetadata(previousRaw, dataset);
+  const now = new Date().toISOString();
+  let metadata: AnalyticsSnapshotMetadata;
+  try {
+    metadata = parseMetadata(
+      JSON.stringify({
+        schemaVersion: 1,
+        dataset,
+        snapshotId: randomUUID(),
+        appCount: records.size,
+        loadedAt: now,
+        lastCheckedAt: now,
+        isFallback: false,
+        source: {
+          ...source,
+          dataAsOf: source.dataAsOf.toISOString(),
+          lastModified: source.lastModified.toISOString(),
+        },
+      }),
+      dataset,
+    );
+  } catch (cause) {
+    throw new AnalyticsRedisDataError(
+      "Invalid analytics publication metadata",
+      { cause },
+    );
+  }
+  if (
+    previous &&
+    (metadata.source.dataAsOf < previous.source.dataAsOf ||
+      (metadata.source.dataAsOf === previous.source.dataAsOf &&
+        metadata.source.lastModified < previous.source.lastModified))
+  ) {
+    throw new AnalyticsSnapshotConflictError(
+      "Cannot replace analytics with an older snapshot",
+    );
+  }
+
+  // Validate and serialize the entire input before the first data write.
+  const entries: Array<readonly [string, string]> = [];
+  for (const [appId, data] of records) {
+    entries.push([
+      appId,
+      JSON.stringify(
+        dataset === "total"
+          ? validateTotals(data, appId)
+          : validateDaily(data, appId),
+      ),
+    ]);
+  }
+  for (let offset = 0; offset < entries.length; offset += WRITE_BATCH_SIZE) {
+    const batch = entries.slice(offset, offset + WRITE_BATCH_SIZE);
+    // Drain the batch before returning a write error; no writes continue after
+    // this publisher settles. Individual commands work across cluster slots.
+    const results = await Promise.allSettled(
+      batch.map(([appId, json]) =>
+        redisCall((redis) =>
+          redis.set(
+            analyticsRedisKeys.data(dataset, appId, metadata.snapshotId),
+            json,
+          ),
+        ),
+      ),
+    );
+    for (const result of results) {
+      if (result.status === "rejected") throw result.reason;
+      if (result.value !== "OK") {
+        throw new AnalyticsRedisUnavailableError(
+          "Analytics row write was not acknowledged",
+        );
+      }
+    }
+    await redisCall((redis) =>
+      redis.sadd(
+        analyticsRedisKeys.apps(dataset, metadata.snapshotId),
+        ...batch.map(([appId]) => appId),
+      ),
+    );
+  }
+
+  // These two keys share the dataset hash tag in Redis Cluster. Checking the
+  // owner and expected metadata in the same script as SET prevents a delayed
+  // writer from publishing after lease expiry or an intervening publication.
+  const published = await redisCall((redis) =>
+    redis.eval(
+      `if redis.call('GET', KEYS[1]) ~= ARGV[1] then return 0 end
+     local current = redis.call('GET', KEYS[2])
+     if (current or '') ~= ARGV[2] then return 0 end
+     redis.call('SET', KEYS[2], ARGV[3])
+     return 1`,
+      2,
+      lockKey,
+      metadataKey,
+      lock.owner,
+      previousRaw ?? "",
+      JSON.stringify(metadata),
+    ),
+  );
+  if (published !== 1) {
+    throw new AnalyticsSnapshotConflictError(
+      "Analytics publication lost its lock or active snapshot changed",
+    );
+  }
+  return metadata;
+}

--- a/web/tests/api/helpers/selfie-check-analytics-redis-store.test.ts
+++ b/web/tests/api/helpers/selfie-check-analytics-redis-store.test.ts
@@ -1,0 +1,545 @@
+import {
+  AnalyticsRedisDataError,
+  AnalyticsRedisUnavailableError,
+  AnalyticsSnapshotConflictError,
+  analyticsRedisKeys,
+  getAnalyticsSnapshotMetadata,
+  getDailyForApp,
+  getTotalsForApp,
+  publishAnalyticsSnapshot,
+  releaseAnalyticsRefreshLock,
+  tryAcquireAnalyticsRefreshLock,
+  type AnalyticsDataset,
+  type AnalyticsRefreshLock,
+} from "@/api/helpers/selfie-check-analytics/redis-store";
+import type { TableObjectDescriptor } from "@/api/helpers/selfie-check-analytics/s3";
+import type { DailyRow, TotalsRow } from "@/lib/selfie-check-analytics";
+
+// #region Mocks
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+// Exercise the real store and Lua scripts using the shared I/O-boundary mock.
+const redis = global.RedisClient!;
+// #endregion
+
+// #region Test Data
+const appIdA = "app_0123456789abcdef0123456789abcdef";
+const appIdB = "app_fedcba9876543210fedcba9876543210";
+
+const makeTotals = (overrides: Partial<TotalsRow> = {}): TotalsRow => ({
+  appId: appIdA,
+  n_users_started_at_least_one_selfie_check_flow: 10,
+  n_users_shared_at_least_one_proof: 8,
+  n_selfie_check_started_sessions: 12,
+  n_face_capture_started_sessions: 10,
+  n_face_capture_completed_sessions: 9,
+  n_proof_shared_sessions: 8,
+  p_selfie_check_to_face_capture_started_completion: 10 / 12,
+  p_face_capture_started_to_completed_completion: 0.9,
+  p_face_capture_completed_to_proof_shared_completion: null,
+  ...overrides,
+});
+
+const makeDaily = (overrides: Partial<DailyRow> = {}): DailyRow => ({
+  appId: appIdA,
+  day: "2026-09-03",
+  os_name: "iOS",
+  n_users_started_selfie_check_flow: 5,
+  n_users_shared_a_proof: 4,
+  cumulative_n_users_shared_a_proof: 8,
+  p_face_capture_completion: null,
+  ...overrides,
+});
+
+const makeSource = (
+  overrides: Partial<TableObjectDescriptor> = {},
+): TableObjectDescriptor => ({
+  bucket: "analytics-bucket",
+  region: "eu-west-1",
+  key: "total/data_20260903_220000.csv",
+  etag: '"etag-1"',
+  identity: 'total/data_20260903_220000.csv:"etag-1"',
+  dataAsOf: new Date("2026-09-03T22:00:00.000Z"),
+  lastModified: new Date("2026-09-03T22:01:00.000Z"),
+  sizeBytes: 1_024,
+  ...overrides,
+});
+
+async function acquire(dataset: AnalyticsDataset = "total") {
+  const lock = await tryAcquireAnalyticsRefreshLock(dataset);
+  if (!lock) throw new Error("Expected an available refresh lock");
+  return lock;
+}
+
+async function publishTotals({
+  rows = [makeTotals()],
+  source = makeSource(),
+  lock,
+}: {
+  rows?: readonly TotalsRow[];
+  source?: TableObjectDescriptor;
+  lock?: AnalyticsRefreshLock;
+} = {}) {
+  const ownedLock = lock ?? (await acquire());
+  try {
+    return await publishAnalyticsSnapshot({
+      dataset: "total",
+      lock: ownedLock,
+      source,
+      records: new Map(rows.map((row) => [row.appId, row])),
+    });
+  } finally {
+    if (!lock) await releaseAnalyticsRefreshLock(ownedLock);
+  }
+}
+
+async function publishDaily(rows = [makeDaily()]) {
+  const lock = await acquire("daily");
+  try {
+    return await publishAnalyticsSnapshot({
+      dataset: "daily",
+      lock,
+      source: makeSource({
+        key: "daily/data_20260903_220000.csv",
+        identity: 'daily/data_20260903_220000.csv:"etag-1"',
+      }),
+      records: new Map([[appIdA, rows]]),
+    });
+  } finally {
+    await releaseAnalyticsRefreshLock(lock);
+  }
+}
+// #endregion
+
+beforeEach(async () => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+  global.RedisClient = redis;
+  await redis.flushall();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  global.RedisClient = redis;
+});
+
+// #region Storage contract and getters
+describe("analytics Redis snapshots [reads]", () => {
+  it("uses app/type/result keys and co-locates publication control keys", () => {
+    expect(analyticsRedisKeys.data("total", appIdA, "version-1")).toBe(
+      `selfie-check-analytics:${appIdA}:total:row:version-1`,
+    );
+    expect(analyticsRedisKeys.data("daily", appIdA, "version-1")).toBe(
+      `selfie-check-analytics:${appIdA}:daily:rows:version-1`,
+    );
+    for (const dataset of ["total", "daily"] as const) {
+      expect(analyticsRedisKeys.metadata(dataset)).toBe(
+        `selfie-check-analytics:{${dataset}}:meta`,
+      );
+      expect(analyticsRedisKeys.refreshLock(dataset)).toBe(
+        `selfie-check-analytics:{${dataset}}:refresh-lock`,
+      );
+    }
+  });
+
+  it("reads only the requested app's totals and preserves null metrics", async () => {
+    const metadata = await publishTotals({
+      rows: [
+        makeTotals(),
+        makeTotals({ appId: appIdB, n_proof_shared_sessions: 99 }),
+      ],
+    });
+    const get = jest.spyOn(redis, "get");
+    expect(await getTotalsForApp(appIdA)).toEqual({
+      data: makeTotals(),
+      metadata,
+    });
+    expect(metadata).toMatchObject({
+      schemaVersion: 1,
+      appCount: 2,
+      isFallback: false,
+      source: { dataAsOf: "2026-09-03T22:00:00.000Z" },
+    });
+    expect(get.mock.calls.map(([key]) => key)).toEqual([
+      analyticsRedisKeys.metadata("total"),
+      analyticsRedisKeys.data("total", appIdA, metadata.snapshotId),
+    ]);
+  });
+
+  it("preserves daily order and distinct OS rows for the same day", async () => {
+    const rows = [
+      makeDaily(),
+      makeDaily({ os_name: "Android" }),
+      makeDaily({ day: "2026-09-02" }),
+    ];
+    const metadata = await publishDaily(rows);
+    await publishTotals();
+    expect(await getDailyForApp(appIdA)).toEqual({ data: rows, metadata });
+  });
+
+  it("returns null only for an app absent from the published dataset", async () => {
+    await publishTotals();
+    expect(await getTotalsForApp(appIdB)).toBeNull();
+  });
+
+  it("reports an unpublished dataset as unavailable", async () => {
+    expect(await getAnalyticsSnapshotMetadata("total")).toBeNull();
+    await expect(getTotalsForApp(appIdA)).rejects.toBeInstanceOf(
+      AnalyticsRedisUnavailableError,
+    );
+  });
+
+  it("reports a missing published row as incomplete data", async () => {
+    const metadata = await publishTotals();
+    await redis.del(
+      analyticsRedisKeys.data("total", appIdA, metadata.snapshotId),
+    );
+    await expect(getTotalsForApp(appIdA)).rejects.toBeInstanceOf(
+      AnalyticsRedisDataError,
+    );
+  });
+
+  it("does not treat missing membership as an absent app", async () => {
+    const metadata = await publishTotals();
+    await redis.del(analyticsRedisKeys.apps("total", metadata.snapshotId));
+    await expect(getTotalsForApp(appIdB)).rejects.toBeInstanceOf(
+      AnalyticsRedisDataError,
+    );
+  });
+
+  it.each([
+    ["malformed JSON", "{"],
+    ["wrong app", JSON.stringify(makeTotals({ appId: appIdB }))],
+    [
+      "invalid metric",
+      JSON.stringify(makeTotals({ n_proof_shared_sessions: -1 })),
+    ],
+  ])("rejects a totals value with %s", async (_label, raw) => {
+    const metadata = await publishTotals();
+    await redis.set(
+      analyticsRedisKeys.data("total", appIdA, metadata.snapshotId),
+      raw,
+    );
+    await expect(getTotalsForApp(appIdA)).rejects.toBeInstanceOf(
+      AnalyticsRedisDataError,
+    );
+  });
+
+  it.each([
+    ["non-array", makeDaily()],
+    ["empty array", []],
+    ["wrong app", [makeDaily({ appId: appIdB })]],
+    ["invalid day", [makeDaily({ day: "2026-02-30" })]],
+    ["duplicate day/OS", [makeDaily(), makeDaily()]],
+  ])("rejects daily data with %s", async (_label, value) => {
+    const metadata = await publishDaily();
+    await redis.set(
+      analyticsRedisKeys.data("daily", appIdA, metadata.snapshotId),
+      JSON.stringify(value),
+    );
+    await expect(getDailyForApp(appIdA)).rejects.toBeInstanceOf(
+      AnalyticsRedisDataError,
+    );
+  });
+
+  it.each([
+    { schemaVersion: 2 },
+    { dataset: "daily" },
+    { appCount: 0 },
+    { loadedAt: "invalid" },
+    { source: {} },
+  ])("rejects incompatible or corrupt metadata: %j", async (overrides) => {
+    const metadata = await publishTotals();
+    await redis.set(
+      analyticsRedisKeys.metadata("total"),
+      JSON.stringify({ ...metadata, ...overrides }),
+    );
+    await expect(getTotalsForApp(appIdA)).rejects.toBeInstanceOf(
+      AnalyticsRedisDataError,
+    );
+  });
+
+  it("rejects invalid lookup IDs before touching Redis", async () => {
+    const get = jest.spyOn(redis, "get");
+    await expect(getTotalsForApp("other-app")).rejects.toBeInstanceOf(
+      AnalyticsRedisDataError,
+    );
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("reports an unconfigured client as unavailable", async () => {
+    global.RedisClient = undefined;
+    await expect(getTotalsForApp(appIdA)).rejects.toBeInstanceOf(
+      AnalyticsRedisUnavailableError,
+    );
+  });
+
+  it("preserves a Redis failure as the cause of an unavailable error", async () => {
+    const cause = new Error("connection refused");
+    jest.spyOn(redis, "get").mockRejectedValueOnce(cause);
+    await expect(getTotalsForApp(appIdA)).rejects.toMatchObject({
+      name: "AnalyticsRedisUnavailableError",
+      cause,
+    });
+  });
+});
+// #endregion
+
+// #region Refresh lease ownership
+describe("analytics Redis snapshots [locks]", () => {
+  it("excludes competing writers for one dataset while allowing the other", async () => {
+    const total = await acquire();
+    expect(await tryAcquireAnalyticsRefreshLock("total")).toBeNull();
+    expect(await tryAcquireAnalyticsRefreshLock("daily")).not.toBeNull();
+    expect(
+      await redis.pttl(analyticsRedisKeys.refreshLock("total")),
+    ).toBeGreaterThan(0);
+    expect(await releaseAnalyticsRefreshLock(total)).toBe(true);
+    expect(await tryAcquireAnalyticsRefreshLock("total")).not.toBeNull();
+  });
+
+  it("prevents an expired owner from releasing or publishing through a replacement lease", async () => {
+    const expired = await acquire();
+    await redis.pexpire(analyticsRedisKeys.refreshLock("total"), -1);
+    const current = await acquire();
+    expect(current.owner).not.toBe(expired.owner);
+    expect(await releaseAnalyticsRefreshLock(expired)).toBe(false);
+    await expect(publishTotals({ lock: expired })).rejects.toBeInstanceOf(
+      AnalyticsSnapshotConflictError,
+    );
+    expect(await redis.get(analyticsRedisKeys.refreshLock("total"))).toBe(
+      current.owner,
+    );
+  });
+
+  it("rejects a lock belonging to a different dataset", async () => {
+    await expect(
+      publishTotals({ lock: await acquire("daily") }),
+    ).rejects.toBeInstanceOf(AnalyticsSnapshotConflictError);
+  });
+});
+// #endregion
+
+// #region Publication and visibility
+describe("analytics Redis snapshots [publication]", () => {
+  it("changes the active snapshot and removes absent apps from reads without deleting the old version", async () => {
+    const previous = await publishTotals({
+      rows: [makeTotals(), makeTotals({ appId: appIdB })],
+    });
+    const current = await publishTotals({
+      rows: [makeTotals({ n_proof_shared_sessions: 20 })],
+    });
+    expect(current.snapshotId).not.toBe(previous.snapshotId);
+    expect((await getTotalsForApp(appIdA))?.data.n_proof_shared_sessions).toBe(
+      20,
+    );
+    expect(await getTotalsForApp(appIdB)).toBeNull();
+    expect(
+      await redis.get(
+        analyticsRedisKeys.data("total", appIdB, previous.snapshotId),
+      ),
+    ).not.toBeNull();
+  });
+
+  it("serves the previous snapshot throughout staging", async () => {
+    const previous = await publishTotals();
+    const originalSet = redis.set.bind(redis);
+    const observations: unknown[] = [];
+    jest
+      .spyOn(redis, "set")
+      .mockImplementation(async (...args: Parameters<typeof redis.set>) => {
+        if (String(args[0]).includes(":row:"))
+          observations.push(await getTotalsForApp(appIdA));
+        return originalSet(...args);
+      });
+    await publishTotals({
+      rows: [makeTotals({ n_proof_shared_sessions: 20 })],
+    });
+    expect(observations).toEqual([{ data: makeTotals(), metadata: previous }]);
+  });
+
+  it("reads a captured snapshot consistently when publication occurs between the two GETs", async () => {
+    const previous = await publishTotals();
+    const originalGet = redis.get.bind(redis);
+    let switched = false;
+    jest.spyOn(redis, "get").mockImplementation(async (key) => {
+      const raw = await originalGet(key);
+      if (key === analyticsRedisKeys.metadata("total") && !switched) {
+        switched = true;
+        await publishTotals({
+          rows: [makeTotals({ n_proof_shared_sessions: 20 })],
+        });
+      }
+      return raw;
+    });
+    expect(await getTotalsForApp(appIdA)).toEqual({
+      data: makeTotals(),
+      metadata: previous,
+    });
+    expect((await getTotalsForApp(appIdA))?.data.n_proof_shared_sessions).toBe(
+      20,
+    );
+  });
+
+  it.each([
+    { dataAsOf: new Date("2026-09-03T21:00:00.000Z") },
+    { lastModified: new Date("2026-09-03T22:00:30.000Z") },
+  ])(
+    "rejects a source older than the active snapshot: %j",
+    async (overrides) => {
+      const previous = await publishTotals();
+      await expect(
+        publishTotals({ source: makeSource(overrides) }),
+      ).rejects.toBeInstanceOf(AnalyticsSnapshotConflictError);
+      expect(await getAnalyticsSnapshotMetadata("total")).toEqual(previous);
+    },
+  );
+
+  it("accepts a newer revision of the same export timestamp", async () => {
+    await publishTotals();
+    const current = await publishTotals({
+      source: makeSource({
+        etag: '"etag-2"',
+        identity: 'total/data_20260903_220000.csv:"etag-2"',
+        lastModified: new Date("2026-09-03T22:02:00.000Z"),
+      }),
+    });
+    expect((await getAnalyticsSnapshotMetadata("total"))?.source.identity).toBe(
+      current.source.identity,
+    );
+  });
+
+  it("rejects empty snapshots and validates every row before writing data", async () => {
+    const lock = await acquire();
+    await expect(publishTotals({ rows: [], lock })).rejects.toBeInstanceOf(
+      AnalyticsRedisDataError,
+    );
+    const set = jest.spyOn(redis, "set");
+    await expect(
+      publishTotals({
+        lock,
+        rows: [
+          makeTotals(),
+          makeTotals({ appId: appIdB, n_proof_shared_sessions: -1 }),
+        ],
+      }),
+    ).rejects.toBeInstanceOf(AnalyticsRedisDataError);
+    expect(set).not.toHaveBeenCalled();
+    expect(await getAnalyticsSnapshotMetadata("total")).toBeNull();
+  });
+
+  it("rejects invalid source dates before writing rows", async () => {
+    const lock = await acquire();
+    const set = jest.spyOn(redis, "set");
+    await expect(
+      publishTotals({
+        lock,
+        source: makeSource({ dataAsOf: new Date("invalid") }),
+      }),
+    ).rejects.toBeInstanceOf(AnalyticsRedisDataError);
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("preserves the active snapshot after a partial row write failure", async () => {
+    const previous = await publishTotals();
+    const originalSet = redis.set.bind(redis);
+    jest
+      .spyOn(redis, "set")
+      .mockImplementation(async (...args: Parameters<typeof redis.set>) => {
+        if (String(args[0]).includes(`:${appIdB}:`))
+          throw new Error("Redis write failed");
+        return originalSet(...args);
+      });
+    await expect(
+      publishTotals({
+        rows: [
+          makeTotals({ n_proof_shared_sessions: 20 }),
+          makeTotals({ appId: appIdB }),
+        ],
+      }),
+    ).rejects.toBeInstanceOf(AnalyticsRedisUnavailableError);
+    expect(await getTotalsForApp(appIdA)).toEqual({
+      data: makeTotals(),
+      metadata: previous,
+    });
+  });
+
+  it("does not publish if membership could not be written", async () => {
+    jest.spyOn(redis, "sadd").mockRejectedValueOnce(new Error("write failed"));
+    await expect(publishTotals()).rejects.toBeInstanceOf(
+      AnalyticsRedisUnavailableError,
+    );
+    expect(await getAnalyticsSnapshotMetadata("total")).toBeNull();
+  });
+
+  it("rechecks ownership at publication after the lease expires during staging", async () => {
+    const previous = await publishTotals();
+    const lock = await acquire();
+    const originalSet = redis.set.bind(redis);
+    jest
+      .spyOn(redis, "set")
+      .mockImplementation(async (...args: Parameters<typeof redis.set>) => {
+        const result = await originalSet(...args);
+        if (String(args[0]).includes(":row:"))
+          await redis.pexpire(analyticsRedisKeys.refreshLock("total"), -1);
+        return result;
+      });
+    await expect(publishTotals({ lock })).rejects.toBeInstanceOf(
+      AnalyticsSnapshotConflictError,
+    );
+    expect(await getAnalyticsSnapshotMetadata("total")).toEqual(previous);
+  });
+
+  it("rejects publication when active metadata changes during staging", async () => {
+    const previous = await publishTotals();
+    const replacement = {
+      ...previous,
+      lastCheckedAt: "2026-09-04T00:00:00.000Z",
+    };
+    const originalSet = redis.set.bind(redis);
+    jest
+      .spyOn(redis, "set")
+      .mockImplementation(async (...args: Parameters<typeof redis.set>) => {
+        const result = await originalSet(...args);
+        if (String(args[0]).includes(":row:"))
+          await originalSet(
+            analyticsRedisKeys.metadata("total"),
+            JSON.stringify(replacement),
+          );
+        return result;
+      });
+    await expect(publishTotals()).rejects.toBeInstanceOf(
+      AnalyticsSnapshotConflictError,
+    );
+    expect(await getAnalyticsSnapshotMetadata("total")).toEqual(replacement);
+  });
+
+  it("uses unique staging keys when an expired writer overlaps a replacement writer for the same S3 object", async () => {
+    const expired = await acquire();
+    const originalSet = redis.set.bind(redis);
+    let replacement;
+    let replaced = false;
+    jest
+      .spyOn(redis, "set")
+      .mockImplementation(async (...args: Parameters<typeof redis.set>) => {
+        if (String(args[0]).includes(":row:") && !replaced) {
+          replaced = true;
+          await redis.pexpire(analyticsRedisKeys.refreshLock("total"), -1);
+          replacement = await publishTotals({
+            rows: [makeTotals({ n_proof_shared_sessions: 20 })],
+          });
+        }
+        return originalSet(...args);
+      });
+    await expect(publishTotals({ lock: expired })).rejects.toBeInstanceOf(
+      AnalyticsSnapshotConflictError,
+    );
+    expect(await getTotalsForApp(appIdA)).toEqual({
+      data: makeTotals({ n_proof_shared_sessions: 20 }),
+      metadata: replacement,
+    });
+  });
+});
+// #endregion


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Analytics snapshots currently live in server memory. This adds the Redis storage layer for a later migration: typed per-app totals/daily getters and a publisher that accepts parsed CSV records and their S3 source descriptor. No production callers are changed in this PR; S3 ingestion, scheduled refresh, API migration, and retention/cleanup follow separately.

Each publication writes JSON rows under a unique snapshot ID, then atomically changes the dataset metadata pointer only after all writes succeed. Dataset-scoped expiring locks and an ownership/metadata check prevent a delayed or competing writer from publishing. Older S3 snapshots are rejected. Totals and daily publish independently.

The row keys follow `selfie-check-analytics:<appId>:<total|daily>:<row|rows>:<snapshotId>`. Metadata and lock keys share the dataset's Redis Cluster hash tag. An immutable app-membership set allows getters to distinguish an app absent from an export from a missing published row, without loading all app IDs on successful reads. Superseded and abandoned snapshots are retained in this storage-only PR; lifecycle management must accompany the refresh integration.

## Validation

- `pnpm exec jest selfie-check-analytics --runInBand --no-cache`: 102 passed, including 39 new storage tests; the opt-in live S3 test was skipped.
- `pnpm exec tsc --noEmit --incremental false`: passed.
- `pnpm format:check`: passed; the two changed files also passed a final formatting check.
- Isolated local three-node Redis Cluster smoke test: 70 apps across 70 hash slots and three write batches; totals/daily reads, missing apps, lock contention, and expired ownership passed. No external Redis or S3 service was used.

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [x] I have updated the documentation as needed.
