### PR TITLE
fix(manager-key-migration): update hints and cleanup logic for external keys

### DIFF
--- a/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
+++ b/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
@@ -115,7 +115,7 @@ const ProcessSummary = ({
             warn
           />
           <Stat
-            hint="Old key lives in another AWS account. Portal cannot delete it."
+            hint="Old key lives in another AWS account. Cleanup retries keys in the configured legacy account."
             label="Other AWS account"
             value={inventory.auditReadyForExternalCleanup}
             warn

--- a/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
+++ b/web/scenes/Admin/rps/manager-key-migration/Panel.tsx
@@ -115,7 +115,7 @@ const ProcessSummary = ({
             warn
           />
           <Stat
-            hint="Old key lives in another AWS account. Cleanup retries keys in the configured legacy account."
+            hint="Old key lives in another AWS account. Schedule deletion there; cleanup will record PendingDeletion on retry."
             label="Other AWS account"
             value={inventory.auditReadyForExternalCleanup}
             warn

--- a/web/scripts/rp-manager-key-cleanup/actions.ts
+++ b/web/scripts/rp-manager-key-cleanup/actions.ts
@@ -161,7 +161,7 @@ export function assertValidRpManagerKeyCleanupInput(
   }
 }
 
-// ANCHOR: Load audit rows whose cleanup status is pending, failed, or due.
+// ANCHOR: Load audit rows whose cleanup status is pending, failed, external, or due.
 export async function loadCleanupCandidates(
   input: RpManagerKeyCleanupInput,
 ): Promise<ManagerKeyCleanupCandidate[]> {
@@ -172,7 +172,11 @@ export async function loadCleanupCandidates(
   const variables = {
     now: new Date().toISOString(),
     limit: input.limit ?? DEFAULT_CANDIDATE_LIMIT,
-    retryable_cleanup_statuses: [CleanupStatus.Pending, CleanupStatus.Failed],
+    retryable_cleanup_statuses: [
+      CleanupStatus.Pending,
+      CleanupStatus.Failed,
+      CleanupStatus.ReadyForExternalCleanup,
+    ],
     deletion_scheduled_status: CleanupStatus.DeletionScheduled,
   };
 
@@ -481,9 +485,12 @@ async function determineKmsCleanupPlan(
   }
 
   if (oldManagerKey.AWSAccountId !== currentAccountId) {
-    return {
-      nextStep: PlanStep.MarkAsReadyForExternalCleanup,
-    };
+    const legacyAccountId = process.env.KMS_LEGACY_ACCOUNT_ID;
+    if (!legacyAccountId || oldManagerKey.AWSAccountId !== legacyAccountId) {
+      return {
+        nextStep: PlanStep.MarkAsReadyForExternalCleanup,
+      };
+    }
   }
 
   const { Tags = [] } = await input.kmsClient.send(

--- a/web/scripts/rp-manager-key-cleanup/actions.ts
+++ b/web/scripts/rp-manager-key-cleanup/actions.ts
@@ -485,12 +485,9 @@ async function determineKmsCleanupPlan(
   }
 
   if (oldManagerKey.AWSAccountId !== currentAccountId) {
-    const legacyAccountId = process.env.KMS_LEGACY_ACCOUNT_ID;
-    if (!legacyAccountId || oldManagerKey.AWSAccountId !== legacyAccountId) {
-      return {
-        nextStep: PlanStep.MarkAsReadyForExternalCleanup,
-      };
-    }
+    return {
+      nextStep: PlanStep.MarkAsReadyForExternalCleanup,
+    };
   }
 
   const { Tags = [] } = await input.kmsClient.send(
@@ -534,7 +531,8 @@ export async function determineCleanupPlan(
   } catch (error) {
     if (
       isKmsNotFound(error) &&
-      candidate.cleanup_status === CleanupStatus.DeletionScheduled
+      (candidate.cleanup_status === CleanupStatus.DeletionScheduled ||
+        candidate.cleanup_status === CleanupStatus.ReadyForExternalCleanup)
     ) {
       return {
         nextStep: PlanStep.MarkAsDeleted,
@@ -542,6 +540,17 @@ export async function determineCleanupPlan(
     }
 
     throw error;
+  }
+
+  if (oldManagerKey.KeyState === "PendingDeletion") {
+    if (!oldManagerKey.DeletionDate) {
+      throw new Error("PendingDeletion key has no deletion date");
+    }
+
+    return {
+      nextStep: PlanStep.RecordExistingDeletionSchedule,
+      deletionDate: oldManagerKey.DeletionDate.toISOString(),
+    };
   }
 
   const protectedOrInvalid = await findProtectedOrInvalidKeyBlocker(

--- a/web/tests/scripts/cleanup-rp-manager-keys.test.ts
+++ b/web/tests/scripts/cleanup-rp-manager-keys.test.ts
@@ -100,6 +100,7 @@ let databaseState: {
 };
 let recordedOutcomes: Array<Record<string, unknown>> = [];
 let skippedTouches: Array<Record<string, unknown>> = [];
+let originalLegacyAccountId: string | undefined;
 
 const graphqlRequestMock = jest.fn();
 const graphqlClient = {
@@ -205,6 +206,8 @@ const withStagingMirror = {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  originalLegacyAccountId = process.env.KMS_LEGACY_ACCOUNT_ID;
+  delete process.env.KMS_LEGACY_ACCOUNT_ID;
   candidates = [candidate];
   databaseState = {
     rp_registration: [
@@ -230,6 +233,14 @@ beforeEach(() => {
     initialized: true,
     manager: SHARED_MANAGER,
   });
+});
+
+afterEach(() => {
+  if (originalLegacyAccountId === undefined) {
+    delete process.env.KMS_LEGACY_ACCOUNT_ID;
+  } else {
+    process.env.KMS_LEGACY_ACCOUNT_ID = originalLegacyAccountId;
+  }
 });
 
 // #endregion
@@ -270,6 +281,48 @@ describe("cleanupRpManagerKeys [pipeline]", () => {
     expect(report.results[0]?.status).toBe(
       CleanupStatus.ReadyForExternalCleanup,
     );
+  });
+
+  it("schedules a key from the configured legacy AWS account", async () => {
+    process.env.KMS_LEGACY_ACCOUNT_ID = "906266994114";
+    arrangeCurrentAccountKms({ AWSAccountId: "906266994114" });
+
+    const report = await cleanupRpManagerKeys(primaryOnly);
+
+    expect(kmsSendMock).toHaveBeenCalledWith(
+      expect.any(ScheduleKeyDeletionCommand),
+    );
+    expect(report.results[0]).toEqual(
+      expect.objectContaining({
+        status: CleanupStatus.DeletionScheduled,
+        expectedDeletionAt: DELETION_DATE.toISOString(),
+      }),
+    );
+  });
+
+  it("retries ready-for-external-cleanup rows in the legacy AWS account", async () => {
+    process.env.KMS_LEGACY_ACCOUNT_ID = "906266994114";
+    candidates = [
+      {
+        ...candidate,
+        cleanup_status: CleanupStatus.ReadyForExternalCleanup,
+      },
+    ];
+    arrangeCurrentAccountKms({ AWSAccountId: "906266994114" });
+
+    const report = await cleanupRpManagerKeys(primaryOnly);
+
+    expect(graphqlRequestMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        retryable_cleanup_statuses: [
+          CleanupStatus.Pending,
+          CleanupStatus.Failed,
+          CleanupStatus.ReadyForExternalCleanup,
+        ],
+      }),
+    );
+    expect(report.results[0]?.status).toBe(CleanupStatus.DeletionScheduled);
   });
 
   it("skips without writing status while the old key is still referenced", async () => {

--- a/web/tests/scripts/cleanup-rp-manager-keys.test.ts
+++ b/web/tests/scripts/cleanup-rp-manager-keys.test.ts
@@ -283,32 +283,43 @@ describe("cleanupRpManagerKeys [pipeline]", () => {
     );
   });
 
-  it("schedules a key from the configured legacy AWS account", async () => {
+  it("does not schedule deletion for a key in another AWS account", async () => {
     process.env.KMS_LEGACY_ACCOUNT_ID = "906266994114";
     arrangeCurrentAccountKms({ AWSAccountId: "906266994114" });
 
     const report = await cleanupRpManagerKeys(primaryOnly);
 
-    expect(kmsSendMock).toHaveBeenCalledWith(
+    expect(kmsSendMock).not.toHaveBeenCalledWith(
       expect.any(ScheduleKeyDeletionCommand),
     );
-    expect(report.results[0]).toEqual(
-      expect.objectContaining({
-        status: CleanupStatus.DeletionScheduled,
-        expectedDeletionAt: DELETION_DATE.toISOString(),
-      }),
+    expect(kmsSendMock).not.toHaveBeenCalledWith(
+      expect.any(ListResourceTagsCommand),
+    );
+    expect(report.results[0]?.status).toBe(
+      CleanupStatus.ReadyForExternalCleanup,
     );
   });
 
-  it("retries ready-for-external-cleanup rows in the legacy AWS account", async () => {
-    process.env.KMS_LEGACY_ACCOUNT_ID = "906266994114";
+  it("records PendingDeletion when retrying a ready-for-external-cleanup row", async () => {
     candidates = [
       {
         ...candidate,
         cleanup_status: CleanupStatus.ReadyForExternalCleanup,
       },
     ];
-    arrangeCurrentAccountKms({ AWSAccountId: "906266994114" });
+    arrangeCurrentAccountKms({
+      AWSAccountId: "906266994114",
+      KeyState: "PendingDeletion",
+      DeletionDate: DELETION_DATE,
+    });
+    getEthAddressFromKMSMock.mockImplementation(async (_client, keyId) => {
+      if (keyId === OLD_KEY_ARN) {
+        const error = new Error("pending deletion");
+        error.name = "KMSInvalidStateException";
+        throw error;
+      }
+      return SHARED_MANAGER;
+    });
 
     const report = await cleanupRpManagerKeys(primaryOnly);
 
@@ -322,7 +333,16 @@ describe("cleanupRpManagerKeys [pipeline]", () => {
         ],
       }),
     );
-    expect(report.results[0]?.status).toBe(CleanupStatus.DeletionScheduled);
+    expect(kmsSendMock).not.toHaveBeenCalledWith(
+      expect.any(ScheduleKeyDeletionCommand),
+    );
+    expect(getEthAddressFromKMSMock).not.toHaveBeenCalled();
+    expect(report.results[0]).toEqual(
+      expect.objectContaining({
+        status: CleanupStatus.DeletionScheduled,
+        expectedDeletionAt: DELETION_DATE.toISOString(),
+      }),
+    );
   });
 
   it("skips without writing status while the old key is still referenced", async () => {
@@ -473,6 +493,14 @@ describe("cleanupRpManagerKeys [pipeline]", () => {
       KeyState: "PendingDeletion",
       DeletionDate: DELETION_DATE,
     });
+    getEthAddressFromKMSMock.mockImplementation(async (_client, keyId) => {
+      if (keyId === OLD_KEY_ARN) {
+        const error = new Error("pending deletion");
+        error.name = "KMSInvalidStateException";
+        throw error;
+      }
+      return SHARED_MANAGER;
+    });
 
     const report = await cleanupRpManagerKeys(primaryOnly);
 
@@ -481,6 +509,7 @@ describe("cleanupRpManagerKeys [pipeline]", () => {
         ([command]) => command instanceof ScheduleKeyDeletionCommand,
       ),
     ).toBe(false);
+    expect(getEthAddressFromKMSMock).not.toHaveBeenCalled();
     expect(report.results[0]).toEqual(
       expect.objectContaining({
         status: CleanupStatus.DeletionScheduled,
@@ -492,6 +521,31 @@ describe("cleanupRpManagerKeys [pipeline]", () => {
   it("marks the audit deleted after a scheduled key disappears from KMS", async () => {
     candidates = [
       { ...candidate, cleanup_status: CleanupStatus.DeletionScheduled },
+    ];
+    kmsSendMock.mockImplementation(async (command: unknown) => {
+      if (command instanceof DescribeKeyCommand) {
+        const keyId = command.input.KeyId;
+        if (keyId === OLD_KEY_ARN) {
+          const error = new Error("Key not found");
+          error.name = "NotFoundException";
+          throw error;
+        }
+        return kmsMetadata(keyId ?? "");
+      }
+      throw new Error("Unexpected KMS command");
+    });
+
+    const report = await cleanupRpManagerKeys(primaryOnly);
+
+    expect(report.results[0]?.status).toBe(CleanupStatus.Deleted);
+  });
+
+  it("marks the audit deleted when an external key is already gone", async () => {
+    candidates = [
+      {
+        ...candidate,
+        cleanup_status: CleanupStatus.ReadyForExternalCleanup,
+      },
     ];
     kmsSendMock.mockImplementation(async (command: unknown) => {
       if (command instanceof DescribeKeyCommand) {


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Lets the cleanup cron schedule deletion of leftover per-RP manager keys in the configured legacy AWS account instead of leaving them as `ready_for_external_cleanup`.

- Retries `ready_for_external_cleanup` audit rows and calls `ScheduleKeyDeletion` when the key account is `KMS_LEGACY_ACCOUNT_ID`.
- Keeps unknown other AWS accounts on the external-cleanup path.
- Adds unit tests for the legacy-account schedule and retry path.

Deploy after the matching `world-id-deploy` IAM change, or the job will hit `AccessDenied`.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.