### PR TITLE
fix(verify): surface and constrain the accepted protocol version (H1 #3989317)

### DIFF
--- a/web/api/v4/verify/index.ts
+++ b/web/api/v4/verify/index.ts
@@ -8,6 +8,7 @@ import { validateRequestSchema } from "@/api/helpers/validate-request-schema";
 import { logger } from "@/lib/logger";
 import { NextRequest } from "next/server";
 import {
+  isProtocolVersionBelowMinimum,
   schema,
   SessionProofRequest,
   UniquenessProofResponseV3,
@@ -63,6 +64,35 @@ export async function POST(
 
   if (!isValid) {
     return handleError(req);
+  }
+
+  // `protocol_version` describes the proof that was supplied, not the
+  // integration that asked for it, so a relying party forwarding an IDKit
+  // result verbatim forwards whichever version the credential holder chose to
+  // mint. `min_protocol_version` is the RP's own floor. It is enforced before
+  // any verification work so a rejected downgrade costs no sequencer or RPC
+  // call.
+  if (
+    parsedParams.min_protocol_version &&
+    isProtocolVersionBelowMinimum(
+      parsedParams.protocol_version,
+      parsedParams.min_protocol_version,
+    )
+  ) {
+    logger.warn("Rejected proof below the relying party's minimum protocol", {
+      app_id: routeId,
+      protocol_version: parsedParams.protocol_version,
+      min_protocol_version: parsedParams.min_protocol_version,
+    });
+
+    return errorResponse({
+      statusCode: 400,
+      code: "protocol_version_not_allowed",
+      detail: `This proof uses protocol version ${parsedParams.protocol_version}, but this request requires at least ${parsedParams.min_protocol_version}.`,
+      attribute: "protocol_version",
+      req,
+      app_id: routeId,
+    });
   }
 
   let client;

--- a/web/api/v4/verify/request-schema.ts
+++ b/web/api/v4/verify/request-schema.ts
@@ -181,16 +181,49 @@ const integrityBundleSchema = yup
       !value || Buffer.byteLength(JSON.stringify(value), "utf8") <= 8192,
   );
 
+/** Supported protocol versions, listed oldest first. */
+export const SUPPORTED_PROTOCOL_VERSIONS = ["3.0", "4.0"] as const;
+
+export type ProtocolVersion = (typeof SUPPORTED_PROTOCOL_VERSIONS)[number];
+
+/**
+ * Whether `version` is older than the `minimum` a relying party will accept.
+ * Ordering comes from SUPPORTED_PROTOCOL_VERSIONS rather than from a string
+ * comparison, so adding a version only means appending to that list.
+ */
+export function isProtocolVersionBelowMinimum(
+  version: string,
+  minimum: string,
+): boolean {
+  return (
+    SUPPORTED_PROTOCOL_VERSIONS.indexOf(version as ProtocolVersion) <
+    SUPPORTED_PROTOCOL_VERSIONS.indexOf(minimum as ProtocolVersion)
+  );
+}
+
 // Base schema - responses validated in custom test based on protocol version
 export const schema = yup
   .object({
-    // Protocol version at root level
+    // Protocol version at root level. This describes the proof the caller
+    // supplied, so it is attacker-influenced whenever a relying party forwards
+    // an IDKit result verbatim. Use `min_protocol_version` to constrain it.
     protocol_version: yup
       .string()
-      .oneOf(["3.0", "4.0"])
+      .oneOf([...SUPPORTED_PROTOCOL_VERSIONS])
       .required("protocol_version is required"),
 
-    // Nonce used in the RP signature
+    // Lowest protocol version this relying party accepts. The RP sets it from
+    // its own configuration rather than from the IDKit result, so it stays
+    // trustworthy even when `protocol_version` does not. Absent means every
+    // supported version is accepted.
+    min_protocol_version: yup
+      .string()
+      .oneOf([...SUPPORTED_PROTOCOL_VERSIONS])
+      .optional(),
+
+    // Nonce used in the RP signature. Only the 4.0 circuit takes it as a public
+    // input; 3.0 (Semaphore) proofs commit to `signal_hash` instead and are
+    // therefore never bound to this value.
     nonce: yup.string().strict().required("nonce is required"),
 
     // Action identifier required for uniqueness proofs
@@ -220,9 +253,19 @@ export const schema = yup
       .required("responses array is required"),
   })
   .test("request-validation", "Request validation failed", function (value) {
-    const { action, session_id } = value;
+    const { action, session_id, protocol_version } = value;
 
     if (session_id) {
+      // Session proofs are a 4.0-only construct: the session nullifier and the
+      // session id are public inputs of the 4.0 circuit and have no 3.0
+      // equivalent.
+      if (protocol_version && protocol_version !== "4.0") {
+        return this.createError({
+          path: "protocol_version",
+          message: "session proofs require protocol_version 4.0",
+        });
+      }
+
       // Session proofs must NOT have action field
       if (action) {
         return this.createError({
@@ -331,6 +374,7 @@ export interface UniquenessProofResponseV3 {
 
 export interface UniquenessProofRequestV3 {
   protocol_version: "3.0";
+  min_protocol_version?: "3.0" | "4.0";
   nonce: string;
   action: string;
   action_description?: string;
@@ -353,6 +397,7 @@ export interface UniquenessProofResponseV4 {
 
 export interface UniquenessProofRequestV4 {
   protocol_version: "4.0";
+  min_protocol_version?: "3.0" | "4.0";
   nonce: string;
   action: string;
   action_description?: string;
@@ -377,6 +422,7 @@ export interface SessionProofRequest {
   session_id: string;
   nonce: string;
   protocol_version: "4.0";
+  min_protocol_version?: "3.0" | "4.0";
   environment?: "production" | "staging" | "sandbox";
   integrity_bundle?: IntegrityBundle;
   responses: SessionResponseItem[];

--- a/web/api/v4/verify/session-proof/handler.ts
+++ b/web/api/v4/verify/session-proof/handler.ts
@@ -10,6 +10,10 @@ type SessionProofSuccessResponse = {
   success: true;
   session_id: string;
   environment: "production" | "staging" | "sandbox";
+  // Always 4.0: the session nullifier and session id are 4.0 circuit public
+  // inputs, and the request schema rejects any other version for session
+  // proofs. Reported so relying parties can assert on it uniformly.
+  protocol_version: "4.0";
   results: SessionResult[];
   message: string;
 };
@@ -127,6 +131,7 @@ export async function handleSessionProofVerification(
       success: true,
       session_id: sessionId,
       environment: requestedEnvironment,
+      protocol_version: "4.0",
       results: verificationResults,
       message: "Session proof verified successfully",
     },

--- a/web/api/v4/verify/uniqueness-proof/handler.ts
+++ b/web/api/v4/verify/uniqueness-proof/handler.ts
@@ -37,6 +37,10 @@ type UniquenessProofSuccessResponse = {
   nullifier: string; // Hex format `0x` prefixed
   created_at?: string;
   environment: string;
+  // The protocol the accepted proof was actually verified under. Only 4.0
+  // binds `nonce` as a circuit public input, so a relying party that has
+  // migrated must check this to reject a proof it cannot bind to a session.
+  protocol_version: "3.0" | "4.0";
   results: UniquenessResult[];
   message: string;
 };
@@ -267,6 +271,7 @@ export async function handleUniquenessProofVerification(
         nullifier: normalizedNullifier,
         created_at: existingNullifier.created_at,
         environment: requestedEnvironment,
+        protocol_version: protocolVersion,
         results: verificationResults,
         message: "Proof verified successfully (nullifier reuse)",
       },
@@ -327,6 +332,7 @@ export async function handleUniquenessProofVerification(
         nullifier: normalizedNullifier,
         created_at: insertResult.insert_nullifier_v4_one.created_at,
         environment: requestedEnvironment,
+        protocol_version: protocolVersion,
         results: verificationResults,
         message: "Proof verified successfully",
       },
@@ -356,6 +362,7 @@ export async function handleUniquenessProofVerification(
           action: actionV4.action,
           nullifier: normalizedNullifier,
           environment: requestedEnvironment,
+          protocol_version: protocolVersion,
           results: verificationResults,
           message: "Proof verified successfully (nullifier reuse)",
         },

--- a/web/tests/api/v4/request-schema.test.ts
+++ b/web/tests/api/v4/request-schema.test.ts
@@ -46,6 +46,82 @@ describe("v4 verify request schema", () => {
     expect(parsed.responses[0]?.identifier).toBe("selfie");
   });
 
+  it("preserves min_protocol_version after schema validation", async () => {
+    const parsed = await schema.validate({
+      protocol_version: "3.0",
+      min_protocol_version: "4.0",
+      nonce: "0x01",
+      action: "test-action",
+      responses: [
+        {
+          identifier: "orb",
+          merkle_root: "0x01",
+          nullifier: "0x02",
+          proof: "0x03",
+        },
+      ],
+    });
+
+    expect(parsed.min_protocol_version).toBe("4.0");
+  });
+
+  it("rejects an unsupported min_protocol_version", async () => {
+    await expect(
+      schema.validate({
+        protocol_version: "4.0",
+        min_protocol_version: "5.0",
+        nonce: "0x01",
+        action: "test-action",
+        responses: [
+          {
+            identifier: "credential",
+            issuer_schema_id: 128,
+            nullifier: "0x02",
+            expires_at_min: 1772584197,
+            proof: ["0x1", "0x2", "0x3", "0x4", "0x5"],
+          },
+        ],
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("rejects a session proof that declares protocol_version 3.0", async () => {
+    await expect(
+      schema.validate({
+        protocol_version: "3.0",
+        nonce: "0x01",
+        session_id: "session_test",
+        responses: [
+          {
+            identifier: "orb",
+            merkle_root: "0x01",
+            nullifier: "0x02",
+            proof: "0x03",
+          },
+        ],
+      }),
+    ).rejects.toThrow("session proofs require protocol_version 4.0");
+  });
+
+  it("accepts a session proof on protocol_version 4.0", async () => {
+    const parsed = await schema.validate({
+      protocol_version: "4.0",
+      nonce: "0x01",
+      session_id: "session_test",
+      responses: [
+        {
+          identifier: "credential",
+          issuer_schema_id: 128,
+          session_nullifier: ["0x01", "0x02"],
+          expires_at_min: 1772584197,
+          proof: ["0x1", "0x2", "0x3", "0x4", "0x5"],
+        },
+      ],
+    });
+
+    expect(parsed.session_id).toBe("session_test");
+  });
+
   it('preserves the "sandbox" environment after schema validation', async () => {
     const parsed = await schema.validate({
       protocol_version: "4.0",

--- a/web/tests/api/v4/verify.test.ts
+++ b/web/tests/api/v4/verify.test.ts
@@ -66,6 +66,13 @@ const selfieCheckV4Response = {
   sybil_score: 10,
 };
 
+const v3Response = {
+  identifier: "orb",
+  merkle_root: "0x01",
+  nullifier: "0x02",
+  proof: "0x03",
+};
+
 const createRequest = (body: Record<string, unknown>) =>
   new NextRequest(new URL(`/api/v4/verify/${appId}`, "http://localhost:3000"), {
     method: "POST",
@@ -181,6 +188,88 @@ describe("/api/v4/verify [integrity bundle]", () => {
         integrityBundle: { ...integrityBundle, version: 2 },
         responses: [selfieCheckV4Response],
       }),
+    );
+  });
+});
+// #endregion
+
+// #region Protocol version floor
+describe("/api/v4/verify [min_protocol_version]", () => {
+  it("rejects a 3.0 proof when the relying party requires 4.0", async () => {
+    const req = createRequest({
+      protocol_version: "3.0",
+      min_protocol_version: "4.0",
+      nonce: "1",
+      action: "verify",
+      responses: [v3Response],
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ app_id: appId }) });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      code: "protocol_version_not_allowed",
+      attribute: "protocol_version",
+    });
+    // The floor is enforced before any verification work is done.
+    expect(mockResolveRpRegistration).not.toHaveBeenCalled();
+    expect(mockVerifyIntegrityBundle).not.toHaveBeenCalled();
+    expect(mockHandleUniquenessProofVerification).not.toHaveBeenCalled();
+  });
+
+  it("accepts a 3.0 proof when the relying party still allows 3.0", async () => {
+    const req = createRequest({
+      protocol_version: "3.0",
+      min_protocol_version: "3.0",
+      nonce: "1",
+      action: "verify",
+      responses: [v3Response],
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ app_id: appId }) });
+
+    expect(res.status).toBe(200);
+    expect(mockHandleUniquenessProofVerification).toHaveBeenCalledWith(
+      expect.anything(),
+      rpId,
+      appId,
+      expect.objectContaining({ protocol_version: "3.0" }),
+      req,
+    );
+  });
+
+  it("accepts a 3.0 proof when no floor is declared", async () => {
+    const req = createRequest({
+      protocol_version: "3.0",
+      nonce: "1",
+      action: "verify",
+      responses: [v3Response],
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ app_id: appId }) });
+
+    expect(res.status).toBe(200);
+    expect(mockHandleUniquenessProofVerification).toHaveBeenCalled();
+  });
+
+  it("accepts a 4.0 proof when the relying party requires 4.0", async () => {
+    const req = createRequest({
+      protocol_version: "4.0",
+      min_protocol_version: "4.0",
+      nonce: "1",
+      action: "verify",
+      responses: [v4Response],
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ app_id: appId }) });
+
+    expect(res.status).toBe(200);
+    expect(mockHandleUniquenessProofVerification).toHaveBeenCalledWith(
+      expect.anything(),
+      rpId,
+      appId,
+      expect.objectContaining({ protocol_version: "4.0" }),
+      req,
     );
   });
 });

--- a/web/tests/api/v4/verify/uniqueness-proof/handler.test.ts
+++ b/web/tests/api/v4/verify/uniqueness-proof/handler.test.ts
@@ -10,9 +10,24 @@ import { semaphoreProofParamsMock } from "../../../__mocks__/proof.mock";
 
 // #region Mocks
 const FetchActionV4 = jest.fn();
+const CreateActionV4 = jest.fn();
+const CheckNullifierV4 = jest.fn();
+const InsertNullifierV4 = jest.fn();
 
 jest.mock("@/api/v4/verify/graphql/fetch-action-v4.generated", () => ({
   getSdk: () => ({ FetchActionV4 }),
+}));
+
+jest.mock("@/api/v4/verify/graphql/create-action-v4.generated", () => ({
+  getSdk: () => ({ CreateActionV4 }),
+}));
+
+jest.mock("@/api/v4/verify/graphql/check-nullifier-v4.generated", () => ({
+  getSdk: () => ({ CheckNullifierV4 }),
+}));
+
+jest.mock("@/api/v4/verify/graphql/insert-nullifier-v4.generated", () => ({
+  getSdk: () => ({ InsertNullifierV4 }),
 }));
 
 jest.mock("@/lib/logger", () => ({
@@ -26,6 +41,12 @@ jest.mock(
   }),
   { virtual: true },
 );
+
+const verifyProofOnChain = jest.fn();
+
+jest.mock("@/api/helpers/temporal-rpc", () => ({
+  verifyProofOnChain: (...args: unknown[]) => verifyProofOnChain(...args),
+}));
 // #endregion
 
 // #region Test Data
@@ -50,6 +71,13 @@ const request = new NextRequest("http://localhost/api/v4/verify", {
 beforeEach(() => {
   jest.clearAllMocks();
   FetchActionV4.mockResolvedValue({ action_v4: [] });
+  CreateActionV4.mockResolvedValue({
+    insert_action_v4_one: { id: "action_v4_test", action: "test-action" },
+  });
+  CheckNullifierV4.mockResolvedValue({ nullifier_v4: [] });
+  InsertNullifierV4.mockResolvedValue({
+    insert_nullifier_v4_one: { created_at: "2026-01-01T00:00:00.000Z" },
+  });
   global.fetch = jest.fn((url: string | URL) => {
     const sequencerUrl = url.toString();
 
@@ -128,6 +156,114 @@ describe("handleUniquenessProofVerification [environment mismatch]", () => {
         },
       ],
     });
+  });
+});
+// #endregion
+
+// #region Accepted protocol version disclosure
+describe("handleUniquenessProofVerification [protocol_version disclosure]", () => {
+  it("reports 3.0 on a success reached through the legacy sequencer path", async () => {
+    const response = await handleUniquenessProofVerification(
+      {} as never,
+      rpId,
+      appId,
+      {
+        action: "test-action",
+        nonce: "1",
+        protocol_version: "3.0",
+        responses: [
+          {
+            identifier: LegacyVerificationLevel.Orb,
+            signal_hash: semaphoreProofParamsMock.signal_hash,
+            merkle_root: semaphoreProofParamsMock.merkle_root,
+            nullifier: semaphoreProofParamsMock.nullifier_hash,
+            proof: semaphoreProofParamsMock.proof,
+          },
+        ],
+      },
+      request,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      protocol_version: "3.0",
+    });
+    // The 3.0 path never forwards the nonce, which is exactly why the accepted
+    // version has to be disclosed.
+    expect(verifyProofOnChain).not.toHaveBeenCalled();
+  });
+
+  it("reports 4.0 on a success reached through the on-chain verifier", async () => {
+    process.env.VERIFIER_CONTRACT_ADDRESS = "0xverifier";
+    verifyProofOnChain.mockResolvedValue({ success: true });
+
+    const response = await handleUniquenessProofVerification(
+      {} as never,
+      rpId,
+      appId,
+      {
+        action: "test-action",
+        nonce: "1",
+        protocol_version: "4.0",
+        responses: [
+          {
+            identifier: "credential",
+            signal_hash: "0x0",
+            issuer_schema_id: "128",
+            nullifier: "0x02",
+            expires_at_min: "1772584197",
+            proof: ["0x1", "0x2", "0x3", "0x4", "0x5"],
+          },
+        ],
+      },
+      request,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      protocol_version: "4.0",
+    });
+    // 4.0 binds the nonce as a circuit public input.
+    expect(verifyProofOnChain).toHaveBeenCalledWith(
+      expect.objectContaining({ nonce: 1n }),
+      "0xverifier",
+    );
+  });
+
+  it("reports 3.0 when an existing nullifier short-circuits the insert", async () => {
+    CheckNullifierV4.mockResolvedValue({
+      nullifier_v4: [{ created_at: "2026-01-01T00:00:00.000Z" }],
+    });
+
+    const response = await handleUniquenessProofVerification(
+      {} as never,
+      rpId,
+      appId,
+      {
+        action: "test-action",
+        nonce: "1",
+        protocol_version: "3.0",
+        responses: [
+          {
+            identifier: LegacyVerificationLevel.Orb,
+            signal_hash: semaphoreProofParamsMock.signal_hash,
+            merkle_root: semaphoreProofParamsMock.merkle_root,
+            nullifier: semaphoreProofParamsMock.nullifier_hash,
+            proof: semaphoreProofParamsMock.proof,
+          },
+        ],
+      },
+      request,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      protocol_version: "3.0",
+    });
+    expect(InsertNullifierV4).not.toHaveBeenCalled();
   });
 });
 // #endregion


### PR DESCRIPTION
## Vulnerability (H1 #3989317)

`POST /api/v4/verify/:id` dispatches on a **client-supplied** `protocol_version` with no server-side floor and no per-RP pinning. Three facts combine:

1. **`nonce` is required but unused on the 3.0 path.** `request-schema.ts` requires `nonce` for every request regardless of version, but `handler.ts` only forwards it on the 4.0 branch (`processUniquenessProofV4(..., parsedParams.nonce!, ...)`, which passes it to the on-chain verifier as a circuit public input). `processUniquenessProofV3` never receives it — the 3.0 signature is `(appId, action, responses, isStaging)`. The `signal_hash` a Semaphore proof commits to also defaults to `keccak256("")` when the caller omits it, so a 3.0 proof can carry no session binding at all.

   The integrity bundle does not compensate: `computeProofIntegrityDigest` hashes the nonce only on the 4.0 branch; the v3 branch hashes the domain and the proof strings only. And `integrity_bundle` is optional except for Self Check 4.0.

2. **The success response never discloses the accepted version.** All three success returns emitted `{success, action, nullifier, created_at?, environment, results, message}`. A relying party that has migrated to 4.0 had no way to tell a 4.0 verification from a 3.0 one.

3. **Nothing constrains the choice.** `resolveRpRegistration` selects `rp_id, app_id, mode, signer_address, status, app{...}` — and neither `rp_registration` nor `action_v4` carries any protocol-version column, so there is no existing server state to pin against. The only `allow_legacy_proofs` in the repo is an IDKit **client** prop (`scenes/.../TryAction/CodeBlock`, `useLegacyKioskRequest.ts`), i.e. it is attacker-controlled, not a server-side allowance.

Net effect: an attacker with their own World ID mints a 3.0 proof, and any RP that forwards an IDKit result verbatim forwards the downgraded `protocol_version` along with it. Replay is bounded to the same `app_id + action` (external nullifier is `H(app_id, action)`), but within that scope the proof is replayable with arbitrary nonces, and the RP cannot detect it. The report's headline impersonation claim additionally requires capturing another person's proof and is not demonstrated.

`c4b73a7f2` (#2268) touched this area but only added `detect_environment_mismatch` to the v3 call and surfaced `environment_mismatch` at the top level. It does not address version disclosure, nonce binding, or pinning.

## Fix

**Disclosure (applies to everyone, no opt-in).** Success responses now carry `protocol_version`: the version actually verified for uniqueness proofs, and the literal `"4.0"` for session proofs. A migrated RP can now reject anything below its expectation.

**Pinning (opt-in).** New optional request field `min_protocol_version`. The RP sets it from *its own* configuration rather than from the IDKit result, so it stays trustworthy even when `protocol_version` does not. Enforced in `index.ts` immediately after schema validation — before RP resolution, integrity verification, and any sequencer/RPC call — so a rejected downgrade costs no downstream work. Returns `400 protocol_version_not_allowed` and a `logger.warn` (rare, security-relevant, high-entropy → a log rather than a metric).

Ordering comes from `SUPPORTED_PROTOCOL_VERSIONS` (oldest first) via `isProtocolVersionBelowMinimum`, not a string comparison, so adding a version is an append. An unrecognised version sorts below everything, i.e. fails closed.

**Server-side validation, zero compat cost.** Session proofs now must declare `protocol_version: "4.0"`. Previously `session_id` + `"3.0"` validated responses against the v3 item schema and then routed to the session handler, which hardcodes `"4.0"` and reads `item.session_nullifier[0]` — a field the v3 schema does not carry. Such a request could never verify; it is now rejected at the schema.

## Residual risk

- **3.0 proofs are still accepted by default.** A hard cut would break in-flight legacy integrations, so the floor is opt-in. An RP that neither sets `min_protocol_version` nor checks the returned `protocol_version` remains exposed to the downgrade exactly as before. This is a deliberate compatibility trade — closing it fully needs a per-RP flag in `rp_registration` (a migration plus a Portal UI to set it) and a deprecation window, which is out of scope here.
- **The 3.0 path still drops the nonce.** It cannot be fixed server-side: a Semaphore proof commits to `signal_hash` chosen at proof time, so a 3.0 proof cannot retroactively bind to the v4 `nonce`. The schema comment now states this invariant explicitly instead of implying a binding that does not exist. RPs needing session binding on 3.0 must use `signal_hash`.
- **Replay scope is unchanged** — still bounded to `app_id + action` by the external nullifier.

## Compatibility impact

- `min_protocol_version` is optional; omitting it preserves today's behaviour exactly.
- `protocol_version` on success responses is purely additive.
- The session-proof version check only rejects requests that already always failed.
- No migration, no config, no feature flag: the change is opt-in per request, so rollout and rollback are inherently gradual and reversible.

## Tests

`web/tests/api/v4/verify.test.ts` — floor enforcement, both sides: 3.0 blocked under a 4.0 floor (asserting nothing downstream ran), 3.0 allowed under a 3.0 floor, 3.0 allowed with no floor, 4.0 allowed under a 4.0 floor.

`web/tests/api/v4/request-schema.test.ts` — `min_protocol_version` survives validation, an unsupported value is rejected, session + 3.0 rejected, session + 4.0 accepted.

`web/tests/api/v4/verify/uniqueness-proof/handler.test.ts` — response shape against the real handler with mocks only at the I/O boundary (GraphQL SDKs, sequencer `fetch`, `verifyProofOnChain`): reports `3.0` on the sequencer path, `4.0` on the on-chain path (asserting the nonce reaches the verifier there and not on 3.0), and `3.0` on the existing-nullifier short-circuit.

Verified: `npx tsc --noEmit` clean, `npx jest tests/api` 839 passed, `pnpm format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
