### PR TITLE
fix(portal): reset API key edits and trim key names

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeyTable/ViewDetailsModal/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/ApiKeyTable/ViewDetailsModal/index.tsx
@@ -22,7 +22,7 @@ import { UpdateKeyDocument } from "@/scenes/common/Teams/TeamId/Team/ApiKeys/pag
 const schema = yup
   .object()
   .shape({
-    name: yup.string().required("A key name is required"),
+    name: yup.string().trim().required("A key name is required"),
     isActive: yup.boolean().default(true),
   })
   .noUnknown();
@@ -59,13 +59,15 @@ export const ViewDetailsModal = memo(function ViewDetailsModal(
     },
   });
 
-  // Add use effect here so default values update when the props change
+  // Start each edit session with saved values, discarding any canceled edits.
   useEffect(() => {
+    if (!isOpen) return;
+
     reset({
       name: name,
       isActive: isActive,
     });
-  }, [name, isActive, reset]);
+  }, [isOpen, keyId, name, isActive, reset]);
 
   const submit = async (values: ViewDetailsFormValues) => {
     if (updatingKey || !keyId) return;

--- a/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/CreateKeyModal/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Team/sections/ApiKeys/CreateKeyModal/index.tsx
@@ -22,7 +22,7 @@ import { InsertKeyDocument } from "@/scenes/common/Teams/TeamId/Team/ApiKeys/pag
 const schema = yup
   .object()
   .shape({
-    name: yup.string().required("A key name is required"),
+    name: yup.string().trim().required("A key name is required"),
   })
   .noUnknown();
 


### PR DESCRIPTION
Reset the API-key edit form on reopening so canceled name and activation changes are discarded. Trim names on create and edit, rejecting whitespace-only names.

Validation: formatting and TypeScript checks passed.
