### PR TITLE
fix(verify): harden World App integrity bundle handling (H1 #3963744)

### DIFF
--- a/web/api/v4/verify/integrity-bundle.ts
+++ b/web/api/v4/verify/integrity-bundle.ts
@@ -25,6 +25,9 @@ const INTEGRITY_BUNDLE_VERSIONS = [1, 2] as const;
 const JWKS_CACHE_TTL_SECONDS = 24 * 60 * 60;
 const SIGNATURE_TIMESTAMP_THRESHOLD_SECONDS = 5 * 60;
 const JWKS_FETCH_TIMEOUT_MS = 4_000;
+// Outlives the window in which a bundle timestamp is still accepted, so a
+// bundle can never survive its single-use record.
+const BUNDLE_SINGLE_USE_TTL_SECONDS = SIGNATURE_TIMESTAMP_THRESHOLD_SECONDS * 2;
 
 type IntegrityEnvironment = "production" | "staging";
 
@@ -287,6 +290,149 @@ export function computeProofIntegrityDigest(params: {
   }
 
   return hasher.digest();
+}
+
+/**
+ * Deterministic serialization of an arbitrary parsed-request value. Object keys
+ * are sorted so that two structurally identical response arrays always produce
+ * the same bytes regardless of the key order they arrived in.
+ */
+function stableSerialize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableSerialize).join(",")}]`;
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const record = value as Record<string, unknown>;
+
+    const entries = Object.keys(record)
+      .filter((key) => record[key] !== undefined)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableSerialize(record[key])}`);
+
+    return `{${entries.join(",")}}`;
+  }
+
+  return JSON.stringify(value) ?? "null";
+}
+
+/**
+ * Identifies the exact proof payload a bundle is being spent on. Everything the
+ * digest fails to cover (nullifiers, proof elements, signal hashes, schema ids)
+ * is included here, so reusing one attestation for a different payload is
+ * detectable even though the signature itself still verifies.
+ */
+export function computeIntegrityPayloadFingerprint(params: {
+  nonce: string;
+  protocolVersion: "3.0" | "4.0";
+  responses:
+    | UniquenessProofResponseV3[]
+    | UniquenessProofResponseV4[]
+    | SessionResponseItem[];
+}) {
+  return createHash("sha256")
+    .update(
+      stableSerialize({
+        nonce: params.nonce,
+        protocol_version: params.protocolVersion,
+        responses: params.responses,
+      }),
+    )
+    .digest("hex");
+}
+
+/**
+ * Single-use key for one device attestation.
+ *
+ * Derived from values the caller cannot re-encode: the device public key comes
+ * from the attestation-service-signed JWT, and the signature digest is computed
+ * server-side. Keying on the raw `signature` bytes instead would be bypassable —
+ * signatures are verified with `lowS: false`, so an attacker can flip `s` to
+ * `n - s` (or re-encode the DER/CBOR wrapper) and present the same attestation
+ * under a different key.
+ */
+function integrityBundleUseKey(params: {
+  devicePublicKey: Uint8Array;
+  rpId: string;
+  signatureDigest: Uint8Array;
+}) {
+  const hasher = createHash("sha256");
+  addLengthPrefixedString(hasher, params.rpId);
+  hasher.update(u32be(params.devicePublicKey.length));
+  hasher.update(params.devicePublicKey);
+  hasher.update(params.signatureDigest);
+
+  return `integrity_bundle_use:v1:${hasher.digest("hex")}`;
+}
+
+/**
+ * Binds one verified attestation to one proof payload.
+ *
+ * The digest the device signs does not cover the proofs themselves, so a bundle
+ * that verifies for one set of responses also verifies for any other set under
+ * the same nonce. Claiming the bundle atomically caps that at a single payload:
+ * an identical retry (same responses, e.g. after a transient downstream error)
+ * still succeeds, while the same attestation carrying different proofs is
+ * rejected.
+ *
+ * Fails open when Redis is unavailable, matching `checkRateLimit`: this is
+ * defence in depth layered on top of signature verification, and hard-failing
+ * would take verification down on a single infra dependency.
+ */
+async function claimIntegrityBundleUse(params: {
+  fingerprint: string;
+  key: string;
+  rpId: string;
+}) {
+  const redis = global.RedisClient;
+
+  if (!redis) {
+    logger.warn("Integrity bundle single-use check skipped — Redis missing", {
+      rp_id: params.rpId,
+    });
+    return;
+  }
+
+  let claimed: "OK" | null;
+  try {
+    claimed = await redis.set(
+      params.key,
+      params.fingerprint,
+      "EX",
+      BUNDLE_SINGLE_USE_TTL_SECONDS,
+      "NX",
+    );
+  } catch (error) {
+    logger.warn("Integrity bundle single-use check failed — Redis error", {
+      error: error instanceof Error ? error.message : String(error),
+      rp_id: params.rpId,
+    });
+    return;
+  }
+
+  if (claimed === "OK") {
+    return;
+  }
+
+  let claimedFingerprint: string | null;
+  try {
+    claimedFingerprint = await redis.get(params.key);
+  } catch (error) {
+    logger.warn("Integrity bundle single-use lookup failed — Redis error", {
+      error: error instanceof Error ? error.message : String(error),
+      rp_id: params.rpId,
+    });
+    return;
+  }
+
+  // Expired between the SET and the GET: nothing left to compare against.
+  if (claimedFingerprint === null) {
+    return;
+  }
+
+  if (claimedFingerprint !== params.fingerprint) {
+    throw new IntegrityBundleError("integrity_bundle_already_used");
+  }
 }
 
 export function computeIntegritySignatureDigest(params: {
@@ -657,8 +803,11 @@ function verifyIOSSignature(params: {
 export async function verifyIntegrityBundle(
   params: IntegrityVerificationParams,
 ): Promise<IntegrityVerificationResult> {
+  let bundleVersion: number | undefined;
+
   try {
     const bundle = normalizeIntegrityBundle(params.integrityBundle);
+    bundleVersion = bundle.version;
     validateTimestamp(bundle.timestamp);
 
     const isSelfieCheckV4 =
@@ -702,6 +851,22 @@ export async function verifyIntegrityBundle(
       });
     }
 
+    // Only reached once the attestation itself is verified, so an attacker
+    // cannot burn a key for someone else's bundle.
+    await claimIntegrityBundleUse({
+      fingerprint: computeIntegrityPayloadFingerprint({
+        nonce: params.nonce,
+        protocolVersion: params.protocolVersion,
+        responses: params.responses,
+      }),
+      key: integrityBundleUseKey({
+        devicePublicKey,
+        rpId: params.rpId,
+        signatureDigest,
+      }),
+      rpId: params.rpId,
+    });
+
     return { success: true };
   } catch (error) {
     const reason =
@@ -713,6 +878,8 @@ export async function verifyIntegrityBundle(
       error: error instanceof Error ? error.message : String(error),
       environment: params.environment ?? DEFAULT_INTEGRITY_ENVIRONMENT,
       reason,
+      bundle_version: bundleVersion,
+      response_count: params.responses.length,
       protocol_version: params.protocolVersion,
       rp_id: params.rpId,
     });

--- a/web/tests/api/v4/integrity-bundle.test.ts
+++ b/web/tests/api/v4/integrity-bundle.test.ts
@@ -1,4 +1,5 @@
 import {
+  computeIntegrityPayloadFingerprint,
   computeIntegritySignatureDigest,
   computeProofIntegrityDigest,
   normalizeIntegrityBundle,
@@ -58,6 +59,33 @@ const selfieResponse = {
   issuer_schema_id: "11",
   sybil_score: 10,
 };
+
+// A second, unrelated proof under the same nonce — what a stolen bundle would
+// be paired with.
+const otherResponse = {
+  ...response,
+  nullifier: "0x99",
+  proof: ["0x9", "0x8", "0x7", "0x6", "0x5"] as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ],
+};
+
+/**
+ * Flips `s` to `n - s`. Signatures are verified with `lowS: false`, so the
+ * result still verifies while having different bytes — the reason the
+ * single-use key is derived from the device key and digest rather than from
+ * the client-supplied signature.
+ */
+function malleateAndroidSignature(signatureHex: string) {
+  const signature = p256.Signature.fromDER(signatureHex);
+  const flipped = new p256.Signature(signature.r, p256.CURVE.n - signature.s);
+
+  return Buffer.from(flipped.toDERRawBytes()).toString("hex");
+}
 
 function createAgKey(): AgKey {
   const { privateKey, publicKey } = generateKeyPairSync("ec", {
@@ -528,6 +556,200 @@ describe("integrity bundle verification", () => {
         error: expect.stringContaining('unexpected "aud" claim value'),
         reason: "invalid_integrity_token",
         rp_id: RP_ID,
+      }),
+    );
+  });
+
+  // The device signs a digest that does not cover the proofs, so the signature
+  // alone cannot tell the two payloads apart. Pinned so a future digest change
+  // that closes this (bundle version 3) shows up as a failure here.
+  it("still accepts a first use against responses the device never signed", async () => {
+    const { agPublicJwk, integrityBundle, nonce } = await createBundle({
+      signedResponses: [response],
+    });
+    jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ keys: [agPublicJwk] }), {
+        status: 200,
+      }),
+    );
+
+    const result = await verifyIntegrityBundle({
+      integrityBundle,
+      nonce,
+      protocolVersion: "4.0",
+      responses: [otherResponse],
+      rpId: RP_ID,
+    });
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it("allows an identical retry of the same bundle and responses", async () => {
+    const { agPublicJwk, integrityBundle, nonce } = await createBundle();
+    jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ keys: [agPublicJwk] }), {
+        status: 200,
+      }),
+    );
+
+    const firstResult = await verifyIntegrityBundle({
+      integrityBundle,
+      nonce,
+      protocolVersion: "4.0",
+      responses: [response],
+      rpId: RP_ID,
+    });
+    const retryResult = await verifyIntegrityBundle({
+      integrityBundle,
+      nonce,
+      protocolVersion: "4.0",
+      responses: [response],
+      rpId: RP_ID,
+    });
+
+    expect(firstResult).toEqual({ success: true });
+    expect(retryResult).toEqual({ success: true });
+  });
+
+  it("rejects a bundle reused for a different set of responses", async () => {
+    const { agPublicJwk, integrityBundle, nonce } = await createBundle();
+    jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ keys: [agPublicJwk] }), {
+        status: 200,
+      }),
+    );
+
+    const firstResult = await verifyIntegrityBundle({
+      integrityBundle,
+      nonce,
+      protocolVersion: "4.0",
+      responses: [response],
+      rpId: RP_ID,
+    });
+    const replayResult = await verifyIntegrityBundle({
+      integrityBundle,
+      nonce,
+      protocolVersion: "4.0",
+      responses: [otherResponse],
+      rpId: RP_ID,
+    });
+
+    expect(firstResult).toEqual({ success: true });
+    expect(replayResult).toEqual({
+      success: false,
+      reason: "integrity_bundle_already_used",
+    });
+  });
+
+  it("rejects a re-encoded signature reused for different responses", async () => {
+    const { agPublicJwk, integrityBundle, nonce } = await createBundle();
+    jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ keys: [agPublicJwk] }), {
+        status: 200,
+      }),
+    );
+
+    const firstResult = await verifyIntegrityBundle({
+      integrityBundle,
+      nonce,
+      protocolVersion: "4.0",
+      responses: [response],
+      rpId: RP_ID,
+    });
+
+    const malleatedSignature = malleateAndroidSignature(
+      integrityBundle.signature,
+    );
+    expect(malleatedSignature).not.toBe(integrityBundle.signature);
+
+    const replayResult = await verifyIntegrityBundle({
+      integrityBundle: { ...integrityBundle, signature: malleatedSignature },
+      nonce,
+      protocolVersion: "4.0",
+      responses: [otherResponse],
+      rpId: RP_ID,
+    });
+
+    expect(firstResult).toEqual({ success: true });
+    expect(replayResult).toEqual({
+      success: false,
+      reason: "integrity_bundle_already_used",
+    });
+  });
+
+  it("falls open on the single-use check when Redis is unavailable", async () => {
+    const { agPublicJwk, integrityBundle, nonce } = await createBundle();
+    // Without Redis there is no JWKS cache either, so every call refetches and
+    // needs its own unconsumed Response body.
+    jest.spyOn(global, "fetch").mockImplementation(async () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ keys: [agPublicJwk] }), {
+          status: 200,
+        }),
+      ),
+    );
+
+    const redis = global.RedisClient;
+    global.RedisClient = undefined;
+
+    try {
+      const firstResult = await verifyIntegrityBundle({
+        integrityBundle,
+        nonce,
+        protocolVersion: "4.0",
+        responses: [response],
+        rpId: RP_ID,
+      });
+      const replayResult = await verifyIntegrityBundle({
+        integrityBundle,
+        nonce,
+        protocolVersion: "4.0",
+        responses: [otherResponse],
+        rpId: RP_ID,
+      });
+
+      expect(firstResult).toEqual({ success: true });
+      expect(replayResult).toEqual({ success: true });
+    } finally {
+      global.RedisClient = redis;
+    }
+  });
+
+  it("fingerprints responses independently of object key order", () => {
+    const reordered = {
+      proof: response.proof,
+      expires_at_min: response.expires_at_min,
+      nullifier: response.nullifier,
+      issuer_schema_id: response.issuer_schema_id,
+      signal_hash: response.signal_hash,
+      identifier: response.identifier,
+    };
+
+    expect(
+      computeIntegrityPayloadFingerprint({
+        nonce: "0x01",
+        protocolVersion: "4.0",
+        responses: [reordered],
+      }),
+    ).toBe(
+      computeIntegrityPayloadFingerprint({
+        nonce: "0x01",
+        protocolVersion: "4.0",
+        responses: [response],
+      }),
+    );
+
+    expect(
+      computeIntegrityPayloadFingerprint({
+        nonce: "0x01",
+        protocolVersion: "4.0",
+        responses: [otherResponse],
+      }),
+    ).not.toBe(
+      computeIntegrityPayloadFingerprint({
+        nonce: "0x01",
+        protocolVersion: "4.0",
+        responses: [response],
       }),
     );
   });


