### PR TITLE
fix: enable face check for all apps in precheck

### DIFF
--- a/web/api/v1/precheck/[app_id]/index.ts
+++ b/web/api/v1/precheck/[app_id]/index.ts
@@ -18,7 +18,6 @@ import { getSdk as getAppPrecheckByActionSdk } from "./graphql/app-precheck-by-a
 import { getSdk as getAppPrecheckSdk } from "./graphql/app-precheck.generated";
 import { getSdk as getFetchRpRegistrationForPrecheckSdk } from "./graphql/fetch-rp-registration-for-precheck.generated";
 
-const FACE_CHECK_ENABLED_APPS_PARAMETER = "whitelisted-apps/face-check";
 // Whitelist some partner demo apps, that are not verified but we want to show their logos
 const APPS_TO_SHOW_UNVERIFIED_LOGO = [
   "app_staging_c8137371ceac59890774ccc932e11dcf",
@@ -95,12 +94,6 @@ export async function POST(
   const useCustomExternalNullifier =
     APPS_WITH_CUSTOM_EXTERNAL_NULLIFIER.includes(app_id) && action !== "";
 
-  const faceCheckEnabledAppsPromise =
-    global.ParameterStore?.getParameter<string[]>(
-      FACE_CHECK_ENABLED_APPS_PARAMETER,
-      [],
-    ) ?? Promise.resolve([] as string[]);
-
   const client = await getAPIServiceGraphqlClient();
 
   // ANCHOR: Fetch app from Hasura
@@ -148,8 +141,6 @@ export async function POST(
 
   const unverified_app_metadata = rawAppValues.app_metadata[0];
   const verified_app_metadata = rawAppValues.verified_app_metadata[0];
-  const faceCheckEnabledApps = await faceCheckEnabledAppsPromise;
-  const enableFaceCheck = faceCheckEnabledApps?.includes(app_id) ?? false;
   // If an image is present it should store it's relative path and extension ie logo.png
   let logo_img_url = verified_app_metadata?.logo_img_url
     ? getCDNImageUrl(rawAppValues.id, verified_app_metadata?.logo_img_url)
@@ -184,7 +175,7 @@ export async function POST(
       verified_app_metadata?.integration_url ??
       unverified_app_metadata?.integration_url ??
       "",
-    enable_face_check: enableFaceCheck,
+    enable_face_check: true,
     actions: rawAppValues.actions,
   };
 

--- a/web/tests/api/v1/precheck.test.ts
+++ b/web/tests/api/v1/precheck.test.ts
@@ -100,7 +100,7 @@ describe("/api/v1/precheck/[app_id]", () => {
       engine: "cloud",
       verified_app_logo:
         "https://cdn.test.com/app_staging_6d1c9fb86751a40d952749022db1c1/logo_img.png",
-      enable_face_check: false,
+      enable_face_check: true,
       sign_in_with_world_id: false,
       can_user_verify: "undetermined", // Because no `nullifier_hash` was provided
       action: {
@@ -111,10 +111,7 @@ describe("/api/v1/precheck/[app_id]", () => {
         max_accounts_per_user: 1,
       },
     });
-    expect(getParameter).toHaveBeenCalledWith(
-      "whitelisted-apps/face-check",
-      [],
-    );
+    expect(getParameter).not.toHaveBeenCalled();
   });
 
   test("can fetch precheck response unverified", async () => {
@@ -145,7 +142,7 @@ describe("/api/v1/precheck/[app_id]", () => {
       is_staging: true,
       engine: "cloud",
       verified_app_logo: "",
-      enable_face_check: false,
+      enable_face_check: true,
       sign_in_with_world_id: false,
       can_user_verify: "undetermined", // Because no `nullifier_hash` was provided
       action: {
@@ -160,43 +157,6 @@ describe("/api/v1/precheck/[app_id]", () => {
 
   test("creates action on the fly when it does not exist", async () => {
     // TODO
-  });
-
-  test("can fetch precheck response with face check enabled", async () => {
-    const getParameter = jest
-      .fn()
-      .mockResolvedValue(["app_staging_6d1c9fb86751a40d952749022db1c1"]);
-    global.ParameterStore = {
-      getParameter,
-    } as unknown as NonNullable<typeof global.ParameterStore>;
-
-    const request = new NextRequest(
-      "http://localhost:3000/api/v1/precheck/app_staging_6d1c9fb86751a40d952749022db1c1",
-      {
-        method: "POST",
-        body: JSON.stringify(exampleValidRequestPayload),
-      },
-    );
-
-    AppPrecheckQuery.mockResolvedValue({
-      app: [{ ...appPayload }],
-    });
-
-    const response = await POST(request, {
-      params: Promise.resolve({
-        app_id: "app_staging_6d1c9fb86751a40d952749022db1c1",
-      }),
-    });
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
-      id: "app_staging_6d1c9fb86751a40d952749022db1c1",
-      enable_face_check: true,
-    });
-    expect(getParameter).toHaveBeenCalledWith(
-      "whitelisted-apps/face-check",
-      [],
-    );
   });
 
   test("can fetch precheck response with nullifier", async () => {


### PR DESCRIPTION
This PR enables face check for every app returned by `/precheck`.

- Return `enable_face_check: true` and remove the Parameter Store allowlist lookup.
- Update existing tests to cover enabled responses without allowlisting.
- Validation: precheck Jest suite (14 tests), TypeScript check, and formatting check pass.
