### PR TITLE
fix(ci): bump api-tests runner tier to arc-public-xlarge-amd64-runner

### DIFF
--- a/.github/workflows/ci-app-router.yml
+++ b/.github/workflows/ci-app-router.yml
@@ -111,7 +111,7 @@ jobs:
   api-tests:
     name: API Tests
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     timeout-minutes: 3
     defaults:
       run:


### PR DESCRIPTION
## Summary
- The `API Tests` job (`.github/workflows/ci-app-router.yml`) runs on `arc-public-large-amd64-runner` and regularly exhausts node memory.
- Traced 8 confirmed OOM-killed pods on this runner group over a 14-day window (Datadog) back to this specific job — cross-referenced against every failed/cancelled job across all public worldcoin repos with CI activity in the window, this job accounted for half of all `arc-public-large-amd64-runner` OOM events found.
- Other jobs in the same workflow (`build` → Test build, `end-to-end` → End-to-end Tests) are already on `arc-public-xlarge-amd64-runner` / `arc-public-2xlarge-amd64-runner`; `api-tests` was the one left behind on the smaller tier.
- `lint`, `docker-build`, `integration-tests`, `unit-tests` are untouched — no OOM evidence for those.

## Test plan
- [ ] CI on this PR exercises `API Tests` on the new `arc-public-xlarge-amd64-runner` group — confirm it goes green without hitting the same cancellation pattern.
- [ ] After merge, monitor Datadog (`kube_namespace:actions-runner-controller OOM`) for a few days to confirm this actually resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)