### PR DESCRIPTION
Triage + partial fix for HackerOne #3963744.

## The report, verified against `main`

**The claim is correct.** The protocol 4.0 proof-integrity digest does not cover the proofs it is supposed to attest.

`computeProofIntegrityDigest` (`web/api/v4/verify/integrity-bundle.ts`):

- **Bundle version 1** — `sha256(PROOF_INTEGRITY_V4_DOMAIN || nonce_be32)`. The `responses` argument is accepted and entirely discarded.
- **Bundle version 2** (added by #2303) — additionally hashes `u32be(responses.length)` and, per response, a claims vector that today holds only the Self Check `sybil_score` (`issuer_schema_id === 11`).

Neither version binds `nullifier`, the five `proof` elements, `signal_hash`, `issuer_schema_id`, `expires_at_min`, `action`, or `session_id`. The V3 branch, by contrast, length-prefix-hashes every response proof.

So the device attestation says only *"an attested device saw nonce N at time T for rp_id X"* (plus, under v2, *"…for k responses with these sybil_scores"*). It is cryptographically unbound to the proof data verified immediately afterward in `handleUniquenessProofVerification` / `handleSessionProofVerification`.

### Impact

`nonce` is client-supplied and is a public input to the on-chain proof (`uniqueness-proof/verify-v4.ts`, `session-proof/verify-util.ts`), so proofs must be generated *for* that nonce — but any number of proofs, from any number of identities and unattested devices, can be generated under one attacker-chosen nonce. Combined with the fact that nothing marked a bundle as spent, a single attested-device bundle could launder unlimited separately-obtained proof sets for the 5-minute timestamp window.

### What #2303 changed about severity

The report's mitigating context ("the bundle is optional, its success result is discarded, no relying party can consume it") is **stale**. `web/api/v4/verify/index.ts` now hard-requires a version 2 bundle for any Self Check response and 403s otherwise, so the bundle is a live security gate, not an unused signal. Under v2 an attacker's substituted payload must match the signed response count and sybil_score — a small search space, not a barrier.

## What this PR fixes

Each verified attestation is bound to **one** proof payload. After signature verification, the bundle is claimed atomically in Redis (`SET … EX … NX`) against a fingerprint of `(nonce, protocol_version, responses)`:

- first use → claim succeeds, verification proceeds;
- identical retry (same responses, e.g. after a transient downstream failure) → stored fingerprint matches, still succeeds;
- same attestation carrying **different** responses → rejected as `integrity_bundle_already_used`.

This caps the report's stated realistic amplification at 1 proof set per attested-device signature, without touching the signed digest.

Two details worth review attention:

- **The key is not the signature.** It is `sha256(rp_id ‖ device_public_key ‖ signature_digest)` — the device key comes from the attestation-service-signed JWT and the digest is computed server-side, both outside caller control. Keying on the client-supplied `signature` hex would be bypassable: signatures are verified with `lowS: false`, so flipping `s` to `n − s` yields different bytes that still verify. There is a regression test for exactly this.
- **The claim happens after signature verification**, so an attacker cannot burn a key for somebody else's bundle.

TTL is `2 × SIGNATURE_TIMESTAMP_THRESHOLD_SECONDS` (10 min), which outlives the window in which a bundle timestamp is still accepted, so a bundle can never outlive its single-use record.

Also adds `bundle_version` and `response_count` to the failure log — previously there was no way to tell from telemetry which bundle version was rejected.

## What this PR does NOT fix, and why

**The digest still does not commit to the proof data.** That is the root cause, and it cannot be fixed in this repo alone.

The digest is a shared protocol: the World App produces the P-256 attestation over it, the portal verifies it. Changing what the portal hashes would reject every bundle produced by every deployed World App build. That is a flag day, not a deploy.

The real fix is a **bundle version 3** whose 4.0 branch commits to each response, mirroring the V3 branch's length-prefixed construction — something like:

```
sha256(
  "worldcoin/proof-integrity/v4"
  || nonce_be32
  || u32be(responses.length)
  || for each response:
       u32be(len) || identifier
       u32be(len) || signal_hash
       u32be(len) || issuer_schema_id
       u32be(len) || nullifier            (or both session_nullifier elements)
       u32be(len) || expires_at_min
       u32be(len) || credential_genesis_issued_at_min
       u32be(5)   || each proof element, length-prefixed
       u32be(claims.length) || claims...   (existing v2 claims vector)
  || u32be(len) || action                  (or session_id)
)
```

The World App would have to sign that digest and emit `version: 3`; the portal would then widen `INTEGRITY_BUNDLE_VERSIONS` and the `oneOf([1, 2])` in `request-schema.ts` and add the branch. **I deliberately did not add a speculative v3 branch here** — accepting a `version: 3` bundle no client can produce is untestable dead code, and the exact field set and encoding have to be agreed with the World App team, not guessed. Tracking that cross-repo work is the follow-up.

Related: surfacing the attestation outcome in the API response is a public-API/product decision rather than a security fix, so it is also out of scope here. The outcome is now at least a hard gate for Self Check (#2303) and legible in failure telemetry.

## Rollout / compatibility

- **No change to the signed digest** → every currently deployed World App build keeps verifying. This is deliberately backward compatible.
- **No request or response schema change.** The only new outcome is a 403 `integrity_verification_failed` on a bundle reused for a *different* payload — which no honest client does, since World App mints a bundle per verification.
- **Retries stay safe.** The fingerprint comparison means an RP retrying the identical request after a 5xx is explicitly allowed; only payload substitution is blocked. This was the main availability risk considered, and it is why the lock is fingerprint-keyed rather than a plain replay lock.
- **Fails open on Redis unavailability**, matching the existing `checkRateLimit` precedent, with a warn log. Hard-failing would take Self Check verification down globally on a single infra dependency, for a control that is defence in depth layered on top of signature verification.
- **Added load** is one `SET NX` (plus a `GET` only on collision) per request that carries an integrity bundle, against the Redis instance already used for the JWKS cache on the same path. Negligible.
- **Rollback** is a plain revert; the only persisted state is short-TTL keys under `integrity_bundle_use:v1:` that expire on their own within 10 minutes.

## Tests

`web/tests/api/v4/integrity-bundle.test.ts`, both sides of the new guard:

- identical retry of the same bundle and responses → allowed
- bundle reused for a different response set → `integrity_bundle_already_used`
- **re-encoded (`s` → `n − s`) signature** reused for different responses → still rejected, proving the key is not signature-derived
- Redis unavailable → falls open
- fingerprint is stable across object key order, and distinguishes different responses
- a first use against responses the device never signed still succeeds — pinning the *unfixed* digest gap so a future v3 shows up here as a failure

Verification run on this branch:

- `npx tsc --noEmit` — clean
- `npx jest tests/api/v4` — 8 suites, 73 tests passed
- `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
