### PR TITLE
fix: allow worldidstg deepface deeplinks

### DIFF
--- a/web/api/v2/minikit/send-notification/schema.ts
+++ b/web/api/v2/minikit/send-notification/schema.ts
@@ -32,6 +32,7 @@ const isValidDeepFaceUniversalLink = (value: string): boolean => {
 const DEEP_FACE_DEEPLINK_PREFIXES = [
   "worldapp://verify?",
   "worldid://verify?",
+  "worldidstg://verify?",
 ] as const;
 
 const isValidDeepFaceDeepLink = (value: string): boolean => {
@@ -64,7 +65,7 @@ const isValidMiniAppDeepLink = (
 };
 
 const MINI_APP_PATH_ERROR_MESSAGE =
-  "mini_app_path must be a valid WorldApp or World ID deeplink (worldapp://mini-app?app_id= or worldid://mini-app?app_id=), a Deep Face Universal Link (https://world.org/verify?t=deepface), or a Deep Face deeplink (worldapp://verify?t=deepface or worldid://verify?t=deepface)";
+  "mini_app_path must be a valid WorldApp or World ID deeplink (worldapp://mini-app?app_id= or worldid://mini-app?app_id=), a Deep Face Universal Link (https://world.org/verify?t=deepface), or a Deep Face deeplink (worldapp://verify?t=deepface, worldid://verify?t=deepface, or worldidstg://verify?t=deepface)";
 
 export const sendNotificationBodySchemaV1 = yup
   .object({


### PR DESCRIPTION
This PR fixes validation errors for staging DeepFace notification deeplinks.

- Allow `worldidstg://verify?t=deepface` in V1 and V2 notification schemas.
- Include the staging scheme in the validation error message.
- Validation: 53 relevant tests, type checking, formatting, and direct schema checks passed.
