### PR TITLE
feat(analytics): track daily and totals view selections

### DIFF
--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MetricsFrame/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MetricsFrame/index.tsx
@@ -15,7 +15,9 @@ import {
 } from "@/lib/selfie-check-analytics";
 import { AnalyticsAppEligibility } from "@/scenes/PortalV3/layout/Shell/SidebarNav";
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@headlessui/react";
-import { useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import posthog from "posthog-js";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   DailyMetricChart,
   type DailyMetricChartType,
@@ -38,6 +40,7 @@ const TIMEFRAME_OPTIONS = [
 }[];
 
 type TimeframeValue = (typeof TIMEFRAME_OPTIONS)[number]["value"];
+type AnalyticsView = "totals" | "daily";
 
 /** Daily metrics displayed in the same order as the analytics contract. */
 const CHART_METRICS = [
@@ -126,6 +129,44 @@ export const MetricsFrame = (props: {
   const [totals, setTotals] = useState<TotalsState>({ kind: "loading" });
   const [timeframe, setTimeframe] = useState<TimeframeValue>("14");
   const [osName, setOsName] = useState(ALL_OPERATING_SYSTEMS);
+  const teamId = useParams<{ teamId?: string }>()?.teamId;
+  const selectedView = useRef<AnalyticsView>("totals");
+  const lastPageEntry = useRef<string | null>(null);
+
+  const captureView = useCallback(
+    (view: AnalyticsView, source: "page_entry" | "tab_switch") => {
+      try {
+        if (
+          !teamId ||
+          process.env.NEXT_PUBLIC_POSTHOG_DISABLED === "true" ||
+          posthog.has_opted_out_capturing()
+        )
+          return;
+        posthog.capture("selfie_check_analytics_view_selected", {
+          appId: props.appId,
+          teamId,
+          view,
+          source,
+        });
+      } catch (error) {
+        // Telemetry must never prevent entry or tab navigation.
+        console.warn("Failed to capture analytics view selection", {
+          dependency: "posthog",
+          failureClass: error instanceof Error ? error.name : "UnknownError",
+        });
+      }
+    },
+    [props.appId, teamId],
+  );
+
+  useEffect(() => {
+    if (!teamId) return;
+    const entry = `${teamId}:${props.appId}`;
+    if (lastPageEntry.current === entry) return;
+    // Preserve the guard through Strict Mode effect replay, not real remounts.
+    lastPageEntry.current = entry;
+    captureView(selectedView.current, "page_entry");
+  }, [props.appId, teamId, captureView]);
 
   const operatingSystems = useMemo(
     () =>
@@ -301,7 +342,14 @@ export const MetricsFrame = (props: {
             </p>
           )}
         </div>
-        <TabGroup>
+        <TabGroup
+          onChange={(index) => {
+            const view = index === 0 ? "totals" : "daily";
+            if (selectedView.current === view) return;
+            selectedView.current = view;
+            captureView(view, "tab_switch");
+          }}
+        >
           <TabList
             aria-label="Analytics views"
             className="flex gap-6 border-b border-portal-border"

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MetricsFrame/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MetricsFrame/index.tsx
@@ -14,6 +14,7 @@ import {
   type TotalsRow,
 } from "@/lib/selfie-check-analytics";
 import { AnalyticsAppEligibility } from "@/scenes/PortalV3/layout/Shell/SidebarNav";
+import { useUser } from "@auth0/nextjs-auth0/client";
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@headlessui/react";
 import { useParams } from "next/navigation";
 import posthog from "posthog-js";
@@ -130,6 +131,8 @@ export const MetricsFrame = (props: {
   const [timeframe, setTimeframe] = useState<TimeframeValue>("14");
   const [osName, setOsName] = useState(ALL_OPERATING_SYSTEMS);
   const teamId = useParams<{ teamId?: string }>()?.teamId;
+  const { user, isLoading } = useUser();
+  const allowTracking = user?.hasura?.is_allow_tracking === true;
   const selectedView = useRef<AnalyticsView>("totals");
   const lastPageEntry = useRef<string | null>(null);
 
@@ -145,6 +148,7 @@ export const MetricsFrame = (props: {
           );
         }
         if (
+          !allowTracking ||
           process.env.NEXT_PUBLIC_POSTHOG_DISABLED === "true" ||
           posthog.has_opted_out_capturing()
         )
@@ -158,17 +162,24 @@ export const MetricsFrame = (props: {
         });
       }
     },
-    [props.appId, teamId],
+    [props.appId, teamId, allowTracking],
   );
 
   useEffect(() => {
-    if (!teamId) return;
+    if (!teamId || isLoading) return;
     const entry = `${teamId}:${props.appId}`;
     if (lastPageEntry.current === entry) return;
-    // Preserve the guard through Strict Mode effect replay, not real remounts.
-    lastPageEntry.current = entry;
-    captureView(selectedView.current, "page_entry");
-  }, [props.appId, teamId, captureView]);
+    let active = true;
+    // Let the ancestor provider reconcile identity/consent before entry capture.
+    queueMicrotask(() => {
+      if (!active) return;
+      lastPageEntry.current = entry;
+      captureView(selectedView.current, "page_entry");
+    });
+    return () => {
+      active = false;
+    };
+  }, [props.appId, teamId, captureView, isLoading]);
 
   const operatingSystems = useMemo(
     () =>

--- a/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MetricsFrame/index.tsx
+++ b/web/scenes/PortalV3/Teams/TeamId/Apps/AppId/MetricsFrame/index.tsx
@@ -136,18 +136,20 @@ export const MetricsFrame = (props: {
   const captureView = useCallback(
     (view: AnalyticsView, source: "page_entry" | "tab_switch") => {
       try {
+        if (!teamId) return;
+        const properties = { appId: props.appId, teamId, view, source };
+        if (process.env.NODE_ENV === "development") {
+          console.info(
+            "[analytics] selfie_check_analytics_view_selected (local preview)",
+            properties,
+          );
+        }
         if (
-          !teamId ||
           process.env.NEXT_PUBLIC_POSTHOG_DISABLED === "true" ||
           posthog.has_opted_out_capturing()
         )
           return;
-        posthog.capture("selfie_check_analytics_view_selected", {
-          appId: props.appId,
-          teamId,
-          view,
-          source,
-        });
+        posthog.capture("selfie_check_analytics_view_selected", properties);
       } catch (error) {
         // Telemetry must never prevent entry or tab navigation.
         console.warn("Failed to capture analytics view selection", {

--- a/web/tests/unit/pv3-analytics-metrics-frame.test.tsx
+++ b/web/tests/unit/pv3-analytics-metrics-frame.test.tsx
@@ -290,6 +290,30 @@ it.each(["environment", "opt-out"])(
   },
 );
 
+it.each(["development", "production"] as const)(
+  "handles local previews in %s without sending disabled tracking",
+  async (environment) => {
+    jest.replaceProperty(process.env, "NODE_ENV", environment);
+    process.env.NEXT_PUBLIC_POSTHOG_DISABLED = "true";
+    const info = jest.spyOn(console, "info").mockImplementation(() => {});
+    render(<MetricsFrame appId={appId} />);
+    await screen.findByRole("region", { name: "Analytics overview" });
+    await selectTab("Daily trends");
+    if (environment === "development") {
+      expect(info.mock.calls).toEqual(
+        [
+          expectedSelection("totals", "page_entry"),
+          expectedSelection("daily", "tab_switch"),
+        ].map(([event, properties]) => [
+          `[analytics] ${event} (local preview)`,
+          properties,
+        ]),
+      );
+    } else expect(info).not.toHaveBeenCalled();
+    expect(posthog.capture).not.toHaveBeenCalled();
+  },
+);
+
 it("keeps navigation working when PostHog throws", async () => {
   jest.mocked(posthog.capture).mockImplementation(() => {
     throw new Error("PostHog unavailable");

--- a/web/tests/unit/pv3-analytics-metrics-frame.test.tsx
+++ b/web/tests/unit/pv3-analytics-metrics-frame.test.tsx
@@ -6,10 +6,13 @@ import { MetricsFrame } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/MetricsF
 import type { DailyRow, TotalsRow } from "@/lib/selfie-check-analytics";
 import { appId } from "../fixtures/selfie-check-analytics";
 import posthog from "posthog-js";
-import { StrictMode } from "react";
+import { StrictMode, useEffect } from "react";
 
 // #region I/O mocks
-jest.mock("@auth0/nextjs-auth0", () => ({ useUser: jest.fn() }));
+const mockUseUser = jest.fn();
+jest.mock("@auth0/nextjs-auth0/client", () => ({
+  useUser: () => mockUseUser(),
+}));
 jest.mock("next/navigation", () => ({
   useParams: () => ({ teamId: "team_0123456789abcdef0123456789abcdef" }),
 }));
@@ -24,6 +27,7 @@ const originalPostHogDisabled = process.env.NEXT_PUBLIC_POSTHOG_DISABLED;
 // #endregion
 
 // #region Test Data
+const trackingUser = { hasura: { is_allow_tracking: true } };
 const dailyRows: DailyRow[] = [
   { day: "2026-08-01", os_name: "Unknown" },
   { day: "2026-08-17", os_name: "Android" },
@@ -80,6 +84,7 @@ const expectLegends = (names: string[]) => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockUseUser.mockReturnValue({ user: trackingUser, isLoading: false });
   delete process.env.NEXT_PUBLIC_POSTHOG_DISABLED;
   jest.mocked(posthog.capture).mockReset();
   jest
@@ -194,9 +199,6 @@ it("captures entry once through Strict Mode, fetch completion, and rerenders", a
     </StrictMode>
   );
   const { rerender } = render(content);
-  expect(selectionEvents()).toEqual([
-    expectedSelection("totals", "page_entry"),
-  ]);
   await screen.findByRole("region", { name: "Analytics overview" });
   rerender(content);
   fireEvent.click(screen.getByRole("tab", { name: "All time" }));
@@ -273,11 +275,16 @@ it("captures a new app entry using the actual selected tab and current app ID", 
   ]);
 });
 
-it.each(["environment", "opt-out"])(
+it.each(["environment", "opt-out", "profile"])(
   "does not capture entry or switches when disabled by %s",
   async (reason) => {
     if (reason === "environment")
       process.env.NEXT_PUBLIC_POSTHOG_DISABLED = "true";
+    else if (reason === "profile")
+      mockUseUser.mockReturnValue({
+        user: { hasura: { is_allow_tracking: false } },
+        isLoading: false,
+      });
     else jest.mocked(posthog.has_opted_out_capturing).mockReturnValue(true);
     render(<MetricsFrame appId={appId} />);
     await screen.findByRole("region", { name: "Analytics overview" });
@@ -289,6 +296,26 @@ it.each(["environment", "opt-out"])(
     expect(posthog.capture).not.toHaveBeenCalled();
   },
 );
+
+it("waits for current user and ancestor consent sync before capturing entry", async () => {
+  mockUseUser.mockReturnValue({ isLoading: true });
+  jest.mocked(posthog.has_opted_out_capturing).mockReturnValue(true);
+  const Parent = () => {
+    useEffect(() => {
+      if (!mockUseUser().isLoading)
+        jest.mocked(posthog.has_opted_out_capturing).mockReturnValue(false);
+    });
+    return <MetricsFrame appId={appId} />;
+  };
+  const { rerender } = render(<Parent />);
+  await screen.findByRole("region", { name: "Analytics overview" });
+  expect(posthog.capture).not.toHaveBeenCalled();
+  mockUseUser.mockReturnValue({ user: trackingUser, isLoading: false });
+  await act(async () => rerender(<Parent />));
+  expect(selectionEvents()).toEqual([
+    expectedSelection("totals", "page_entry"),
+  ]);
+});
 
 it.each(["development", "production"] as const)(
   "handles local previews in %s without sending disabled tracking",

--- a/web/tests/unit/pv3-analytics-metrics-frame.test.tsx
+++ b/web/tests/unit/pv3-analytics-metrics-frame.test.tsx
@@ -5,12 +5,22 @@ import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { MetricsFrame } from "@/scenes/PortalV3/Teams/TeamId/Apps/AppId/MetricsFrame";
 import type { DailyRow, TotalsRow } from "@/lib/selfie-check-analytics";
 import { appId } from "../fixtures/selfie-check-analytics";
+import posthog from "posthog-js";
+import { StrictMode } from "react";
 
 // #region I/O mocks
 jest.mock("@auth0/nextjs-auth0", () => ({ useUser: jest.fn() }));
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ teamId: "team_0123456789abcdef0123456789abcdef" }),
+}));
+jest.mock("posthog-js", () => ({
+  __esModule: true,
+  default: { capture: jest.fn(), has_opted_out_capturing: jest.fn() },
+}));
 const fetchMock = jest.fn();
 const originalFetch = global.fetch;
 const originalResizeObserver = global.ResizeObserver;
+const originalPostHogDisabled = process.env.NEXT_PUBLIC_POSTHOG_DISABLED;
 // #endregion
 
 // #region Test Data
@@ -70,6 +80,12 @@ const expectLegends = (names: string[]) => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  delete process.env.NEXT_PUBLIC_POSTHOG_DISABLED;
+  jest.mocked(posthog.capture).mockReset();
+  jest
+    .mocked(posthog.has_opted_out_capturing)
+    .mockReset()
+    .mockReturnValue(false);
   global.fetch = fetchMock;
   // jsdom has no layout engine or ResizeObserver.
   global.ResizeObserver = class {
@@ -91,6 +107,9 @@ beforeEach(() => {
   serve();
 });
 afterEach(() => {
+  if (originalPostHogDisabled === undefined)
+    delete process.env.NEXT_PUBLIC_POSTHOG_DISABLED;
+  else process.env.NEXT_PUBLIC_POSTHOG_DISABLED = originalPostHogDisabled;
   global.fetch = originalFetch;
   global.ResizeObserver = originalResizeObserver;
   jest.restoreAllMocks();
@@ -144,6 +163,146 @@ it("filters every daily chart without changing the lifetime section", async () =
 
   fireEvent.click(screen.getByRole("tab", { name: "All time" }));
   expect(screen.getByText("20 sessions")).toBeInTheDocument();
+});
+// #endregion
+
+// #region Analytics view selection events
+const selectionEvents = () => jest.mocked(posthog.capture).mock.calls;
+const selectTab = async (name: string) => {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("tab", { name }));
+  });
+};
+const expectedSelection = (
+  view: "totals" | "daily",
+  source: "page_entry" | "tab_switch",
+  selectedAppId = appId,
+) => [
+  "selfie_check_analytics_view_selected",
+  {
+    appId: selectedAppId,
+    teamId: "team_0123456789abcdef0123456789abcdef",
+    view,
+    source,
+  },
+];
+
+it("captures entry once through Strict Mode, fetch completion, and rerenders", async () => {
+  const content = (
+    <StrictMode>
+      <MetricsFrame appId={appId} />
+    </StrictMode>
+  );
+  const { rerender } = render(content);
+  expect(selectionEvents()).toEqual([
+    expectedSelection("totals", "page_entry"),
+  ]);
+  await screen.findByRole("region", { name: "Analytics overview" });
+  rerender(content);
+  fireEvent.click(screen.getByRole("tab", { name: "All time" }));
+  expect(selectionEvents()).toEqual([
+    expectedSelection("totals", "page_entry"),
+  ]);
+});
+
+it("captures both directions and revisits, but not filters or the active tab", async () => {
+  const { rerender } = render(<MetricsFrame appId={appId} />);
+  await screen.findByRole("region", { name: "Analytics overview" });
+  await selectTab("Daily trends");
+  await selectTab("Daily trends");
+  fireEvent.change(screen.getByRole("combobox", { name: "Timeframe" }), {
+    target: { value: "7" },
+  });
+  fireEvent.change(screen.getByRole("combobox", { name: "Operating System" }), {
+    target: { value: "iOS" },
+  });
+  rerender(<MetricsFrame appId={appId} initialIsFallback />);
+  await selectTab("All time");
+  await selectTab("Daily trends");
+  expect(selectionEvents()).toEqual([
+    expectedSelection("totals", "page_entry"),
+    expectedSelection("daily", "tab_switch"),
+    expectedSelection("totals", "tab_switch"),
+    expectedSelection("daily", "tab_switch"),
+  ]);
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+it("captures a fresh entry after leaving and returning to the same app", async () => {
+  const { unmount } = render(<MetricsFrame appId={appId} />);
+  await screen.findByRole("region", { name: "Analytics overview" });
+  unmount();
+  render(<MetricsFrame appId={appId} />);
+  await screen.findByRole("region", { name: "Analytics overview" });
+  expect(selectionEvents()).toEqual([
+    expectedSelection("totals", "page_entry"),
+    expectedSelection("totals", "page_entry"),
+  ]);
+});
+
+it("captures keyboard navigation in both directions", async () => {
+  render(<MetricsFrame appId={appId} />);
+  await screen.findByRole("region", { name: "Analytics overview" });
+  const totalsTab = screen.getByRole("tab", { name: "All time" });
+  act(() => totalsTab.focus());
+  fireEvent.keyDown(totalsTab, { key: "ArrowRight" });
+  const dailyTab = screen.getByRole("tab", { name: "Daily trends" });
+  expect(dailyTab).toHaveAttribute("aria-selected", "true");
+  fireEvent.keyDown(dailyTab, { key: "ArrowLeft" });
+  expect(totalsTab).toHaveAttribute("aria-selected", "true");
+  expect(selectionEvents()).toEqual([
+    expectedSelection("totals", "page_entry"),
+    expectedSelection("daily", "tab_switch"),
+    expectedSelection("totals", "tab_switch"),
+  ]);
+});
+
+it("captures a new app entry using the actual selected tab and current app ID", async () => {
+  const { rerender } = render(<MetricsFrame appId={appId} />);
+  await screen.findByRole("region", { name: "Analytics overview" });
+  fireEvent.click(screen.getByRole("tab", { name: "Daily trends" }));
+  const nextAppId = "app_fedcba9876543210fedcba9876543210";
+  fetchMock.mockResolvedValue(response({}, 503));
+  await act(async () => rerender(<MetricsFrame appId={nextAppId} />));
+  fireEvent.click(screen.getByRole("tab", { name: "All time" }));
+  expect(selectionEvents()).toEqual([
+    expectedSelection("totals", "page_entry"),
+    expectedSelection("daily", "tab_switch"),
+    expectedSelection("daily", "page_entry", nextAppId),
+    expectedSelection("totals", "tab_switch", nextAppId),
+  ]);
+});
+
+it.each(["environment", "opt-out"])(
+  "does not capture entry or switches when disabled by %s",
+  async (reason) => {
+    if (reason === "environment")
+      process.env.NEXT_PUBLIC_POSTHOG_DISABLED = "true";
+    else jest.mocked(posthog.has_opted_out_capturing).mockReturnValue(true);
+    render(<MetricsFrame appId={appId} />);
+    await screen.findByRole("region", { name: "Analytics overview" });
+    fireEvent.click(screen.getByRole("tab", { name: "Daily trends" }));
+    expect(screen.getByRole("tab", { name: "Daily trends" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(posthog.capture).not.toHaveBeenCalled();
+  },
+);
+
+it("keeps navigation working when PostHog throws", async () => {
+  jest.mocked(posthog.capture).mockImplementation(() => {
+    throw new Error("PostHog unavailable");
+  });
+  const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+  render(<MetricsFrame appId={appId} />);
+  await screen.findByRole("region", { name: "Analytics overview" });
+  fireEvent.click(screen.getByRole("tab", { name: "Daily trends" }));
+  expect(screen.getByRole("tab", { name: "Daily trends" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  expect(warn).toHaveBeenCalledTimes(2);
 });
 // #endregion
 

--- a/web/tests/unit/pv3-sidebar-section-nav.test.tsx
+++ b/web/tests/unit/pv3-sidebar-section-nav.test.tsx
@@ -6,6 +6,9 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 
 // #region Mocks
+jest.mock("@auth0/nextjs-auth0/client", () => ({
+  useUser: () => ({ user: null, isLoading: false }),
+}));
 const usePathname = jest.fn();
 const useParams = jest.fn();
 const useSearchParams = jest.fn();


### PR DESCRIPTION
## Why

Standard procedure to track important pages with posthog events

## What

- `selfie_check_analytics_view_selected` from `MetricsFrame` with only `appId`, `teamId`, `view` (`totals` / `daily`)
- Keep development-only browser-console messages marked `(local preview)`. 

- [x] I have self-reviewed this PR.


