### PR TITLE
fix(verify): bind the face nullifier into the integrity v2 digest

### DIFF
--- a/web/api/v4/verify/integrity-bundle.ts
+++ b/web/api/v4/verify/integrity-bundle.ts
@@ -236,7 +236,14 @@ function claimsForResponse(
     throw new IntegrityBundleError("missing_sybil_score");
   }
 
-  return [encodeClaim(response.sybil_score)];
+  // Bind the identity behind the proof so the signature cannot be reused with
+  // a different proof for the same nonce. Must match the apps' integrityClaims().
+  const nullifier =
+    "nullifier" in response
+      ? response.nullifier
+      : response.session_nullifier[0];
+
+  return [parseNonceToFieldBytes(nullifier), encodeClaim(response.sybil_score)];
 }
 
 export function computeProofIntegrityDigest(params: {

--- a/web/tests/api/v4/integrity-bundle.test.ts
+++ b/web/tests/api/v4/integrity-bundle.test.ts
@@ -268,6 +268,31 @@ describe("integrity bundle verification", () => {
     });
   });
 
+  it("rejects a swapped nullifier in a version 2 bundle", async () => {
+    const { agPublicJwk, integrityBundle, nonce } = await createBundle({
+      version: 2,
+      signedResponses: [selfieResponse],
+    });
+    jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ keys: [agPublicJwk] }), {
+        status: 200,
+      }),
+    );
+
+    const result = await verifyIntegrityBundle({
+      integrityBundle,
+      nonce,
+      protocolVersion: "4.0",
+      responses: [{ ...selfieResponse, nullifier: "0x3" }],
+      rpId: RP_ID,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      reason: "invalid_device_signature",
+    });
+  });
+
   it("verifies an android integrity bundle and caches the AG JWK", async () => {
     const { agPublicJwk, integrityBundle, nonce } = await createBundle();
     const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(

--- a/web/tests/api/v4/integrity-bundle.test.ts
+++ b/web/tests/api/v4/integrity-bundle.test.ts
@@ -59,6 +59,16 @@ const selfieResponse = {
   sybil_score: 10,
 };
 
+const selfieSessionResponse = {
+  identifier: "selfie",
+  signal_hash: "0x0",
+  issuer_schema_id: "11",
+  session_nullifier: ["0x2", "0x7"] as [string, string],
+  expires_at_min: "1772584197",
+  proof: response.proof,
+  sybil_score: 10,
+};
+
 function createAgKey(): AgKey {
   const { privateKey, publicKey } = generateKeyPairSync("ec", {
     namedCurve: "P-256",
@@ -122,7 +132,10 @@ async function createBundle(params?: {
   signatureFormat?: "android_keystore" | "apple_app_attest";
   timestamp?: number;
   version?: 1 | 2;
-  signedResponses?: (typeof response)[] | (typeof selfieResponse)[];
+  signedResponses?:
+    | (typeof response)[]
+    | (typeof selfieResponse)[]
+    | (typeof selfieSessionResponse)[];
 }) {
   const agKey = params?.agKey ?? createAgKey();
   const deviceKey = createDeviceKey();
@@ -291,6 +304,46 @@ describe("integrity bundle verification", () => {
       success: false,
       reason: "invalid_device_signature",
     });
+  });
+
+  it("binds session_nullifier[0] for Self Check session proofs in a version 2 bundle", async () => {
+    const { agPublicJwk, integrityBundle, nonce } = await createBundle({
+      version: 2,
+      signedResponses: [selfieSessionResponse],
+    });
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementation(
+        async () =>
+          new Response(JSON.stringify({ keys: [agPublicJwk] }), {
+            status: 200,
+          }),
+      );
+
+    await expect(
+      verifyIntegrityBundle({
+        integrityBundle,
+        nonce,
+        protocolVersion: "4.0",
+        responses: [selfieSessionResponse],
+        rpId: RP_ID,
+      }),
+    ).resolves.toEqual({ success: true });
+
+    await expect(
+      verifyIntegrityBundle({
+        integrityBundle,
+        nonce,
+        protocolVersion: "4.0",
+        responses: [
+          {
+            ...selfieSessionResponse,
+            session_nullifier: ["0x3", "0x7"] as [string, string],
+          },
+        ],
+        rpId: RP_ID,
+      }),
+    ).resolves.toEqual({ success: false, reason: "invalid_device_signature" });
   });
 
   it("verifies an android integrity bundle and caches the AG JWK", async () => {

--- a/web/tests/api/v4/integrity-bundle.test.ts
+++ b/web/tests/api/v4/integrity-bundle.test.ts
@@ -311,14 +311,12 @@ describe("integrity bundle verification", () => {
       version: 2,
       signedResponses: [selfieSessionResponse],
     });
-    jest
-      .spyOn(global, "fetch")
-      .mockImplementation(
-        async () =>
-          new Response(JSON.stringify({ keys: [agPublicJwk] }), {
-            status: 200,
-          }),
-      );
+    jest.spyOn(global, "fetch").mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ keys: [agPublicJwk] }), {
+          status: 200,
+        }),
+    );
 
     await expect(
       verifyIntegrityBundle({


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

The v2 integrity digest covers the nonce, the response count and `sybil_score`, but not the proof. A genuine device signature therefore verifies against a different identity's proof built for the same nonce, so one attested device can vouch for proofs it did not make.

`claimsForResponse` now hashes the face item's nullifier ahead of `sybil_score` (uniqueness `nullifier`, or `session_nullifier[0]` for session proofs). Digest only, the request schema is unchanged.

Must ship with the World App counterpart worldcoin/world-app-ios#7980, which applies the same rule in `integrityClaims()`. v2 is still behind the app feature flag, so nothing changes for live traffic until it flips.

Linear: [SEC-2973](https://linear.app/worldcoin/issue/SEC-2973/bind-the-face-nullifier-into-the-integrity-bundle-v2-digest)

## Checklist

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.